### PR TITLE
Update sky.com_uk.channels.xml

### DIFF
--- a/sites/sky.com/sky.com_uk.channels.xml
+++ b/sites/sky.com/sky.com_uk.channels.xml
@@ -143,7 +143,6 @@
     <channel lang="en" xmltv_id="SkyCinemaFeelGoodHD.uk" site_id="4020">Sky Cinema Feel Good HD</channel>
     <channel lang="en" xmltv_id="SkyCinemaGreatsHD.uk" site_id="1815">Sky Cinema Greats HD</channel>
     <channel lang="en" xmltv_id="SkyCinemaHitsHD.uk" site_id="4033">Sky Cinema Hits HD</channel>
-    <channel lang="en" xmltv_id="SkyCinemaPremiere1.uk" site_id="1275">Sky Cinema Premiere +1</channel>
     <channel lang="en" xmltv_id="SkyCinemaPremiereHD.uk" site_id="1409">Sky Cinema Premiere HD</channel>
     <channel lang="en" xmltv_id="SkyCinemaSciFiHorror.uk" site_id="1807">Sky Cinema Sci-Fi Horror</channel>
     <channel lang="en" xmltv_id="SkyCinemaSciFiHorrorHD.uk" site_id="4017">Sky Cinema Sci-Fi Horror HD</channel>


### PR DESCRIPTION
Same channel ID for Sky Cinema Premiere +1 and Sky Showcase HD. Premiere +1 does not exist