### PR TITLE
Update superguidatv.it.channels.xml

### DIFF
--- a/sites/superguidatv.it/superguidatv.it.channels.xml
+++ b/sites/superguidatv.it/superguidatv.it.channels.xml
@@ -163,6 +163,7 @@
     <channel lang="it" xmltv_id="VH1Italia.it" site_id="vh1/317">VH1</channel>
     <channel lang="it" xmltv_id="VirginRadioTV.it" site_id="virgin-radio/461">Virgin Radio</channel>
     <channel lang="it" xmltv_id="WarnerTVItaly.it" site_id="warner-tv/1344181813">Warner TV</channel>
+    <channel lang="it" xmltv_id="SanMarinoRTV.sm" site_id="smtv-san-marino/sky-news/116">San Marino RTV</channel>
     <!-- <channel lang="it" xmltv_id="" site_id="dazn/dazn/459">DAZN</channel> -->
     <!-- <channel lang="it" xmltv_id="" site_id="france-24/252">France 24</channel> -->
     <!-- <channel lang="it" xmltv_id="" site_id="sky-news/sky-news/118">Sky News</channel> -->
@@ -178,6 +179,5 @@
     <!-- <channel lang="it" xmltv_id="" site_id="sky-sport-259/sky-sport/65">Sky Sport 259</channel> -->
     <!-- <channel lang="it" xmltv_id="" site_id="sky-sport-260/sky-sport/67">Sky Sport 260</channel> -->
     <!-- <channel lang="it" xmltv_id="" site_id="sky-sport-261/sky-sport/62">Sky Sport 261</channel> -->
-    <!-- <channel lang="it" xmltv_id="" site_id="smtv-san-marino/sky-news/116">SMtv San Marino</channel> -->
   </channels>
 </site>


### PR DESCRIPTION
CHANGELOG: 
- Enabled _San Marino RTV_ EPG. 

_SMtv San Marino_ is _San Marino RTV_. You can compare _[Superguidatv](https://www.superguidatv.it/programmazione-canale/oggi/guida-programmi-tv-smtv-san-marino/sky-news/116/)_ with the original _[San Marino RTV tv guide](https://www.sanmarinortv.sm/programmi/palinsesto)_.
 `https://www.superguidatv.it/programmazione-canale/oggi/guida-programmi-tv-smtv-san-marino/sky-news/116/` `https://www.sanmarinortv.sm/programmi/palinsesto`

Thank you! :3