### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1940,5 +1940,10 @@
     <channel lang="en" xmltv_id="WPXNDT6.us" site_id="83518">TrueReal (WPXN-DT6) New York NY</channel>
     <channel lang="en" xmltv_id="WNYWDT3.us" site_id="81334">FOX Weather OTA (WNYW-DT3) New York NY</channel>
     <channel lang="en" xmltv_id="WCBSDT4.us" site_id="117203">FAVE TV (WCBS-DT4) New York NY</channel>
+    <channel lang="en" xmltv_id="WJLPDT2.us" site_id="92098">Laff (WJLP-DT2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WJLPDT3.us" site_id="99162">Grit (WJLP-DT3) New York, NY</channel>
+    <channel lang="en" xmltv_id="WJLPDT4.us" site_id="99163">ION Mystery (WJLP-DT4) New York, NY</channel>
+    <channel lang="en" xmltv_id="WJLPDT7.us" site_id="120389">Story Television (WJLP-DT7) New York, NY</channel>
+    <channel lang="en" xmltv_id="WJLPDT7.us" site_id="112951">MeTV Plus (WJLP-DT8) New York, NY</channel>
   </channels>
 </site>


### PR DESCRIPTION
Adding WJLP's Missing Sub Channels.
Please Re-Run The Test After https://github.com/iptv-org/database/pull/46 Was Merged.