### PR TITLE
Additions for tvtv.us_us.channels.xml and tvtv.us_ca.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_ca.channels.xml
+++ b/sites/tvtv.us/tvtv.us_ca.channels.xml
@@ -16,6 +16,7 @@
     <channel lang="en" xmltv_id="CBCNewsNetwork.ca" site_id="63287">CBC News Network</channel>
     <channel lang="en" xmltv_id="CBCOttawa.ca" site_id="10097">CBC Ottawa</channel>
     <channel lang="en" xmltv_id="CBCToronto.ca" site_id="10091">CBC Toronto</channel>
+    <channel lang="en" xmltv_id="CBCWindsor.ca" site_id="72772">CBC Windsor</channel>
     <channel lang="en" xmltv_id="CBCWinnipeg.ca" site_id="72940">CBC Winnipeg</channel>
     <channel lang="fr" xmltv_id="CBFT.ca" site_id="45867">Ici Radio-Canada Télé</channel>
     <channel lang="en" xmltv_id="CBSSportsNetworkCanada.ca" site_id="10708">CBS Sports Network Canada</channel>
@@ -23,8 +24,15 @@
     <channel lang="fr" xmltv_id="CFTM.ca" site_id="72755">TVA</channel>
     <channel lang="en" xmltv_id="CHBCDT2.ca" site_id="13834">Global (CHBC-DT-2) Vernon, BC</channel>
     <channel lang="en" xmltv_id="CHKM.ca" site_id="11597">Global (CHKM) Kamloops, BC</channel>
+    <channel lang="en" xmltv_id="CICADT.ca" site_id="70583">TVOntario (CICA-DT) Toronto</channel>
     <channel lang="fr" xmltv_id="CIVM.ca" site_id="63040">Télé-Québec</channel>
     <channel lang="en" xmltv_id="CPACOttawa.ca" site_id="17608">CPAC</channel>
+    <channel lang="en" xmltv_id="CTV2Barrie.ca" site_id="72705">CTV2 (CKVR-DT) Barrie ON</channel>
+    <channel lang="en" xmltv_id="CTV2London.ca" site_id="72720">CTV2 (CFPL-DT) London ON</channel>
+    <channel lang="en" xmltv_id="CTV2Windsor.ca" site_id="72956">CTV2 (CHWI-DT) Wheatley ON</channel>
+    <channel lang="en" xmltv_id="CTVKitchener.ca" site_id="72614">CTV (CKCO-DT) Kitchener ON</channel>
+    <channel lang="en" xmltv_id="CTVSciFiChannel.ca" site_id="72484">CTV Sci-Fi Channel</channel>
+    <channel lang="en" xmltv_id="CTVToronto.ca" site_id="44784">CTV (CFTO-DT) Toronto ON</channel>
     <channel lang="en" xmltv_id="DisneyChannelCanadaWest.ca" site_id="16831">Disney Channel Canada West</channel>
     <channel lang="en" xmltv_id="FairchildTV2.ca" site_id="11397">Fairchild TV 2</channel>
     <channel lang="en" xmltv_id="FightNetwork.ca" site_id="48099">Fight Network</channel>

--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -602,6 +602,7 @@
     <channel lang="en" xmltv_id="KGTVDT4.us" site_id="106657">Court TV Mystery (KGTV4) San Diego, CA</channel>
     <channel lang="en" xmltv_id="KGTVDT5.us" site_id="118806">Bounce (KGTV5) San Diego, CA</channel>
     <channel lang="en" xmltv_id="KGTVDT6.us" site_id="121400">Newsy (KGTV6) San Diego, CA</channel>
+    <channel lang="en" xmltv_id="KGUNDT1.us" site_id="36184">ABC (KGUN-DT1) Tucson AZ</channel>
     <channel lang="en" xmltv_id="KHDTLD3.us" site_id="15453">SonLife Network (KHDT-DT3) Denver, CO</channel>
     <channel lang="en" xmltv_id="KHIZLD1.us" site_id="99756">Court TV (KHIZ) Victorville, CA</channel>
     <channel lang="en" xmltv_id="KHIZLD2.us" site_id="101396">Laff (KHIZ-LD2) Los Angeles, CA</channel>
@@ -1416,6 +1417,7 @@
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="35230">Localish (WABC-DT2) New York NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="50276">This TV (WABC-DT3) New York NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="119697">HSN (WABC-DT4) New York NY</channel>
+    <channel lang="en" xmltv_id="WADLDT1.us" site_id="32511">My Network TV (WADL-DT1) Mount Clemens MI</channel>
     <channel lang="en" xmltv_id="WAGADT1.us" site_id="20430">FOX (WAGA-DT1) Atanta GA</channel>
     <channel lang="en" xmltv_id="WAGADT2.us" site_id="81314">Movies (WAGA-DT2) Atanta GA</channel>
     <channel lang="en" xmltv_id="WAGADT3.us" site_id="94962">Buzzr (WAGA-DT3) Atanta GA</channel>
@@ -1471,6 +1473,7 @@
     <channel lang="en" xmltv_id="WDCADT2.us" site_id="77760">Movies! (WDCA-DT2) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WDCADT3.us" site_id="81318">Heroes and Icons (WDCA-DT3) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WDCWDT1.us" site_id="32744">CW (WDCW-DT1) Washington D.C.</channel>
+    <channel lang="en" xmltv_id="WDIVDT1.us" site_id="20359">NBC (WDIV-DT1) Detroit MI</channel>
     <channel lang="en" xmltv_id="WDNICD1.us" site_id="68610">Telemundo (WDNI-CD1) Indianapolis IN</channel>
     <channel lang="en" xmltv_id="WDPNDT1.us" site_id="64010">MeTV (WDPN-DT1) Philadelphia PA</channel>
     <channel lang="en" xmltv_id="WDPNDT2.us" site_id="76927">Grit (WDPN-DT2) Philadelphia PA</channel>
@@ -1555,6 +1558,7 @@
     <channel lang="en" xmltv_id="WJACDT2.us" site_id="49028">MeTV (WJAC2) Altoona PA</channel>
     <channel lang="en" xmltv_id="WJACDT3.us" site_id="91485">Comet (WJAC3) Altoona PA</channel>
     <channel lang="en" xmltv_id="WJACDT4.us" site_id="98160">CW (WJAC4) Altoona PA</channel>
+    <channel lang="en" xmltv_id="WJBKDT1.us" site_id="19600">FOX (WJBK-DT1) Detroit MI</channel>
     <channel lang="en" xmltv_id="WJLPDT1.us" site_id="75523">MeTV (WJLP-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT5.us" site_id="111255">Retro TV (WJLP-DT5) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT6.us" site_id="115891">Heartland Network (WJLP-DT6) New York, NY</channel>
@@ -1562,6 +1566,7 @@
     <channel lang="en" xmltv_id="WJWDT2.us" site_id="70518">Antenna TV (WJW-DT2) Cleveland OH</channel>
     <channel lang="en" xmltv_id="WJWDT3.us" site_id="106509">Comet (WJW-DT3) Cleveland OH</channel>
     <channel lang="en" xmltv_id="WJWDT4.us" site_id="106510">Charge (WJW-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WKBDDT1.us" site_id="25126">CW (WKBD-DT1) Detroit MI</channel>
     <channel lang="en" xmltv_id="WKBWDT1.us" site_id="24052">abc (WKBW1) Buffalo NY</channel>
     <channel lang="en" xmltv_id="WKBWDT2.us" site_id="56328">Bounce (WKBW2) Buffalo NY</channel>
     <channel lang="en" xmltv_id="WKBWDT3.us" site_id="59301">Court TV Mystery (WKBW3) Buffalo NY</channel>
@@ -1636,7 +1641,9 @@
     <channel lang="en" xmltv_id="WOIODT2.us" site_id="54702">MeTV /My Network TV (WOIO-DT2) Cleveland OH</channel>
     <channel lang="en" xmltv_id="WOIODT3.us" site_id="114149">Dabl (WOIO-DT3) Cleveland OH</channel>
     <channel lang="en" xmltv_id="WOIODT4.us" site_id="121077">Rewind TV (WOIO-DT4) Cleveland OH</channel>
+    <channel lang="en" xmltv_id="WOODDT1.us" site_id="20457">NBC (WOOD-DT1) Grand Rapids MI</channel>
     <channel lang="en" xmltv_id="WorldPokerTour.us" site_id="113372">World Poker Tour </channel>
+    <channel lang="en" xmltv_id="WOTVDT1.us" site_id="34524">ABC (WOTV-DT1) Battle Creek MI</channel>
     <channel lang="en" xmltv_id="WPBSDT4.us" site_id="31734">PBS Kids (WPBS-DT4) Watertown, NY</channel>
     <channel lang="en" xmltv_id="WPBTDT1.us" site_id="26192">PBS (WPBT-DT1) Miami FL</channel>
     <channel lang="en" xmltv_id="WPBTDT2.us" site_id="32576">Create (WPBT-DT2) Miami FL</channel>
@@ -1725,6 +1732,8 @@
     <channel lang="en" xmltv_id="WTVJDT1.us" site_id="21219">NBC (WTVJ-DT1) Miami FL</channel>
     <channel lang="en" xmltv_id="WTVJDT2.us" site_id="45543">Cozi TV (WTVJ-DT2) Miami FL</channel>
     <channel lang="en" xmltv_id="WTVJDT3.us" site_id="63644">NBCLX (WTVJ-DT3) Miami FL</channel>
+    <channel lang="en" xmltv_id="WTVSDT1.us" site_id="25512">PBS (WTVS-DT1) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WTVSDT5.us" site_id="117254">Michigan Learning Channel (WTVS-DT5) Detroit MI</channel>
     <channel lang="en" xmltv_id="WTVUCD3.us" site_id="35645">H&amp;I (WTVU-CD3) Syracuse, NY</channel>
     <channel lang="en" xmltv_id="WTVUCD5.us" site_id="35647">Decades (WTVU-CD5) Syracuse, NY</channel>
     <channel lang="en" xmltv_id="WTVUCD6.us" site_id="35648">Movies! (WTVU-CD6) Syracuse, NY</channel>
@@ -1776,6 +1785,8 @@
     <channel lang="en" xmltv_id="WWJDT2.us" site_id="42610">Start TV (WWJ-DT2) Detroit MI</channel>
     <channel lang="en" xmltv_id="WWJDT3.us" site_id="42611">Dabl (WWJ-DT3) Detroit MI</channel>
     <channel lang="en" xmltv_id="WWJDT4.us" site_id="42612">Fave TV (WWJ-DT4) Detroit MI</channel>
+    <channel lang="en" xmltv_id="WWMTDT1.us" site_id="34884">CBS (WWMT-DT1) Kalamazoo MI</channel>
+    <channel lang="en" xmltv_id="WWMTDT2.us" site_id="34910">CW (WWMT-DT2) Kalamazoo MI</channel>
     <channel lang="en" xmltv_id="WWORDT1.us" site_id="26566">My Network TV (WWOR-DT1) NY</channel>
     <channel lang="en" xmltv_id="WWORDT3.us" site_id="75009">Buzzr (WWOR-DT3) NY</channel>
     <channel lang="en" xmltv_id="WWORDT4.us" site_id="81349">Heroes and Icons (WWOR-DT4) NY</channel>
@@ -1786,6 +1797,7 @@
     <channel lang="en" xmltv_id="WXNYLD3.us" site_id="16444">CGTN Español (WXNY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD4.us" site_id="16446">Retro TV (WXNY-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD5.us" site_id="17346">Retro TV (WXNY-DT5) New York, NY</channel>
+    <channel lang="en" xmltv_id="WXSPCD1.us" site_id="68648">My Network TV (WXSP-CD1) Grand Rapids MI</channel>
     <channel lang="en" xmltv_id="WXTVDT1.us" site_id="35361">Univision Nueva York (WXTV-DT1) NY</channel>
     <channel lang="en" xmltv_id="WXTVDT2.us" site_id="82183">Bounce (WXTV-DT2) NY</channel>
     <channel lang="en" xmltv_id="WXTVDT3.us" site_id="91913">Twist (WXTV-DT3) NY</channel>
@@ -1800,6 +1812,7 @@
     <channel lang="en" xmltv_id="WYBNLD3.us" site_id="17335">THIS (WYBN-LD3) Albany, NY</channel>
     <channel lang="en" xmltv_id="WYBNLD7.us" site_id="17339">Action  (WYBN-LD7) Albany, NY</channel>
     <channel lang="en" xmltv_id="WYBNLD8.us" site_id="17340">NewsNet (WYBN-LD8) Albany, NY</channel>
+    <channel lang="en" xmltv_id="WZZMDT1.us" site_id="31482">ABC (WZZM-DT1) Grand Rapids MI</channel>
     <channel lang="en" xmltv_id="XHASDT2.us" site_id="74026">LATV (XHAS-DT2) San Diego, CA</channel>
     <channel lang="en" xmltv_id="YES2Overflow.us" site_id="17279">YES2 Overflow</channel>
     <channel lang="en" xmltv_id="YurViewArizona.us" site_id="19107">YurView Arizona</channel>


### PR DESCRIPTION
Added to tvtv.us_us.channels.xml:
	KGUNDT1.us	36184
	WADLDT1.us	32511
	WDIVDT1.us	20359
	WJBKDT1.us	19600
	WKBDDT1.us	25126
	WOODDT1.us	20457
	WOTVDT1.us	34524
	WTVSDT1.us	25512
	WTVSDT5.us	117254
	WWMTDT1.us	34884
	WWMTDT2.us	34910
	WXSPCD1.us	68648
	WZZMDT1.us	31482
	
Added to tvtv.us_ca.channels.xml:
	CBCWindsor.ca		72772
	CICADT.ca			70583
	CTV2Barrie.ca			72705
	CTV2London.ca		72720
	CTV2Windsor.ca		72956
	CTVKitchener.ca		72614
	CTVSciFiChannel.ca		72484
	CTVToronto.ca			44784