### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -88,7 +88,7 @@
     <channel lang="en" xmltv_id="Buzzr.us" site_id="93430">Buzzr</channel>
     <channel lang="en" xmltv_id="CaribVision.bb" site_id="49411">CaribVision</channel>
     <channel lang="en" xmltv_id="CarsTV.us" site_id="14988">Cars.TV</channel>
-    <channel lang="en" xmltv_id="CartoonNetworkEast.us" site_id="94799">Cartoon Network East</channel>
+    <channel lang="en" xmltv_id="CartoonNetworkEast.us" site_id="60048">Cartoon Network East</channel>
     <channel lang="en" xmltv_id="CartoonNetworkWest.us" site_id="18151">Cartoon Network West</channel>
     <channel lang="en" xmltv_id="CatholicFaithNetwork.us" site_id="62900">Catholic Faith Network</channel>
     <channel lang="en" xmltv_id="CBHT.us" site_id="14724">CBHT</channel>
@@ -1445,5 +1445,6 @@
     <channel lang="en" xmltv_id="KSTWDT3.us" site_id="104361">Grit (KSTW-DT3) Seattle WA</channel>
     <channel lang="en" xmltv_id="KSTWDT4.us" site_id="112976">Dabl (KSTW-DT4) Seattle WA</channel>
     <channel lang="en" xmltv_id="KSTWDT5.us" site_id="113562">Circle (KSTW-DT5) Seattle WA</channel>
+    <channel lang="en" xmltv_id="Motortrend.us" site_id="31046">Motortrend</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will Fix
●Cartoon Network Showing Spanish EPG, and Wrong Program
●Add Motortrend