### PR TITLE
Update directv.com.ar.config.js

### DIFF
--- a/sites/directv.com.ar/directv.com.ar.config.js
+++ b/sites/directv.com.ar/directv.com.ar.config.js
@@ -1,3 +1,4 @@
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
 const axios = require('axios')
 const dayjs = require('dayjs')
 const utc = require('dayjs/plugin/utc')


### PR DESCRIPTION
Added "process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;" to fix the error "unable to verify the first certificate"