### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1394,7 +1394,7 @@
     <channel lang="en" xmltv_id="WDPNDT2.us" site_id="76927">Grit (WDPN-DT2) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WDPNDT3.us" site_id="90140">Court TV Mystery (WDPN-DT3) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WDPNDT4.us" site_id="91607">Heroes and Icons (WDPN-DT4) Philadelphia PA</channel>
-    <channel lang="en" xmltv_id="WDPNDT5.us" site_id="106849">Retro TV (WDPN-DT5) Philadelphia PA</channel>    
+    <channel lang="en" xmltv_id="WDPNDT5.us" site_id="106849">Retro TV (WDPN-DT5) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WCBSDT1.us" site_id="16689">CBS (WCBS-DT1) New York NY</channel>
     <channel lang="en" xmltv_id="WCBSDT2.us" site_id="74916">Start TV (WCBS-DT2) New York NY</channel>
     <channel lang="en" xmltv_id="WCBSDT3.us" site_id="112501">Dabl (WCBS-DT3) New York NY</channel>
@@ -1415,7 +1415,7 @@
     <channel lang="en" xmltv_id="WWJDT2.us" site_id="42610">Start TV (WWJ-DT2) Detroit MI</channel>
     <channel lang="en" xmltv_id="WWJDT3.us" site_id="42611">Dabl (WWJ-DT3) Detroit MI</channel>
     <channel lang="en" xmltv_id="WWJDT4.us" site_id="42612">Fave TV (WWJ-DT4) Detroit MI</channel>
-    <channel lang="en" xmltv_id="WXTZDT1.us" site_id="19601">abc (WXYZ-DT1) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WXYZDT1.us" site_id="19601">abc (WXYZ-DT1) Detroit MI</channel>
     <channel lang="en" xmltv_id="WXYZDT2.us" site_id="35140">Bounce (WXYZ-DT2) Detroit MI</channel>
     <channel lang="en" xmltv_id="WXYZDT3.us" site_id="35425">Laff (WXYZ-DT3) Detroit MI</channel>
     <channel lang="en" xmltv_id="WXYZDT4.us" site_id="111146">Court TV (WXYZ-DT4) Detroit MI</channel>

--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1394,6 +1394,56 @@
     <channel lang="en" xmltv_id="WDPNDT2.us" site_id="76927">Grit (WDPN-DT2) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WDPNDT3.us" site_id="90140">Court TV Mystery (WDPN-DT3) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WDPNDT4.us" site_id="91607">Heroes and Icons (WDPN-DT4) Philadelphia PA</channel>
-    <channel lang="en" xmltv_id="WDPNDT5.us" site_id="106849">Retro TV (WDPN-DT5) Philadelphia PA</channel>
+    <channel lang="en" xmltv_id="WDPNDT5.us" site_id="106849">Retro TV (WDPN-DT5) Philadelphia PA</channel>    
+    <channel lang="en" xmltv_id="WCBSDT1.us" site_id="16689">CBS (WCBS-DT1) New York NY</channel>
+    <channel lang="en" xmltv_id="WCBSDT2.us" site_id="74916">Start TV (WCBS-DT2) New York NY</channel>
+    <channel lang="en" xmltv_id="WCBSDT3.us" site_id="112501">Dabl (WCBS-DT3) New York NY</channel>
+    <channel lang="en" xmltv_id="WABCDT1.us" site_id="20453">abc (WABC-DT1) New York NY</channel>
+    <channel lang="en" xmltv_id="WABCDT2.us" site_id="35230">Localish (WABC-DT2) New York NY</channel>
+    <channel lang="en" xmltv_id="WABCDT3.us" site_id="50276">This TV (WABC-DT3) New York NY</channel>
+    <channel lang="en" xmltv_id="WABCDT4.us" site_id="119697">HSN (WABC-DT4) New York NY</channel>
+    <channel lang="en" xmltv_id="WNBCDT1.us" site_id="20459">NBC (WNBC-DT1) New York NY</channel>
+    <channel lang="en" xmltv_id="WNBCDT2.us" site_id="44936">Cozi TV (WNBC-DT2) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYWDT1.us" site_id="20360">FOX (WNYW-DT1) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYWDT2.us" site_id="30763">Movies! (WNYW-DT2) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYWDT4.us" site_id="97965">The Grio TV (WNYW-DT4) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYWDT5.us" site_id="112941">Decades (WNYW-DT5) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYEDT1.us" site_id="26196">NYC Life (WNYE-DT1) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYEDT2.us" site_id="28270">NYC Gov. (WNYE-DT2) New York NY</channel>
+    <channel lang="en" xmltv_id="WNYEDT3.us" site_id="28271">CUNY TV (WNYE-DT3) New York NY</channel>
+    <channel lang="en" xmltv_id="WWJDT1.us" site_id="20376">CBS (WWJ-DT1) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WWJDT2.us" site_id="42610">Start TV (WWJ-DT2) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WWJDT3.us" site_id="42611">Dabl (WWJ-DT3) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WWJDT4.us" site_id="42612">Fave TV (WWJ-DT4) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WXTZDT1.us" site_id="19601">abc (WXYZ-DT1) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WXYZDT2.us" site_id="35140">Bounce (WXYZ-DT2) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WXYZDT3.us" site_id="35425">Laff (WXYZ-DT3) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WXYZDT4.us" site_id="111146">Court TV (WXYZ-DT4) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WBTSCD1.us" site_id="28271">NBC (WBTS-CD1) Boston MI</channel>
+    <channel lang="en" xmltv_id="WBTSCD2.us" site_id="28271">Cozi TV (WBTS-CD2) Boston MI</channel>
+    <channel lang="en" xmltv_id="WFXTDT3.us" site_id="20362">FOX (WFXT-DT1) Boston MI</channel>
+    <channel lang="en" xmltv_id="WFXTDT3.us" site_id="81295">Court TV Mystery (WFXT-DT2) Boston MI</channel>
+    <channel lang="en" xmltv_id="WFXTDT3.us" site_id="92241">Laff (WFXT-DT3) Boston MI</channel>
+    <channel lang="en" xmltv_id="KHQDT1.us" site_id="33819">NBC (KHQ-DT1) Spokane WA</channel>
+    <channel lang="en" xmltv_id="KHQDT2.us" site_id="33843">SWX Collage Sports (KHQ-DT2) Spokane WA</channel>
+    <channel lang="en" xmltv_id="KINGDT1.us" site_id="19630">NBC (KING-DT1) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KINGDT2.us" site_id="46081">True Crime Network (KING-DT2) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KINGDT3.us" site_id="106988">Quest (KING-DT3) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KINGDT4.us" site_id="121196">Twist (KING-DT4) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KIRODT1.us" site_id="20290">CBS (KIRO-DT1) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KIRODT2.us" site_id="49928">Cozi TV (KIRO-DT2) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KIRODT3.us" site_id="59434">Laff (KIRO-DT3) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KOMODT1.us" site_id="19629">ABC (KOMO-DT1) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KOMODT2.us" site_id="63537">Comet (KOMO-DT2) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KOMODT3.us" site_id="91578">Charge (KOMO-DT3) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KCPQDT1.us" site_id="21254">FOX (KCPQ-DT1) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KCPQDT2.us" site_id="30904">Court TV (KCPQ-DT2) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KCPQDT3.us" site_id="98013">Court TV Mystery (KCPQ-DT3) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KCPQDT4.us" site_id="108236">Stadium (KCPQ-DT4) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KSTWDT1.us" site_id="21253">CW (KSTW-DT1) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KSTWDT2.us" site_id="92434">Start TV (KSTW-DT2) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KSTWDT3.us" site_id="104361">Grit (KSTW-DT3) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KSTWDT4.us" site_id="112976">Dabl (KSTW-DT4) Seattle WA</channel>
+    <channel lang="en" xmltv_id="KSTWDT5.us" site_id="113562">Circle (KSTW-DT5) Seattle WA</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will 
●Add New York Station When You Using tvtv.us xml.
●Add Canadian Server Related Channel. [To-Do] Canada Version of Peachtree TV is 32795(tvtv.ca)
●Add Seattle Area EPG Support.

[Note]Many IPTV Player Doesn't Support for Using Multiple EPG Source. So I'll Continue to Add to "tvtv-us.xml".