### PR TITLE
Update guidatv.sky.it_it.channels.xml

### DIFF
--- a/sites/guidatv.sky.it/guidatv.sky.it_it.channels.xml
+++ b/sites/guidatv.sky.it/guidatv.sky.it_it.channels.xml
@@ -37,7 +37,7 @@
     <channel lang="it" xmltv_id="DMAXItaly.it" site_id="DTH#8933">DMAX Italia</channel>
     <channel lang="it" xmltv_id="EmiliaRomagna24.it" site_id="DTH#10615">Emilia-Romagna 24</channel>
     <channel lang="it" xmltv_id="EQUtv.it" site_id="DTH#8293">EQUtv</channel>
-    <channel lang="it" xmltv_id="EuronewsItalian.fr" site_id="DTH#801">EuroNews Italiano</channel>
+    <channel lang="it" xmltv_id="EuronewsEnglish.fr" site_id="DTH#801">Euronews English</channel>
     <channel lang="it" xmltv_id="Eurosport1Italy.it" site_id="DTH#9057">Eurosport 1 Italia</channel>
     <channel lang="it" xmltv_id="Eurosport2Italy.it" site_id="DTH#9060">Eurosport 2 Italia</channel>
     <channel lang="it" xmltv_id="ExplorerHDChannel.it" site_id="DTH#11262">Explorer HD Channel</channel>


### PR DESCRIPTION
The Euronews into the "Guida Sky" is the english version:  https://guidatv.sky.it/canali/euronews/801
Anyway the italian version is available on: "tivu.tv" and "tv.blue.ch". Thank you! :3