### PR TITLE
Fix for tvtv.us movie titles

### DIFF
--- a/sites/tvtv.us.config.js
+++ b/sites/tvtv.us.config.js
@@ -23,8 +23,12 @@ module.exports = {
       const icon = item.showPicture
         ? `https://cdn.tvpassport.com/image/show/480x720/${item.showPicture}`
         : null
+      let title = item.showName
+      if (title === "Movie") {
+        title = item.episodeTitle
+      }
       programs.push({
-        title: item.showName,
+        title: title,
         description: item.description,
         category: item.showType,
         start: start.toString(),


### PR DESCRIPTION
Example:
```json
        "showName": "Movie",
        "episodeTitle": "Shiva Baby",
```
This may apply to the Canadian `tvtv.ca` aswell.

Edit: Incase maintainers don't use US listings.
```
~🔥 grep -c '"showName": "Movie"' out.json 
1405
```