### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1554,8 +1554,8 @@
     <channel lang="en" xmltv_id="WFORDT2.us" site_id="92064">Start TV (WFOR-DT2) Miami FL</channel>
     <channel lang="en" xmltv_id="WFORDT3.us" site_id="112327">Dabl (WFOR-DT3) Miami FL</channel>
     <channel lang="en" xmltv_id="WFORDT4.us" site_id="117054">FAVE TV (WFOR-DT4) Miami FL</channel>
-    <channel lang="en" xmltv_id="WSVNDT1.us" site_id="117054">FOX (WSVN-DT1) Miami FL</channel>
-    <channel lang="en" xmltv_id="WSVNDT2.us" site_id="117054">The Grio TV (WSVN-DT2) Miami FL</channel>
+    <channel lang="en" xmltv_id="WSVNDT1.us" site_id="21220">FOX (WSVN-DT1) Miami FL</channel>
+    <channel lang="en" xmltv_id="WSVNDT2.us" site_id="61999">The Grio TV (WSVN-DT2) Miami FL</channel>
     <channel lang="en" xmltv_id="WTVJDT1.us" site_id="21219">NBC (WTVJ-DT1) Miami FL</channel>
     <channel lang="en" xmltv_id="WTVJDT2.us" site_id="45543">Cozi TV (WTVJ-DT2) Miami FL</channel>
     <channel lang="en" xmltv_id="WTVJDT3.us" site_id="63644">NBCLX (WTVJ-DT3) Miami FL</channel>
@@ -1647,5 +1647,32 @@
     <channel lang="en" xmltv_id="WTXLDT3.us" site_id="74751">Geit (WTXL3) Tallahassee FL</channel>
     <channel lang="en" xmltv_id="WTXLDT4.us" site_id="97554">Court TV Mystery (WTXL4) Tallahassee FL</channel>
     <channel lang="en" xmltv_id="WTXLDT5.us" site_id="111254">Court TV (WTXL5) Tallahassee FL</channel>
+    <channel lang="en" xmltv_id="WKYCDT1.us" site_id="20492">NBC (WKYC-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKYCDT2.us" site_id="42697">True Crime Network (WKYC-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKYCDT3.us" site_id="42700">Cozi TV (WKYC-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKYCDT4.us" site_id="107047">Quest (WKYC-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKYCDT5.us" site_id="118839">Twist (WKYC-DT5) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKYCDT6.us" site_id="122046">Shop LC (WKYC-DT6) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WEWSDT1.us" site_id="21101">abc (WEWS-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WEWSDT2.us" site_id="72901">Grit (WEWS-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WEWSDT3.us" site_id="92188">Laff (WEWS-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WEWSDT4.us" site_id="111091">TrueReal (WEWS-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WEWSDT5.us" site_id="118455">HSN (WEWS-DT5) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WJWDT1.us" site_id="21247">FOX (WJW-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WJWDT2.us" site_id="70518">Antenna TV (WJW-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WJWDT3.us" site_id="106509">Comet (WJW-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WJWDT4.us" site_id="106510">Charge (WJW-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WOIODT1.us" site_id="21320">CBS (WOIO-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WOIODT2.us" site_id="54702">MeTV /My Network TV (WOIO-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WOIODT3.us" site_id="114149">Dabl (WOIO-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WOIODT4.us" site_id="121077">Rewind TV (WOIO-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WUABDT1.us" site_id="34516">CW (WUAB-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WUABDT2.us" site_id="46950">Bounce (WUAB-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WUABDT3.us" site_id="74183">Circle (WUAB-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WVIZDT1.us" site_id="44366">PBS (WVIZ-DT1) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WVIZDT2.us" site_id="46488">The Ohio Channel (WVIZ-DT2) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WVIZDT3.us" site_id="57737">PBS World (WVIZ-DT3) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WVIZDT4.us" site_id="57703">PBS Create (WVIZ-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WVIZDT5.us" site_id="102096">PBS Kids (WVIZ-DT5) Cleveland OH</channel>
   </channels>
 </site>


### PR DESCRIPTION
This Patch Will 
●Fix Miami FOX EPG (Wrong Site ID)
●Add Cleveland Area EPG Support