### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1497,5 +1497,28 @@
     <channel lang="en" xmltv_id="WUTVDT1.us" site_id="42945">FOX (WUTV1) Buffalo NY</channel>
     <channel lang="en" xmltv_id="WUTVDT2.us" site_id="42947">TBD. (WUTV2) Buffalo NY</channel>
     <channel lang="en" xmltv_id="WUTVDT3.us" site_id="91397">Charge! (WUTV3) Buffalo NY</channel>
+    <channel lang="en" xmltv_id="FoxNetworksGroup.us" site_id="105450">FOXNET(National)</channel>
+    <channel lang="en" xmltv_id="AdultSwimEast.us" site_id="92425">[adult swim]East</channel>
+    <channel lang="en" xmltv_id="AdultSwimWest.us" site_id="110135">[adult swim]West</channel>
+    <channel lang="en" xmltv_id="WMARDT1.us" site_id="21230">abc (WMAR-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WMARDT2.us" site_id="43979">Grit (WMAR-DT2) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WMARDT3.us" site_id="43981">Bounce (WMAR-DT3) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WMARDT4.us" site_id="106560">Court TV Mystery (WMAR-DT4) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WMARDT5.us" site_id="111220">Court TV (WMAR-DT5) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WRCDT1.us" site_id="19578">NBC (WRC-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WRCDT2.us" site_id="45736">Cozi TV(WRC-DT2) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WRCDT3.us" site_id="114820">NBCLX (WRC-DT5) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WRCDT4.us" site_id="106502">Telemundp (WRC-DT4) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WTTGDT1.us" site_id="20367">FOX (WTTG-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WTTGDT2.us" site_id="94963">Burzzr (WTTG-DT2) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WTTGDT3.us" site_id="102968">MeTV (WTTG-DT3) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WUSADT1.us" site_id="19580">CBS (WUSA-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WUSADT2.us" site_id="47155">True Crime Network (WUSA-DT2) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WUSADT4.us" site_id="118858">Twist (WUSA-DT4) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WDCWDT1.us" site_id="32744">CW (WDCW-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WETADT1.us" site_id="19581">PBS (WETA-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WETADT2.us" site_id="21526">WETA UK (WETA-DT2) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WETADT3.us" site_id="32050">PBS Kids (WETA-DT3) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WETADT4.us" site_id="32052">PBS World (WETA-DT4) Washington D.C.</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will Add
●Add Support For Washington D.C. Area EPG
●Add Following
FOXNET (National Feed of FOX Network For Minor Market)
[adult swm]Only EPG (Will Use for iptv-org)