### PR TITLE
tvtv.us re-write

### DIFF
--- a/sites/tvtv.us/tvtv.us.config.js
+++ b/sites/tvtv.us/tvtv.us.config.js
@@ -1,4 +1,3 @@
-const axios = require('axios')
 const dayjs = require('dayjs')
 const utc = require('dayjs/plugin/utc')
 
@@ -7,144 +6,31 @@ dayjs.extend(utc)
 module.exports = {
   site: 'tvtv.us',
   url: function ({ date, channel }) {
-    return `https://www.tvtv.us/gn/d/v1.1/stations/${
-      channel.site_id
-    }/airings?startDateTime=${date.format()}&endDateTime=${date.add(1, 'd').format()}`
+    return `https://www.tvtv.us/api/v1/lineup/USA-NY71652-DEFAULT/grid/${date.toJSON()}/${date.add(1, 'd').toJSON()}/${channel.site_id}`
   },
   parser: function ({ content }) {
     let programs = []
 
     const items = parseItems(content)
     items.forEach(item => {
-      programs.push({
-        title: parseTitle(item),
-        sub_title: parseSubtitle(item),
-        description: parseDescription(item),
-        category: parseCategory(item),
-        season: parseSeason(item),
-        episode: parseEpisode(item),
-        directors: parseDirectors(item),
-        actors: parseActors(item),
-        date: parseDate(item),
-        start: parseStart(item),
-        stop: parseStop(item),
-        icon: parseIcon(item)
+        const start = dayjs.utc(item.startTime)
+        const stop = start.add(item.runTime, 'm')
+            programs.push({
+            title: item.title,
+            description: item.subtitle,
+            start,
+            stop
       })
     })
 
     return programs
-  },
-  async channels({ country }) {
-    const channels = []
-
-    const data = await axios
-      .get(`https://www.tvtv.${country}/api/stations`)
-      .then(r => r.data)
-      .catch(console.log)
-
-    const stations = data.data.filter(i => !['Radio Station'].includes(i.type))
-    for (const station of stations) {
-      const stationData = await axios
-        .get(`https://www.tvtv.us/gn/d/v1.1/stations/${station.id}`)
-        .then(r => r.data[0] || {})
-        .catch(console.log)
-      if (!stationData) continue
-
-      let channel
-      switch (stationData.type) {
-        case 'Low Power Broadcast':
-        case 'Full Power Broadcast':
-          channel = {
-            site_id: station.id,
-            name: stationData.name,
-            xmltv_id: parseChannelId(stationData),
-            logo: parseChannelIcon(item)
-          }
-          break
-        default:
-          channel = {
-            site_id: station.id,
-            name: stationData.name,
-            logo: parseChannelIcon(item)
-          }
-          break
-      }
-
-      if (channel) {
-        channels.push(channel)
-      }
-    }
-
-    return channels
   }
 }
 
-function parseChannelId(data) {
-  if (!data.callSign) return null
-  if (/^((CB|C[F-K]|V[A-G]|VO|VX|VY|X[J-O])[0-9A-Z-]+)/.test(data.callSign))
-    return `${data.callSign}.ca`
-  if (/^((XH|XE)[0-9A-Z-]+)/.test(data.callSign)) return `${data.callSign}.mx`
-  if (/^((K|N|W)[0-9A-Z-]+)/.test(data.callSign)) return `${data.callSign}.us`
-
-  return null
-}
 
 function parseItems(content) {
-  return JSON.parse(content)
+    const json = JSON.parse(content)
+    if (!json.length) return []
+    return json[0]
 }
 
-function parseStart(item) {
-  return dayjs(item.startTime)
-}
-
-function parseStop(item) {
-  return dayjs(item.endTime)
-}
-
-function parseTitle(item) {
-  return item.program.title
-}
-
-function parseSubtitle(item) {
-  return item.program.episodeTitle
-}
-
-function parseDescription(item) {
-  return item.program.longDescription
-}
-
-function parseCategory(item) {
-  return item.program.genres || []
-}
-
-function parseSeason(item) {
-  return item.program.seasonNum || null
-}
-
-function parseEpisode(item) {
-  return item.program.episodeNum || null
-}
-
-function parseDirectors(item) {
-  return item.program.directors || []
-}
-
-function parseDate(item) {
-  return item.program.releaseDate
-}
-
-function parseActors(item) {
-  return item.program.topCast || []
-}
-
-function parseIcon(item) {
-  return item.program.preferredImage && item.program.preferredImage.uri
-    ? `https://tvtv.us/gn/i/${item.program.preferredImage.uri}`
-    : null
-}
-
-function parseChannelIcon(item) {
-  return item.station.preferredImage && item.station.preferredImage.uri
-    ? `https://tvtv.us/gn/i/${item.station.preferredImage.uri}`
-    : null
-}

--- a/sites/tvtv.us/tvtv.us.test.js
+++ b/sites/tvtv.us/tvtv.us.test.js
@@ -8,7 +8,7 @@ const customParseFormat = require('dayjs/plugin/customParseFormat')
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
 
-const date = dayjs.utc('2022-01-17', 'YYYY-MM-DD').startOf('d')
+const date = dayjs.utc('2022-09-20', 'YYYY-MM-DD').startOf('d')
 const channel = {
   site_id: '62670',
   xmltv_id: 'AMITV.ca',
@@ -17,12 +17,12 @@ const channel = {
 
 it('can generate valid url', () => {
   expect(url({ channel, date })).toBe(
-    'https://www.tvtv.us/gn/d/v1.1/stations/62670/airings?startDateTime=2022-01-17T00:00:00Z&endDateTime=2022-01-18T00:00:00Z'
+    'https://www.tvtv.us/api/v1/lineup/USA-NY71652-DEFAULT/grid/2022-09-20T00:00:00.000Z/2022-09-21T00:00:00.000Z/62670'
   )
 })
 
 it('can parse response', () => {
-  const content = `[{"startTime":"2022-01-20T00:00Z","endTime":"2022-01-20T00:30Z","duration":30,"qualifiers":["CC","DVS"],"program":{"tmsId":"EP031727440006","rootId":"16777148","seriesId":"16640522","subType":"Series","title":"Reflect and Renew With Kevin Naidoo","episodeTitle":"Empowerment","releaseYear":2019,"releaseDate":"2019-04-20","origAirDate":"2019-04-20","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["Health"],"longDescription":"Kevin demonstrates a meditation and yoga practice to reclaim his courage and confidence.","shortDescription":"Kevin demonstrates a meditation and yoga practice to reclaim his courage and confidence.","episodeNum":6,"seasonNum":1,"ratings":[{"body":"Régie du cinéma","code":"G"},{"body":"USA Parental Rating","code":"TVG"},{"body":"Canadian Parental Rating","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"assets/p16640522_b_v9_aa.jpg?w=240&h=360","category":"Banner-L2","text":"yes","primary":"true","tier":"Series"}},"station":{"stationId":"62670","callSign":"AMITV","videoQuality":{"signalType":"Digital","videoType":"SDTV"},"preferredImage":{"width":"360","height":"270","uri":"assets/s62670_ll_h15_ab.png?w=360&h=270","category":"Logo","primary":"true"}}},{"startTime":"2022-01-20T00:30Z","endTime":"2022-01-20T01:00Z","duration":30,"qualifiers":["CC","DVS"],"program":{"tmsId":"EP018574900040","rootId":"12448902","seriesId":"10464580","subType":"Series","title":"Four Senses","episodeTitle":"Sizzled & Seared","releaseYear":2016,"releaseDate":"2016-01-14","origAirDate":"2016-01-14","titleLang":"en","descriptionLang":"en","entityType":"Episode","genres":["House/garden"],"longDescription":"Everything is sizzled and seared as chef Corbin Tomaszeski joins Christine and Carl in the kitchen.","shortDescription":"Everything is sizzled and seared as chef Corbin Tomaszeski joins Christine and Carl in the kitchen.","topCast":["Carl Heinrich","Christine Ha"],"ratings":[{"body":"Canadian Parental Rating","code":"G"},{"body":"USA Parental Rating","code":"TVG"},{"body":"Régie du cinéma","code":"G"}],"preferredImage":{"width":"240","height":"360","uri":"assets/p10464580_b_v7_aa.jpg?w=240&h=360","category":"Banner-L1","text":"yes","primary":"true","tier":"Series"}},"station":{"stationId":"62670","callSign":"AMITV","videoQuality":{"signalType":"Digital","videoType":"SDTV"},"preferredImage":{"width":"360","height":"270","uri":"assets/s62670_ll_h15_ab.png?w=360&h=270","category":"Logo","primary":"true"}}}]`
+  const content = `[[{"programId":"EP039131940001","title":"Beyond the Field","subtitle":"Diversity in Sport","flags":["CC","DVS"],"type":"O","startTime":"2022-09-20T00:00Z","start":0,"duration":30,"runTime":30},{"programId":"EP032368970002","title":"IGotThis","subtitle":"Listen to Dis","flags":["CC","DVS"],"type":"O","startTime":"2022-09-20T00:30Z","start":120,"duration":30,"runTime":30}]]`
 
   const result = parser({ content }).map(p => {
     p.start = p.start.toJSON()
@@ -32,27 +32,16 @@ it('can parse response', () => {
 
   expect(result).toMatchObject([
     {
-      start: '2022-01-20T00:00:00.000Z',
-      stop: '2022-01-20T00:30:00.000Z',
-      title: 'Reflect and Renew With Kevin Naidoo',
-      sub_title: 'Empowerment',
-      description: `Kevin demonstrates a meditation and yoga practice to reclaim his courage and confidence.`,
-      category: ['Health'],
-      season: 1,
-      episode: 6,
-      date: '2019-04-20',
-      icon: 'https://tvtv.us/gn/i/assets/p16640522_b_v9_aa.jpg?w=240&h=360'
+      start: '2022-09-20T00:00:00.000Z',
+      stop: '2022-09-20T00:30:00.000Z',
+      title: 'Beyond the Field',
+      description: `Diversity in Sport`
     },
     {
-      start: '2022-01-20T00:30:00.000Z',
-      stop: '2022-01-20T01:00:00.000Z',
-      title: 'Four Senses',
-      sub_title: 'Sizzled & Seared',
-      description: `Everything is sizzled and seared as chef Corbin Tomaszeski joins Christine and Carl in the kitchen.`,
-      category: ['House/garden'],
-      actors: ['Carl Heinrich','Christine Ha'],
-      date: '2016-01-14',
-      icon: 'https://tvtv.us/gn/i/assets/p10464580_b_v7_aa.jpg?w=240&h=360'
+      start: '2022-09-20T00:30:00.000Z',
+      stop: '2022-09-20T01:00:00.000Z',
+      title: 'IGotThis',
+      description: `Listen to Dis`
     }
   ])
 })

--- a/sites/tvtv.us/tvtv.us_ca.channels.xml
+++ b/sites/tvtv.us/tvtv.us_ca.channels.xml
@@ -39,7 +39,7 @@
     <channel lang="en" xmltv_id="FrissonsTV.ca" site_id="32125">Frissons TV</channel>
     <channel lang="en" xmltv_id="GlobalNewsBC1.ca" site_id="10980">Global News: BC1</channel>
     <channel lang="en" xmltv_id="History2Canada.ca" site_id="26772">History2 Canada</channel>
-    <channel lang="en" xmltv_id="History2HDCanada.ca" site_id="81208">History2 HD Canada</channel>  
+    <channel lang="en" xmltv_id="History2HDCanada.ca" site_id="81208">History2 HD Canada</channel>
     <channel lang="en" xmltv_id="HollywoodSuite00sMovies.ca" site_id="73578">Hollywood Suite 00s Movies</channel>
     <channel lang="en" xmltv_id="HollywoodSuite70sMovies.ca" site_id="73572">Hollywood Suite 70s Movies</channel>
     <channel lang="en" xmltv_id="HollywoodSuite80sMovies.ca" site_id="73574">Hollywood Suite 80s Movies</channel>

--- a/sites/tvtv.us/tvtv.us_ca.channels.xml
+++ b/sites/tvtv.us/tvtv.us_ca.channels.xml
@@ -74,7 +74,7 @@
     <channel lang="en" xmltv_id="StingrayClassicRock.ca" site_id="67567">Stingray Classic Rock</channel>
     <channel lang="en" xmltv_id="StingrayCountry.ca" site_id="35064">Stingray Country</channel>
     <channel lang="en" xmltv_id="StingrayEasyListening.ca" site_id="67573">Stingray Easy Listening</channel>
-    <channel lang="en" xmltv_id="StingrayEverything80s.ca" site_id="67566">Stingray Remember the 80's</channel>
+    <channel lang="en" xmltv_id="StingrayRememberthe80s.ca" site_id="67566">Stingray Remember the 80's</channel>
     <channel lang="en" xmltv_id="StingrayFestival4K.ca" site_id="34379">Stingray Festival 4K</channel>
     <channel lang="en" xmltv_id="StingrayFlashback70s.ca" site_id="67565">Stingray Flashback 70s</channel>
     <channel lang="en" xmltv_id="StingrayFrancoFetes.ca" site_id="17046">Stingray Franco Fêtes</channel>

--- a/sites/tvtv.us/tvtv.us_us-local.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us-local.channels.xml
@@ -81,7 +81,7 @@
     <channel lang="en" xmltv_id="KAHCLD7.us" site_id="102576">Infomercials (KAHC-LD7) Sacramento, CA</channel>
     <channel lang="en" xmltv_id="KAILDT1.us" site_id="34443">TCT (KAIL) Fresno, CA</channel>
     <channel lang="en" xmltv_id="KAILDT2.us" site_id="59987">The Grio (KAIL-DT2) Fresno, CA</channel>
-    <channel lang="en" xmltv_id="KAILDT3.us" site_id="77607">H&amp;I (KAIL3) Fresno, CA</channel>    
+    <channel lang="en" xmltv_id="KAILDT3.us" site_id="77607">H&amp;I (KAIL3) Fresno, CA</channel>
     <channel lang="en" xmltv_id="KAKWDT2.us" site_id="65933">UniMas (KAKW-DT2) Austin, TX</channel>
     <channel lang="en" xmltv_id="KAKZLD2.us" site_id="83293">Daystar (KAKZ-LD2) Palm Springs, CA</channel>
     <channel lang="en" xmltv_id="KAKZLD3.us" site_id="83294">Azteca (KAKZ-LD3) Palm Springs, CA</channel>
@@ -104,7 +104,7 @@
     <channel lang="en" xmltv_id="KAZTCD4.us" site_id="105263">CHARGE! (KAZT-CD4) Phoenix, AZ</channel>
     <channel lang="en" xmltv_id="KAZTDT2.us" site_id="61548">MeTV (KAZT-DT2) Prescott, AZ</channel>
     <channel lang="en" xmltv_id="KAZTDT3.us" site_id="72186">HSN (KAZT-DT3) Prescott, AZ</channel>
-    <channel lang="en" xmltv_id="KAZTDT4.us" site_id="105262">CHARGE! (KAZT-DT4) Prescott, AZ</channel>    
+    <channel lang="en" xmltv_id="KAZTDT4.us" site_id="105262">CHARGE! (KAZT-DT4) Prescott, AZ</channel>
     <channel lang="en" xmltv_id="KBABLD1.us" site_id="67104">PBS (KBAB-LD) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KBABLD2.us" site_id="20364">PBS Plus (KBAB-LD2) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KBABLD3.us" site_id="111306">Daystar (KBAB-LD3) Santa Barbara, CA</channel>
@@ -404,7 +404,7 @@
     <channel lang="en" xmltv_id="KITVDT1.us" site_id="19590">ABC (KITV) Honolulu, HI</channel>
     <channel lang="en" xmltv_id="KITVDT2.us" site_id="55988">MeTV (KITV-DT2) Honolulu, HI</channel>
     <channel lang="en" xmltv_id="KITVDT3.us" site_id="109140">Hawaii TV (KITV-DT3) Honolulu, HI</channel>
-    <channel lang="en" xmltv_id="KIVIDT1.us" site_id="28023">ABC (KIVI-DT1) Boise, ID</channel> 
+    <channel lang="en" xmltv_id="KIVIDT1.us" site_id="28023">ABC (KIVI-DT1) Boise, ID</channel>
     <channel lang="en" xmltv_id="KIXEDT1.us" site_id="42680">PBS (KIXE) Redding, CA</channel>
     <channel lang="en" xmltv_id="KIXEDT2.us" site_id="46790">Create (KIXE-TV2) Redding, CA</channel>
     <channel lang="en" xmltv_id="KIXEDT3.us" site_id="55603">PBS World (KIXE-DT3) Redding, CA</channel>
@@ -441,7 +441,7 @@
     <channel lang="en" xmltv_id="KLCSDT2.us" site_id="43779">PBS Kids (KLCS-DT2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KLFBLD1.us" site_id="78681">Three Angels (KLFB-LD) Salinas, CA</channel>
     <channel lang="en" xmltv_id="KLFBLD2.us" site_id="78682">3ABN Latino (KLFB-LD2) Salinas, CA</channel>
-    <channel lang="en" xmltv_id="KLFBLD3.us" site_id="78683">3ABN Proclaim (KLFB-LD3) Salinas, CA</channel> 
+    <channel lang="en" xmltv_id="KLFBLD3.us" site_id="78683">3ABN Proclaim (KLFB-LD3) Salinas, CA</channel>
     <channel lang="en" xmltv_id="KLKNDT1.us" site_id="31652">ABC (KLKN-DT1) Lincoln, NE</channel>
     <channel lang="en" xmltv_id="KLPDLD2.us" site_id="15462">Decades (KLPD-LD2) Denver, CO</channel>
     <channel lang="en" xmltv_id="KLRACD4.us" site_id="36259">Retro TV (KLRA-CD4) Little Rock, AR</channel>
@@ -679,7 +679,7 @@
     <channel lang="en" xmltv_id="KSEEDT3.us" site_id="57694">LATV (KSEE-DT3) Fresno, CA</channel>
     <channel lang="en" xmltv_id="KSFVCD2.us" site_id="87005">Mana (KSFV-CD2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KSFVCD3.us" site_id="83157">Corner Store (KSFV-CD3) Los Angeles, CA</channel>
-    <channel lang="en" xmltv_id="KSFYDT1.us" site_id="20375">ABC (KSFY-DT1) Sioux Falls, SD</channel> 
+    <channel lang="en" xmltv_id="KSFYDT1.us" site_id="20375">ABC (KSFY-DT1) Sioux Falls, SD</channel>
     <channel lang="en" xmltv_id="KSKJCD1.us" site_id="97134">beIN Sports Xtra (KSKJ-CD) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KSKJCD2.us" site_id="97135">SSTN (KSKJ-DT2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KSKJCD3.us" site_id="97173">Infomercials (KSKJ-CD3) Los Angeles, CA</channel>
@@ -775,7 +775,7 @@
     <channel lang="en" xmltv_id="KTVIDT1.us" site_id="21300">FOX (KTVI-DT1) St Louis, MO</channel>
     <channel lang="en" xmltv_id="KTVIDT2.us" site_id="70954">Antenna TV (KTVI-DT2) St Louis, MO</channel>
     <channel lang="en" xmltv_id="KTVIDT3.us" site_id="98169">Ion Mystery (KTVI-DT3) St Louis, MO</channel>
-    <channel lang="en" xmltv_id="KTVIDT4.us" site_id="112482">Dabl (KTVI-DT4) St Louis, MO</channel>  
+    <channel lang="en" xmltv_id="KTVIDT4.us" site_id="112482">Dabl (KTVI-DT4) St Louis, MO</channel>
     <channel lang="en" xmltv_id="KTVMDT1.us" site_id="30608">NBC (KTVM-DT1) Butte, MT</channel>
     <channel lang="en" xmltv_id="KTVODT1.us" site_id="34831">ABC (KTVO-DT1) Kirskville, MO</channel>
     <channel lang="en" xmltv_id="KTVPLD3.us" site_id="16718">Shop LC (KTVP-LD3) Phoenix, AZ</channel>
@@ -871,7 +871,7 @@
     <channel lang="en" xmltv_id="KVPTDT3.us" site_id="55439">Create (KVPT3) Fresno, CA</channel>
     <channel lang="en" xmltv_id="KVPTDT4.us" site_id="97775">PBS World (KVPT-DT4) Fresno, CA</channel>
     <channel lang="en" xmltv_id="KVSNDT2.us" site_id="18339">UniMás (KVSN-DT2) Colorado Springs, CO</channel>
-    <channel lang="en" xmltv_id="KVUEDT1.us" site_id="33585">ABC (KVUE-DT1) Austin, TX</channel>  
+    <channel lang="en" xmltv_id="KVUEDT1.us" site_id="33585">ABC (KVUE-DT1) Austin, TX</channel>
     <channel lang="en" xmltv_id="KVVGLD1.us" site_id="84439">Azteca (KVVG-LD) Porterville, CA</channel>
     <channel lang="en" xmltv_id="KWGNDT1.us" site_id="20370">CW (KWGN-DT1) Denver, CO</channel>
     <channel lang="en" xmltv_id="KWHYDT1.us" site_id="24023">Canal 22 (KWHY-TV) Los Angeles, CA</channel>
@@ -879,8 +879,8 @@
     <channel lang="en" xmltv_id="KWHYDT3.us" site_id="87653">KWHY-DT3 (KWHY-DT3) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KWHYDT5.us" site_id="97810">Majestadtv (KWHY-DT5) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KWMOLD2.us" site_id="36260">Infomercials (KWMO-LD2) Hot Springs, AR</channel>
-    <channel lang="en" xmltv_id="KWYBDT1.us" site_id="62998">ABC (KWYB-DT1) Butte, MT</channel>   
-    <channel lang="en" xmltv_id="KXANDT1.us" site_id="25147">NBC (KXAN-DT1) Austin, TX</channel>    
+    <channel lang="en" xmltv_id="KWYBDT1.us" site_id="62998">ABC (KWYB-DT1) Butte, MT</channel>
+    <channel lang="en" xmltv_id="KXANDT1.us" site_id="25147">NBC (KXAN-DT1) Austin, TX</channel>
     <channel lang="en" xmltv_id="KXASDT1.us" site_id="19627">NBC (KXAS-DT1) Dallas TX</channel>
     <channel lang="en" xmltv_id="KXASDT2.us" site_id="45803">Cozi TV (KXAS-DT2) Dallas TX</channel>
     <channel lang="en" xmltv_id="KXASDT3.us" site_id="61401">NBCLX (KXAS-DT3) Dallas TX</channel>
@@ -1017,7 +1017,7 @@
     <channel lang="en" xmltv_id="WCIUDT5.us" site_id="70376">MeTV Plus (WCIU-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCIUDT6.us" site_id="59674">Decades (WCIU-DT6) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCMUDT1.us" site_id="66291">PBS (WCMU-TV) Mount Pleasant, MI</channel>
-    <channel lang="en" xmltv_id="WCTIDT1.us" site_id="31042">ABC (WCTI-DT1) New Bern, NC</channel>  
+    <channel lang="en" xmltv_id="WCTIDT1.us" site_id="31042">ABC (WCTI-DT1) New Bern, NC</channel>
     <channel lang="en" xmltv_id="WCTVDT1.us" site_id="44739">CBS (WCTV1) Tallahassee, FL</channel>
     <channel lang="en" xmltv_id="WCTVDT2.us" site_id="46285">MeTV (WCTV2) Tallahassee, FL</channel>
     <channel lang="en" xmltv_id="WCTVDT3.us" site_id="109194">Circle (WCTV3) Tallahassee, FL</channel>
@@ -1163,7 +1163,7 @@
     <channel lang="en" xmltv_id="WJACDT4.us" site_id="98160">CW (WJAC4) Altoona, PA</channel>
     <channel lang="en" xmltv_id="WJBFDT1.us" site_id="35066">ABC (WJBF-DT1) Augusta, GA</channel>
     <channel lang="en" xmltv_id="WJBKDT1.us" site_id="19600">FOX (WJBK-DT1) Detroit, MI</channel>
-    <channel lang="en" xmltv_id="WJLADT1.us" site_id="19579">ABC (WJLA-DT1) Washington, DC</channel>  
+    <channel lang="en" xmltv_id="WJLADT1.us" site_id="19579">ABC (WJLA-DT1) Washington, DC</channel>
     <channel lang="en" xmltv_id="WJLPDT1.us" site_id="75523">MeTV (WJLP-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT2.us" site_id="92098">Laff (WJLP-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WJLPDT3.us" site_id="99162">Grit (WJLP-DT3) New York, NY</channel>
@@ -1235,10 +1235,10 @@
     <channel lang="en" xmltv_id="WMARDT3.us" site_id="43981">Bounce (WMAR-DT3) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WMARDT4.us" site_id="106560">Court TV Mystery (WMAR-DT4) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WMARDT5.us" site_id="111220">Court TV (WMAR-DT5) Washington D.C.</channel>
-    <channel lang="en" xmltv_id="WMBBDT1.us" site_id="30594">ABC (WMBB-DT1) Panama City, FL</channel>   
-    <channel lang="en" xmltv_id="WMBCDT1.us" site_id="35911">WMBC (WMBC-DT1) Newton, NJ</channel> 
-    <channel lang="en" xmltv_id="WMBCDT2.us" site_id="55810">Quest (WMBC-DT2) Newton, NJ</channel>    
-    <channel lang="en" xmltv_id="WMBCDT3.us" site_id="55772">TBD (WMBC-DT3) Newton, NJ</channel>    
+    <channel lang="en" xmltv_id="WMBBDT1.us" site_id="30594">ABC (WMBB-DT1) Panama City, FL</channel>
+    <channel lang="en" xmltv_id="WMBCDT1.us" site_id="35911">WMBC (WMBC-DT1) Newton, NJ</channel>
+    <channel lang="en" xmltv_id="WMBCDT2.us" site_id="55810">Quest (WMBC-DT2) Newton, NJ</channel>
+    <channel lang="en" xmltv_id="WMBCDT3.us" site_id="55772">TBD (WMBC-DT3) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT4.us" site_id="55773">SinoVision (WMBC-DT4) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="62811">New Tang Dynasty (WMBC-DT5) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT7.us" site_id="78580">Aliento Vision (WMBC-DT7) Newton, NJ</channel>
@@ -1327,7 +1327,7 @@
     <channel lang="en" xmltv_id="WPSGDT2.us" site_id="109469">Charge (WPSG-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPSGDT3.us" site_id="109470">Comet (WPSG-DT3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPSGDT4.us" site_id="110654">TBD (WPSG-DT4) Philadelphia, PA</channel>
-    <channel lang="en" xmltv_id="WPSGDT5.us" site_id="113745">Circle (WPSG-DT5) Philadelphia, PA</channel>    
+    <channel lang="en" xmltv_id="WPSGDT5.us" site_id="113745">Circle (WPSG-DT5) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPSUDT1.us" site_id="45799">PBS (WPSU1) Altoona, PA</channel>
     <channel lang="en" xmltv_id="WPSUDT2.us" site_id="49153">Create (WPSU2) Altoona, PA</channel>
     <channel lang="en" xmltv_id="WPSUDT3.us" site_id="49155">PBS World (WPSU3) Altoona, PA</channel>
@@ -1428,7 +1428,7 @@
     <channel lang="en" xmltv_id="WTNHDT1.us" site_id="67497">ABC (WTNH-DT1) Hartford, CT </channel>
     <channel lang="en" xmltv_id="WTNHDT2.us" site_id="67497">Rewind TV (WTNH-DT2) Hartford, CT </channel>
     <channel lang="en" xmltv_id="WTNZDT1.us" site_id="11602">FOX (WTNZ) KNOXVILLE</channel>
-    <channel lang="en" xmltv_id="WTOKDT1.us" site_id="43182">ABC (WTOK-DT1) Meridian, MS</channel>  
+    <channel lang="en" xmltv_id="WTOKDT1.us" site_id="43182">ABC (WTOK-DT1) Meridian, MS</channel>
     <channel lang="en" xmltv_id="WTOLDT1.us" site_id="30754">CBS (WTOL) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WTTGDT1.us" site_id="20367">FOX (WTTG-DT1) Washington D.C.</channel>
     <channel lang="en" xmltv_id="WTTGDT2.us" site_id="94963">Burzzr (WTTG-DT2) Washington D.C.</channel>


### PR DESCRIPTION
tvtv.us appear to have updated their website so the URL used to get data no longer works This is a re-write using a different URL.

Although the URL does reference New York it appears to work for channels in other regions. I haven't checked the output in detail as there are far too many channels but every channel does include some programmes.

The season/episode/category meta-data is no longer available. All we get are times, program name and optionally a very brief sub-title/description, but that's all we really need.

I haven't as yet found a replacement URL to get a channel listing.