### PR TITLE
Update bt.com_uk.channels.xml

### DIFF
--- a/sites/bt.com/bt.com_uk.channels.xml
+++ b/sites/bt.com/bt.com_uk.channels.xml
@@ -34,7 +34,7 @@
     <channel lang="en" xmltv_id="BoomerangUK.uk" site_id="hstb">Boomerang UK</channel>
     <channel lang="en" xmltv_id="BoxNation.uk" site_id="hspk">Box Nation</channel>
     <channel lang="en" xmltv_id="BTSport1.uk" site_id="hspc">BT Sport 1</channel>
-    <channel lang="en" xmltv_id="BTSport10.uk" site_id="hsq6">BT Sport 10</channel>
+    <channel lang="en" xmltv_id="BTSport10.uk" site_id="hsp6">BT Sport 10</channel>
     <channel lang="en" xmltv_id="BTSport2.uk" site_id="hspd">BT Sport 2</channel>
     <channel lang="en" xmltv_id="BTSport3.uk" site_id="hspf">BT Sport 3</channel>
     <channel lang="en" xmltv_id="BTSport4.uk" site_id="hspg">BT Sport 4</channel>


### PR DESCRIPTION
Wrong channel ID for BT Sport 10, was showing Sky Atlantic