### PR TITLE
Add UseeTV EPG

### DIFF
--- a/.github/workflows/useetv.com.yml
+++ b/.github/workflows/useetv.com.yml
@@ -1,7 +1,7 @@
 name: useetv.com
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 7 * * *'
   workflow_dispatch:
   workflow_run:
     workflows: [_trigger]

--- a/.github/workflows/useetv.com.yml
+++ b/.github/workflows/useetv.com.yml
@@ -1,0 +1,17 @@
+name: useetv.com
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+  workflow_run:
+    workflows: [_trigger]
+    types:
+      - completed
+jobs:
+  load:
+    uses: ./.github/workflows/_load.yml
+    with:
+      site: ${{github.workflow}}
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/sites/useetv.com/useetv.com.config.js
+++ b/sites/useetv.com/useetv.com.config.js
@@ -9,7 +9,7 @@ dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
 
 module.exports = {
-  site: 'vidio.com',
+  site: 'useetv.com',
   url({ channel }) {
     return `https://www.useetv.com/tvod/${channel.site_id}`
   },
@@ -63,9 +63,5 @@ function parseTitle($item) {
 function parseItems(content, date) {
   const $ = cheerio.load(content)
 
-  return $(
-    `#pills-${date.format(
-      'YYYY-MM-DD'
-    )} .schedule-item`
-  ).toArray()
+  return $(`#pills-${date.format('YYYY-MM-DD')} .schedule-item`).toArray()
 }

--- a/sites/useetv.com/useetv.com.config.js
+++ b/sites/useetv.com/useetv.com.config.js
@@ -1,0 +1,71 @@
+const cheerio = require('cheerio')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const timezone = require('dayjs/plugin/timezone')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+
+module.exports = {
+  site: 'vidio.com',
+  url({ channel }) {
+    return `https://www.useetv.com/tvod/${channel.site_id}`
+  },
+  parser({ content, date }) {
+    const programs = []
+    const items = parseItems(content, date)
+    items.forEach(item => {
+      const prev = programs[programs.length - 1]
+      const $item = cheerio.load(item)
+      let start = parseStart($item, date)
+      if (prev && start.isBefore(prev.start)) {
+        start = start.add(1, 'd')
+        date = date.add(1, 'd')
+      }
+      let stop = parseStop($item, date)
+      if (stop.isBefore(start)) {
+        stop = stop.add(1, 'd')
+        date = date.add(1, 'd')
+      }
+      programs.push({
+        title: parseTitle($item),
+        start,
+        stop
+      })
+    })
+
+    return programs
+  }
+}
+
+function parseStart($item, date) {
+  const timeString = $item('p').text()
+  const [_, start] = timeString.match(/(\d{2}:\d{2}) -/) || [null, null]
+  const dateString = `${date.format('YYYY-MM-DD')} ${start}`
+
+  return dayjs.tz(dateString, 'YYYY-MM-DD HH:mm', 'Asia/Jakarta')
+}
+
+function parseStop($item, date) {
+  const timeString = $item('p').text()
+  const [_, stop] = timeString.match(/- (\d{2}:\d{2})/) || [null, null]
+  const dateString = `${date.format('YYYY-MM-DD')} ${stop}`
+
+  return dayjs.tz(dateString, 'YYYY-MM-DD HH:mm', 'Asia/Jakarta')
+}
+
+function parseTitle($item) {
+  return $item('b').text()
+}
+
+function parseItems(content, date) {
+  const $ = cheerio.load(content)
+
+  return $(
+    `#pills-${date.format(
+      'YYYY-MM-DD'
+    )} .schedule-item`
+  ).toArray()
+}

--- a/sites/useetv.com/useetv.com.test.js
+++ b/sites/useetv.com/useetv.com.test.js
@@ -1,3 +1,5 @@
+// npx epg-grabber --config=sites/useetv.com/useetv.com.config.js --channels=sites/useetv.com/useetv.com_id.channels.xml --output=guide.xml --timeout=30000 --days=2
+
 const { parser, url, request } = require('./useetv.com.config.js')
 const dayjs = require('dayjs')
 const utc = require('dayjs/plugin/utc')

--- a/sites/useetv.com/useetv.com.test.js
+++ b/sites/useetv.com/useetv.com.test.js
@@ -1,0 +1,55 @@
+const { parser, url, request } = require('./useetv.com.config.js')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+dayjs.extend(utc)
+
+const date = dayjs.utc('2022-08-08', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: 'metrotv',
+  xmltv_id: 'MetroTV.id'
+}
+const content = `<!DOCTYPE html><html><head></head><body><section class="live-tv-channels" id="top"><div><div class="schedule-list"><div id="pills-2022-08-08"><div class="row"><div><a class="schedule-item"><span class="replay"></span><p>07:00 - 07:05</p><b>Headline News</b></a></div><div><a class="schedule-item"><span class="replay"></span><p>07:05 - 07:30</p><b>Editorial Media Indonesia</b></a></div><div><a class="schedule-item"><span class="replay"></span><p>07:30 - 07:45</p><b>Editorial Media Indonesia</b></a></div><div><a class="schedule-item"><span class="replay"></span><p>07:45 - 08:00</p><b>Editorial Media Indonesia</b></a></div></div></div></div></div></section></body>`
+
+it('can generate valid url', () => {
+  expect(url({ channel })).toBe('https://www.useetv.com/tvod/metrotv')
+})
+
+it('can parse response', () => {
+  const result = parser({ content, channel, date }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(result).toMatchObject([
+    {
+      title: 'Headline News',
+      start: '2022-08-08T00:00:00.000Z',
+      stop: '2022-08-08T00:05:00.000Z'
+    },
+    {
+      title: 'Editorial Media Indonesia',
+      start: '2022-08-08T00:05:00.000Z',
+      stop: '2022-08-08T00:30:00.000Z'
+    },
+    {
+      title: 'Editorial Media Indonesia',
+      start: '2022-08-08T00:30:00.000Z',
+      stop: '2022-08-08T00:45:00.000Z'
+    },
+    {
+      title: 'Editorial Media Indonesia',
+      start: '2022-08-08T00:45:00.000Z',
+      stop: '2022-08-08T01:00:00.000Z'
+    }
+  ])
+})
+
+it('can handle empty guide', () => {
+  const result = parser({
+    date,
+    channel,
+    content: `<!DOCTYPE html><html><head></head><body></body></html>`
+  })
+  expect(result).toMatchObject([])
+})

--- a/sites/useetv.com/useetv.com_id.channels.xml
+++ b/sites/useetv.com/useetv.com_id.channels.xml
@@ -9,17 +9,17 @@
     <channel lang="id" xmltv_id="Trans7.id" site_id="trans7">Trans7</channel>
     <channel lang="id" xmltv_id="TransTV.id" site_id="transtv">TransTV</channel>
     <channel lang="id" xmltv_id="ANTV.id" site_id="antv">ANTV</channel>
-    <channel lang="id" xmltv_id="TVOne.id" site_id="tvone">TV One</channel>
+    <channel lang="id" xmltv_id="tvOne.id" site_id="tvone">TV One</channel>
     <channel lang="id" xmltv_id="MetroTV.id" site_id="metrotv">Metro TV</channel>
     <channel lang="id" xmltv_id="KompasTV.id" site_id="kompastv">Kompas TV</channel>
-    <channel lang="id" xmltv_id="iNews.id" site_id="inews">iNews</channel>
+    <channel lang="id" xmltv_id="INews.id" site_id="inews">iNews</channel>
     <channel lang="id" xmltv_id="TVRINasional.id" site_id="tvri">TVRI</channel>
     <channel lang="id" xmltv_id="RajawaliTV.id" site_id="rtv">Rajawali TV</channel>
     <channel lang="id" xmltv_id="RodjaTV.id" site_id="rodjatv">Rodja TV</channel>
     <channel lang="id" xmltv_id="JTV.id" site_id="jtv">JTV</channel>
     <channel lang="id" xmltv_id="MNCNews.id" site_id="mncnews">MNC News</channel>
     <channel lang="id" xmltv_id="BeritaSatu.id" site_id="beritasatu">Berita Satu</channel>
-    <channel lang="id" xmltv_id="RRINET.id" site_id="rrinet">RRI NET</channel>
+    <channel lang="id" xmltv_id="RRINet.id" site_id="rrinet">RRI NET</channel>
     <channel lang="id" xmltv_id="BaliTV.id" site_id="balitv">Bali TV</channel>
     <channel lang="id" xmltv_id="MQTV.id" site_id="mqtv">MQTV</channel>
     <channel lang="id" xmltv_id="MTATV.id" site_id="mtatv">MTATV</channel>
@@ -101,7 +101,7 @@
     <!-- <channel lang="id" xmltv_id="Formosa.id" site_id="formosa">Formosa</channel> -->
     <!-- <channel lang="id" xmltv_id="SGEM.id" site_id="sgem">SGEM</channel> -->
     <!-- UNSURE- GUESS --><channel lang="id" xmltv_id="ZhejiangSatelliteTVInternational.cn" site_id="zhejiang">Zhejiang</channel>
-    <channel lang="id" xmltv_id="Shenzen.id" site_id="shenzen">Shenzen</channel>
+    <!-- <channel lang="id" xmltv_id="Shenzen.id" site_id="shenzen">Shenzen</channel> -->
     <!-- <channel lang="id" xmltv_id="EBCAsia.id" site_id="ettvasia">EBC Asia</channel> -->
     <channel lang="id" xmltv_id="CTiAsia.tw" site_id="ctiasia">CTI Asia</channel>
     <channel lang="id" xmltv_id="CartoonNetworkAsia.sg" site_id="cartoonnetwork">Cartoon Network</channel>

--- a/sites/useetv.com/useetv.com_id.channels.xml
+++ b/sites/useetv.com/useetv.com_id.channels.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site site="useetv.com">
+  <channels>
+    <channel lang="id" xmltv_id="UseePrime.id" site_id="useeprime">UseePrime</channel>
+    <channel lang="id" xmltv_id="UseePhoto.id" site_id="useephoto">Usee Photo</channel>
+    <!-- <channel lang="id" xmltv_id="IndiKids.id" site_id="indikids">IndiKids</channel> -->
+    <channel lang="id" xmltv_id="RuangTrampil.id" site_id="useeinfo">Ruang Trampil</channel>
+    <channel lang="id" xmltv_id="SEAToday.id" site_id="seatoday">SEA Today</channel>
+    <channel lang="id" xmltv_id="Trans7.id" site_id="trans7">Trans7</channel>
+    <channel lang="id" xmltv_id="TransTV.id" site_id="transtv">TransTV</channel>
+    <channel lang="id" xmltv_id="ANTV.id" site_id="antv">ANTV</channel>
+    <channel lang="id" xmltv_id="TVOne.id" site_id="tvone">TV One</channel>
+    <channel lang="id" xmltv_id="MetroTV.id" site_id="metrotv">Metro TV</channel>
+    <channel lang="id" xmltv_id="KompasTV.id" site_id="kompastv">Kompas TV</channel>
+    <channel lang="id" xmltv_id="iNews.id" site_id="inews">iNews</channel>
+    <channel lang="id" xmltv_id="TVRINasional.id" site_id="tvri">TVRI</channel>
+    <channel lang="id" xmltv_id="RajawaliTV.id" site_id="rtv">Rajawali TV</channel>
+    <channel lang="id" xmltv_id="RodjaTV.id" site_id="rodjatv">Rodja TV</channel>
+    <channel lang="id" xmltv_id="JTV.id" site_id="jtv">JTV</channel>
+    <channel lang="id" xmltv_id="MNCNews.id" site_id="mncnews">MNC News</channel>
+    <channel lang="id" xmltv_id="BeritaSatu.id" site_id="beritasatu">Berita Satu</channel>
+    <channel lang="id" xmltv_id="RRINET.id" site_id="rrinet">RRI NET</channel>
+    <channel lang="id" xmltv_id="BaliTV.id" site_id="balitv">Bali TV</channel>
+    <channel lang="id" xmltv_id="MQTV.id" site_id="mqtv">MQTV</channel>
+    <channel lang="id" xmltv_id="MTATV.id" site_id="mtatv">MTATV</channel>
+    <!-- <channel lang="id" xmltv_id="AlQuranKareem.id" site_id="alquran">AlQuran Kareem</channel> -->
+    <channel lang="id" xmltv_id="JakTV.id" site_id="jaktv">JakTV</channel>
+    <channel lang="id" xmltv_id="NusantaraTV.id" site_id="nusantaratv">Nusantara TV</channel>
+    <!-- <channel lang="id" xmltv_id="Antara.id" site_id="antara">Antara</channel> -->
+    <!-- <channel lang="id" xmltv_id="MuhammadiyahTV.id" site_id="muhammadiyahtv">Muhammadiyah TV</channel> -->
+    <!-- <channel lang="id" xmltv_id="Prambors.id" site_id="pramborstv">Prambors</channel> -->
+    <channel lang="id" xmltv_id="TVEdukasi.id" site_id="tvedukasi">TV Edukasi</channel>
+    <channel lang="id" xmltv_id="ArirangTV.kr" site_id="arirang">Arirang</channel>
+    <channel lang="id" xmltv_id="TVMUI.id" site_id="muitv">MUI TV</channel>
+    <channel lang="id" xmltv_id="TawafTV.id" site_id="tawaftv">Tawaf TV</channel>
+    <channel lang="id" xmltv_id="TV9Nusantara.id" site_id="tv9">TV9 NU</channel>
+    <!-- <channel lang="id" xmltv_id="IndonesianaTV.id" site_id="indonesiana">Indonesiana TV</channel> -->
+    <!-- <channel lang="id" xmltv_id="UtamiTV.id" site_id="utamitv">Utami TV</channel> -->
+    <channel lang="id" xmltv_id="CCTV4Asia.cn" site_id="cctv4">CCTV4</channel>
+    <channel lang="id" xmltv_id="DWEnglish.de" site_id="dwtv">DW (English)</channel>
+    <channel lang="id" xmltv_id="ABCAustraliaAsia.au" site_id="abcaustralia">ABC Australia</channel>
+    <!-- <channel lang="id" xmltv_id="ChineseDrama.id" site_id="chinesedrama">Chinese Drama</channel> -->
+    <channel lang="id" xmltv_id="EuronewsEnglish.fr" site_id="euronews">Euronews</channel>
+    <channel lang="id" xmltv_id="TRTWorld.tr" site_id="trtworld">TRT World</channel>
+    <channel lang="id" xmltv_id="France24English.fr" site_id="france24">France 24</channel>
+    <channel lang="id" xmltv_id="CGTNDocumentary.cn" site_id="cgtndocumentary">CGTN Documentary</channel>
+    <channel lang="id" xmltv_id="SCTV.id" site_id="sctv">SCTV</channel>
+    <channel lang="id" xmltv_id="Indosiar.id" site_id="indosiar">Indosiar</channel>
+    <!-- <channel lang="id" xmltv_id="UseeSports.id" site_id="useesport">UseeSports</channel> -->
+    <!-- <channel lang="id" xmltv_id="UseeSports2.id" site_id="useesports2">UseeSports2</channel> -->
+    <channel lang="id" xmltv_id="beINSports1Indonesia.id" site_id="bein1">beIN Sports 1</channel>
+    <channel lang="id" xmltv_id="beINSports3Indonesia.id" site_id="bein2">beIN Sports 3</channel>
+    <channel lang="id" xmltv_id="SPOTV.kr" site_id="spotv">SPOTV</channel>
+    <channel lang="id" xmltv_id="SPOTV2.kr" site_id="spotv2">SPOTV2</channel>
+    <channel lang="id" xmltv_id="NBATV.us" site_id="nba">NBA</channel>
+    <channel lang="id" xmltv_id="NBATVHD.us" site_id="nba">NBA</channel>
+    <channel lang="id" xmltv_id="eGGNetwork.my" site_id="egg">egg network</channel>
+    <channel lang="id" xmltv_id="FightSports.us" site_id="fightsport">Fight Sport</channel>
+    <channel lang="id" xmltv_id="TVNMovies.hk" site_id="tvnmovies">TVN Movies</channel>
+    <channel lang="id" xmltv_id="IMC.id" site_id="imc">IMC</channel>
+    <channel lang="id" xmltv_id="GalaxyPremium.id" site_id="galaxypremium">Galaxy Premium</channel>
+    <channel lang="id" xmltv_id="Galaxy.id" site_id="galaxy">Galaxy</channel>
+    <!-- <channel lang="id" xmltv_id="Hits.id" site_id="hits">Hits</channel> -->
+    <!-- <channel lang="id" xmltv_id="Flik.id" site_id="flik">Flik</channel> -->
+    <channel lang="id" xmltv_id="BioskopIndonesia.id" site_id="bioskopindonesia">Bioskop Indonesia</channel>
+    <channel lang="id" xmltv_id="CelestialMoviesIndonesia.id" site_id="celestialmovie">Celestial Movie</channel>
+    <channel lang="id" xmltv_id="ZeeBioskop.id" site_id="zbioskop">ZBioskop</channel>
+    <channel lang="id" xmltv_id="ParamountNetworkIndonesia.id" site_id="paramount">Paramount</channel>
+    <channel lang="id" xmltv_id="Thrill.hk" site_id="thrill">Thrill</channel>
+    <channel lang="id" xmltv_id="MyCinemaAsia.id" site_id="mycinemaasia">My Cinema Asia</channel>
+    <channel lang="id" xmltv_id="MyFamily.id" site_id="myfamily">My Family</channel>
+    <channel lang="id" xmltv_id="MyCinema.id" site_id="mycinema">My Cinema</channel>
+    <channel lang="id" xmltv_id="CinemaWorld.my" site_id="cinemaworld">Cinema World</channel>
+    <channel lang="id" xmltv_id="CNNIndonesia.id" site_id="cnnindonesia">CNN Indonesia</channel>
+    <channel lang="id" xmltv_id="CNBCIndonesia.id" site_id="cnbcindonesia">CNBC Indonesia</channel>
+    <channel lang="id" xmltv_id="BloombergTVAsiaPacific.hk" site_id="bloomberg">Bloomberg</channel>
+    <channel lang="id" xmltv_id="CNA.sg" site_id="newsasia">News Asia</channel>
+    <channel lang="id" xmltv_id="CNNInternationalAsiaPacific.hk" site_id="cnninternational">CNN International</channel>
+    <channel lang="id" xmltv_id="AlJazeeraChannel.qa" site_id="aljazeera">Aljazeera</channel>
+    <channel lang="id" xmltv_id="CNBCAsia.sg" site_id="cnbcasia">CNBC Asia</channel>
+    <channel lang="id" xmltv_id="TVBSNews.tw" site_id="tvbs">TVBS News</channel>
+    <channel lang="id" xmltv_id="TVNAsia.hk" site_id="tvn">TVN</channel>
+    <channel lang="id" xmltv_id="AXNHDIndonesia.id" site_id="axn">AXN</channel>
+    <channel lang="id" xmltv_id="AXNIndonesia.id" site_id="axn">AXN</channel>
+    <channel lang="id" xmltv_id="KPlus.sg" site_id="kplus">Kplus</channel>
+    <channel lang="id" xmltv_id="KBSWorld.kr" site_id="kbsworld">KBS World</channel>
+    <channel lang="id" xmltv_id="CitraDrama.id" site_id="cdrama">Citra Drama </channel>
+    <channel lang="id" xmltv_id="WarnerTVSoutheastAsia.us" site_id="warner">Warner</channel>
+    <channel lang="id" xmltv_id="RockExtreme.sg" site_id="blueantextreme">Rock Extreme</channel>
+    <channel lang="id" xmltv_id="TLCSoutheastAsia.us" site_id="tlc">TLC</channel>
+    <channel lang="id" xmltv_id="HistoryAsia.us" site_id="history">History</channel>
+    <channel lang="id" xmltv_id="DuniaLain.id" site_id="dunialain">Dunia Lain</channel>
+    <channel lang="id" xmltv_id="RockEntertainment.sg" site_id="blueant">Rock Entertainment</channel>
+    <channel lang="id" xmltv_id="AniplusAsia.sg" site_id="aniplus">ANIPlus</channel>
+    <channel lang="id" xmltv_id="AnimaxAsia.sg" site_id="animax">Animax</channel>
+    <channel lang="id" xmltv_id="OneTVAsia.sg" site_id="sone">SONE</channel>
+    <channel lang="id" xmltv_id="Kix.hk" site_id="kix">Kix</channel>
+    <channel lang="id" xmltv_id="LifetimeAsia.us" site_id="lifetime">Lifetime</channel>
+    <channel lang="id" xmltv_id="TV5MondeAsia.fr" site_id="tv5monde">TV5Monde</channel>
+    <channel lang="id" xmltv_id="NHKWorldPremium.jp" site_id="nhkpremium">NHK World Premium</channel>
+    <!-- <channel lang="id" xmltv_id="Formosa.id" site_id="formosa">Formosa</channel> -->
+    <!-- <channel lang="id" xmltv_id="SGEM.id" site_id="sgem">SGEM</channel> -->
+    <!-- UNSURE- GUESS --><channel lang="id" xmltv_id="ZhejiangSatelliteTVInternational.cn" site_id="zhejiang">Zhejiang</channel>
+    <channel lang="id" xmltv_id="Shenzen.id" site_id="shenzen">Shenzen</channel>
+    <!-- <channel lang="id" xmltv_id="EBCAsia.id" site_id="ettvasia">EBC Asia</channel> -->
+    <channel lang="id" xmltv_id="CTiAsia.tw" site_id="ctiasia">CTI Asia</channel>
+    <channel lang="id" xmltv_id="CartoonNetworkAsia.sg" site_id="cartoonnetwork">Cartoon Network</channel>
+    <channel lang="id" xmltv_id="Horee.id" site_id="horee">Horee</channel>
+    <channel lang="id" xmltv_id="NickJrAsia.sg" site_id="nickjr">Nick Junior</channel>
+    <channel lang="id" xmltv_id="NickelodeonAsia.sg" site_id="nickelodeon">Nickelodeon</channel>
+    <channel lang="id" xmltv_id="DuniaAnak.id" site_id="duniaanak">Dunia anak</channel>
+    <channel lang="id" xmltv_id="BoomerangAsia.sg" site_id="boomerang">Boomerang</channel>
+    <channel lang="id" xmltv_id="MyKidz.id" site_id="mykids">MyKidz</channel>
+    <channel lang="id" xmltv_id="MentariTV.id" site_id="mentaritv">Mentari TV</channel>
+    <!-- <channel lang="id" xmltv_id="DaVinciLearning.id" site_id="davinci">Da Vinci Learning</channel> -->
+    <channel lang="id" xmltv_id="NationalGeographicHDIndonesia.id" site_id="natgeo">Nat Geo</channel>
+    <channel lang="id" xmltv_id="NationalGeographicIndonesia.id" site_id="natgeo">Nat Geo</channel>
+    <channel lang="id" xmltv_id="DiscoveryChannelHDIndonesia.id" site_id="disco">Discovery Channel</channel>
+    <channel lang="id" xmltv_id="DiscoveryChannelIndonesia.id" site_id="disco">Discovery Channel</channel>
+    <channel lang="id" xmltv_id="NationalGeographicWildHDIndonesia.id" site_id="natgeowild">Nat Geo Wild</channel>
+    <channel lang="id" xmltv_id="NationalGeographicWildIndonesia.id" site_id="natgeowild">Nat Geo Wild</channel>
+    <channel lang="id" xmltv_id="TechStorm.sg" site_id="techstorm">Tech Storm</channel>
+    <channel lang="id" xmltv_id="CrimePlusInvestigationAsia.us" site_id="crimeinvestigation">Crime Investigation</channel>
+    <channel lang="id" xmltv_id="LinguaChannel.id" site_id="lingua">Lingua</channel>
+    <!-- <channel lang="id" xmltv_id="PandaTV.id" site_id="pandatv">Panda TV</channel> -->
+    <channel lang="id" xmltv_id="AsianFoodNetwork.sg" site_id="afc">Asian Food Network</channel>
+    <channel lang="id" xmltv_id="HGTVAsia.us" site_id="hgtv">HGTV</channel>
+    <channel lang="id" xmltv_id="EatNGo.id" site_id="eatgo">Eat N Go</channel>
+    <channel lang="id" xmltv_id="FashionTVAsia.fr" site_id="fashiontv">FashionTV</channel>
+    <channel lang="id" xmltv_id="MTVLive.uk" site_id="mtvlive">MTV Live</channel>
+    <channel lang="id" xmltv_id="CitraDangdut.id" site_id="citradangdut">Citra Dangdut</channel>
+    <!-- <channel lang="id" xmltv_id="I-Konser.id" site_id="ikonser">I-Konser</channel> -->
+    <channel lang="id" xmltv_id="OChannel.id" site_id="ochannel">O Channel</channel>
+    <channel lang="id" xmltv_id="nsert.id" site_id="insert">Insert</channel>
+    <!-- <channel lang="id" xmltv_id="KCON2022.id" site_id="kcon1">KCON 2022</channel> -->
+    <!-- <channel lang="id" xmltv_id="SPOTV-MotoGP.id" site_id="motogp">SPOTV - MotoGP</channel> -->
+    <channel lang="id" xmltv_id="NET.id" site_id="net">Net.</channel>
+    <channel lang="id" xmltv_id="DAAITV.id" site_id="daaitv">Daai TV</channel>
+    <channel lang="id" xmltv_id="IDXChannel.id" site_id="idx">IDX</channel>
+    <!-- <channel lang="id" xmltv_id="MusikIndonesia.id" site_id="musikindo">Musik Indonesia</channel> -->
+    <!-- <channel lang="id" xmltv_id="MMITV.id" site_id="mmi">MMI TV</channel> -->
+    <channel lang="id" xmltv_id="MShopSignature.id" site_id="mncshop">M Shop</channel>
+    <channel lang="id" xmltv_id="SeruChannel.id" site_id="seru">Seru!</channel>
+    <channel lang="id" xmltv_id="UChannel.id" site_id="uchannel">UChannel</channel>
+    <!-- <channel lang="id" xmltv_id="ElJohnTV.id" site_id="eljohn">El John TV</channel> -->
+    <channel lang="id" xmltv_id="NHKWorldJapan.jp" site_id="nhkworld">NHK World Japan</channel>
+    <channel lang="id" xmltv_id="ATV.id" site_id="atv">ATV</channel>
+    <channel lang="id" xmltv_id="OutdoorChannelInternational.us" site_id="outdoor">Outdoor Channel</channel>
+    <channel lang="id" xmltv_id="HorizonSports.us" site_id="horizonsport">Horizon Sports</channel>
+    <!-- <channel lang="id" xmltv_id="HItsMovie.id" site_id="hitsmovie">HIts Movie</channel> -->
+    <channel lang="id" xmltv_id="StarChineseMoviesSouthEastAsia.hk" site_id="starchinesemovies">Star Chinese Movies</channel>
+    <channel lang="id" xmltv_id="StarChineseChannelInternational.hk" site_id="starchinesechannel">Star Chinese Channel</channel>
+    <!-- <channel lang="id" xmltv_id="KungfuTV.id" site_id="kungfutv">Kungfu TV</channel> -->
+    <channel lang="id" xmltv_id="BabyFirst.us" site_id="babyfirst">Baby First</channel>
+    <channel lang="id" xmltv_id="DreamWorksChannelAsia.us" site_id="dreamworks">Dreamworks</channel>
+  </channels>
+</site>
+
+<!-- 
+  Get all channels from https://www.useetv.com/tv/live:
+  [...document.querySelectorAll('.channel-item')].map(el => `<channel lang="id" xmltv_id="${el.dataset.name.replaceAll(' ', '')}.id" site_id="${el.href.replace('https://www.useetv.com/livetv/', '')}">${el.dataset.name}</channel>`).join('\n')
+ -->


### PR DESCRIPTION
Here's EPG of all channels on https://www.useetv.com/tv/live, by getting it's schedule from the TV On Demand page (https://www.useetv.com/tvod/metrotv). Even though some channels don't have TVOD, the schedules can still be seen on the page.

It only works for getting today's schedule only, no future schedules.

Resolves #657