### PR TITLE
Update tv24.se_se.channels.xml

### DIFF
--- a/sites/tv24.se/tv24.se_se.channels.xml
+++ b/sites/tv24.se/tv24.se_se.channels.xml
@@ -54,7 +54,6 @@
     <channel lang="sv" xmltv_id="DisneyChannelScandinavia.uk" site_id="disney-channel">Disney Channel</channel>
     <channel lang="sv" xmltv_id="DisneyJuniorScandinavia.uk" site_id="disney-junior">Disney Junior</channel>
     <channel lang="sv" xmltv_id="DiTV.se" site_id="di-tv-hd">Di TV HD</channel>
-    <channel lang="sv" xmltv_id="DunaTV.hu" site_id="duna-tv-hd">Duna TV HD</channel>
     <channel lang="sv" xmltv_id="DR1.dk" site_id="dr1">DR1</channel>
     <channel lang="sv" xmltv_id="DR2.dk" site_id="dr2">DR2</channel>
     <channel lang="sv" xmltv_id="DRRamasjang.dk" site_id="dr-ramasjang">DR Ramasjang</channel>
@@ -210,6 +209,7 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="dr2-hd">DR2 HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dr3">DR3</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dr3-hd">DR3 HD</channel> -->
+    <!-- <channel lang="sv" xmltv_id="" site_id="duna-tv-hd">Duna TV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dw">Deutsche Welle</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="esportstv-hd">eSportsTV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="euronews">euronews</channel> -->

--- a/sites/tv24.se/tv24.se_se.channels.xml
+++ b/sites/tv24.se/tv24.se_se.channels.xml
@@ -137,7 +137,7 @@
     <channel lang="sv" xmltv_id="TV2Zebra.no" site_id="tv-2-zebra">TV 2 Zebra</channel>
     <channel lang="sv" xmltv_id="TV2Zulu.dk" site_id="tv2-zulu">TV2 Zulu</channel>
     <channel lang="sv" xmltv_id="TV3Plus.lv" site_id="tv3-plus">TV3 Plus</channel>
-    <channel lang="sv" xmltv_id="TV3Sweden.se" site_id="tv3">TV3</channel>
+    <channel lang="sv" xmltv_id="TV3.se" site_id="tv3">TV3</channel>
     <channel lang="sv" xmltv_id="TV4.se" site_id="tv4">TV4</channel>
     <channel lang="sv" xmltv_id="TV4Fakta.se" site_id="tv4-fakta">TV4 Fakta</channel>
     <channel lang="sv" xmltv_id="TV4Film.se" site_id="tv4-film">TV4 Film</channel>

--- a/sites/tv24.se/tv24.se_se.channels.xml
+++ b/sites/tv24.se/tv24.se_se.channels.xml
@@ -7,9 +7,11 @@
     <channel lang="sv" xmltv_id="AnimalPlanetHDSweden.se" site_id="animal-planet-hd">Animal Planet HD</channel>
     <channel lang="sv" xmltv_id="AnimalPlanetSweden.se" site_id="animal-planet">Animal Planet</channel>
     <channel lang="sv" xmltv_id="ATGLive.se" site_id="atg-live">ATG Live</channel>
+    <channel lang="sv" xmltv_id="AxessTV.se" site_id="axess-tv">Axess TV</channel>
     <channel lang="sv" xmltv_id="BBCBritNordic.uk" site_id="bbc-brit">BBC Brit</channel>
     <channel lang="sv" xmltv_id="BBCEarthNordic.uk" site_id="bbc-earth">BBC Earth</channel>
     <channel lang="sv" xmltv_id="BBCWorldNewsEurope.uk" site_id="bbc-world-news">BBC World News</channel>
+    <channel lang="sv" xmltv_id="BoomerangNordic.uk" site_id="boomerang">Boomerang</channel>
     <channel lang="sv" xmltv_id="CartoonNetworkSweden.se" site_id="cartoon-network">Cartoon Network</channel>
     <channel lang="sv" xmltv_id="CBSRealityEurope.us" site_id="cbs-reality">CBS Reality</channel>
     <channel lang="sv" xmltv_id="CGTNEurope.cn" site_id="cgtn">CGTN</channel>
@@ -51,6 +53,8 @@
     <channel lang="sv" xmltv_id="DiscoveryPlusExtra8.se" site_id="discovery-extra-8">Discovery+ Extra 8</channel>
     <channel lang="sv" xmltv_id="DisneyChannelScandinavia.uk" site_id="disney-channel">Disney Channel</channel>
     <channel lang="sv" xmltv_id="DisneyJuniorScandinavia.uk" site_id="disney-junior">Disney Junior</channel>
+    <channel lang="sv" xmltv_id="DiTV.se" site_id="di-tv-hd">Di TV HD</channel>
+    <channel lang="sv" xmltv_id="DunaTV.hu" site_id="duna-tv-hd">Duna TV HD</channel>
     <channel lang="sv" xmltv_id="DR1.dk" site_id="dr1">DR1</channel>
     <channel lang="sv" xmltv_id="DR2.dk" site_id="dr2">DR2</channel>
     <channel lang="sv" xmltv_id="DRRamasjang.dk" site_id="dr-ramasjang">DR Ramasjang</channel>
@@ -63,13 +67,17 @@
     <channel lang="sv" xmltv_id="FightSports.us" site_id="fight-sports">Fight Sports</channel>
     <channel lang="sv" xmltv_id="FoodNetworkEMEA.us" site_id="food-network">Food Network</channel>
     <channel lang="sv" xmltv_id="FuelTV.us" site_id="fuel-tv">Fuel TV</channel>
+    <channel lang="sv" xmltv_id="GinxeSportsTVInternational.uk" site_id="ginx-esports-tv">GINX eSports TV</channel>
     <channel lang="sv" xmltv_id="Godare.se" site_id="godare">Godare</channel>
     <channel lang="sv" xmltv_id="GospelChannelScandinavia.is" site_id="gospel-channel">Gospel Channel</channel>
+    <channel lang="sv" xmltv_id="GodTVScandinavia.uk" site_id="god">God</channel>
     <channel lang="sv" xmltv_id="HayatPlus.ba" site_id="hayat-plus">Hayat Plus</channel>
+    <channel lang="sv" xmltv_id="History2Nordic.us" site_id="h2">H2</channel>
     <channel lang="sv" xmltv_id="HistorySweden.se" site_id="history">History</channel>
     <channel lang="sv" xmltv_id="HorseCountryTV.uk" site_id="horse-country">Horse &amp; Country (UK)</channel>
     <channel lang="sv" xmltv_id="HorseCountryTVSweden.se" site_id="horse-country-tv">Horse &amp; Country TV</channel>
     <channel lang="sv" xmltv_id="HRT1.hr" site_id="hrt1">HRT1</channel>
+    <channel lang="sv" xmltv_id="InvestigationDiscoverySweden.se" site_id="id">ID</channel>
     <channel lang="sv" xmltv_id="Kanal10.se" site_id="kanal-10">Kanal 10</channel>
     <channel lang="sv" xmltv_id="Kanal11.se" site_id="kanal-11">Kanal 11</channel>
     <channel lang="sv" xmltv_id="Kanal4.dk" site_id="kanal-4">Kanal 4</channel>
@@ -82,6 +90,7 @@
     <channel lang="sv" xmltv_id="MezzoLiveHD.fr" site_id="mezzo-live-hd">Mezzo Live HD</channel>
     <channel lang="sv" xmltv_id="MotorvisionTV.de" site_id="motorvision-tv">Motorvision TV</channel>
     <channel lang="sv" xmltv_id="MTV3.fi" site_id="mtv3">MTV3</channel>
+    <channel lang="sv" xmltv_id="MTV00s.uk" site_id="mtv-00s-europe">MTV 00s Europe</channel>
     <channel lang="sv" xmltv_id="MTV80s.uk" site_id="mtv-80s">MTV 80s</channel>
     <channel lang="sv" xmltv_id="MTV90s.uk" site_id="mtv-90s">MTV 90s</channel>
     <channel lang="sv" xmltv_id="NationalGeographicHDSweden.se" site_id="national-geographic-hd">National Geographic HD</channel>
@@ -95,6 +104,8 @@
     <channel lang="sv" xmltv_id="NRK3.no" site_id="nrk3">NRK3</channel>
     <channel lang="sv" xmltv_id="NRKSuperTV.no" site_id="nrk-super">NRK Super</channel>
     <channel lang="sv" xmltv_id="OutTV.nl" site_id="outtv">OUTtv</channel>
+    <channel lang="sv" xmltv_id="ParamountPlusMovies.se" site_id="paramount-movies">Paramount+ Movies</channel>
+    <channel lang="sv" xmltv_id="ParamountPlusSeries.se" site_id="paramount-series">Paramount+ Series</channel>
     <channel lang="sv" xmltv_id="PinkPlus.rs" site_id="pink-plus">Pink Plus</channel>
     <channel lang="sv" xmltv_id="ProSiebenGermany.de" site_id="prosieben">ProSieben</channel>
     <channel lang="sv" xmltv_id="ProTVInternational.ro" site_id="pro-tv-int">Pro TV int</channel>
@@ -115,6 +126,7 @@
     <channel lang="sv" xmltv_id="SVT24HD.se" site_id="svt24-hd">SVT24 HD</channel>
     <channel lang="sv" xmltv_id="SVT2HD.se" site_id="svt2-hd">SVT2 HD</channel>
     <channel lang="sv" xmltv_id="SVTBarn.se" site_id="svt-barn">SVT Barn</channel>
+    <channel lang="sv" xmltv_id="SVTBarnSVT24.se" site_id="svt-barnsvt24">SVT Barn/SVT24</channel>
     <channel lang="sv" xmltv_id="TLCSweden.se" site_id="tlc">TLC</channel>
     <channel lang="sv" xmltv_id="TravelChannelEMEA.uk" site_id="travel-channel">Travel Channel</channel>
     <channel lang="sv" xmltv_id="TV10.se" site_id="tv10">TV10</channel>
@@ -139,6 +151,7 @@
     <channel lang="sv" xmltv_id="TVEInternacionalEuropeAsia.es" site_id="tve-internacional">TVE Internacional</channel>
     <channel lang="sv" xmltv_id="TVNorge.no" site_id="tvnorge">TVNorge</channel>
     <channel lang="sv" xmltv_id="TVPPolonia.pl" site_id="tvp-polonia">TVP Polonia</channel>
+    <channel lang="sv" xmltv_id="TVVisjonNorway.no" site_id="visjon-norge-hd">Visjon Norge HD</channel>
     <channel lang="sv" xmltv_id="V4.no" site_id="v4">V4</channel>
     <channel lang="sv" xmltv_id="VFilmActionHD.se" site_id="v-film-action-hd">V Film Action HD</channel>
     <channel lang="sv" xmltv_id="VFilmFamily.se" site_id="v-film-family">V Film Family</channel>
@@ -166,13 +179,11 @@
     <channel lang="sv" xmltv_id="ZDF.de" site_id="zdf">ZDF</channel>
     <!-- <channel lang="sv" xmltv_id="" site_id="al-jazeera-hd">Al Jazeera HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="arte">ARTE</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="axess-tv">Axess TV</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="bbc-brit-hd">BBC Brit HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="bbc-earth-hd">BBC Earth HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="bbc-world-news-hd">BBC World News HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="bloomberg-hd">Bloomberg HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="bloomberg-tv-hd-uk">Bloomberg TV HD (UK)</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="boomerang">Boomerang</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="c-more-fotbollhockeystars-hd">C More Fotboll/Hockey/Stars HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="c-more-golfsf-kanalen">C More Golf/SF-Kanalen</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="c-more-live-2-ppv">C More Live 2 (PPV)</channel> -->
@@ -187,7 +198,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="classica-hd">Classica HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="cnbc-hd">CNBC HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="cnn-international-hd">CNN International HD</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="di-tv-hd">Di TV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="discovery-hd-showcase">Discovery HD Showcase</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="discovery-hd-text">Discovery HD - Text</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="discovery-science">Discovery Science</channel> -->
@@ -200,7 +210,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="dr2-hd">DR2 HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dr3">DR3</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dr3-hd">DR3 HD</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="duna-tv-hd">Duna TV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="dw">Deutsche Welle</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="esportstv-hd">eSportsTV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="euronews">euronews</channel> -->
@@ -213,14 +222,10 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="france-24-english-hd">France 24 English HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="ftv-hd">FTV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="fuel-tv-hd">Fuel TV HD</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="ginx-esports-tv">GINX eSports TV</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="god">God</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="h2">H2</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="h2-hd">H2 HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="high-tv-3d">High TV 3D</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="history-channel">History Channel</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="history-hd">History HD</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="id">ID</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="kanal-11-hd">Kanal 11 HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="kanal-11-hd-text">Kanal 11 HD - Text</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="kanal-5-hd-text">Kanal 5 HD - Text</channel> -->
@@ -233,7 +238,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="manchester-united-television-hd">Manchester United Television HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="motorvision-tv-hd">Motorvision TV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="mtv">MTV</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="mtv-00s-europe">MTV 00s Europe</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="mtv-hd">MTV HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="mtv-hits-international">MTV Hits International</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="mtv-live-hd">MTV Live HD</channel> -->
@@ -250,8 +254,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="oppna-kanalen-stockholm">Öppna Kanalen Stockholm</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="oppna-kanalen-vaxjo">Öppna Kanalen Växjö</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="oppna-kanalen-vs">Öppna kanalen VS</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="paramount-movies">Paramount+ Movies</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="paramount-series">Paramount+ Series</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="rt">RT</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="rtl">RTL</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="rtlzwei">RTLZWEI</channel> -->
@@ -263,7 +265,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="sportkanalen-hd">Sportkanalen HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="super-rtl">Super RTL</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="svt-barn-hd">SVT Barn HD</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="svt-barnsvt24">SVT Barn/SVT24</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="svt1-sodertalje">SVT1 Södertälje</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="svtbsvt24-hd">SVTB/SVT24 HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="svtbsvt24-hd-text">SVTB/SVT24 HD - Text</channel> -->
@@ -303,7 +304,6 @@
     <!-- <channel lang="sv" xmltv_id="" site_id="viasat-motor">Viasat Motor</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="viasat-series">Viasat Series</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="viasat-sport-premium">Viasat Sport Premium</channel> -->
-    <!-- <channel lang="sv" xmltv_id="" site_id="visjon-norge-hd">Visjon Norge HD</channel> -->
     <!-- <channel lang="sv" xmltv_id="" site_id="vox">VOX</channel> -->
   </channels>
 </site>


### PR DESCRIPTION
Moved some channels up from the exclusion list.

xmltv_id for "SVTBarnSVT24.se" has been added to the database in a separate pull request in iptv-org/databas. Checks for it have successfully passed, but a review is required.