### PR TITLE
Update movistarplus.es.channels.xml

### DIFF
--- a/sites/movistarplus.es/movistarplus.es.channels.xml
+++ b/sites/movistarplus.es/movistarplus.es.channels.xml
@@ -27,7 +27,6 @@
     <channel lang="es" xmltv_id="BomCine.es" site_id="BOMCIN">Bom Cine</channel>
     <channel lang="es" xmltv_id="Calle13.es" site_id="CL13">Calle 13</channel>
     <channel lang="es" xmltv_id="Canal24Horas.es" site_id="24H">Canal 24 Horas</channel>
-    <channel lang="es" xmltv_id="Canal33Madrid.es" site_id="C33">Canal 33 Madrid</channel>
     <channel lang="es" xmltv_id="CanalCocina.es" site_id="CACOC">Canal Cocina</channel>
     <channel lang="es" xmltv_id="CanalExtremadura.es" site_id="EXTRE">Canal Extremadura</channel>
     <channel lang="es" xmltv_id="CanalExtremaduraSatelite.es" site_id="EXTREM">Canal Extremadura Satélite</channel>
@@ -61,6 +60,7 @@
     <channel lang="es" xmltv_id="DMAXSpain.es" site_id="DCRMAX">DMAX España</channel>
     <channel lang="es" xmltv_id="DreamWorksChannelSpain.es" site_id="DWSP">DreamWorks TV</channel>
     <channel lang="es" xmltv_id="EITBBasque.es" site_id="ETB">EITB Basque</channel>
+    <channel lang="es" xmltv_id="El33SX3.es" site_id="C33">El33/SX3</channel>
     <channel lang="es" xmltv_id="ElGarageTV.ar" site_id="GARAGE">El Garage TV</channel>
     <channel lang="es" xmltv_id="ElToroTV.es" site_id="INTECO">El Toro TV</channel>
     <channel lang="es" xmltv_id="Energy.es" site_id="ENERGY">Energy</channel>


### PR DESCRIPTION
Add El33/SX3, remove Canal33 Madrid as the EPG with site ID C33 is for the Catalan channel, not Canal 33 Madrid.