### PR TITLE
Fix of Philadelphia, Add Chicago

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1316,7 +1316,7 @@
     <channel lang="en" xmltv_id="WPHLDT1.us" site_id="32619">PHL17 (WPHL-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPHLDT2.us" site_id="50876">Antenna TV (WPHL-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPHLDT3.us" site_id="70278">Court TV (WPHL-DT3) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="WFMZDT1.us" site_id="20289">WFMZ69 (WFMZ-DT1) Philadelphia, PA</channel>    <channel lang="en" xmltv_id="WBBMDT1.us" site_id="20289">CBS (WBBM-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WBBMDT1.us" site_id="20289">CBS (WBBM-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WBBMDT2.us" site_id="91649">Start TV (WFMZ-DT2) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WBBMDT3.us" site_id="112504">Dabl (WFMZ-DT3) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WBBMDT4.us" site_id="117193">Fave TV (WBBM-DT4) Chicago, IL</channel>

--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1299,12 +1299,12 @@
     <channel lang="en" xmltv_id="ZeeTVUSA.in" site_id="33377">Zee TV USA</channel>
     <channel lang="en" xmltv_id="ZeeZest.in" site_id="32345">Zee Zest</channel>
     <channel lang="en" xmltv_id="ZingUSA.in" site_id="72524">Zing USA</channel>
-    <channel lang="en" xmltv_id="WCAUDT1.us" site_id="70248">NBC (WCAU-DT1) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WCAUDT1.us" site_id="19613">NBC (WCAU-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WCAUDT2.us" site_id="45807">Cozi (WCAU-DT2) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="KYWDT1.us" site_id="10853">CBS (KYW-DT1) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="KYWDT1.us" site_id="19611">CBS (KYW-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="KYWDT2.us" site_id="77056">Start TV (KYW-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="KYWDT3.us" site_id="112555">Dabl (KYW-DT3) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="WPVIDT1.us" site_id="11794">ABC (WPVI-DT1) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WPVIDT1.us" site_id="19612">ABC (WPVI-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPVIDT2.us" site_id="43156">Localish (WPVI-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPVIDT3.us" site_id="43139">This TV (KYW-DT3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WTXFDT1.us" site_id="19614">FOX (WTXF-DT1) Philadelphia, PA</channel>
@@ -1313,9 +1313,36 @@
     <channel lang="en" xmltv_id="WHYYDT1.us" site_id="24114">PBS (WHYY-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WHYYDT2.us" site_id="45913">PBS World (WHYY-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WHYYDT3.us" site_id="51000">PBS Kids (WHYY-DT2) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="WPHLDT1.us" site_id="11778">PHL17 (WPHL-DT1) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WPHLDT1.us" site_id="32619">PHL17 (WPHL-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPHLDT2.us" site_id="50876">Antenna TV (WPHL-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPHLDT3.us" site_id="70278">Court TV (WPHL-DT3) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="WFMZDT1.us" site_id="20289">WFMZ69 (WFMZ-DT1) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WFMZDT1.us" site_id="20289">WFMZ69 (WFMZ-DT1) Philadelphia, PA</channel>    <channel lang="en" xmltv_id="WBBMDT1.us" site_id="20289">CBS (WBBM-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WBBMDT2.us" site_id="91649">Start TV (WFMZ-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WBBMDT3.us" site_id="112504">Dabl (WFMZ-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WBBMDT4.us" site_id="117193">Fave TV (WBBM-DT4) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WMAQDT1.us" site_id="20452">NBC (WMAQ-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WMAQDT2.us" site_id="45805">Cozi TV (WMAQ-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WMAQDT5.us" site_id="114819">NBCLX (WMAQ-DT5) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WFLDDT1.us" site_id="20361">FOX (WFLD-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WFLDDT2.us" site_id="108535">Movies! (WFLD-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WFLDDT3.us" site_id="81275">Buzzr! (WFMZ-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WFLDDT4.us" site_id="108537">The GrioTV (WFLD-DT4) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WLSDT1.us" site_id="20456">ABC (WLS-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WLSDT2.us" site_id="35892">Localish (WLS-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WLSDT3.us" site_id="46236">This TV (WLS-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WGNDT1.us" site_id="20455">WGN9 (WGN-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WGNDT2.us" site_id="31044">Antenna TV (WGN-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WGNDT3.us" site_id="83118">Court TV (WGN-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WGNDT4.us" site_id="106422">Rewind TV (WGN-DT4) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WGNDT5.us" site_id="120897">TBD. (WGN-DT5) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WTTWDT1.us" site_id="30415">PBS (WTTW-DT1) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WTTWDT2.us" site_id="36111">WTTW Prime (WTTW-DT2) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WTTWDT3.us" site_id="49346">Create and World (WTTW-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WTTWDT4.us" site_id="55343">PBS Kids (WTTW-DT4) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WCTV.us" site_id="44739">CBS (WCTV1) Tallahassee, FL</channel>
+    <channel lang="en" xmltv_id="WCTV-TV2.us" site_id="46285">MeTV (WCTV2) Tallahassee, FL</channel>
+    <channel lang="en" xmltv_id="WTWC-TV.us" site_id="36063">NBC (WTWC1) Tallahassee, FL</channel>
+    <channel lang="en" xmltv_id="WTWC-TV2.us" site_id="50901">FOX (WTWC2) Tallahassee, FL</channel>
+    <channel lang="en" xmltv_id="WCTV.us" site_id="43722">CW (WTLF1) Tallahassee, FL</channel>
   </channels>
 </site>

--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1319,10 +1319,8 @@
     <channel lang="en" xmltv_id="WBBMDT1.us" site_id="20289">CBS (WBBM-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WBBMDT2.us" site_id="91649">Start TV (WFMZ-DT2) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WBBMDT3.us" site_id="112504">Dabl (WFMZ-DT3) Chicago, IL</channel>
-    <channel lang="en" xmltv_id="WBBMDT4.us" site_id="117193">Fave TV (WBBM-DT4) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WMAQDT1.us" site_id="20452">NBC (WMAQ-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WMAQDT2.us" site_id="45805">Cozi TV (WMAQ-DT2) Chicago, IL</channel>
-    <channel lang="en" xmltv_id="WMAQDT5.us" site_id="114819">NBCLX (WMAQ-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WFLDDT1.us" site_id="20361">FOX (WFLD-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WFLDDT2.us" site_id="108535">Movies! (WFLD-DT2) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WFLDDT3.us" site_id="81275">Buzzr! (WFMZ-DT3) Chicago, IL</channel>
@@ -1338,11 +1336,5 @@
     <channel lang="en" xmltv_id="WTTWDT1.us" site_id="30415">PBS (WTTW-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WTTWDT2.us" site_id="36111">WTTW Prime (WTTW-DT2) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WTTWDT3.us" site_id="49346">Create and World (WTTW-DT3) Chicago, IL</channel>
-    <channel lang="en" xmltv_id="WTTWDT4.us" site_id="55343">PBS Kids (WTTW-DT4) Chicago, IL</channel>
-    <channel lang="en" xmltv_id="WCTV.us" site_id="44739">CBS (WCTV1) Tallahassee, FL</channel>
-    <channel lang="en" xmltv_id="WCTV-TV2.us" site_id="46285">MeTV (WCTV2) Tallahassee, FL</channel>
-    <channel lang="en" xmltv_id="WTWC-TV.us" site_id="36063">NBC (WTWC1) Tallahassee, FL</channel>
-    <channel lang="en" xmltv_id="WTWC-TV2.us" site_id="50901">FOX (WTWC2) Tallahassee, FL</channel>
-    <channel lang="en" xmltv_id="WCTV.us" site_id="43722">CW (WTLF1) Tallahassee, FL</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will
●FIX Philadelphia EPG Showing Wrong Program Due to Wrong SiteID, Fixed Them, EPG Will FIX Next Update.
●Add Support for Chicago EPG.
Due No Access to EPG-ID Assign Page, It Tallahassee TVG-ID May Fix Later.

