### PR TITLE
Update tivu.tv_it.channels.xml

### DIFF
--- a/sites/tivu.tv/tivu.tv_it.channels.xml
+++ b/sites/tivu.tv/tivu.tv_it.channels.xml
@@ -21,7 +21,7 @@
     <channel lang="it" xmltv_id="France24French.fr" site_id="137">France 24 HD (en Français)</channel>
     <channel lang="it" xmltv_id="Frisbee.it" site_id="223">frisbee</channel>
     <channel lang="it" xmltv_id="Giallo.it" site_id="172">GIALLO</channel>
-    <channel lang="it" xmltv_id="GoldTV.it" site_id="228">Gold TV</channel>
+    <channel lang="it" xmltv_id="GoldTVSat.it" site_id="228">Gold TV</channel>
     <channel lang="it" xmltv_id="HGTVItaly.it" site_id="210">HGTV</channel>
     <channel lang="it" xmltv_id="HorseTV.it" site_id="213">Horse TV</channel>
     <channel lang="it" xmltv_id="Iris.it" site_id="106">Iris</channel>


### PR DESCRIPTION
- Fixed: from Gold TV terrestrial to Gold TV satellite ID EPG