### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -9,7 +9,6 @@
     <channel lang="en" xmltv_id="AccuWeather.us" site_id="56193">AccuWeather</channel>
     <channel lang="en" xmltv_id="ActionMaxEast.us" site_id="18433">ActionMax East</channel>
     <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="18434">ActionMax West</channel>
-    <channel lang="en" xmltv_id="AdultSwimWest.us" site_id="33513">Adult Swim West</channel>
     <channel lang="en" xmltv_id="AEEast.us" site_id="51529">A&amp;E East</channel>
     <channel lang="en" xmltv_id="AEWest.us" site_id="21760">A&amp;E West</channel>
     <channel lang="en" xmltv_id="AlResalah.sa" site_id="31969">Al Resalah</channel>
@@ -1079,7 +1078,7 @@
     <channel lang="en" xmltv_id="Pac12BayArea.us" site_id="76370">Pac-12 Bay Area</channel>
     <channel lang="en" xmltv_id="Pac12LosAngeles.us" site_id="76375">Pac-12 Los Angeles</channel>
     <channel lang="en" xmltv_id="Pac12Mountain.us" site_id="76374">Pac-12 Mountain</channel>
-    <channel lang="en" xmltv_id="Pac12Networks.us" site_id="10705">Pac-12 Networks</channel>
+    <channel lang="en" xmltv_id="Pac12Networks.us" site_id="76366">Pac-12 Networks</channel>
     <channel lang="en" xmltv_id="Pac12Oregon.us" site_id="76371">Pac-12 Oregon</channel>
     <channel lang="en" xmltv_id="Pac12Washington.us" site_id="76373">Pac-12 Washington</channel>
     <channel lang="en" xmltv_id="ParamountNetworkEast.us" site_id="11163">Paramount Network East</channel>
@@ -1521,5 +1520,7 @@
     <channel lang="en" xmltv_id="WETADT3.us" site_id="32050">PBS Kids (WETA-DT3) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WETADT4.us" site_id="32052">PBS World (WETA-DT4) Washington D.C.</channel>
     <channel lang="en" xmltv_id="PlutoTVSPORTBeINSportsXtra.us" site_id="113143">beIN Sports Xtra (English-USA) </channel>
+    <channel lang="en" xmltv_id="NHKWorldJapan.jp" site_id="59155">NHK World (US-National) </channel>
+
   </channels>
 </site>


### PR DESCRIPTION
Mini-Patch, This Will Fix
●Adult Swim West Showing Wrong Program (Duplicate of Same tvg-id)
●PAC12 Network Showing Wrong Program (Site ID Error)
●Add NHK World