### PR TITLE
Update directv.com_us.channels.xml

### DIFF
--- a/sites/directv.com/directv.com_us.channels.xml
+++ b/sites/directv.com/directv.com_us.channels.xml
@@ -91,9 +91,9 @@
     <channel lang="en" xmltv_id="EEast.us" site_id="236">E! East</channel>
     <channel lang="en" xmltv_id="ElevenSportsUSA.us" site_id="623">Eleven Sports USA</channel>
     <channel lang="en" xmltv_id="Enlace.cr" site_id="448">Enlace</channel>
-    <channel lang="en" xmltv_id="EpixEast.us" site_id="558">Epix East</channel>
-    <channel lang="en" xmltv_id="Epix2East.us" site_id="559">Epix 2 East</channel>
-    <channel lang="en" xmltv_id="EpixHits.us" site_id="560">Epix Hits</channel>
+    <channel lang="en" xmltv_id="Epix.us" site_id="534">Epix</channel>
+    <channel lang="en" xmltv_id="Epix2.us" site_id="535">Epix 2</channel>
+    <channel lang="en" xmltv_id="EpixHits.us" site_id="536">Epix Hits</channel>
     <channel lang="en" xmltv_id="ESPN2.us" site_id="209">ESPN 2 US</channel>
     <channel lang="en" xmltv_id="ESPNDeportes.us" site_id="466">ESPN Deportes</channel>
     <channel lang="en" xmltv_id="ESPNews.us" site_id="207">ESPNews</channel>
@@ -172,9 +172,16 @@
     <channel lang="en" xmltv_id="Karusel.ru" site_id="2145">Karusel International</channel>
     <channel lang="en" xmltv_id="KBSKorea.kr" site_id="2085">KBS Korea</channel>
     <channel lang="en" xmltv_id="KBSWorld.kr" site_id="2082">KBS World</channel>
-    <channel lang="en" xmltv_id="KCBSDT1.us" site_id="391">CBS West</channel>
-    <channel lang="en" xmltv_id="KNBCDT1.us" site_id="393">NBC WEST</channel>
-    <channel lang="en" xmltv_id="KTTVDT1.us" site_id="399">Fox West</channel>
+    <channel lang="en" xmltv_id="KCBSDT1.us" site_id="964">CBS Los Angeles</channel>
+    <channel lang="en" xmltv_id="KNBCDT1.us" site_id="965">NBC Los Angeles</channel>
+    <channel lang="en" xmltv_id="KTLADT1.us" site_id="966">KTLA Los Angeles</channel>
+    <channel lang="en" xmltv_id="KABCDT1.us" site_id="967">ABC Los Angeles</channel>
+    <channel lang="en" xmltv_id="KCALDT1.us" site_id="968">KCAL Los Angeles</channel>
+    <channel lang="en" xmltv_id="KTTVDT1.us" site_id="969">Fox Los Angeles</channel>
+    <channel lang="en" xmltv_id="KCOPDT1.us" site_id="1203">KCOP Los Angeles</channel>
+    <channel lang="en" xmltv_id="KCETDT1.us" site_id="1207">KCET Los Angeles</channel>
+    <channel lang="en" xmltv_id="KMEXDT1.us" site_id="1209">Univision Los Angeles</channel>
+    <channel lang="en" xmltv_id="KVEADT1.us" site_id="1213">Telemundo Los Angeles</channel>
     <channel lang="en" xmltv_id="LifetimeEast.us" site_id="252">Lifetime East</channel>
     <channel lang="en" xmltv_id="LifetimeMoviesEast.us" site_id="253">Lifetime Movies East</channel>
     <channel lang="en" xmltv_id="LinkTV.us" site_id="375">Link TV</channel>

--- a/sites/directv.com/directv.com_us.channels.xml
+++ b/sites/directv.com/directv.com_us.channels.xml
@@ -167,7 +167,6 @@
     <channel lang="en" xmltv_id="JBS.us" site_id="388">JBS</channel>
     <channel lang="en" xmltv_id="JewelryTV.us" site_id="72">Jewelry TV</channel>
     <channel lang="en" xmltv_id="JusticeCentralTV.us" site_id="383">Justice Central TV</channel>
-    <channel lang="en" xmltv_id="KABCDT1.us" site_id="397">ABC WEST</channel>
     <channel lang="en" xmltv_id="KapatidTV5.ph" site_id="2071">Kapatid TV 5</channel>
     <channel lang="en" xmltv_id="Karusel.ru" site_id="2145">Karusel International</channel>
     <channel lang="en" xmltv_id="KBSKorea.kr" site_id="2085">KBS Korea</channel>
@@ -295,10 +294,8 @@
     <channel lang="en" xmltv_id="StarzEncoreActionEast.us" site_id="541">Starz Encore Action East</channel>
     <channel lang="en" xmltv_id="StarzEncoreBlackEast.us" site_id="540">Starz Encore Black East</channel>
     <channel lang="en" xmltv_id="StarzEncoreClassicEast.us" site_id="537">Starz Encore Classic East</channel>
-    <channel lang="en" xmltv_id="StarzEncoreEast.us" site_id="535">Starz Encore East</channel>
     <channel lang="en" xmltv_id="StarzEncoreFamilyEast.us" site_id="542">Starz Encore Family East</channel>
     <channel lang="en" xmltv_id="StarzEncoreSuspenseEast.us" site_id="539">Starz Encore Suspense East</channel>
-    <channel lang="en" xmltv_id="StarzEncoreWest.us" site_id="536">Starz Encore West</channel>
     <channel lang="en" xmltv_id="StarzEncoreWesternsEast.us" site_id="538">Starz Encore Westerns East</channel>
     <channel lang="en" xmltv_id="StarzInBlackEast.us" site_id="530">Starz In Black East</channel>
     <channel lang="en" xmltv_id="StarzKidsFamilyEast.us" site_id="527">Starz Kids &amp; Family East</channel>

--- a/sites/tvpassport.com/tvpassport.com_us.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com_us.channels.xml
@@ -3,9 +3,9 @@
   <channels>
     <channel lang="en" xmltv_id="DiscoveryChannelWest.us" site_id="discovery-channel-us-pacific-feed/1206">Discovery Channel (US) Pacific Feed</channel>
     <channel lang="en" xmltv_id="DisneyXDWest.us" site_id="disney-xd-usa-pacific-feed/1208">Disney XD USA Pacific Feed</channel>
-    <channel lang="en" xmltv_id="Epix2East.us" site_id="epix2-east/11485">Epix 2 East</channel>
+    <channel lang="en" xmltv_id="Epix2.us" site_id="epix2-east/11485">Epix 2 East</channel>
     <channel lang="en" xmltv_id="EpixDriveIn.us" site_id="epix-drivein/11487">Epix Drive-In</channel>
-    <channel lang="en" xmltv_id="EpixEast.us" site_id="epix-hd-east/7610">Epix East</channel>
+    <channel lang="en" xmltv_id="Epix.us" site_id="epix-hd-east/7610">Epix East</channel>
     <channel lang="en" xmltv_id="EpixHits.us" site_id="epix-hits/11486">Epix Hits</channel>
     <channel lang="en" xmltv_id="USANetworkWest.us" site_id="usa-network-pacific/2144">USA Network West</channel>
     <channel lang="en" xmltv_id="W20CQD1.us" site_id="hope-channel-w20cqd-hempstead-ny/16436">Hope Channel (W20CQ-D) Hempstead, NY</channel>

--- a/sites/tvtv.us/tvtv.us_us.channels.xml
+++ b/sites/tvtv.us/tvtv.us_us.channels.xml
@@ -183,11 +183,10 @@
     <channel lang="en" xmltv_id="EEast.us" site_id="10989">E! East</channel>
     <channel lang="en" xmltv_id="ElectricNow.us" site_id="112797">Electric Now</channel>
     <channel lang="en" xmltv_id="Enlace.cr" site_id="20286">Enlace</channel>
-    <channel lang="en" xmltv_id="Epix2East.us" site_id="73075">Epix2 East</channel>
+    <channel lang="en" xmltv_id="Epix2.us" site_id="73075">Epix2 East</channel>
     <channel lang="en" xmltv_id="EpixDriveIn.us" site_id="68409">Epix Drive-In</channel>
-    <channel lang="en" xmltv_id="EpixEast.us" site_id="65669">Epix East</channel>
+    <channel lang="en" xmltv_id="Epix.us" site_id="65669">Epix East</channel>
     <channel lang="en" xmltv_id="EpixHits.us" site_id="74073">Epix Hits</channel>
-    <channel lang="en" xmltv_id="EpixWest.us" site_id="66073">Epix West</channel>
     <channel lang="en" xmltv_id="EsperanzaTV.us" site_id="65095">Esperanza TV</channel>
     <channel lang="en" xmltv_id="ESPN.us" site_id="10179">ESPN</channel>
     <channel lang="en" xmltv_id="ESPN2.us" site_id="45507">ESPN 2</channel>


### PR DESCRIPTION
EpixWest.us, EpixEast.us, Epix2West.us, Epix2East.us, must be removed in favor of Epix.us, Epix2.us, and there are no separate broadcasts.