### PR TITLE
Disable seezntv.com

### DIFF
--- a/sites/seezntv.com/seezntv.com.config.js
+++ b/sites/seezntv.com/seezntv.com.config.js
@@ -10,6 +10,7 @@ dayjs.extend(customParseFormat)
 
 module.exports = {
   site: 'seezntv.com',
+  skip: true, // NOTE: the site was closed on December 31, 2022
   days: 2,
   url: function ({ channel }) {
     return `https://api.seezntv.com/svc/menu/app6/api/epg_proglist?ch_no=${channel.site_id}&search_day=1`


### PR DESCRIPTION
The site was closed on December 31, 2022.

![image translated](https://user-images.githubusercontent.com/7253922/213887804-2a6d2498-8022-44de-a7f0-0e4b90483e98.jpg)

https://www.seezntv.com/