### PR TITLE
Update tvpassport.com_us.channels.xml

### DIFF
--- a/sites/tvpassport.com/tvpassport.com_us.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com_us.channels.xml
@@ -98,6 +98,7 @@
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="localish-wabcdt2-new-york-ny/10497">Localish (WABC-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="this-wabctv3-new-york-ny/11049">THIS (WABC-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
+    <channel lang="en" xmltv_id="WBBZDT1.us" site_id="metv-wbbz-buffalo-ny/9936">Independent (WBBZ-TV) Springville, NY</channel>
     <channel lang="en" xmltv_id="WBGUDT1.us" site_id="pbs-wbgu-bowling-green-oh/3025">PBS (WBGU-TV) Bowling Green, OH</channel>
     <channel lang="en" xmltv_id="WBSFDT1.us" site_id="cw-wbsf-flint-mi/6958">CW (WBSF) Bay City, MI</channel>
     <channel lang="en" xmltv_id="WBUPDT1.us" site_id="abc-wbup-ishpeming-mi/4944">ABC (WBUP) Ishpeming, MI</channel>

--- a/sites/tvpassport.com/tvpassport.com_us.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com_us.channels.xml
@@ -100,6 +100,7 @@
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WBBZDT1.us" site_id="metv-wbbz-buffalo-ny/9936">Independent (WBBZ-TV) Springville, NY</channel>
     <channel lang="en" xmltv_id="WBGUDT1.us" site_id="pbs-wbgu-bowling-green-oh/3025">PBS (WBGU-TV) Bowling Green, OH</channel>
+    <channel lang="en" xmltv_id="WBKPDT1.us" site_id="cw-wbkp-calumet-mi/4943">CW (WBKP) Calumet, MI</channel>
     <channel lang="en" xmltv_id="WBSFDT1.us" site_id="cw-wbsf-flint-mi/6958">CW (WBSF) Bay City, MI</channel>
     <channel lang="en" xmltv_id="WBUPDT1.us" site_id="abc-wbup-ishpeming-mi/4944">ABC (WBUP) Ishpeming, MI</channel>
     <channel lang="en" xmltv_id="WCBSDT1.us" site_id="cbs-wcbs-new-york-ny/1766">CBS (WCBS) New York, NY</channel>

--- a/sites/tvpassport.com/tvpassport.com_us.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com_us.channels.xml
@@ -127,6 +127,7 @@
     <channel lang="en" xmltv_id="WJLPDT4.us" site_id="ion-mystery-wjlp4-new-jerseynew-york/20041">ION Mystery (WJLP4) New Jersey/New York</channel>
     <channel lang="en" xmltv_id="WJLPDT5.us" site_id="retro-tv-wjlp5-middletown-township-nj/35854">Retro TV (WJLP5) Middletown Township, NJ</channel>
     <channel lang="en" xmltv_id="WJLPDT6.us" site_id="heartland-wjlp6-middletown-township-nj/33652">Heartland (WJLP6) Middletown Township, NJ</channel>
+    <channel lang="en" xmltv_id="WJMNDT1.us" site_id="wjmn-escanaba-mi/4993">MNT (WJMN-TV) Escanaba, MI</channel>
     <channel lang="en" xmltv_id="WJRTDT1.us" site_id="abc-wjrt-flint-mi/480">ABC (WJRT-TV) Flint, MI</channel>
     <channel lang="en" xmltv_id="WKARDT1.us" site_id="pbs-wkar-east-lansing-mi/13241">PBS (WKAR-TV) East Lansing, MI</channel>
     <channel lang="en" xmltv_id="WKOBLD1.us" site_id="azteca-wkob-new-york-ny/5096">Azteca (WKOB) New York, NY</channel>


### PR DESCRIPTION
Added WBBZDT1.us
  It does clear MeTV much of the day, but has a lot of locally produced programming. The full MeTV schedule runs on WBBZ-DT3.