### PR TITLE
Disable guide.dstv.com

### DIFF
--- a/sites/guide.dstv.com/guide.dstv.com.config.js
+++ b/sites/guide.dstv.com/guide.dstv.com.config.js
@@ -9,6 +9,7 @@ dayjs.extend(customParseFormat)
 
 module.exports = {
   site: 'guide.dstv.com',
+  skip: true, // NOTE: website is down (HTTP Server Error 503)
   days: 2,
   request: {
     cache: {


### PR DESCRIPTION
Website has been down for the last 10 days (https://github.com/iptv-org/epg/actions/workflows/guide.dstv.com.yml).

<img width="278" alt="image" src="https://user-images.githubusercontent.com/7253922/213887311-9f3ca6b0-eaf6-4985-bd98-f57e8ffd2a3d.png">

https://guide.dstv.com/