### PR TITLE
Update tvtv.us_us-local.channels.xml

### DIFF
--- a/sites/tvtv.us/tvtv.us_us-local.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us-local.channels.xml
@@ -989,6 +989,8 @@
     <channel lang="en" xmltv_id="WBSFDT1.us" site_id="63898">CW (WBSF) Bay City, MI</channel>
     <channel lang="en" xmltv_id="WBTSCD1.us" site_id="91446">NBC (WBTS-CD1) Boston, MA</channel>
     <channel lang="en" xmltv_id="WBTSCD2.us" site_id="91447">Cozi TV (WBTS-CD2) Boston, MA</channel>
+    <channel lang="en" xmltv_id="WBTWDT1.us" site_id="30155">CBS (WBTW) Florence, SC</channel>
+    <channel lang="en" xmltv_id="WBTWDT2.us" site_id="52756">MyNetworkTV (WBTW-DT2) Florence, SC</channel>
     <channel lang="en" xmltv_id="WBUPDT1.us" site_id="63903">ABC (WBUP) Ishpeming, MI</channel>
     <channel lang="en" xmltv_id="WBXZLP11.us" site_id="34242">NewsNet (WBXZ-LP11) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WBXZLP12.us" site_id="34243">THIS (WBXZ-LP12) Buffalo, NY</channel>
@@ -1048,6 +1050,7 @@
     <channel lang="en" xmltv_id="WDPNDT3.us" site_id="90140">Court TV Mystery (WDPN-DT3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WDPNDT4.us" site_id="91607">Heroes and Icons (WDPN-DT4) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WDPNDT5.us" site_id="106849">Retro TV (WDPN-DT5) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WECTDT1.us" site_id="42834">NBC (WECT) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WEDHDT1.us" site_id="53126">PBS (WEDH-DT1) Hartford, CT </channel>
     <channel lang="en" xmltv_id="WEDHDT2.us" site_id="63442">PBS Kids (WEDH-DT2) Hartford, CT </channel>
     <channel lang="en" xmltv_id="WEDHDT3.us" site_id="69134">CPTV Spilit (WEDH-DT3) Hartford, CT </channel>
@@ -1095,6 +1098,7 @@
     <channel lang="en" xmltv_id="WFUTDT2.us" site_id="67228">True Crime Network (WFUT-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT3.us" site_id="85948">getTV (WFUT-DT3) New York, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT4.us" site_id="90175">Bounce TV (WFUT-DT4) New York, NY</channel>
+    <channel lang="en" xmltv_id="WFXBDT1.us" site_id="34536">FOX (WFXB) Myrtle Beach, SC</channel>
     <channel lang="en" xmltv_id="WFXTDT1.us" site_id="20362">FOX (WFXT-DT1) Boston MI</channel>
     <channel lang="en" xmltv_id="WFXTDT2.us" site_id="81295">Court TV Mystery (WFXT-DT2) Boston MI</channel>
     <channel lang="en" xmltv_id="WFXTDT3.us" site_id="92241">Laff (WFXT-DT3) Boston MI</channel>
@@ -1148,6 +1152,7 @@
     <channel lang="en" xmltv_id="WHYYDT1.us" site_id="24114">PBS (WHYY-DT1) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WHYYDT2.us" site_id="45913">PBS World (WHYY-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WHYYDT3.us" site_id="51000">PBS Kids (WHYY-DT2) Philadelphia, PA</channel>
+    <channel lang="en" xmltv_id="WILMLD1.us" site_id="48638">WILM-TV10 (WILM-LD) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WINPDT1.us" site_id="45992">ION Television (WINP-DT1) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WINPDT2.us" site_id="72113">Bounce (WINP-DT2) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WINPDT3.us" site_id="72115">Court TV (WINP-DT3) Pittsburgh, PA</channel>
@@ -1245,6 +1250,7 @@
     <channel lang="en" xmltv_id="WMBCDT4.us" site_id="55773">SinoVision (WMBC-DT4) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="62811">New Tang Dynasty (WMBC-DT5) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT7.us" site_id="78580">Aliento Vision (WMBC-DT7) Newton, NJ</channel>
+    <channel lang="en" xmltv_id="WMBFDT1.us" site_id="59517">NBC (WMBF-TV) Myrtle Beach, SC</channel>
     <channel lang="en" xmltv_id="WMBQCD1.us" site_id="76311">FNX (WMBQ-CD) New York, NY</channel>
     <channel lang="en" xmltv_id="WMCNDT1.us" site_id="11976">WMCN44/ShopHQ (WMCN-DT1) Princeton, NJ</channel>
     <channel lang="en" xmltv_id="WMEUCD1.us" site_id="67657">The U (WMEU-CD1) Chicago, IL</channel>
@@ -1307,6 +1313,9 @@
     <channel lang="en" xmltv_id="WPCWDT2.us" site_id="100908">Heroes and Icons (WPCW-DT2) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WPCWDT3.us" site_id="104896">Grit (WPCW-DT3) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WPCWDT4.us" site_id="109241">Circle (WPCW-DT4) Pittsburgh, PA</channel>
+    <channel lang="en" xmltv_id="WPDEDT1.us" site_id="34557">ABC (WPDE-TV) Florence, SC</channel>
+    <channel lang="en" xmltv_id="WPDEDT2.us" site_id="66446">CW (WPDE-DT2) Florence, SC</channel>
+    <channel lang="en" xmltv_id="WPDEDT4.us" site_id="103850">Weather on the 15s (WPDE-DT4) Florence, SC</channel>
     <channel lang="en" xmltv_id="WPGHDT1.us" site_id="21249">FOX (WPGH-DT1) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WPGHDT2.us" site_id="46027">Antenna TV (WPGH-DT2) Pittsburgh, PA</channel>
     <channel lang="en" xmltv_id="WPGHDT3.us" site_id="91490">Charge! (WPGH-DT3) Pittsburgh, PA</channel>
@@ -1370,6 +1379,9 @@
     <channel lang="en" xmltv_id="WRLHDT3.us" site_id="69969">Comet TV (WRLH-DT3) Richmond, KY</channel>
     <channel lang="en" xmltv_id="WRLHDT4.us" site_id="102233">CHARGE! (WRLH-DT4) Richmond, KY</channel>
     <channel lang="en" xmltv_id="WRLHDT5.us" site_id="112986">Dabl (WRLH-DT5) Richmond, KY</channel>
+    <channel lang="en" xmltv_id="WRLKDT1.us" site_id="21896">PBS (WRLK-TV) Columbia, SC</channel>
+    <channel lang="en" xmltv_id="WRLKDT2.us" site_id="24095">Create (WRLK-DT2) Columbia, SC</channel>
+    <channel lang="en" xmltv_id="WRLKDT3.us" site_id="33854">World (WRLK-DT3) Columbia, SC</channel>
     <channel lang="en" xmltv_id="WRNNDT1.us" site_id="101453">WRNN/ShopHQ (WRNN-DT1) New Rochelle, NY</channel>
     <channel lang="en" xmltv_id="WRNNDT2.us" site_id="55565">Circle (WRNN-DT2) Kingston, NY</channel>
     <channel lang="en" xmltv_id="WRNNDT3.us" site_id="55567">Canal de La Fe (WRNN-DT3) New York, NY</channel>
@@ -1398,6 +1410,7 @@
     <channel lang="en" xmltv_id="WSFLDT2.us" site_id="51525">Court TV (WSFL-DT2) Miami, FL</channel>
     <channel lang="en" xmltv_id="WSFLDT3.us" site_id="68675">Antenna TV (WSFL-DT3) Miami, FL</channel>
     <channel lang="en" xmltv_id="WSFLDT4.us" site_id="70585">TrueReal (WSFL-DT4) Miami, FL</channel>
+    <channel lang="en" xmltv_id="WSFXDT1.us" site_id="35487">FOX (WSFX-TV) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WSMHDT1.us" site_id="52618">FOX (WSMH) Flint MI</channel>
     <channel lang="en" xmltv_id="WSNSDT1.us" site_id="24521">Telemundo (WSNS-DT1) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WSNSDT2.us" site_id="67535">TeleXitos (WSNS-DT2) Chicago, IL</channel>
@@ -1485,6 +1498,9 @@
     <channel lang="en" xmltv_id="WUCWDT3.us" site_id="69640">Charge (WUCW-DT3) St Paul, MN</channel>
     <channel lang="en" xmltv_id="WUCWDT4.us" site_id="99041">TBD (WUCW-DT4) St Paul, MN</channel>
     <channel lang="en" xmltv_id="WUCWDT5.us" site_id="120698">Rewind TV (WUCW-DT5) St Paul, MN</channel>
+    <channel lang="en" xmltv_id="WUNCDT1.us" site_id="30645">PBS (WUNC-TV) Chapel Hill, NC</channel>
+    <channel lang="en" xmltv_id="WUNCDT3.us" site_id="30647">Explorer Channel (WUNC-DT3) Chapel Hill, NC</channel>
+    <channel lang="en" xmltv_id="WUNCDT4.us" site_id="30648">North Carolina Channel (WUNC-DT4) Chapel Hill, NC</channel>
     <channel lang="en" xmltv_id="WUOALD3.us" site_id="19913">Court TV Mystery (WUOA-LD3) Birminghamg, AL</channel>
     <channel lang="en" xmltv_id="WUOALD4.us" site_id="31752">GetTV (WUOA-LD4) Birmingham, AL</channel>
     <channel lang="en" xmltv_id="WUOALD5.us" site_id="31753">QVC (WUOA-LD5) Birmingham, AL</channel>
@@ -1515,6 +1531,9 @@
     <channel lang="en" xmltv_id="WVLTDT1.us" site_id="11627">CBS (WVLT) KNOXVILLE</channel>
     <channel lang="en" xmltv_id="WVTTCD4.us" site_id="36323">Infomercials (WVTT-CD4) Olean, NY</channel>
     <channel lang="en" xmltv_id="WVVCLD2.us" site_id="17385">Cornerstone (WVVC-LD2) Utica, NY</channel>
+    <channel lang="en" xmltv_id="WWAYDT1.us" site_id="43730">ABC (WWAY) Wilmington, NC</channel>
+    <channel lang="en" xmltv_id="WWAYDT2.us" site_id="43989">CBS (WWAY-DT2) Wilmington, NC</channel>
+    <channel lang="en" xmltv_id="WWAYDT3.us" site_id="46992">CW (WWAY-DT3) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WWBTDT1.us" site_id="30305">NBC (WWBT-DT) Richmond, KY</channel>
     <channel lang="en" xmltv_id="WWBTDT2.us" site_id="30674">MeTV (WWBT-DT2) Richmond, KY</channel>
     <channel lang="en" xmltv_id="WWBTDT3.us" site_id="30675">Circle (WWBT-DT3) Richmond, KY</channel>


### PR DESCRIPTION
This intends to address #1075. I did not add channels that appear to relay national feeds 24/7. Given that, I added WWAYDT1.us, WWAYDT2.us, WWAYDT3.us, WECTDT1.us, WBTWDT1.us, WBTWDT2.us, WPDEDT1.us, WPDEDT2.us, WPDEDT4.us, WSFXDT1.us, WMBFDT1.us, and WFXBDT1.us. Since WHMC is South Carolina Educational Television, I added the SCETV Headquarters station's WRLKDT1.us, WRLKDT2.us, and WRLKDT3.us.

I added independent WILMLD1.us and the PBS North Carolina flagship digital channels that did not directly relay national feeds (WUNCDT1.us, WUNCDT3.us, and WUNCDT4.us).