### PR TITLE
Add Tallahassee and Atlanta Support

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1335,6 +1335,44 @@
     <channel lang="en" xmltv_id="WGNDT5.us" site_id="120897">TBD. (WGN-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WTTWDT1.us" site_id="30415">PBS (WTTW-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WTTWDT2.us" site_id="36111">WTTW Prime (WTTW-DT2) Chicago, IL</channel>
-    <channel lang="en" xmltv_id="WTTWDT3.us" site_id="49346">Create and World (WTTW-DT3) Chicago, IL</channel>
+    <channel lang="en" xmltv_id="WTTWDT3.us" site_id="49346">Create and World (WTTW-DT3) Chicago, IL</channel>    <channel lang="en" xmltv_id="WCTVDT1.us" site_id="44739">CBS (WCTV1) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WCTVDT2.us" site_id="46285">MeTV (WCTV2) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WCTVDT3.us" site_id="109194">Circle (WCTV3) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WCTVDT4.us" site_id="113519">ION Television (WCTV4) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WCTVDT5.us" site_id="118313">True Crime Network (WCTV5) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTWCDT1.us" site_id="36063">NBC (WCTV1) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTWCDT2.us" site_id="50901">FOX (WCTV2) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTWCDT3.us" site_id="43722">Charge! (WCTV3) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTLFDT1.us" site_id="70965">The CW (WTLF1) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTLFDT2.us" site_id="97223">Comet (WTLF2) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WTLFDT3.us" site_id="102330">TBD. (WTLF3) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WFSUDT1.us" site_id="35387">PBS (WFSU1) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WFSUDT1.us" site_id="35391">Create (WFSU3) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WFSUDT1.us" site_id="35393">PBS Kids (WFSU4) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WSBDT1.us" site_id="19586">ABC (WSB-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WSBDT2.us" site_id="59472">Bounce (WSB-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WSBDT3.us" site_id="92262">Dabl (WSB-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGCLDT1.us" site_id="19587">CBS (WGCL-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGCLDT2.us" site_id="63920">Cozi TV (WGCL-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGCLDT3.us" site_id="46099">Grit (WGCL-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGCLDT3.us" site_id="119577">Fave TV (WGCL-DT4) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WXIADT1.us" site_id="19587">NBC (WXIA-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WXIADT2.us" site_id="48961">Twist (WXIA-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WXIADT3.us" site_id="63920">True Crime Network (WXIA-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WXIADT4.us" site_id="107026">Quest (WXIA-DT4) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WAGADT1.us" site_id="20430">FOX (WAGA-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WAGADT2.us" site_id="81314">Movies (WAGA-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WAGADT3.us" site_id="94962">Buzzr (WAGA-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WAGADT4.us" site_id="104952">the GrioTV (WAGA-DT4) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WAGADT5.us" site_id="112717">Decades (WAGA-DT5) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WUPADT1.us" site_id="32793">CW (WUPA-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WUPADT2.us" site_id="92417">Start TV (WUPA-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WUPADT3.us" site_id="109126">Comet (WUPA-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WUPADT4.us" site_id="110189">MeTV (WUPA-DT4) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WUPADT5.us" site_id="112373">Start TV(WUPA-DT5) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGTVDT1.us" site_id="59210">PBS (WUPA-DT1) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGTVDT2.us" site_id="61543">Create (WUPA-DT2) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGTVDT3.us" site_id="61567">PBS World(WUPA-DT3) Atanta GA</channel>
+    <channel lang="en" xmltv_id="WGTVDT4.us" site_id="102035">PBS Kids(WUPA-DT4) Atanta GA</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will Add Tallahassee and Atlanta Area OTA Support.

#493

[Note]WFSU2, Airing The Florida Channel Was Skipped (Source Still Showing "The Florida Channel")