### PR TITLE
Fix: Sony Channels are Viasat now

### DIFF
--- a/sites/musor.tv/musor.tv_hu.channels.xml
+++ b/sites/musor.tv/musor.tv_hu.channels.xml
@@ -130,8 +130,8 @@
     <channel lang="hu" xmltv_id="RTLPlus.hu" site_id="RTL_PLUSZ">RTL+</channel>
     <channel lang="hu" xmltv_id="SkyNewsInternational.uk" site_id="SKYNEWS">Sky News</channel>
     <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="SLAGERTV">Sláger TV (HD)</channel>
-    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="SONY_MAX">Viasat2</channel>
-    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
+    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="SONY_MAX">Viasat2</channel>
+    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
     <channel lang="hu" xmltv_id="SorozatPlus.hu" site_id="SOROZAT">Sorozat+</channel>
     <channel lang="hu" xmltv_id="SpektrumHungary.hu" site_id="SPEKTRUM">Spektrum (HD)</channel>
     <channel lang="hu" xmltv_id="SpektrumHomeHungary.hu" site_id="SPEKTRUMHOME">Spektrum Home (HD)</channel>
@@ -163,9 +163,9 @@
     <channel lang="hu" xmltv_id="UjbudaTV.hu" site_id="UJBUDA_TV">Újbuda TV</channel>
     <channel lang="hu" xmltv_id="Viasat3.hu" site_id="VIASAT3">Viasat3 (HD)</channel>
     <channel lang="hu" xmltv_id="Viasat6.hu" site_id="VIASAT6">Viasat6</channel>
-    <channel lang="hu" xmltv_id="ViasatExplore.se" site_id="VIASATEXP">Viasat Explore (HD)</channel>
-    <channel lang="hu" xmltv_id="ViasatHistory.se" site_id="VIASATHIST">Viasat History (HD)</channel>
-    <channel lang="hu" xmltv_id="ViasatNature.se" site_id="VIASATNAT">Viasat Nature (HD)</channel>
+    <channel lang="hu" xmltv_id="ViasatExploreHungary.hu" site_id="VIASATEXP">Viasat Explore (HD)</channel>
+    <channel lang="hu" xmltv_id="ViasatHistoryHungary.hu" site_id="VIASATHIST">Viasat History (HD)</channel>
+    <channel lang="hu" xmltv_id="ViasatNatureHungary.hu" site_id="VIASATNAT">Viasat Nature (HD)</channel>
     <channel lang="hu" xmltv_id="ZalaegerszegiTV.hu" site_id="ZEG_TV">Zalaegerszegi TV</channel>
     <channel lang="hu" xmltv_id="Zenebutik.hu" site_id="ZENEBUTIK">Zenebutik TV</channel>
   </channels>

--- a/sites/musor.tv/musor.tv_hu.channels.xml
+++ b/sites/musor.tv/musor.tv_hu.channels.xml
@@ -159,11 +159,11 @@
     <channel lang="hu" xmltv_id="TVEger.hu" site_id="TV_EGER">TV Eger</channel>
     <channel lang="hu" xmltv_id="TVPaprikaHungary.hu" site_id="PAPRIKA">TV Paprika (HD)</channel>
     <channel lang="hu" xmltv_id="UjbudaTV.hu" site_id="UJBUDA_TV">Újbuda TV</channel>
-    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="SONY_MAX">Viasat2</channel>
+    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="VIASAT2">Viasat2</channel>
     <channel lang="hu" xmltv_id="Viasat3.hu" site_id="VIASAT3">Viasat3 (HD)</channel>
     <channel lang="hu" xmltv_id="Viasat6.hu" site_id="VIASAT6">Viasat6</channel>
     <channel lang="hu" xmltv_id="ViasatExploreHungary.hu" site_id="VIASATEXP">Viasat Explore (HD)</channel>
-    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
+    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="VIASATFILM">Viasat Film</channel>
     <channel lang="hu" xmltv_id="ViasatHistoryHungary.hu" site_id="VIASATHIST">Viasat History (HD)</channel>
     <channel lang="hu" xmltv_id="ViasatNatureHungary.hu" site_id="VIASATNAT">Viasat Nature (HD)</channel>
     <channel lang="hu" xmltv_id="ZalaegerszegiTV.hu" site_id="ZEG_TV">Zalaegerszegi TV</channel>

--- a/sites/musor.tv/musor.tv_hu.channels.xml
+++ b/sites/musor.tv/musor.tv_hu.channels.xml
@@ -130,8 +130,6 @@
     <channel lang="hu" xmltv_id="RTLPlus.hu" site_id="RTL_PLUSZ">RTL+</channel>
     <channel lang="hu" xmltv_id="SkyNewsInternational.uk" site_id="SKYNEWS">Sky News</channel>
     <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="SLAGERTV">Sláger TV (HD)</channel>
-    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="SONY_MAX">Viasat2</channel>
-    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
     <channel lang="hu" xmltv_id="SorozatPlus.hu" site_id="SOROZAT">Sorozat+</channel>
     <channel lang="hu" xmltv_id="SpektrumHungary.hu" site_id="SPEKTRUM">Spektrum (HD)</channel>
     <channel lang="hu" xmltv_id="SpektrumHomeHungary.hu" site_id="SPEKTRUMHOME">Spektrum Home (HD)</channel>
@@ -161,9 +159,11 @@
     <channel lang="hu" xmltv_id="TVEger.hu" site_id="TV_EGER">TV Eger</channel>
     <channel lang="hu" xmltv_id="TVPaprikaHungary.hu" site_id="PAPRIKA">TV Paprika (HD)</channel>
     <channel lang="hu" xmltv_id="UjbudaTV.hu" site_id="UJBUDA_TV">Újbuda TV</channel>
+    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="SONY_MAX">Viasat2</channel>
     <channel lang="hu" xmltv_id="Viasat3.hu" site_id="VIASAT3">Viasat3 (HD)</channel>
     <channel lang="hu" xmltv_id="Viasat6.hu" site_id="VIASAT6">Viasat6</channel>
     <channel lang="hu" xmltv_id="ViasatExploreHungary.hu" site_id="VIASATEXP">Viasat Explore (HD)</channel>
+    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
     <channel lang="hu" xmltv_id="ViasatHistoryHungary.hu" site_id="VIASATHIST">Viasat History (HD)</channel>
     <channel lang="hu" xmltv_id="ViasatNatureHungary.hu" site_id="VIASATNAT">Viasat Nature (HD)</channel>
     <channel lang="hu" xmltv_id="ZalaegerszegiTV.hu" site_id="ZEG_TV">Zalaegerszegi TV</channel>

--- a/sites/musor.tv/musor.tv_hu.channels.xml
+++ b/sites/musor.tv/musor.tv_hu.channels.xml
@@ -130,8 +130,8 @@
     <channel lang="hu" xmltv_id="RTLPlus.hu" site_id="RTL_PLUSZ">RTL+</channel>
     <channel lang="hu" xmltv_id="SkyNewsInternational.uk" site_id="SKYNEWS">Sky News</channel>
     <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="SLAGERTV">Sláger TV (HD)</channel>
-    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="SONY_MAX">Sony Max</channel>
-    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="SONY_MOVIE_CHANNEL">Sony Movie Channel</channel>
+    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="SONY_MAX">Viasat2</channel>
+    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="SONY_MOVIE_CHANNEL">Viasat Film</channel>
     <channel lang="hu" xmltv_id="SorozatPlus.hu" site_id="SOROZAT">Sorozat+</channel>
     <channel lang="hu" xmltv_id="SpektrumHungary.hu" site_id="SPEKTRUM">Spektrum (HD)</channel>
     <channel lang="hu" xmltv_id="SpektrumHomeHungary.hu" site_id="SPEKTRUMHOME">Spektrum Home (HD)</channel>

--- a/sites/tvmusor.hu/tvmusor.hu_hu.channels.xml
+++ b/sites/tvmusor.hu/tvmusor.hu_hu.channels.xml
@@ -65,9 +65,7 @@
     <channel lang="hu" xmltv_id="RTLKlub.hu" site_id="5">RTL Klub</channel>
     <channel lang="hu" xmltv_id="RTLPlus.hu" site_id="178">RTL+</channel>
     <channel lang="hu" xmltv_id="SkyNewsInternational.uk" site_id="158">Sky News International</channel>
-    <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="216">Sláger TV</channel>
-    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="132">Viasat2</channel>
-    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="138">Viasat Film</channel>
+    <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="216">Sláger TV</channel>   
     <channel lang="hu" xmltv_id="SorozatPlus.hu" site_id="179">Sorozat+</channel>
     <channel lang="hu" xmltv_id="SpektrumHungary.hu" site_id="9">Spektrum</channel>
     <channel lang="hu" xmltv_id="SpilerTV1.hu" site_id="305">Spíler1 TV</channel>
@@ -85,9 +83,11 @@
     <channel lang="hu" xmltv_id="TV4.hu" site_id="38">Story4</channel>
     <channel lang="hu" xmltv_id="TVPaprikaHungary.hu" site_id="46">TV Paprika</channel>
     <channel lang="hu" xmltv_id="VH1Europe.uk" site_id="99">VH1</channel>
+    <channel lang="hu" xmltv_id="Viasat2.hu" site_id="132">Viasat2</channel>  
     <channel lang="hu" xmltv_id="Viasat3.hu" site_id="21">Viasat3</channel>
     <channel lang="hu" xmltv_id="Viasat6.hu" site_id="164">Viasat6</channel>
     <channel lang="hu" xmltv_id="ViasatExplore.se" site_id="65">Viasat Explore</channel>
+    <channel lang="hu" xmltv_id="ViasatFilm.hu" site_id="138">Viasat Film</channel>
     <channel lang="hu" xmltv_id="ViasatHistory.se" site_id="66">Viasat History</channel>
     <channel lang="hu" xmltv_id="ViasatNature.se" site_id="223">Viasat Nature</channel>
     <!-- <channel lang="hu" xmltv_id="" site_id="226">FilmBox</channel> -->

--- a/sites/tvmusor.hu/tvmusor.hu_hu.channels.xml
+++ b/sites/tvmusor.hu/tvmusor.hu_hu.channels.xml
@@ -66,8 +66,8 @@
     <channel lang="hu" xmltv_id="RTLPlus.hu" site_id="178">RTL+</channel>
     <channel lang="hu" xmltv_id="SkyNewsInternational.uk" site_id="158">Sky News International</channel>
     <channel lang="hu" xmltv_id="SlagerTV.hu" site_id="216">Sláger TV</channel>
-    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="132">Sony Max</channel>
-    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="138">Sony Movie Channel</channel>
+    <channel lang="hu" xmltv_id="SonyMaxHungary.hu" site_id="132">Viasat2</channel>
+    <channel lang="hu" xmltv_id="SonyMovieChannelHungary.hu" site_id="138">Viasat Film</channel>
     <channel lang="hu" xmltv_id="SorozatPlus.hu" site_id="179">Sorozat+</channel>
     <channel lang="hu" xmltv_id="SpektrumHungary.hu" site_id="9">Spektrum</channel>
     <channel lang="hu" xmltv_id="SpilerTV1.hu" site_id="305">Spíler1 TV</channel>

--- a/sites/tvprofil.com/tvprofil.com_hu.channels.xml
+++ b/sites/tvprofil.com/tvprofil.com_hu.channels.xml
@@ -45,8 +45,6 @@
     <channel lang="hr" xmltv_id="RTLIIHungary.hu" site_id="hu/tvmusor#rtl-ii-hu">RTL II</channel>
     <channel lang="hr" xmltv_id="RTLKlub.hu" site_id="hu/tvmusor#rtl-klub">RTL Klub</channel>
     <channel lang="hr" xmltv_id="SlagerTV.hu" site_id="hu/tvmusor#magyar-slager-tv">Sláger TV</channel>
-    <channel lang="hr" xmltv_id="SonyMaxHungary.hu" site_id="hu/tvmusor#sony-max-hu">Viasat2</channel>
-    <channel lang="hr" xmltv_id="SonyMovieChannelHungary.hu" site_id="hu/tvmusor#sony-movie-channel-hu">Viasat Film</channel>
     <channel lang="hr" xmltv_id="SorozatPlus.hu" site_id="hu/tvmusor#sorozat">Sorozat+</channel>
     <channel lang="hr" xmltv_id="SpektrumHungary.hu" site_id="hu/tvmusor#spektrum-tv">Spektrum</channel>
     <channel lang="hr" xmltv_id="SpektrumHomeHungary.hu" site_id="hu/tvmusor#spektrum-home-hu">Spektrum Home</channel>
@@ -63,8 +61,10 @@
     <channel lang="hr" xmltv_id="TV2Sef.hu" site_id="hu/tvmusor#tv2-sef">TV2 Séf</channel>
     <channel lang="hr" xmltv_id="TV4.hu" site_id="hu/tvmusor#tv4-hu">TV4</channel>
     <channel lang="hr" xmltv_id="TVPaprikaHungary.hu" site_id="hu/tvmusor#tv-paprika">TV Paprika</channel>
+    <channel lang="hr" xmltv_id="Viasat2.hu" site_id="hu/tvmusor#sony-max-hu">Viasat2</channel>   
     <channel lang="hr" xmltv_id="Viasat3.hu" site_id="hu/tvmusor#viasat3">Viasat3</channel>
     <channel lang="hr" xmltv_id="Viasat6.hu" site_id="hu/tvmusor#tv6">Viasat6</channel>
+    <channel lang="hr" xmltv_id="ViasatFilm.hu" site_id="hu/tvmusor#sony-movie-channel-hu">Viasat Film</channel>
     <channel lang="hr" xmltv_id="Zenebutik.hu" site_id="hu/tvmusor#zenebutik">Zenebutik</channel>
   </channels>
 </site>

--- a/sites/tvprofil.com/tvprofil.com_hu.channels.xml
+++ b/sites/tvprofil.com/tvprofil.com_hu.channels.xml
@@ -61,10 +61,10 @@
     <channel lang="hr" xmltv_id="TV2Sef.hu" site_id="hu/tvmusor#tv2-sef">TV2 Séf</channel>
     <channel lang="hr" xmltv_id="TV4.hu" site_id="hu/tvmusor#tv4-hu">TV4</channel>
     <channel lang="hr" xmltv_id="TVPaprikaHungary.hu" site_id="hu/tvmusor#tv-paprika">TV Paprika</channel>
-    <channel lang="hr" xmltv_id="Viasat2.hu" site_id="hu/tvmusor#sony-max-hu">Viasat2</channel>   
+    <channel lang="hr" xmltv_id="Viasat2.hu" site_id="hu/tvmusor#viasat2">Viasat2</channel>   
     <channel lang="hr" xmltv_id="Viasat3.hu" site_id="hu/tvmusor#viasat3">Viasat3</channel>
     <channel lang="hr" xmltv_id="Viasat6.hu" site_id="hu/tvmusor#tv6">Viasat6</channel>
-    <channel lang="hr" xmltv_id="ViasatFilm.hu" site_id="hu/tvmusor#sony-movie-channel-hu">Viasat Film</channel>
+    <channel lang="hr" xmltv_id="ViasatFilm.hu" site_id="hu/tvmusor#viasatfilm">Viasat Film</channel>
     <channel lang="hr" xmltv_id="Zenebutik.hu" site_id="hu/tvmusor#zenebutik">Zenebutik</channel>
   </channels>
 </site>

--- a/sites/tvprofil.com/tvprofil.com_hu.channels.xml
+++ b/sites/tvprofil.com/tvprofil.com_hu.channels.xml
@@ -45,8 +45,8 @@
     <channel lang="hr" xmltv_id="RTLIIHungary.hu" site_id="hu/tvmusor#rtl-ii-hu">RTL II</channel>
     <channel lang="hr" xmltv_id="RTLKlub.hu" site_id="hu/tvmusor#rtl-klub">RTL Klub</channel>
     <channel lang="hr" xmltv_id="SlagerTV.hu" site_id="hu/tvmusor#magyar-slager-tv">Sláger TV</channel>
-    <channel lang="hr" xmltv_id="SonyMaxHungary.hu" site_id="hu/tvmusor#sony-max-hu">Sony Max Hungary</channel>
-    <channel lang="hr" xmltv_id="SonyMovieChannelHungary.hu" site_id="hu/tvmusor#sony-movie-channel-hu">Sony Movie Channel Hungary</channel>
+    <channel lang="hr" xmltv_id="SonyMaxHungary.hu" site_id="hu/tvmusor#sony-max-hu">Viasat2</channel>
+    <channel lang="hr" xmltv_id="SonyMovieChannelHungary.hu" site_id="hu/tvmusor#sony-movie-channel-hu">Viasat Film</channel>
     <channel lang="hr" xmltv_id="SorozatPlus.hu" site_id="hu/tvmusor#sorozat">Sorozat+</channel>
     <channel lang="hr" xmltv_id="SpektrumHungary.hu" site_id="hu/tvmusor#spektrum-tv">Spektrum</channel>
     <channel lang="hr" xmltv_id="SpektrumHomeHungary.hu" site_id="hu/tvmusor#spektrum-home-hu">Spektrum Home</channel>


### PR DESCRIPTION
Hi @freearhey,
Maybe  xmltv_ids should be modified, I don't know.
Thanks

Btw:
About channel name changes  https://hu.wikipedia.org/wiki/Viasat_2 https://hu.wikipedia.org/wiki/Viasat_Film