### PR TITLE
Added missing channel "Puls 4" to site "magentatv.at"

### DIFF
--- a/sites/magentatv.at/magentatv.at_at.channels.xml
+++ b/sites/magentatv.at/magentatv.at_at.channels.xml
@@ -101,6 +101,7 @@
     <channel lang="de" xmltv_id="ProSiebenFun.de" site_id="ProSieben_FUN_HD">ProSieben FUN HD</channel>
     <channel lang="de" xmltv_id="ProSiebenMaxxAustria.at" site_id="ProSieben_Maxx_HD">ProSieben Maxx Austria</channel>
     <channel lang="de" xmltv_id="Puls24.at" site_id="PULS24_HD">Puls 24</channel>
+    <channel lang="de" xmltv_id="Puls4.at" site_id="PULS_4_HD">Puls 4</channel>
     <channel lang="de" xmltv_id="QVC2Deutsch.us" site_id="QVC_2_HD">QVC2 Deutsch</channel>
     <channel lang="de" xmltv_id="QVCGermany.us" site_id="QVC_HD">QVC Deutschland</channel>
     <channel lang="de" xmltv_id="QVCStyleGermany.us" site_id="QVC_Beauty_Style">QVC Style Deutschland</channel>


### PR DESCRIPTION
Attention: The correct site_id is PULS_4_HD