### PR TITLE
Add 60s cache to dsmart.com.tr epg-grabber

### DIFF
--- a/sites/dsmart.com.tr/dsmart.com.tr.config.js
+++ b/sites/dsmart.com.tr/dsmart.com.tr.config.js
@@ -6,6 +6,11 @@ dayjs.extend(utc)
 module.exports = {
   site: 'dsmart.com.tr',
   days: 2,
+  request: {
+    cache: {
+      ttl: 60 * 1000 // 60 seconds response cache
+    }
+  },
   url({ date, channel }) {
     return `https://www.dsmart.com.tr/api/v1/public/epg/schedules?page=1&limit=500&day=${date.format(
       'YYYY-MM-DD'


### PR DESCRIPTION
It's extremely inefficient to use the EPG endpoint with the existing config because it fetches the whole EPG JSON using the same URL for every single channel. It's good to add some response cache to reduce this inefficiency. 