### PR TITLE
not Chinese

### DIFF
--- a/sites/epg.i-cable.com/epg.i-cable.com.channels.xml
+++ b/sites/epg.i-cable.com/epg.i-cable.com.channels.xml
@@ -31,7 +31,7 @@
     <channel lang="en" xmltv_id="DMAXSoutheastAsia.sg" site_id="759">DMAX</channel>
     <channel lang="en" xmltv_id="DragonTV.cn" site_id="334">Dragon TV</channel>
     <channel lang="en" xmltv_id="DreamWorksChannelAsia.us" site_id="510">DreamWorks</channel>
-    <channel lang="en" xmltv_id="DWDeutsch.de" site_id="140">DW (Deutsch)</channel>
+    <channel lang="de" xmltv_id="DWDeutsch.de" site_id="140">DW (Deutsch)</channel>
     <channel lang="en" xmltv_id="DWEnglish.de" site_id="139">DW (English)</channel>
     <channel lang="en" xmltv_id="EBCYOYO.tw" site_id="502">Asia YOYO TV</channel>
     <channel lang="en" xmltv_id="ETTVAsiaNews.tw" site_id="114">ETTV AsiaNews</channel>
@@ -43,7 +43,7 @@
     <channel lang="en" xmltv_id="FashionTVAsia.fr" site_id="375">Fashion TV</channel>
     <channel lang="en" xmltv_id="FightSports.us" site_id="652">FIGHT SPORTS</channel>
     <channel lang="en" xmltv_id="France24English.fr" site_id="135">France 24 English</channel>
-    <channel lang="en" xmltv_id="France24French.fr" site_id="134">France 24 French</channel>
+    <channel lang="fr" xmltv_id="France24French.fr" site_id="134">France 24 French</channel>
     <channel lang="en" xmltv_id="GlobalTrekker.sg" site_id="708">Global Trekker [HD]</channel>
     <channel lang="en" xmltv_id="GuangdongSatelliteTV.cn" site_id="305">GRT GBA Satellite TV</channel>
     <channel lang="en" xmltv_id="HITS.sg" site_id="310">HITS [HD]</channel>
@@ -96,57 +96,39 @@
     <channel lang="en" xmltv_id="tvNAsia.hk" site_id="377">tvN</channel>
     <channel lang="en" xmltv_id="WION.in" site_id="852">WION</channel>
     <channel lang="en" xmltv_id="ZeeCinemaAsia.in" site_id="853">Zee Cinema</channel>
-    <channel lang="en" xmltv_id="ZeeTVAsiaPacific.sg" site_id="851">Zee TV</channel>
+    <channel lang="hi" xmltv_id="ZeeTVAsiaPacific.sg" site_id="851">Zee TV</channel>
     <channel lang="en" xmltv_id="Zing.in" site_id="854">Zing</channel>
-    <channel lang="zh" xmltv_id="ABCAustralia.au" site_id="326">ABC Australia</channel>
-    <channel lang="zh" xmltv_id="AlJazeeraEnglish.qa" site_id="133">半島電視台英語頻道</channel>
     <channel lang="zh" xmltv_id="AnimalPlanetSoutheastAsia.sg" site_id="757">動物星球頻道</channel>
-    <channel lang="zh" xmltv_id="ArirangTV.kr" site_id="325">Arirang TV</channel>
     <channel lang="zh" xmltv_id="AsianFoodNetwork.sg" site_id="717">亞洲美食頻道 [HD]</channel>
     <channel lang="zh" xmltv_id="BBCEarthAsia.uk" site_id="721">BBC Earth</channel>
     <channel lang="zh" xmltv_id="BBCLifestyleAsia.uk" site_id="760">BBC Lifestyle</channel>
-    <channel lang="zh" xmltv_id="BBCWorldNewsAsiaPacific.uk" site_id="122">BBC WorldNews</channel>
     <channel lang="zh" xmltv_id="BloombergTVAsia.hk" site_id="155">Bloomberg TV</channel>
     <channel lang="zh" xmltv_id="BoomerangAsia.sg" site_id="512">Boomerang 頻道</channel>
     <channel lang="zh" xmltv_id="CartoonNetworkAsia.sg" site_id="511">卡通頻道</channel>
-    <channel lang="zh" xmltv_id="CBeebiesAsia.uk" site_id="517">CBeebies</channel>
     <channel lang="zh" xmltv_id="CCTV1.cn" site_id="341">中央電視台綜合頻道 [HD]</channel>
     <channel lang="zh" xmltv_id="CCTV11.cn" site_id="340">中央電視台戲曲頻道</channel>
     <channel lang="zh" xmltv_id="CCTV13.cn" site_id="111">中央電視台新聞頻道</channel>
     <channel lang="zh" xmltv_id="CCTV4Asia.cn" site_id="112">中央電視台中文國際頻道</channel>
-    <channel lang="zh" xmltv_id="CGTN.cn" site_id="129">中國環球電視網</channel>
-    <channel lang="zh" xmltv_id="CGTNDocumentary.cn" site_id="722">中國環球電視網紀錄頻道 [HD]</channel>
     <channel lang="zh" xmltv_id="ChannelBlue.hk" site_id="901">歡樂台</channel>
     <channel lang="zh" xmltv_id="ChannelFire.hk" site_id="902">惹火台</channel>
     <channel lang="zh" xmltv_id="CNAInternational.sg" site_id="130">亞洲新聞台</channel>
-    <channel lang="zh" xmltv_id="CNBCAsia.sg" site_id="127">CNBC HK</channel>
-    <channel lang="zh" xmltv_id="CNNInternationalAsiaPacific.hk" site_id="124">CNNI</channel>
-    <channel lang="zh" xmltv_id="DaVinciAsia.de" site_id="513">達文西頻道</channel>
     <channel lang="zh" xmltv_id="DiscoveryAsia.sg" site_id="710">Discovery Asia [HD]</channel>
     <channel lang="zh" xmltv_id="DiscoveryChannelSoutheastAsia.sg" site_id="754">Discovery</channel>
     <channel lang="zh" xmltv_id="DiscoveryScienceSoutheastAsia.sg" site_id="758">Discovery科學頻道</channel>
     <channel lang="zh" xmltv_id="DMAXSoutheastAsia.sg" site_id="759">DMAX</channel>
     <channel lang="zh" xmltv_id="DragonTV.cn" site_id="334">東方衛視國際頻道</channel>
     <channel lang="zh" xmltv_id="DreamWorksChannelAsia.us" site_id="510">夢工廠</channel>
-    <channel lang="zh" xmltv_id="DWDeutsch.de" site_id="140">DW (Deutsch)</channel>
-    <channel lang="zh" xmltv_id="DWEnglish.de" site_id="139">DW (English)</channel>
     <channel lang="zh" xmltv_id="EBCAsia.tw" site_id="331">東森亞洲衛視</channel>
     <channel lang="zh" xmltv_id="EBCYOYO.tw" site_id="502">東森亞洲幼幼台</channel>
     <channel lang="zh" xmltv_id="ETTVAsiaNews.tw" site_id="114">東森亞洲新聞台</channel>
     <channel lang="zh" xmltv_id="EuronewsEnglish.fr" site_id="136">euronews(Eng)</channel>
     <channel lang="zh" xmltv_id="EuronewsPortuguese.fr" site_id="137">euronews(Por)</channel>
-    <channel lang="zh" xmltv_id="EurosportAsia.fr" site_id="651">歐洲體育頻道</channel>
     <channel lang="zh" xmltv_id="EVE.us" site_id="756">EVE</channel>
-    <channel lang="zh" xmltv_id="FashionTVAsia.fr" site_id="375">Fashion TV</channel>
-    <channel lang="zh" xmltv_id="FightSports.us" site_id="652">FIGHT SPORTS</channel>
-    <channel lang="zh" xmltv_id="France24English.fr" site_id="135">France 24 English</channel>
-    <channel lang="zh" xmltv_id="France24French.fr" site_id="134">France 24 French</channel>
     <channel lang="zh" xmltv_id="GlobalTrekker.sg" site_id="708">Global Trekker [HD]</channel>
     <channel lang="zh" xmltv_id="GuangdongSatelliteTV.cn" site_id="305">大灣區衛視</channel>
     <channel lang="zh" xmltv_id="HITS.sg" site_id="310">HITS [HD]</channel>
     <channel lang="zh" xmltv_id="HITSMovies.sg" site_id="213">HITS MOVIES [HD]</channel>
     <channel lang="zh" xmltv_id="HKIBC.hk" site_id="005">香港國際財經台</channel>
-    <channel lang="zh" xmltv_id="HLN.us" site_id="125">CNN HLN News</channel>
     <channel lang="zh" xmltv_id="HOYTV.hk" site_id="003">HOY TV</channel>
     <channel lang="zh" xmltv_id="HubeiSatelliteTV.cn" site_id="337">湖北衛視</channel>
     <channel lang="zh" xmltv_id="HunanTVInternational.cn" site_id="336">湖南廣播電視台國際頻道</channel>
@@ -164,36 +146,23 @@
     <channel lang="zh" xmltv_id="iCABLESportsPlus1.hk" site_id="662">Sports Plus 1</channel>
     <channel lang="zh" xmltv_id="iCABLESportsPlus2.hk" site_id="664">Sports Plus 2</channel>
     <channel lang="zh" xmltv_id="iCABLESportsPlus3.hk" site_id="665">Sports Plus 3</channel>
-    <channel lang="zh" xmltv_id="LFCTV.uk" site_id="654">LFCTV</channel>
-    <channel lang="zh" xmltv_id="MTVLive.uk" site_id="333">MTV Live</channel>
     <channel lang="zh" xmltv_id="MyCinemaEurope.ch" site_id="252">光影歐洲</channel>
     <channel lang="zh" xmltv_id="NationalGeographicHongKong.hk" site_id="752">國家地理頻道</channel>
     <channel lang="zh" xmltv_id="NationalGeographicWildHongKong.hk" site_id="751">國家地理野生頻道</channel>
-    <channel lang="zh" xmltv_id="NHKWorldJapan.jp" site_id="126">NHK World-Japan</channel>
-    <channel lang="zh" xmltv_id="NHKWorldPremium.jp" site_id="322">NHK World Pr</channel>
     <channel lang="zh" xmltv_id="NickelodeonAsia.sg" site_id="514">Nickelodeon</channel>
-    <channel lang="zh" xmltv_id="NickJrAsia.sg" site_id="515">Nick Jr.</channel>
-    <channel lang="zh" xmltv_id="OutdoorChannelInternational.us" site_id="761">戶外頻道</channel>
     <channel lang="zh" xmltv_id="ParamountNetworkAsia.us" site_id="312">Paramount Network Asia [HD]</channel>
-    <channel lang="zh" xmltv_id="PetClubTV.hk" site_id="730">Pet Club TV</channel>
     <channel lang="zh" xmltv_id="PhoenixChineseChannel.hk" site_id="376">鳯凰衛視中文台</channel>
     <channel lang="zh" xmltv_id="PhoenixHongKongChannel.hk" site_id="304">鳳凰衛視香港台</channel>
     <channel lang="zh" xmltv_id="PhoenixInfoNewsChannel.hk" site_id="154">鳳凰衛視資訊台</channel>
     <channel lang="zh" xmltv_id="ROCKEntertainment.sg" site_id="378">ROCK綜藝娛樂</channel>
     <channel lang="zh" xmltv_id="ROCKExtreme.sg" site_id="318">ROCK超極娛樂 [HD]</channel>
-    <channel lang="zh" xmltv_id="RT.ru" site_id="131">Russia Today</channel>
     <channel lang="zh" xmltv_id="ShenzhenSatelliteTVInternational.cn" site_id="335">深圳電視台</channel>
-    <channel lang="zh" xmltv_id="SkyNewsInternational.uk" site_id="121">Sky News</channel>
     <channel lang="zh" xmltv_id="StarChineseChannel.hk" site_id="332">衛視中文台</channel>
     <channel lang="zh" xmltv_id="StarChineseMovies.hk" site_id="204">衛視電影台 [HD]</channel>
-    <channel lang="zh" xmltv_id="TechStorm.sg" site_id="610">TechStorm [HD]</channel>
     <channel lang="zh" xmltv_id="Thrill.hk" site_id="219">驚慄電影台</channel>
     <channel lang="zh" xmltv_id="TLCSoutheastAsia.sg" site_id="755">旅遊生活頻道</channel>
     <channel lang="zh" xmltv_id="TravelChannelSoutheastAsia.sg" site_id="718">旅遊頻道 [HD]</channel>
     <channel lang="zh" xmltv_id="tvNAsia.hk" site_id="377">tvN</channel>
-    <channel lang="zh" xmltv_id="WION.in" site_id="852">WION</channel>
     <channel lang="zh" xmltv_id="ZeeCinemaAsia.in" site_id="853">Zee Cinema</channel>
-    <channel lang="zh" xmltv_id="ZeeTVAsiaPacific.sg" site_id="851">Zee TV</channel>
-    <channel lang="zh" xmltv_id="Zing.in" site_id="854">Zing</channel>
   </channels>
 </site>

--- a/sites/epg.i-cable.com/epg.i-cable.com.config.js
+++ b/sites/epg.i-cable.com/epg.i-cable.com.config.js
@@ -61,7 +61,7 @@ module.exports = {
     })
 
     return channels.map(c => {
-      let name = lang === 'en' ? c.channel_name_en : c.channel_name
+      let name = lang === 'zh' ? c.channel_name : c.channel_name_en
       name = c.remark_id == 3 ? `${name} [HD]` : name
 
       return {

--- a/sites/mytvsuper.com/mytvsuper.com.channels.xml
+++ b/sites/mytvsuper.com/mytvsuper.com.channels.xml
@@ -61,27 +61,20 @@
     <channel lang="zh" xmltv_id="AlJazeeraEnglish.qa" site_id="CJAZ">半島電視台英語頻道</channel>
     <channel lang="zh" xmltv_id="AnimalPlanetSoutheastAsia.sg" site_id="ANP">動物星球頻道</channel>
     <channel lang="zh" xmltv_id="AnimaxHongKong.hk" site_id="CANI">Animax</channel>
-    <channel lang="zh" xmltv_id="ArirangTV.kr" site_id="CARI">Arirang TV</channel>
     <channel lang="zh" xmltv_id="AsianDrama.hk" site_id="CTVS">亞洲劇台</channel>
     <channel lang="zh" xmltv_id="AsianVariety.hk" site_id="CWIN">亞洲綜藝台</channel>
     <channel lang="zh" xmltv_id="AXNHongKong.hk" site_id="CAXN">AXN</channel>
     <channel lang="zh" xmltv_id="BBCEarthAsia.uk" site_id="BBE">BBC Earth</channel>
     <channel lang="zh" xmltv_id="BBCLifestyleAsia.uk" site_id="BBL">BBC Lifestyle</channel>
-    <channel lang="zh" xmltv_id="BBCWorldNewsAsiaPacific.uk" site_id="BBW">BBC World News</channel>
-    <channel lang="zh" xmltv_id="CBeebiesAsia.uk" site_id="BBB">CBeebies</channel>
     <channel lang="zh" xmltv_id="CCM.hk" site_id="CCCM">天映經典頻道</channel>
     <channel lang="zh" xmltv_id="ChinaMovieChannel.cn" site_id="CMC">中國電影頻道</channel>
     <channel lang="zh" xmltv_id="ChineseDrama.hk" site_id="CDR3">華語劇台</channel>
     <channel lang="zh" xmltv_id="ChineseOperaChannel.hk" site_id="CCOC">戲曲台</channel>
     <channel lang="zh" xmltv_id="ClassicMovies.hk" site_id="CCLM">粵語片台</channel>
-    <channel lang="zh" xmltv_id="CNAInternational.sg" site_id="CCNA">亞洲新聞台</channel>
     <channel lang="zh" xmltv_id="CreationTV.hk" site_id="CRE">創世電視</channel>
     <channel lang="zh" xmltv_id="DiscoveryChannelSoutheastAsia.sg" site_id="DSC">Discovery頻道</channel>
     <channel lang="zh" xmltv_id="DiscoveryScienceSoutheastAsia.sg" site_id="SCI">Discovery科學頻道</channel>
-    <channel lang="zh" xmltv_id="DWEnglish.de" site_id="CDW1">DW</channel>
     <channel lang="zh" xmltv_id="EntertainmentNews.hk" site_id="CTVE">娛樂新聞台</channel>
-    <channel lang="zh" xmltv_id="EurosportAsia.fr" site_id="EUS">歐洲體育台</channel>
-    <channel lang="zh" xmltv_id="FashionOne.uk" site_id="CFF1">FASHION ONE</channel>
     <channel lang="zh" xmltv_id="France24English.fr" site_id="CF24">France 24</channel>
     <channel lang="zh" xmltv_id="GEM.sg" site_id="GEM">GEM</channel>
     <channel lang="zh" xmltv_id="GlobalTrekker.sg" site_id="SMS">Global Trekker</channel>
@@ -94,16 +87,13 @@
     <channel lang="zh" xmltv_id="LoveNature4K.ca" site_id="LN4">Love Nature 4K</channel>
     <channel lang="zh" xmltv_id="MainlandNewsChannel.hk" site_id="CMN1">神州新聞台</channel>
     <channel lang="zh" xmltv_id="MeiAhMovieChannel.hk" site_id="CMAM">美亞電影台</channel>
-    <channel lang="zh" xmltv_id="MezzoLiveHD.fr" site_id="CMEZ">Mezzo Live HD</channel>
     <channel lang="zh" xmltv_id="myTVSUPER18.hk" site_id="C18">myTV SUPER 18台</channel>
     <channel lang="zh" xmltv_id="myTVSUPERLiveSoccer1.hk" site_id="EVT1">myTV SUPER直播足球1台</channel>
     <channel lang="zh" xmltv_id="myTVSUPERLiveSoccer2.hk" site_id="EVT2">myTV SUPER直播足球2台</channel>
     <channel lang="zh" xmltv_id="myTVSUPERLiveSoccer3.hk" site_id="EVT3">myTV SUPER直播足球3台</channel>
     <channel lang="zh" xmltv_id="myTVSUPERLiveSoccer4.hk" site_id="EVT4">myTV SUPER直播足球4台</channel>
     <channel lang="zh" xmltv_id="myTVSUPERLiveSoccer5.hk" site_id="EVT5">myTV SUPER直播足球5台</channel>
-    <channel lang="zh" xmltv_id="NHKWorldJapan.jp" site_id="CNHK">NHK World-Japan</channel>
     <channel lang="zh" xmltv_id="NickelodeonAsia.sg" site_id="CNIKO">Nickelodeon</channel>
-    <channel lang="zh" xmltv_id="NickJrAsia.sg" site_id="CNIJR">Nick Jr</channel>
     <channel lang="zh" xmltv_id="ParamountNetworkAsia.us" site_id="PAR">Paramount Network</channel>
     <channel lang="zh" xmltv_id="Pearl.hk" site_id="P">明珠台</channel>
     <channel lang="zh" xmltv_id="ROCKEntertainment.sg" site_id="CRTE">ROCK綜藝娛樂</channel>

--- a/sites/nowplayer.now.com/nowplayer.now.com.channels.xml
+++ b/sites/nowplayer.now.com/nowplayer.now.com.channels.xml
@@ -35,7 +35,7 @@
     <channel lang="en" xmltv_id="DiscoveryScienceSoutheastAsia.sg" site_id="211">Discovery Science</channel>
     <channel lang="en" xmltv_id="DMAXSoutheastAsia.sg" site_id="212">DMAX Southeast Asia</channel>
     <channel lang="en" xmltv_id="DreamWorksChannelAsia.us" site_id="440">DreamWorks TV</channel>
-    <channel lang="en" xmltv_id="DWDeutsch.de" site_id="765">DW Deutsch</channel>
+    <channel lang="de" xmltv_id="DWDeutsch.de" site_id="765">DW Deutsch</channel>
     <channel lang="en" xmltv_id="DWEnglish.de" site_id="324">DW English</channel>
     <channel lang="en" xmltv_id="EBCNewsAsia.tw" site_id="371">EBC News Asia</channel>
     <channel lang="en" xmltv_id="ETTVAsiaNews.tw" site_id="162">ETTV Asia News</channel>
@@ -158,17 +158,14 @@
     <channel lang="zh" xmltv_id="DaVinciAsia.de" site_id="460">Da Vinci Asia</channel>
     <channel lang="zh" xmltv_id="DiscoveryAsia.sg" site_id="208">Discovery Asia</channel>
     <channel lang="zh" xmltv_id="DiscoveryChannelSoutheastAsia.sg" site_id="209">Discovery Channel</channel>
-    <channel lang="zh" xmltv_id="DiscoveryScienceSoutheastAsia.sg" site_id="211">Discovery Science</channel>    
+    <channel lang="zh" xmltv_id="DiscoveryScienceSoutheastAsia.sg" site_id="211">Discovery Science</channel>
     <channel lang="zh" xmltv_id="DMAXSoutheastAsia.sg" site_id="212">DMAX Southeast Asia</channel>
     <channel lang="zh" xmltv_id="DreamWorksChannelAsia.us" site_id="440">DreamWorks TV Asia</channel>
-    <channel lang="zh" xmltv_id="DWDeutsch.de" site_id="765">DW Deutsch</channel>
     <channel lang="zh" xmltv_id="EBCNewsAsia.tw" site_id="371">EBC News Asia</channel>
     <channel lang="zh" xmltv_id="ETTVAsiaNews.tw" site_id="162">ETTV Asia News</channel>
     <channel lang="zh" xmltv_id="FightSports.us" site_id="642">Fight Sports</channel>
     <channel lang="zh" xmltv_id="FoodNetworkAsia.sg" site_id="526">Food Network Asia</channel>
     <channel lang="zh" xmltv_id="France24French.fr" site_id="715">France 24 Français</channel>
-    <channel lang="zh" xmltv_id="GMALifeTV.ph" site_id="721">GMA Life TV</channel>
-    <channel lang="zh" xmltv_id="GMANewsTVInternational.ph" site_id="722">GMA News TV International</channel>
     <channel lang="zh" xmltv_id="GMAPinoyTVAsiaPacific.ph" site_id="720">GMA Pinoy TV Asia-Pacific</channel>
     <channel lang="zh" xmltv_id="HBOAsia.sg" site_id="115">HBO Asia</channel>
     <channel lang="zh" xmltv_id="HBOFamilyAsia.sg" site_id="112">HBO Family Asia</channel>
@@ -224,7 +221,6 @@
     <channel lang="zh" xmltv_id="RugbyPassTV.uk" site_id="679">RugbyPass TV</channel>
     <channel lang="zh" xmltv_id="SanshaTV.cn" site_id="553">Sansha TV</channel>
     <channel lang="zh" xmltv_id="ShenzhenSatelliteTV.cn" site_id="540">Shenzhen Satellite TV</channel>
-    <channel lang="zh" xmltv_id="SkyNews.uk" site_id="323">Sky News UK</channel>
     <channel lang="zh" xmltv_id="SonyEntertainmentTelevision.in" site_id="771">SET India</channel>
     <channel lang="zh" xmltv_id="SonySABAsia.in" site_id="774">Sony SAB TV Asia</channel>
     <channel lang="zh" xmltv_id="StarBharat.in" site_id="797">Star Bharat India</channel>
@@ -246,7 +242,6 @@
     <channel lang="zh" xmltv_id="WarnerTVAsia.us" site_id="510">Warner TV Southeast Asia</channel>
     <channel lang="zh" xmltv_id="YicaiTV.cn" site_id="338">Yicai TV</channel>
     <channel lang="zh" xmltv_id="ZeeCinemaAsia.in" site_id="781">Zee Cinema Asia</channel>
-    <channel lang="zh" xmltv_id="ZeeNews.in" site_id="785">Zee News</channel>
     <channel lang="zh" xmltv_id="ZeeTVAsiaPacific.sg" site_id="782">Zee TV Asia Pacific</channel>
     <channel lang="zh" xmltv_id="ZhejiangSatelliteTV.cn" site_id="555">Zhejiang Satellite TV</channel>
   </channels>

--- a/sites/tv.blue.ch/tv.blue.ch.channels.xml
+++ b/sites/tv.blue.ch/tv.blue.ch.channels.xml
@@ -599,7 +599,7 @@
     <channel lang="tr" xmltv_id="TRTSpor.tr" site_id="1479">TRT Spor</channel>
     <channel lang="tr" xmltv_id="TRTTurk.tr" site_id="620">TRT Türk</channel>
     <channel lang="tr" xmltv_id="TV8International.tr" site_id="638">TV 8 International</channel>
-    <channel lang="zh" xmltv_id="CCTV4Europe.cn" site_id="88">CCTV 4 Europe</channel>
-    <channel lang="zh" xmltv_id="PhoenixInfoNewsChannel.hk" site_id="306">Phoenix InfoNews Channel</channel>
+    <channel lang="en" xmltv_id="CCTV4Europe.cn" site_id="88">CCTV 4 Europe</channel>
+    <channel lang="en" xmltv_id="PhoenixInfoNewsChannel.hk" site_id="306">Phoenix InfoNews Channel</channel>
   </channels>
 </site>


### PR DESCRIPTION
Removed Chinese channels where data was a duplicate of the English guide

Some 'English' guides were other languages.