### PR TITLE
Update tvtv.us_us.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -1944,5 +1944,8 @@
     <channel lang="en" xmltv_id="WJLPDT4.us" site_id="99163">ION Mystery (WJLP-DT4) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT7.us" site_id="120389">Story Television (WJLP-DT7) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT8.us" site_id="112951">MeTV Plus (WJLP-DT8) New York, NY</channel>
+    <channel lang="en" xmltv_id="NewsNet.us" site_id="92205">Newsnet</channel>
+    <channel lang="en" xmltv_id="BeINSportsXtraenEspanol.us" site_id="122816">beIN Sports Xtra En Espanol</channel>
+    <channel lang="en" xmltv_id="DWEnglish.de" site_id="43771">DW English OTA</channel>
   </channels>
 </site>


### PR DESCRIPTION
Fix #627. Force to Add These.
●Newsnet (Using WYBN-LD8, Cobleskill NY)
●beIN Sports Xtra En Espanol (Using W30EH-D4, Fort Wayne ID)
●DW English (Using WDSC-DT3, Daytona FL)
All Of Them Are Must Be Showing Eastern Time EPG.