### PR TITLE
Added More Channels to TVPassport

### DIFF
--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -8,6 +8,7 @@
     <channel lang="en" xmltv_id="ABCNewsLive.us" site_id="abc-news-live/36224">ABC News Live</channel>
     <channel lang="en" xmltv_id="ABCSpark.ca" site_id="abc-spark/10281">ABC Spark</channel>
     <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
+    <channel lang="en" xmltv_id="ActionMaxEast.us" site_id="actionmax-eastern/1377">Actionmax Eastern</channel>
     <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="actionmax-pacific-hd/8473">Actionmax Pacific HD</channel>
     <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
     <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
@@ -59,6 +60,8 @@
     <channel lang="en" xmltv_id="CBUTDT.ca" site_id="cbc-cbut-vancouver-bc/180">CBC (CBUT) Vancouver, BC</channel>
     <channel lang="en" xmltv_id="CBWTDT.ca" site_id="cbc-cbwt-winnipeg-mb/110">CBC (CBWT) Winnipeg, MB</channel>
     <channel lang="en" xmltv_id="CBXTDT.ca" site_id="cbc-cbxt-edmonton-ab/146">CBC (CBXT) Edmonton, AB</channel>
+    <channel lang="en" xmltv_id="CinemaxEast.us" site_id="cinemax-eastern-feed/632">Cinemax Eastern</channel>
+    <channel lang="en" xmltv_id="CinemaxWest.us" site_id="cinemax-pacific-hd/3568">Cinemax Pacific</channel>
     <channel lang="en" xmltv_id="CMTEast.us" site_id="cmt-us-eastern-feed-hd/6344">CMT East</channel>
     <channel lang="en" xmltv_id="CNBC.us" site_id="cnbc-usa/201">CNBC</channel>
     <channel lang="en" xmltv_id="CNN.us" site_id="cnn/70">CNN</channel>
@@ -68,7 +71,12 @@
     <channel lang="en" xmltv_id="Crave3.ca" site_id="crave3-east/85">Crave 3</channel>
     <channel lang="en" xmltv_id="Crave4.ca" site_id="crave4/320">Crave 4</channel>
     <channel lang="en" xmltv_id="CSPAN2.us" site_id="cspan-2/1050">C-SPAN 2</channel>
+    <channel lang="en" xmltv_id="DiscoveryChannelEast.us" site_id="discovery-channel-us-eastern-feed/649">Discovery Channel (US) Eastern Feed</channel>
     <channel lang="en" xmltv_id="DiscoveryChannelWest.us" site_id="discovery-channel-us-pacific-feed/1206">Discovery Channel (US) Pacific Feed</channel>
+    <channel lang="en" xmltv_id="DiscoveryFamily.us" site_id="discovery-family-channel-hd/8518">Discovery Family (US)</channel>
+    <channel lang="en" xmltv_id="DisneyChannelEast.us" site_id="disney-eastern-feed/595">Disney Channel USA Eastern Feed</channel>
+    <channel lang="en" xmltv_id="DisneyJuniorEast.us" site_id="disney-junior-usa-east/6867">Disney Junior USA Eastern Feed</channel>
+    <channel lang="en" xmltv_id="DisneyXDEast.us" site_id="disney-xd-usa-eastern-feed/1053">Disney XD USA Eastern Feed</channel>
     <channel lang="en" xmltv_id="DisneyXDWest.us" site_id="disney-xd-usa-pacific-feed/1208">Disney XD USA Pacific Feed</channel>
     <channel lang="en" xmltv_id="ESPN.us" site_id="espn/594">ESPN</channel>
     <channel lang="en" xmltv_id="ESPN2.us" site_id="espn2/650">ESPN 2</channel>
@@ -80,8 +88,14 @@
     <channel lang="en" xmltv_id="FoxNewsChannel.us" site_id="fox-news/1083">FOX News</channel>
     <channel lang="en" xmltv_id="FreeformEast.us" site_id="freeform-east-feed/1011">Freeform</channel>
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
+    <channel lang="en" xmltv_id="FuseEast.us" site_id="fuse-tv-hd-eastern/6221">Fuse East</channel>
+    <channel lang="en" xmltv_id="FXEast.us" site_id="fx-networks-east-coast-hd/6111">FX East</channel>
     <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
+    <channel lang="en" xmltv_id="FXMovieChannel.us" site_id="fx-movie-channel-hd/8463">FX Movie Channel</channel>
+    <channel lang="en" xmltv_id="FXXEast.us" site_id="fxx-usa-hd-eastern/7506">FXX East</channel>
     <channel lang="en" xmltv_id="FXXWest.us" site_id="fxx-usa-pacific/19080">FXX West</channel>
+    <channel lang="en" xmltv_id="FYIEast.us" site_id="fyi-usa-hd-eastern/6211">FYI East</channel>
+    <channel lang="en" xmltv_id="GolTV.us" site_id="gol-tv-usa-hd/12608">GolTV US</channel>
     <channel lang="en" xmltv_id="GreatAmericanLiving.us" site_id="gac-living/16158">Great American Living</channel>
     <channel lang="en" xmltv_id="Grit.us" site_id="grit-network/14377">Grit</channel>
     <channel lang="en" xmltv_id="HallmarkChannelEast.us" site_id="hallmark-channel-hd-eastern/6213">Hallmark Channel East</channel>
@@ -186,13 +200,17 @@
     <channel lang="en" xmltv_id="KYAZDT2.us" site_id="metv-plus-kyazdt2-houston-tx/15499">MeTV Plus (KYAZ-DT2) Houston TX</channel>
     <channel lang="en" xmltv_id="LogoEast.us" site_id="logo-east/2091">Logo East</channel>
     <channel lang="en" xmltv_id="LogoWest.us" site_id="logo-pacific/13460">Logo West</channel>
+    <channel lang="en" xmltv_id="MagnoliaNetwork.us" site_id="magnolia-hd-east/8114">Magnolia Network</channel>
+    <channel lang="en" xmltv_id="MagnoliaNetworEast.us" site_id="magnolia-hd-east/8114">Magnolia East</channel>
     <channel lang="en" xmltv_id="MeTV.us" site_id="metv-network/16325">MeTV Network</channel>
     <channel lang="en" xmltv_id="MGMPlusDriveIn.us" site_id="epix-drivein/11487">MGM+ Drive-In</channel>
     <channel lang="en" xmltv_id="MGMPlusEast.us" site_id="epix-hd-east/7610">MGM+ East</channel>
     <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusMarquee.us" site_id="epix-hits/11486">MGM+ Marquee</channel>
     <channel lang="en" xmltv_id="MGMPlusWest.us" site_id="epix-pacific/13443">MGM+ Pacific</channel>
+    <channel lang="en" xmltv_id="MoreMaxEast.us" site_id="moremax-eastern-hd/7097">MoreMax Eastern</channel>
     <channel lang="en" xmltv_id="MoreMaxWest.us" site_id="moremax-pacific-hd/8472">Moremax Pacific HD</channel>
+    <channel lang="en" xmltv_id="MovieMaxEast.us" site_id="moviemax-hd/7101">MovieMax Eastern</channel>
     <channel lang="en" xmltv_id="MovieMaxWest.us" site_id="moviemax-pacific/2625">MovieMax West</channel>
     <channel lang="en" xmltv_id="MoviePlexEast.us" site_id="movieplex-eastern/1066">MoviePlex East</channel>
     <channel lang="en" xmltv_id="MoviePlexWest.us" site_id="movieplex-pacific/1220">MoviePlex West</channel>
@@ -245,6 +263,7 @@
     <channel lang="en" xmltv_id="TheMovieChannelEast.us" site_id="tmc-hd-eastern/4352">The Movie Channel East</channel>
     <channel lang="en" xmltv_id="TheMovieChannelXtraEast.us" site_id="tmc-xtra-hd-eastern/7113">The Movie Channel Xtra East</channel>
     <channel lang="en" xmltv_id="TheWeatherChannel.us" site_id="the-weather-channel-hd/5599">The Weather Channel</channel>
+    <channel lang="en" xmltv_id="ThrillerMaxEast.us" site_id="thrillermax-east/1652">Thrillermax Eastern</channel>
     <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
     <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
     <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -5,12 +5,12 @@
     <channel lang="en" xmltv_id="5StarMaxEast.us" site_id="5-star-max-eastern/636">5 StarMax East</channel>
     <channel lang="en" xmltv_id="5StarMaxWest.us" site_id="5-star-max-pacific/2627">5StarMax West</channel>
     <channel lang="en" xmltv_id="ABCEast.us" site_id="abc-eastern/1224">ABC Eastern</channel>
-    <channel lang="en" xmltv_id="ABCNewsLive.us" site_id="abc-news-live/36224">ABC News Live</channel>
-    <channel lang="en" xmltv_id="ABCSpark.ca" site_id="abc-spark/10281">ABC Spark</channel>
     <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
-    <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="actionmax-pacific-hd/8473">Actionmax Pacific HD</channel>
     <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
     <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
+    <channel lang="en" xmltv_id="ABCNewsLive.us" site_id="abc-news-live/36224">ABC News Live</channel>
+    <channel lang="en" xmltv_id="ABCSpark.ca" site_id="abc-spark/10281">ABC Spark</channel>
+    <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="actionmax-pacific-hd/8473">Actionmax Pacific HD</channel>
     <channel lang="en" xmltv_id="AMCPlus.us" site_id="amc/35317">AMC+</channel>
     <channel lang="en" xmltv_id="AMCWest.us" site_id="amc-pacific-feed/1262">AMC West</channel>
     <channel lang="en" xmltv_id="AnimalPlanetWest.us" site_id="animal-planet-us-hd-west/11524">Animal Planet West</channel>
@@ -28,13 +28,13 @@
     <channel lang="en" xmltv_id="BallySportsNewOrleans.us" site_id="bally-sports-new-orleans/12558">Bally Sports New Orleans</channel>
     <channel lang="en" xmltv_id="BallySportsNorth.us" site_id="bally-sports-north/1234">Bally Sports North</channel>
     <channel lang="en" xmltv_id="BallySportsOhio.us" site_id="bally-sports-ohio/1089">Bally Sports Ohio</channel>
-    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
     <channel lang="en" xmltv_id="BallySportsSanDiego.us" site_id="bally-sports-san-diego/10272">Bally Sports San Diego</channel>
     <channel lang="en" xmltv_id="BallySportsSoCal.us" site_id="bally-sports-socal/2592">Bally Sports SoCal</channel>
     <channel lang="en" xmltv_id="BallySportsSouth.us" site_id="bally-sports-south-hd/4520">Bally Sports South</channel>
     <channel lang="en" xmltv_id="BallySportsSoutheast.us" site_id="bally-sports-southeast/1352">Bally Sports Southeast</channel>
-    <channel lang="en" xmltv_id="BallySportsSouthSouthCarolinas.us" site_id="bally-sports-south-carolinas/4531">Bally Sports South South Carolinas</channel>
     <channel lang="en" xmltv_id="BallySportsSouthwest.us" site_id="bally-sports-southwest/1106">Bally Sports Southwest</channel>
+    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
+    <channel lang="en" xmltv_id="BallySportsSouthSouthCarolinas.us" site_id="bally-sports-south-carolinas/4531">Bally Sports South South Carolinas</channel>
     <channel lang="en" xmltv_id="BallySportsWisconsin.us" site_id="bally-sports-wisconsin/6760">Bally Sports Wisconsin</channel>
     <channel lang="en" xmltv_id="BBCAmericaEast.us" site_id="bbc-america-east/615">BBC America East</channel>
     <channel lang="en" xmltv_id="BBCWorldNewsNorthAmerica.uk" site_id="bbc-world-north-america/527">BBC World News North America</channel>
@@ -59,10 +59,10 @@
     <channel lang="en" xmltv_id="CBUTDT.ca" site_id="cbc-cbut-vancouver-bc/180">CBC (CBUT) Vancouver, BC</channel>
     <channel lang="en" xmltv_id="CBWTDT.ca" site_id="cbc-cbwt-winnipeg-mb/110">CBC (CBWT) Winnipeg, MB</channel>
     <channel lang="en" xmltv_id="CBXTDT.ca" site_id="cbc-cbxt-edmonton-ab/146">CBC (CBXT) Edmonton, AB</channel>
+    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="CMTEast.us" site_id="cmt-us-eastern-feed-hd/6344">CMT East</channel>
     <channel lang="en" xmltv_id="CNBC.us" site_id="cnbc-usa/201">CNBC</channel>
     <channel lang="en" xmltv_id="CNN.us" site_id="cnn/70">CNN</channel>
-    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="Crave1.ca" site_id="crave1-east/72">Crave 1</channel>
     <channel lang="en" xmltv_id="Crave2.ca" site_id="crave2-east/86">Crave 2</channel>
     <channel lang="en" xmltv_id="Crave3.ca" site_id="crave3-east/85">Crave 3</channel>
@@ -74,15 +74,15 @@
     <channel lang="en" xmltv_id="ESPN2.us" site_id="espn2/650">ESPN 2</channel>
     <channel lang="en" xmltv_id="EWest.us" site_id="e-entertainment-usa-pacific-feed/1213">E! West</channel>
     <channel lang="en" xmltv_id="FlixWest.us" site_id="flix-pacific/3387">Flix West</channel>
-    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxBusiness.us" site_id="fox-business/4656">Fox Business</channel>
     <channel lang="en" xmltv_id="FoxEast.us" site_id="fox-eastern/1229">FOX Eastern</channel>
+    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxNewsChannel.us" site_id="fox-news/1083">FOX News</channel>
     <channel lang="en" xmltv_id="FreeformEast.us" site_id="freeform-east-feed/1011">Freeform</channel>
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
     <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
     <channel lang="en" xmltv_id="FXXWest.us" site_id="fxx-usa-pacific/19080">FXX West</channel>
-    <channel lang="en" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
+    <channel lang="es" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
     <channel lang="en" xmltv_id="GreatAmericanLiving.us" site_id="gac-living/16158">Great American Living</channel>
     <channel lang="en" xmltv_id="Grit.us" site_id="grit-network/14377">Grit</channel>
     <channel lang="en" xmltv_id="HallmarkChannelEast.us" site_id="hallmark-channel-hd-eastern/6213">Hallmark Channel East</channel>
@@ -126,12 +126,12 @@
     <channel lang="en" xmltv_id="KCNCDT1.us" site_id="cbs-kcnc-denver-co/1566">CBS (KCNC-TV) Denver, CO</channel>
     <channel lang="en" xmltv_id="KCOPDT1.us" site_id="mnt-kcop-los-angeles-ca/1811">KCOP (KCOP) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KCPQDT1.us" site_id="fox-kcpq-tacoma-wa/32824">FOX (KCPQ) Tacoma, WA</channel>
-    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
-    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
-    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KEYTDT1.us" site_id="abc-keyt-santa-barbara-ca/2308">ABC (KEYT) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT2.us" site_id="cbs-keytdt2-my-rtn-santa-barbara-ca/5877">CBS (KEYT-DT2) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT3.us" site_id="mnt-keyttv3-santa-barbara-ca/33700">MNT (KEYT-DT3) Santa Barbara, CA</channel>
+    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
+    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
+    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KFJXDT1.us" site_id="fox-kfjx-pittsburg-ks/2426">FOX (KFJX) Pittsburg, KS</channel>
     <channel lang="en" xmltv_id="KFNBDT1.us" site_id="fox-kfnb-casper-wy/9916">FOX (KFNB) Casper, WY</channel>
     <channel lang="en" xmltv_id="KFSNDT1.us" site_id="abc-kfsn-fresno-ca/2686">ABC (KFSN) Fresno, CA</channel>
@@ -147,8 +147,8 @@
     <channel lang="en" xmltv_id="KLCSDT3.us" site_id="create-klcs3-los-angeles-ca/11230">Create (KLCS3) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMBCDT1.us" site_id="abc-kmbc-kansas-city-mo/2453">ABC (KMBC) Kansas City, MO</channel>
     <channel lang="en" xmltv_id="KMBCDT2.us" site_id="metv-kmbctv2-kansas-city-mo/7267">MeTV (KMBC-DT2) Kansas City, MO</channel>
-    <channel lang="en" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
-    <channel lang="en" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMGHDT1.us" site_id="abc-kmgh-denver-co/1568">ABC (KMGH) Denver, CO</channel>
     <channel lang="en" xmltv_id="KNBCDT1.us" site_id="nbc-knbc-los-angeles-ca/2588">NBC (KNBC) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KNTVDT1.us" site_id="nbc-kntv-san-francisco-ca/3262">NBC (KNTV) San Francisco, CA</channel>
@@ -175,14 +175,14 @@
     <channel lang="en" xmltv_id="KTMFDT1.us" site_id="abc-ktmf-missoula-mt/4940">ABC (KTMF) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT2.us" site_id="fox-ktmf2-missoula-mt/8933">FOX (KTMF-DT2) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT3.us" site_id="swx-right-now-ktmf3-missoula-mt/35958">SWX (KTMF-DT3) Missoula, MT</channel>
-    <channel lang="en" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
+    <channel lang="es" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
     <channel lang="en" xmltv_id="KTTVDT1.us" site_id="fox-kttv-los-angeles-ca/1949">FOX (KTTV) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KTVDDT1.us" site_id="mnt-ktvd-denver-co/1565">MNT (KTVD) Denver, CO</channel>
     <channel lang="en" xmltv_id="KTVFDT1.us" site_id="nbc-ktvf-fairbanks-ak/5121">NBC (KTVF) Fairbanks, AK</channel>
     <channel lang="en" xmltv_id="KTVQDT2.us" site_id="cw-ktvq2-billings-mt/8943">CW (KTVQ-DT2) Billings, MT</channel>
     <channel lang="en" xmltv_id="KTVUDT1.us" site_id="fox-ktvu-san-francisco-ca/2145">FOX (KTVU) San Francisco, CA</channel>
     <channel lang="en" xmltv_id="KUFMDT1.us" site_id="pbs-kufm-missoula-mt/13228">PBS (KUFM-TV) Missoula, MT</channel>
-    <channel lang="en" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KWCHDT1.us" site_id="cbs-kwch-wichita-ks/1546">CBS (KWCH) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KWCHDT4.us" site_id="circle-kwchdt4-hutchinsonm-ks/34557">Circle (KWCH-DT4) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KXDFCD1.us" site_id="cbs-k13xd-fairbanks-ak/4960">CBS (KXDF-CD) Fairbanks, AK</channel>
@@ -191,17 +191,17 @@
     <channel lang="en" xmltv_id="LogoEast.us" site_id="logo-east/2091">Logo East</channel>
     <channel lang="en" xmltv_id="LogoWest.us" site_id="logo-pacific/13460">Logo West</channel>
     <channel lang="en" xmltv_id="MeTV.us" site_id="metv-network/16325">MeTV Network</channel>
+    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusDriveIn.us" site_id="epix-drivein/11487">MGM+ Drive-In</channel>
     <channel lang="en" xmltv_id="MGMPlusEast.us" site_id="epix-hd-east/7610">MGM+ East</channel>
-    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusMarquee.us" site_id="epix-hits/11486">MGM+ Marquee</channel>
     <channel lang="en" xmltv_id="MGMPlusWest.us" site_id="epix-pacific/13443">MGM+ Pacific</channel>
     <channel lang="en" xmltv_id="MoreMaxWest.us" site_id="moremax-pacific-hd/8472">Moremax Pacific HD</channel>
     <channel lang="en" xmltv_id="MovieMaxWest.us" site_id="moviemax-pacific/2625">MovieMax West</channel>
     <channel lang="en" xmltv_id="MoviePlexEast.us" site_id="movieplex-eastern/1066">MoviePlex East</channel>
     <channel lang="en" xmltv_id="MoviePlexWest.us" site_id="movieplex-pacific/1220">MoviePlex West</channel>
-    <channel lang="en" xmltv_id="MSG.us" site_id="msg-madison-square-gardens-hd/4695">MSG</channel>
     <channel lang="en" xmltv_id="MSNBC.us" site_id="msnbc-usa/655">MSNBC</channel>
+    <channel lang="en" xmltv_id="MSG.us" site_id="msg-madison-square-gardens-hd/4695">MSG</channel>
     <channel lang="en" xmltv_id="NBCEast.us" site_id="nbc-network-eastern/1227">NBC Network Eastern</channel>
     <channel lang="en" xmltv_id="NBCSportsBoston.us" site_id="nbc-sports-boston/4529">NBC Sports Boston</channel>
     <channel lang="en" xmltv_id="News12Conneticut.us" site_id="news-12-connecticut/20178">News12 Conneticut</channel>
@@ -246,12 +246,12 @@
     <channel lang="en" xmltv_id="TCMEast.us" site_id="turner-classic-movies-usa/176">Turner Classic Movies USA</channel>
     <channel lang="en" xmltv_id="TelemundoEast.us" site_id="telemundo-east-hd/33284">Telemundo East</channel>
     <channel lang="en" xmltv_id="TelemundoWest.us" site_id="telemundo-pacific-feed/2013">Telemundo West</channel>
-    <channel lang="en" xmltv_id="TheMovieChannelEast.us" site_id="tmc-hd-eastern/4352">The Movie Channel East</channel>
-    <channel lang="en" xmltv_id="TheMovieChannelXtraEast.us" site_id="tmc-xtra-hd-eastern/7113">The Movie Channel Xtra East</channel>
-    <channel lang="en" xmltv_id="TheWeatherChannel.us" site_id="the-weather-channel-hd/5599">The Weather Channel</channel>
     <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
     <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
     <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>
+    <channel lang="en" xmltv_id="TheMovieChannelEast.us" site_id="tmc-hd-eastern/4352">The Movie Channel East</channel>
+    <channel lang="en" xmltv_id="TheMovieChannelXtraEast.us" site_id="tmc-xtra-hd-eastern/7113">The Movie Channel Xtra East</channel>
+    <channel lang="en" xmltv_id="TheWeatherChannel.us" site_id="the-weather-channel-hd/5599">The Weather Channel</channel>
     <channel lang="en" xmltv_id="TNTWest.us" site_id="tnt-pacific-feed/2252">TNT West</channel>
     <channel lang="en" xmltv_id="TravelChannelEast.us" site_id="travel-us-east/662">Travel Channel East</channel>
     <channel lang="en" xmltv_id="truTVWest.us" site_id="trutv-usa-pacific-hd/18808">truTV USA Pacific HD</channel>
@@ -260,19 +260,17 @@
     <channel lang="en" xmltv_id="TSN3.ca" site_id="tsn3/13719">TSN3</channel>
     <channel lang="en" xmltv_id="TSN4.ca" site_id="tsn4/279">TSN4</channel>
     <channel lang="en" xmltv_id="TSN5.ca" site_id="tsn5/278">TSN5</channel>
-    <channel lang="en" xmltv_id="TVLandWest.us" site_id="tv-land-pacific/210">TV Land West</channel>
     <channel lang="en" xmltv_id="TVOne.us" site_id="tv-one/2287">TV One</channel>	  
+    <channel lang="en" xmltv_id="TVLandWest.us" site_id="tv-land-pacific/210">TV Land West</channel>
     <channel lang="en" xmltv_id="USANetworkWest.us" site_id="usa-network-pacific/2144">USA Network West</channel>
     <channel lang="en" xmltv_id="VH1West.us" site_id="vh1-pacific-feed/1270">VH1 West</channel>
     <channel lang="en" xmltv_id="VICETV.us" site_id="vice/624">Vice</channel>
     <channel lang="en" xmltv_id="W20CQD1.us" site_id="hope-channel-w20cqd-hempstead-ny/16436">Hope Channel (W20CQ-D) Hempstead, NY</channel>
-    <channel lang="en" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
     <channel lang="en" xmltv_id="WABCDT1.us" site_id="abc-wabc-new-york-ny/1769">ABC (WABC) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="localish-wabcdt2-new-york-ny/10497">Localish (WABC-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="this-wabctv3-new-york-ny/11049">THIS (WABC-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WADLDT1.us" site_id="wadl-tv-detroit-mi/10217">MNT (WADL) Mount Clemens, MI</channel>
-    <channel lang="en" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
     <channel lang="en" xmltv_id="WBALDT1.us" site_id="nbc-wbal-baltimore-md/3236">NBC (WBAL-TV) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT2.us" site_id="metv-wbaltv2-baltimore-md/11796">MeTV (WBAL-DT2) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT4.us" site_id="the-grio-wbaltv4-baltimore-md/36930">The Grio (WBAL-DT4) Baltimore, MD</channel>
@@ -290,10 +288,10 @@
     <channel lang="en" xmltv_id="WCBSDT1.us" site_id="cbs-wcbs-new-york-ny/1766">CBS (WCBS) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT2.us" site_id="start-tv-wcbstv2-new-york-ny/11045">Start TV (WCBS-TV2) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT3.us" site_id="dabl-wcbstv3-new-york-ny/34131">DABL (WCBS-TV3) New York, NY</channel>
+    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCIUDT1.us" site_id="cw26-wciu-chicago-il/1834">CW (WCIU) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCIUDT5.us" site_id="story-wciutv5-chicago-il/11342">Story (WCIU-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCMUDT1.us" site_id="pbs-wcmu-mt-pleasant-mi/9304">PBS (WCMU-TV) Mount Pleasant, MI</channel>
-    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCVBDT1.us" site_id="abc-wcvb-boston-ma/133">ABC (WCVB-TV) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCVBDT2.us" site_id="metv-wcvbdt2-boston/10773">MeTV (WCVB-DT2) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCWJDT1.us" site_id="cw-wcwj-jacksonville-fl/2046">CW (WCWJ) Jacksonville, FL</channel>
@@ -318,7 +316,6 @@
     <channel lang="en" xmltv_id="WFQXDT2.us" site_id="cw-wfqxtv2-traverse-citycadillac-mi/31612">CW (WFQX-DT2) Cadillac, MI</channel>
     <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV) Orlando, FL</channel>
     <channel lang="en" xmltv_id="WFTYDT1.us" site_id="unimas-wfty-smithtown-ny/1961">UniMás (WFTY) Smithtown, NY</channel>
-    <channel lang="en" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WFTYDT4.us" site_id="ion-mystery-wftydt4-smithtown-ny/19460">ION Mystery (WFTY-DT4) Smithtown, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT2.us" site_id="true-crime-network-wfutdt2-newark-nj/16472">True Crime Network (WFUT-DT2) Newark, NJ</channel>
     <channel lang="en" xmltv_id="WFUTDT3.us" site_id="gettv-wfutdt3-newark-nj/16429">GetTV (WFUT-DT3) Newark, NJ</channel>
@@ -331,7 +328,6 @@
     <channel lang="en" xmltv_id="WHDHDT2.us" site_id="this-whdh2-hudson-nh/8041">THIS (WHDH) Boston, MA</channel>
     <channel lang="en" xmltv_id="WHNELD9.us" site_id="newsnet-whneld9-flint-mi/35849">NewsNet (WHNE-LD9) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WIVBDT1.us" site_id="cbs-wivb-buffalo-ny/88">CBS (WIVB) Buffalo, NY</channel>
-    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
     <channel lang="en" xmltv_id="WJAXDT1.us" site_id="cbs-wjax-jacksonville-fl/2048">CBS (WJAX) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WJLADT1.us" site_id="abc-wjla-district-of-columbia/1555">ABC (WJLA) District of Columbia</channel>
     <channel lang="en" xmltv_id="WJLPDT1.us" site_id="metv-wjlp-new-jerseynew-york/5138">MeTV (WJLP) New Jersey</channel>
@@ -352,10 +348,8 @@
     <channel lang="en" xmltv_id="WKARDT1.us" site_id="pbs-wkar-east-lansing-mi/13241">PBS (WKAR-TV) East Lansing, MI</channel>
     <channel lang="en" xmltv_id="WKBWDT1.us" site_id="abc-wkbw-buffalo-ny/89">ABC (WKBW) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD1.us" site_id="azteca-wkob-new-york-ny/5096">Azteca (WKOB) New York, NY</channel>
-    <channel lang="en" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD3.us" site_id="peace-tv-wkobld3-new-york-ny/11085">Peace TV (WKOB-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD5.us" site_id="sonlife-network-wkobld5-new-york-ny/11087">SonLife Network (WKOB-LD5) New York, NY</channel>
-    <channel lang="en" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD7.us" site_id="shop-lc-wkobdt7-new-york-ny/16454">Shop LC (WKOB-DT7) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD8.us" site_id="ontv4u-wkobdt8-new-york-ny/17491">ONTV4U (WKOB-DT8) New York, NY</channel>
     <channel lang="en" xmltv_id="WKRNDT1.us" site_id="abc-wkrn-nashville-tn/1886">ABC (WKRN) Nashville, TN</channel>
@@ -379,7 +373,6 @@
     <channel lang="en" xmltv_id="WMARDT5.us" site_id="court-tv-wmartv5-baltimore-md/34056">Court TV (WMAR-DT5) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WMBCDT2.us" site_id="quest-wmbctv2-newton-nj/16467">Quest (WMBC-TV2) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="new-tang-dynasty-tv-wmbcdt5-newton-nj/15033">New Tang Dynasty TV (WMBC-DT5) Newton, NJ</channel>
-    <channel lang="en" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBQCD1.us" site_id="biztv-wmbqcd-new-york-ny/16459">Biz-TV (WMBQ-CD) New York, NY</channel>
     <channel lang="en" xmltv_id="WMBQCD2.us" site_id="hope-channel-wmbqcd2-new-york-ny/16460">Hope Channel (WMBQ-CD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WMEUCD1.us" site_id="the-u-wmeucd-chicago-il/12512">The U (WMEU-CD) Chicago, IL</channel>
@@ -389,20 +382,16 @@
     <channel lang="en" xmltv_id="WNDTCD1.us" site_id="fnx-wndtcd-manhattan-ny/34515">FNX (WNDT-CD) Manhattan, NY</channel>
     <channel lang="en" xmltv_id="WNETDT1.us" site_id="pbs-wnet-new-york-ny/1774">PBS (WNET) New York, NY</channel>
     <channel lang="en" xmltv_id="WNETDT2.us" site_id="pbs-kids-wnetdt2-new-york-ny/2088">PBS Kids (WNET-DT2) New York, NY</channel>
-    <channel lang="en" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNJBDT1.us" site_id="nj-pbs-wnjb-new-brunswick-nj/2124">NJ PBS (WNJB) New Brunswick, NJ</channel>
     <channel lang="en" xmltv_id="WNJNDT1.us" site_id="nj-pbs-wnjn-montclair-nj/2574">NJ PBS (WNJN) Montclair, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT1.us" site_id="nj-pbs-wnjt-trenton-nj/2564">NJ PBS (WNJT) Trenton, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT2.us" site_id="nhk-world-wnjttv2-trenton-nj/32845">NHK World (WNJT-TV2) Trenton, NJ</channel>
-    <channel lang="en" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
-    <channel lang="en" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
     <channel lang="en" xmltv_id="WNMFLD1.us" site_id="infomercials-wnmf-new-york-ny/17860">Infomercials (WNMF) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMFLD2.us" site_id="jewelry-tv-wnmfld2-new-york-ny/17861">Jewelry TV (WNMF-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMUDT1.us" site_id="pbs-wnmu-marquette-mi/481">PBS (WNMU) Marquette, MI</channel>
     <channel lang="en" xmltv_id="WNWODT1.us" site_id="nbc-wnwo-toledo-oh/259">NBC (WNWO-TV) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WNXYLD1.us" site_id="cgtn-wnxyld-new-york-ny/16456">CGTN (WNXY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNXYLD2.us" site_id="cctv4-wnxyld2-new-york-ny/16457">CCTV-4 (WNXY-LD2) New York, NY</channel>
-    <channel lang="en" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT1.us" site_id="nyc-life-wnyedt1-new-york-ny/10011">NYC Life (WNYE-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT2.us" site_id="nyc-gov-wnyedt2-new-york-ny/11074">NYC Gov (WNYE-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT3.us" site_id="cuny-wnyedt3-new-york-ny/11075">CUNY (WNYE-DT3) New York, NY</channel>
@@ -416,17 +405,15 @@
     <channel lang="en" xmltv_id="WNYWDT5.us" site_id="decades-wnyw5-new-york-ny/34342">Decades (WNYW5) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD1.us" site_id="cgtn-wnyxld-new-york-ny/16441">CGTN (WNYX-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD2.us" site_id="cctv4-wnyxld2-new-york-ny/16442">CCTV-4 (WNYX-LD2) New York, NY</channel>
-    <channel lang="en" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD4.us" site_id="revn-wnyxld4-new-york-ny/16447">REV&apos;N (WNYX-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD5.us" site_id="retro-tv-wnyxld5-new-york-ny/17849">Retro TV (WNYX-LD5) New York, NY</channel>
     <channel lang="en" xmltv_id="WOIDT1.us" site_id="abc-woi-des-moines-ia/1245">ABC (WOI) Des Moines, IA</channel>
-    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="WPCWDT1.us" site_id="cw-wpcw-pittsburgh-pa/3187">CW (WPCW) Jeannette, PA</channel>
     <channel lang="en" xmltv_id="WPIXDT1.us" site_id="wpix-new-york-superstation/63">CW (WPIX) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT2.us" site_id="antenna-wpix2-new-york-ny/10745">Antenna (WPIX2) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT3.us" site_id="court-tv-wpix3-new-york-ny/9723">Court TV (WPIX3) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT4.us" site_id="rewind-tv-us-wpix4-new-york-ny/32844">Rewind TV US (WPIX4) New York, NY</channel>
-    <channel lang="en" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
+    <channel lang="es" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
     <channel lang="en" xmltv_id="WPVIDT2.us" site_id="localish-wpvidt2-philadelphia-pa/8852">Localish (WPVI-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPVIDT3.us" site_id="this-wpvitv3-philadelphia-pa/14662">THIS (WPVI-TV3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPXNDT1.us" site_id="ion-wpxn-new-york-ny/1778">ION (WPXN) New York, NY</channel>
@@ -452,7 +439,6 @@
     <channel lang="en" xmltv_id="WTATDT1.us" site_id="fox-wtat-charleston-sc/1097">FOX (WTAT) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WTBYDT1.us" site_id="tbn-wtby-new-york-ny/2575">TBN (WTBY) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT2.us" site_id="smile-wtbytv2-new-york-ny/11093">Smile (WTBY-TV2) New York, NY</channel>
-    <channel lang="en" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT4.us" site_id="positiv-wtbytv4-new-york-ny/11095">PosiTiV (WTBY-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WTLVDT1.us" site_id="nbc-wtlv-jacksonville-fl/1435">NBC (WTLV) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WTNHDT1.us" site_id="abc-wtnh-sd-new-haven-ct/17476">ABC (WTNH) SD New Haven, CT</channel>
@@ -462,7 +448,6 @@
     <channel lang="en" xmltv_id="WTVGDT2.us" site_id="cw-wtvgdt2-toledo-oh/10390">CW (WTVG-DT2) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WTVSDT5.us" site_id="mlc-wtvsdt5-detroit-mi/36121">Michigan Learning Channel (WTVS-DT5) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WTVTDT1.us" site_id="fox-wtvt-tampa-bay-fl/2552">FOX (WTVT) Tampa Bay, FL</channel>
-    <channel lang="en" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WVUEDT1.us" site_id="fox-wvue-new-orleans-la/1745">FOX (WVUE) New Orleans, LA</channel>
     <channel lang="en" xmltv_id="WWAYDT2.us" site_id="cbs-wway2-wilmington-nc/7209">CBS (WWAY2) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WWJDT4.us" site_id="fave-tv-wwjtv4-detroit-mi/35971">Fave TV (WWJ-DT4) Detroit, MI</channel>
@@ -473,16 +458,31 @@
     <channel lang="en" xmltv_id="WXINDT1.us" site_id="fox-wxin-indianapolis-in/1374">FOX (WXIN) Indianapolis, IN</channel>
     <channel lang="en" xmltv_id="WXNYLD1.us" site_id="cgtn-wxnyld-new-york-ny/11078">CGTN (WXNY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD2.us" site_id="cctv4-wxnyld2-new-york-ny/16443">CCTV-4 (WXNY-LD2) New York, NY</channel>
-    <channel lang="en" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD4.us" site_id="retro-tv-wxnyld4-new-york-ny/16446">Retro TV (WXNY-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD5.us" site_id="retro-tv-wxnyld5-new-york-ny/17346">Retro TV (WXNY-LD5) New York, NY</channel>
-    <channel lang="en" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT2.us" site_id="bounce-wxtvdt2-paterson-nj/16452">Bounce (WXTV-DT2) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT3.us" site_id="twist-wxtvdt3-paterson-nj/16450">Twist (WXTV-DT3) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT4.us" site_id="grit-tv-wxtvdt4-paterson-nj/16451">Grit TV (WXTV-DT4) Paterson, NJ</channel>
-    <channel lang="en" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WYXNLD1.us" site_id="cgtn-wyxnld-new-york-ny/29736">CGTN (WYXN-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WZMQDT2.us" site_id="cbs-wzmq2-marquette-mi/17308">CBS (WZMQ-DT2) Marquette, MI</channel>
+    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
+    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
+    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
+    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
+    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
+    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
+    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
+    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
+    <channel lang="es" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
+    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
+    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="YesNetwork.us" site_id="yes-network/1953">YES Network</channel>
     <channel lang="en" xmltv_id="YTATV.us" site_id="youtoo-america-network/5463">Youtoo America - Network</channel>
   </channels>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -5,12 +5,12 @@
     <channel lang="en" xmltv_id="5StarMaxEast.us" site_id="5-star-max-eastern/636">5 StarMax East</channel>
     <channel lang="en" xmltv_id="5StarMaxWest.us" site_id="5-star-max-pacific/2627">5StarMax West</channel>
     <channel lang="en" xmltv_id="ABCEast.us" site_id="abc-eastern/1224">ABC Eastern</channel>
-    <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
-    <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
-    <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
     <channel lang="en" xmltv_id="ABCNewsLive.us" site_id="abc-news-live/36224">ABC News Live</channel>
     <channel lang="en" xmltv_id="ABCSpark.ca" site_id="abc-spark/10281">ABC Spark</channel>
+    <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
     <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="actionmax-pacific-hd/8473">Actionmax Pacific HD</channel>
+    <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
+    <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
     <channel lang="en" xmltv_id="AMCPlus.us" site_id="amc/35317">AMC+</channel>
     <channel lang="en" xmltv_id="AMCWest.us" site_id="amc-pacific-feed/1262">AMC West</channel>
     <channel lang="en" xmltv_id="AnimalPlanetWest.us" site_id="animal-planet-us-hd-west/11524">Animal Planet West</channel>
@@ -28,13 +28,13 @@
     <channel lang="en" xmltv_id="BallySportsNewOrleans.us" site_id="bally-sports-new-orleans/12558">Bally Sports New Orleans</channel>
     <channel lang="en" xmltv_id="BallySportsNorth.us" site_id="bally-sports-north/1234">Bally Sports North</channel>
     <channel lang="en" xmltv_id="BallySportsOhio.us" site_id="bally-sports-ohio/1089">Bally Sports Ohio</channel>
+    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
     <channel lang="en" xmltv_id="BallySportsSanDiego.us" site_id="bally-sports-san-diego/10272">Bally Sports San Diego</channel>
     <channel lang="en" xmltv_id="BallySportsSoCal.us" site_id="bally-sports-socal/2592">Bally Sports SoCal</channel>
     <channel lang="en" xmltv_id="BallySportsSouth.us" site_id="bally-sports-south-hd/4520">Bally Sports South</channel>
     <channel lang="en" xmltv_id="BallySportsSoutheast.us" site_id="bally-sports-southeast/1352">Bally Sports Southeast</channel>
-    <channel lang="en" xmltv_id="BallySportsSouthwest.us" site_id="bally-sports-southwest/1106">Bally Sports Southwest</channel>
-    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
     <channel lang="en" xmltv_id="BallySportsSouthSouthCarolinas.us" site_id="bally-sports-south-carolinas/4531">Bally Sports South South Carolinas</channel>
+    <channel lang="en" xmltv_id="BallySportsSouthwest.us" site_id="bally-sports-southwest/1106">Bally Sports Southwest</channel>
     <channel lang="en" xmltv_id="BallySportsWisconsin.us" site_id="bally-sports-wisconsin/6760">Bally Sports Wisconsin</channel>
     <channel lang="en" xmltv_id="BBCAmericaEast.us" site_id="bbc-america-east/615">BBC America East</channel>
     <channel lang="en" xmltv_id="BBCWorldNewsNorthAmerica.uk" site_id="bbc-world-north-america/527">BBC World News North America</channel>
@@ -59,10 +59,10 @@
     <channel lang="en" xmltv_id="CBUTDT.ca" site_id="cbc-cbut-vancouver-bc/180">CBC (CBUT) Vancouver, BC</channel>
     <channel lang="en" xmltv_id="CBWTDT.ca" site_id="cbc-cbwt-winnipeg-mb/110">CBC (CBWT) Winnipeg, MB</channel>
     <channel lang="en" xmltv_id="CBXTDT.ca" site_id="cbc-cbxt-edmonton-ab/146">CBC (CBXT) Edmonton, AB</channel>
-    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="CMTEast.us" site_id="cmt-us-eastern-feed-hd/6344">CMT East</channel>
     <channel lang="en" xmltv_id="CNBC.us" site_id="cnbc-usa/201">CNBC</channel>
     <channel lang="en" xmltv_id="CNN.us" site_id="cnn/70">CNN</channel>
+    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="Crave1.ca" site_id="crave1-east/72">Crave 1</channel>
     <channel lang="en" xmltv_id="Crave2.ca" site_id="crave2-east/86">Crave 2</channel>
     <channel lang="en" xmltv_id="Crave3.ca" site_id="crave3-east/85">Crave 3</channel>
@@ -74,9 +74,9 @@
     <channel lang="en" xmltv_id="ESPN2.us" site_id="espn2/650">ESPN 2</channel>
     <channel lang="en" xmltv_id="EWest.us" site_id="e-entertainment-usa-pacific-feed/1213">E! West</channel>
     <channel lang="en" xmltv_id="FlixWest.us" site_id="flix-pacific/3387">Flix West</channel>
+    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxBusiness.us" site_id="fox-business/4656">Fox Business</channel>
     <channel lang="en" xmltv_id="FoxEast.us" site_id="fox-eastern/1229">FOX Eastern</channel>
-    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxNewsChannel.us" site_id="fox-news/1083">FOX News</channel>
     <channel lang="en" xmltv_id="FreeformEast.us" site_id="freeform-east-feed/1011">Freeform</channel>
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
@@ -88,7 +88,7 @@
     <channel lang="en" xmltv_id="HallmarkChannelEast.us" site_id="hallmark-channel-hd-eastern/6213">Hallmark Channel East</channel>
     <channel lang="en" xmltv_id="HallmarkChannelWest.us" site_id="hallmark-channel-hd-pacific/17058">Hallmark Channel West</channel>
     <channel lang="en" xmltv_id="HallmarkDrama.us" site_id="hallmark-drama/32480">Hallmark Drama</channel>
-    <channel lang="en" xmltv_id="HallmarkMoviesMysteriesEast.us" site_id="hallmark-movies-mysteries-eastern/4453">Hallmark Movies &amp; Mysteries East</channel>		
+    <channel lang="en" xmltv_id="HallmarkMoviesMysteriesEast.us" site_id="hallmark-movies-mysteries-eastern/4453">Hallmark Movies &amp; Mysteries East</channel>
     <channel lang="en" xmltv_id="HBOCanada1.ca" site_id="hbo1/84">HBO Canada 1</channel>
     <channel lang="en" xmltv_id="HBOCanada2.ca" site_id="hbo-2-eastern-feed-hd/6313">HBO Canada 2</channel>
     <channel lang="en" xmltv_id="HBOComedyWest.us" site_id="hbo-comedy-pacific/2593">HBO Comedy West</channel>
@@ -110,7 +110,7 @@
     <channel lang="en" xmltv_id="KATVDT2.us" site_id="comet-tv-katv2-little-rock-ar/6517">Comet (KATV-DT2) Little Rick, AR</channel>
     <channel lang="en" xmltv_id="KATVDT3.us" site_id="charge-katv3-little-rock-ar/10443">Charge (KATV-DT3) Little Rick, AR</channel>
     <channel lang="en" xmltv_id="KATVDT4.us" site_id="tbd-tv-katv4-little-rock-ar/31562">TBD (KATV-DT4) Little Rick, AR</channel>
-    <channel lang="en" xmltv_id="KAZADT1.us" site_id="metv-kaza-los-angeles-ca/3247">Me TV (KAZA) Los Angeles, CA</channel>  
+    <channel lang="en" xmltv_id="KAZADT1.us" site_id="metv-kaza-los-angeles-ca/3247">Me TV (KAZA) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KBCWDT1.us" site_id="cw-kbcw-san-francisco-ca/3562">CW (KBCW) San Francisco, CA</channel>
     <channel lang="en" xmltv_id="KBCWDT2.us" site_id="comet-tv-kbcw2-san-francisco-ca/32957">Comet (KBCW-DT2) San Francisco, CA</channel>
     <channel lang="en" xmltv_id="KBCWDT3.us" site_id="metv-kbcw3-san-francisco-ca/33786">MeTV (KCBW-DT3) San Francisco, CA</channel>
@@ -126,12 +126,12 @@
     <channel lang="en" xmltv_id="KCNCDT1.us" site_id="cbs-kcnc-denver-co/1566">CBS (KCNC-TV) Denver, CO</channel>
     <channel lang="en" xmltv_id="KCOPDT1.us" site_id="mnt-kcop-los-angeles-ca/1811">KCOP (KCOP) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KCPQDT1.us" site_id="fox-kcpq-tacoma-wa/32824">FOX (KCPQ) Tacoma, WA</channel>
+    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
+    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
+    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KEYTDT1.us" site_id="abc-keyt-santa-barbara-ca/2308">ABC (KEYT) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT2.us" site_id="cbs-keytdt2-my-rtn-santa-barbara-ca/5877">CBS (KEYT-DT2) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT3.us" site_id="mnt-keyttv3-santa-barbara-ca/33700">MNT (KEYT-DT3) Santa Barbara, CA</channel>
-    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
-    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
-    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KFJXDT1.us" site_id="fox-kfjx-pittsburg-ks/2426">FOX (KFJX) Pittsburg, KS</channel>
     <channel lang="en" xmltv_id="KFNBDT1.us" site_id="fox-kfnb-casper-wy/9916">FOX (KFNB) Casper, WY</channel>
     <channel lang="en" xmltv_id="KFSNDT1.us" site_id="abc-kfsn-fresno-ca/2686">ABC (KFSN) Fresno, CA</channel>
@@ -175,7 +175,7 @@
     <channel lang="en" xmltv_id="KTMFDT1.us" site_id="abc-ktmf-missoula-mt/4940">ABC (KTMF) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT2.us" site_id="fox-ktmf2-missoula-mt/8933">FOX (KTMF-DT2) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT3.us" site_id="swx-right-now-ktmf3-missoula-mt/35958">SWX (KTMF-DT3) Missoula, MT</channel>
-    <channel lang="es" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
+    <channel lang="en" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
     <channel lang="en" xmltv_id="KTTVDT1.us" site_id="fox-kttv-los-angeles-ca/1949">FOX (KTTV) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KTVDDT1.us" site_id="mnt-ktvd-denver-co/1565">MNT (KTVD) Denver, CO</channel>
     <channel lang="en" xmltv_id="KTVFDT1.us" site_id="nbc-ktvf-fairbanks-ak/5121">NBC (KTVF) Fairbanks, AK</channel>
@@ -191,17 +191,17 @@
     <channel lang="en" xmltv_id="LogoEast.us" site_id="logo-east/2091">Logo East</channel>
     <channel lang="en" xmltv_id="LogoWest.us" site_id="logo-pacific/13460">Logo West</channel>
     <channel lang="en" xmltv_id="MeTV.us" site_id="metv-network/16325">MeTV Network</channel>
-    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusDriveIn.us" site_id="epix-drivein/11487">MGM+ Drive-In</channel>
     <channel lang="en" xmltv_id="MGMPlusEast.us" site_id="epix-hd-east/7610">MGM+ East</channel>
+    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusMarquee.us" site_id="epix-hits/11486">MGM+ Marquee</channel>
     <channel lang="en" xmltv_id="MGMPlusWest.us" site_id="epix-pacific/13443">MGM+ Pacific</channel>
     <channel lang="en" xmltv_id="MoreMaxWest.us" site_id="moremax-pacific-hd/8472">Moremax Pacific HD</channel>
     <channel lang="en" xmltv_id="MovieMaxWest.us" site_id="moviemax-pacific/2625">MovieMax West</channel>
     <channel lang="en" xmltv_id="MoviePlexEast.us" site_id="movieplex-eastern/1066">MoviePlex East</channel>
     <channel lang="en" xmltv_id="MoviePlexWest.us" site_id="movieplex-pacific/1220">MoviePlex West</channel>
-    <channel lang="en" xmltv_id="MSNBC.us" site_id="msnbc-usa/655">MSNBC</channel>
     <channel lang="en" xmltv_id="MSG.us" site_id="msg-madison-square-gardens-hd/4695">MSG</channel>
+    <channel lang="en" xmltv_id="MSNBC.us" site_id="msnbc-usa/655">MSNBC</channel>
     <channel lang="en" xmltv_id="NBCEast.us" site_id="nbc-network-eastern/1227">NBC Network Eastern</channel>
     <channel lang="en" xmltv_id="NBCSportsBoston.us" site_id="nbc-sports-boston/4529">NBC Sports Boston</channel>
     <channel lang="en" xmltv_id="News12Conneticut.us" site_id="news-12-connecticut/20178">News12 Conneticut</channel>
@@ -246,12 +246,12 @@
     <channel lang="en" xmltv_id="TCMEast.us" site_id="turner-classic-movies-usa/176">Turner Classic Movies USA</channel>
     <channel lang="en" xmltv_id="TelemundoEast.us" site_id="telemundo-east-hd/33284">Telemundo East</channel>
     <channel lang="en" xmltv_id="TelemundoWest.us" site_id="telemundo-pacific-feed/2013">Telemundo West</channel>
-    <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
-    <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
-    <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>
     <channel lang="en" xmltv_id="TheMovieChannelEast.us" site_id="tmc-hd-eastern/4352">The Movie Channel East</channel>
     <channel lang="en" xmltv_id="TheMovieChannelXtraEast.us" site_id="tmc-xtra-hd-eastern/7113">The Movie Channel Xtra East</channel>
     <channel lang="en" xmltv_id="TheWeatherChannel.us" site_id="the-weather-channel-hd/5599">The Weather Channel</channel>
+    <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
+    <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
+    <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>
     <channel lang="en" xmltv_id="TNTWest.us" site_id="tnt-pacific-feed/2252">TNT West</channel>
     <channel lang="en" xmltv_id="TravelChannelEast.us" site_id="travel-us-east/662">Travel Channel East</channel>
     <channel lang="en" xmltv_id="truTVWest.us" site_id="trutv-usa-pacific-hd/18808">truTV USA Pacific HD</channel>
@@ -260,17 +260,19 @@
     <channel lang="en" xmltv_id="TSN3.ca" site_id="tsn3/13719">TSN3</channel>
     <channel lang="en" xmltv_id="TSN4.ca" site_id="tsn4/279">TSN4</channel>
     <channel lang="en" xmltv_id="TSN5.ca" site_id="tsn5/278">TSN5</channel>
-    <channel lang="en" xmltv_id="TVOne.us" site_id="tv-one/2287">TV One</channel>	  
     <channel lang="en" xmltv_id="TVLandWest.us" site_id="tv-land-pacific/210">TV Land West</channel>
+    <channel lang="en" xmltv_id="TVOne.us" site_id="tv-one/2287">TV One</channel>	
     <channel lang="en" xmltv_id="USANetworkWest.us" site_id="usa-network-pacific/2144">USA Network West</channel>
     <channel lang="en" xmltv_id="VH1West.us" site_id="vh1-pacific-feed/1270">VH1 West</channel>
     <channel lang="en" xmltv_id="VICETV.us" site_id="vice/624">Vice</channel>
     <channel lang="en" xmltv_id="W20CQD1.us" site_id="hope-channel-w20cqd-hempstead-ny/16436">Hope Channel (W20CQ-D) Hempstead, NY</channel>
+    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
     <channel lang="en" xmltv_id="WABCDT1.us" site_id="abc-wabc-new-york-ny/1769">ABC (WABC) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="localish-wabcdt2-new-york-ny/10497">Localish (WABC-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="this-wabctv3-new-york-ny/11049">THIS (WABC-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WADLDT1.us" site_id="wadl-tv-detroit-mi/10217">MNT (WADL) Mount Clemens, MI</channel>
+    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
     <channel lang="en" xmltv_id="WBALDT1.us" site_id="nbc-wbal-baltimore-md/3236">NBC (WBAL-TV) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT2.us" site_id="metv-wbaltv2-baltimore-md/11796">MeTV (WBAL-DT2) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT4.us" site_id="the-grio-wbaltv4-baltimore-md/36930">The Grio (WBAL-DT4) Baltimore, MD</channel>
@@ -288,10 +290,10 @@
     <channel lang="en" xmltv_id="WCBSDT1.us" site_id="cbs-wcbs-new-york-ny/1766">CBS (WCBS) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT2.us" site_id="start-tv-wcbstv2-new-york-ny/11045">Start TV (WCBS-TV2) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT3.us" site_id="dabl-wcbstv3-new-york-ny/34131">DABL (WCBS-TV3) New York, NY</channel>
-    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCIUDT1.us" site_id="cw26-wciu-chicago-il/1834">CW (WCIU) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCIUDT5.us" site_id="story-wciutv5-chicago-il/11342">Story (WCIU-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCMUDT1.us" site_id="pbs-wcmu-mt-pleasant-mi/9304">PBS (WCMU-TV) Mount Pleasant, MI</channel>
+    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCVBDT1.us" site_id="abc-wcvb-boston-ma/133">ABC (WCVB-TV) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCVBDT2.us" site_id="metv-wcvbdt2-boston/10773">MeTV (WCVB-DT2) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCWJDT1.us" site_id="cw-wcwj-jacksonville-fl/2046">CW (WCWJ) Jacksonville, FL</channel>
@@ -316,6 +318,7 @@
     <channel lang="en" xmltv_id="WFQXDT2.us" site_id="cw-wfqxtv2-traverse-citycadillac-mi/31612">CW (WFQX-DT2) Cadillac, MI</channel>
     <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV) Orlando, FL</channel>
     <channel lang="en" xmltv_id="WFTYDT1.us" site_id="unimas-wfty-smithtown-ny/1961">UniMás (WFTY) Smithtown, NY</channel>
+    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WFTYDT4.us" site_id="ion-mystery-wftydt4-smithtown-ny/19460">ION Mystery (WFTY-DT4) Smithtown, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT2.us" site_id="true-crime-network-wfutdt2-newark-nj/16472">True Crime Network (WFUT-DT2) Newark, NJ</channel>
     <channel lang="en" xmltv_id="WFUTDT3.us" site_id="gettv-wfutdt3-newark-nj/16429">GetTV (WFUT-DT3) Newark, NJ</channel>
@@ -328,6 +331,7 @@
     <channel lang="en" xmltv_id="WHDHDT2.us" site_id="this-whdh2-hudson-nh/8041">THIS (WHDH) Boston, MA</channel>
     <channel lang="en" xmltv_id="WHNELD9.us" site_id="newsnet-whneld9-flint-mi/35849">NewsNet (WHNE-LD9) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WIVBDT1.us" site_id="cbs-wivb-buffalo-ny/88">CBS (WIVB) Buffalo, NY</channel>
+    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
     <channel lang="en" xmltv_id="WJAXDT1.us" site_id="cbs-wjax-jacksonville-fl/2048">CBS (WJAX) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WJLADT1.us" site_id="abc-wjla-district-of-columbia/1555">ABC (WJLA) District of Columbia</channel>
     <channel lang="en" xmltv_id="WJLPDT1.us" site_id="metv-wjlp-new-jerseynew-york/5138">MeTV (WJLP) New Jersey</channel>
@@ -348,8 +352,10 @@
     <channel lang="en" xmltv_id="WKARDT1.us" site_id="pbs-wkar-east-lansing-mi/13241">PBS (WKAR-TV) East Lansing, MI</channel>
     <channel lang="en" xmltv_id="WKBWDT1.us" site_id="abc-wkbw-buffalo-ny/89">ABC (WKBW) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD1.us" site_id="azteca-wkob-new-york-ny/5096">Azteca (WKOB) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD3.us" site_id="peace-tv-wkobld3-new-york-ny/11085">Peace TV (WKOB-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD5.us" site_id="sonlife-network-wkobld5-new-york-ny/11087">SonLife Network (WKOB-LD5) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD7.us" site_id="shop-lc-wkobdt7-new-york-ny/16454">Shop LC (WKOB-DT7) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD8.us" site_id="ontv4u-wkobdt8-new-york-ny/17491">ONTV4U (WKOB-DT8) New York, NY</channel>
     <channel lang="en" xmltv_id="WKRNDT1.us" site_id="abc-wkrn-nashville-tn/1886">ABC (WKRN) Nashville, TN</channel>
@@ -373,6 +379,7 @@
     <channel lang="en" xmltv_id="WMARDT5.us" site_id="court-tv-wmartv5-baltimore-md/34056">Court TV (WMAR-DT5) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WMBCDT2.us" site_id="quest-wmbctv2-newton-nj/16467">Quest (WMBC-TV2) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="new-tang-dynasty-tv-wmbcdt5-newton-nj/15033">New Tang Dynasty TV (WMBC-DT5) Newton, NJ</channel>
+    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBQCD1.us" site_id="biztv-wmbqcd-new-york-ny/16459">Biz-TV (WMBQ-CD) New York, NY</channel>
     <channel lang="en" xmltv_id="WMBQCD2.us" site_id="hope-channel-wmbqcd2-new-york-ny/16460">Hope Channel (WMBQ-CD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WMEUCD1.us" site_id="the-u-wmeucd-chicago-il/12512">The U (WMEU-CD) Chicago, IL</channel>
@@ -382,16 +389,20 @@
     <channel lang="en" xmltv_id="WNDTCD1.us" site_id="fnx-wndtcd-manhattan-ny/34515">FNX (WNDT-CD) Manhattan, NY</channel>
     <channel lang="en" xmltv_id="WNETDT1.us" site_id="pbs-wnet-new-york-ny/1774">PBS (WNET) New York, NY</channel>
     <channel lang="en" xmltv_id="WNETDT2.us" site_id="pbs-kids-wnetdt2-new-york-ny/2088">PBS Kids (WNET-DT2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNJBDT1.us" site_id="nj-pbs-wnjb-new-brunswick-nj/2124">NJ PBS (WNJB) New Brunswick, NJ</channel>
     <channel lang="en" xmltv_id="WNJNDT1.us" site_id="nj-pbs-wnjn-montclair-nj/2574">NJ PBS (WNJN) Montclair, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT1.us" site_id="nj-pbs-wnjt-trenton-nj/2564">NJ PBS (WNJT) Trenton, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT2.us" site_id="nhk-world-wnjttv2-trenton-nj/32845">NHK World (WNJT-TV2) Trenton, NJ</channel>
+    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
+    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
     <channel lang="en" xmltv_id="WNMFLD1.us" site_id="infomercials-wnmf-new-york-ny/17860">Infomercials (WNMF) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMFLD2.us" site_id="jewelry-tv-wnmfld2-new-york-ny/17861">Jewelry TV (WNMF-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMUDT1.us" site_id="pbs-wnmu-marquette-mi/481">PBS (WNMU) Marquette, MI</channel>
     <channel lang="en" xmltv_id="WNWODT1.us" site_id="nbc-wnwo-toledo-oh/259">NBC (WNWO-TV) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WNXYLD1.us" site_id="cgtn-wnxyld-new-york-ny/16456">CGTN (WNXY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNXYLD2.us" site_id="cctv4-wnxyld2-new-york-ny/16457">CCTV-4 (WNXY-LD2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT1.us" site_id="nyc-life-wnyedt1-new-york-ny/10011">NYC Life (WNYE-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT2.us" site_id="nyc-gov-wnyedt2-new-york-ny/11074">NYC Gov (WNYE-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT3.us" site_id="cuny-wnyedt3-new-york-ny/11075">CUNY (WNYE-DT3) New York, NY</channel>
@@ -405,15 +416,17 @@
     <channel lang="en" xmltv_id="WNYWDT5.us" site_id="decades-wnyw5-new-york-ny/34342">Decades (WNYW5) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD1.us" site_id="cgtn-wnyxld-new-york-ny/16441">CGTN (WNYX-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD2.us" site_id="cctv4-wnyxld2-new-york-ny/16442">CCTV-4 (WNYX-LD2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD4.us" site_id="revn-wnyxld4-new-york-ny/16447">REV&apos;N (WNYX-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD5.us" site_id="retro-tv-wnyxld5-new-york-ny/17849">Retro TV (WNYX-LD5) New York, NY</channel>
     <channel lang="en" xmltv_id="WOIDT1.us" site_id="abc-woi-des-moines-ia/1245">ABC (WOI) Des Moines, IA</channel>
+    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="WPCWDT1.us" site_id="cw-wpcw-pittsburgh-pa/3187">CW (WPCW) Jeannette, PA</channel>
     <channel lang="en" xmltv_id="WPIXDT1.us" site_id="wpix-new-york-superstation/63">CW (WPIX) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT2.us" site_id="antenna-wpix2-new-york-ny/10745">Antenna (WPIX2) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT3.us" site_id="court-tv-wpix3-new-york-ny/9723">Court TV (WPIX3) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT4.us" site_id="rewind-tv-us-wpix4-new-york-ny/32844">Rewind TV US (WPIX4) New York, NY</channel>
-    <channel lang="es" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
+    <channel lang="en" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
     <channel lang="en" xmltv_id="WPVIDT2.us" site_id="localish-wpvidt2-philadelphia-pa/8852">Localish (WPVI-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPVIDT3.us" site_id="this-wpvitv3-philadelphia-pa/14662">THIS (WPVI-TV3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPXNDT1.us" site_id="ion-wpxn-new-york-ny/1778">ION (WPXN) New York, NY</channel>
@@ -439,6 +452,7 @@
     <channel lang="en" xmltv_id="WTATDT1.us" site_id="fox-wtat-charleston-sc/1097">FOX (WTAT) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WTBYDT1.us" site_id="tbn-wtby-new-york-ny/2575">TBN (WTBY) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT2.us" site_id="smile-wtbytv2-new-york-ny/11093">Smile (WTBY-TV2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT4.us" site_id="positiv-wtbytv4-new-york-ny/11095">PosiTiV (WTBY-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WTLVDT1.us" site_id="nbc-wtlv-jacksonville-fl/1435">NBC (WTLV) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WTNHDT1.us" site_id="abc-wtnh-sd-new-haven-ct/17476">ABC (WTNH) SD New Haven, CT</channel>
@@ -448,6 +462,7 @@
     <channel lang="en" xmltv_id="WTVGDT2.us" site_id="cw-wtvgdt2-toledo-oh/10390">CW (WTVG-DT2) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WTVSDT5.us" site_id="mlc-wtvsdt5-detroit-mi/36121">Michigan Learning Channel (WTVS-DT5) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WTVTDT1.us" site_id="fox-wtvt-tampa-bay-fl/2552">FOX (WTVT) Tampa Bay, FL</channel>
+    <channel lang="en" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WVUEDT1.us" site_id="fox-wvue-new-orleans-la/1745">FOX (WVUE) New Orleans, LA</channel>
     <channel lang="en" xmltv_id="WWAYDT2.us" site_id="cbs-wway2-wilmington-nc/7209">CBS (WWAY2) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WWJDT4.us" site_id="fave-tv-wwjtv4-detroit-mi/35971">Fave TV (WWJ-DT4) Detroit, MI</channel>
@@ -458,32 +473,17 @@
     <channel lang="en" xmltv_id="WXINDT1.us" site_id="fox-wxin-indianapolis-in/1374">FOX (WXIN) Indianapolis, IN</channel>
     <channel lang="en" xmltv_id="WXNYLD1.us" site_id="cgtn-wxnyld-new-york-ny/11078">CGTN (WXNY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD2.us" site_id="cctv4-wxnyld2-new-york-ny/16443">CCTV-4 (WXNY-LD2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD4.us" site_id="retro-tv-wxnyld4-new-york-ny/16446">Retro TV (WXNY-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD5.us" site_id="retro-tv-wxnyld5-new-york-ny/17346">Retro TV (WXNY-LD5) New York, NY</channel>
+    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT2.us" site_id="bounce-wxtvdt2-paterson-nj/16452">Bounce (WXTV-DT2) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT3.us" site_id="twist-wxtvdt3-paterson-nj/16450">Twist (WXTV-DT3) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT4.us" site_id="grit-tv-wxtvdt4-paterson-nj/16451">Grit TV (WXTV-DT4) Paterson, NJ</channel>
+    <channel lang="en" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WYXNLD1.us" site_id="cgtn-wyxnld-new-york-ny/29736">CGTN (WYXN-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WZMQDT2.us" site_id="cbs-wzmq2-marquette-mi/17308">CBS (WZMQ-DT2) Marquette, MI</channel>
-    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
-    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
-    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
-    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
-    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
-    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
-    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
-    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
-    <channel lang="es" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
-    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
-    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="YesNetwork.us" site_id="yes-network/1953">YES Network</channel>
-    <channel lang="en" xmltv_id="YTATV.us" site_id="youtoo-america-network/5463">Youtoo America - Network</channel>
+    <channel lang="en" xmltv_id="YTATV.us" site_id="youtoo-america-network/5463">Youtoo America - Network</channel> 
   </channels>
 </site>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -82,7 +82,6 @@
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
     <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
     <channel lang="en" xmltv_id="FXXWest.us" site_id="fxx-usa-pacific/19080">FXX West</channel>
-    <channel lang="es" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
     <channel lang="en" xmltv_id="GreatAmericanLiving.us" site_id="gac-living/16158">Great American Living</channel>
     <channel lang="en" xmltv_id="Grit.us" site_id="grit-network/14377">Grit</channel>
     <channel lang="en" xmltv_id="HallmarkChannelEast.us" site_id="hallmark-channel-hd-eastern/6213">Hallmark Channel East</channel>
@@ -147,8 +146,6 @@
     <channel lang="en" xmltv_id="KLCSDT3.us" site_id="create-klcs3-los-angeles-ca/11230">Create (KLCS3) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMBCDT1.us" site_id="abc-kmbc-kansas-city-mo/2453">ABC (KMBC) Kansas City, MO</channel>
     <channel lang="en" xmltv_id="KMBCDT2.us" site_id="metv-kmbctv2-kansas-city-mo/7267">MeTV (KMBC-DT2) Kansas City, MO</channel>
-    <channel lang="es" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
-    <channel lang="es" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMGHDT1.us" site_id="abc-kmgh-denver-co/1568">ABC (KMGH) Denver, CO</channel>
     <channel lang="en" xmltv_id="KNBCDT1.us" site_id="nbc-knbc-los-angeles-ca/2588">NBC (KNBC) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KNTVDT1.us" site_id="nbc-kntv-san-francisco-ca/3262">NBC (KNTV) San Francisco, CA</channel>
@@ -182,7 +179,6 @@
     <channel lang="en" xmltv_id="KTVQDT2.us" site_id="cw-ktvq2-billings-mt/8943">CW (KTVQ-DT2) Billings, MT</channel>
     <channel lang="en" xmltv_id="KTVUDT1.us" site_id="fox-ktvu-san-francisco-ca/2145">FOX (KTVU) San Francisco, CA</channel>
     <channel lang="en" xmltv_id="KUFMDT1.us" site_id="pbs-kufm-missoula-mt/13228">PBS (KUFM-TV) Missoula, MT</channel>
-    <channel lang="es" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KWCHDT1.us" site_id="cbs-kwch-wichita-ks/1546">CBS (KWCH) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KWCHDT4.us" site_id="circle-kwchdt4-hutchinsonm-ks/34557">Circle (KWCH-DT4) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KXDFCD1.us" site_id="cbs-k13xd-fairbanks-ak/4960">CBS (KXDF-CD) Fairbanks, AK</channel>
@@ -266,13 +262,11 @@
     <channel lang="en" xmltv_id="VH1West.us" site_id="vh1-pacific-feed/1270">VH1 West</channel>
     <channel lang="en" xmltv_id="VICETV.us" site_id="vice/624">Vice</channel>
     <channel lang="en" xmltv_id="W20CQD1.us" site_id="hope-channel-w20cqd-hempstead-ny/16436">Hope Channel (W20CQ-D) Hempstead, NY</channel>
-    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
     <channel lang="en" xmltv_id="WABCDT1.us" site_id="abc-wabc-new-york-ny/1769">ABC (WABC) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="localish-wabcdt2-new-york-ny/10497">Localish (WABC-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="this-wabctv3-new-york-ny/11049">THIS (WABC-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WADLDT1.us" site_id="wadl-tv-detroit-mi/10217">MNT (WADL) Mount Clemens, MI</channel>
-    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
     <channel lang="en" xmltv_id="WBALDT1.us" site_id="nbc-wbal-baltimore-md/3236">NBC (WBAL-TV) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT2.us" site_id="metv-wbaltv2-baltimore-md/11796">MeTV (WBAL-DT2) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT4.us" site_id="the-grio-wbaltv4-baltimore-md/36930">The Grio (WBAL-DT4) Baltimore, MD</channel>
@@ -318,7 +312,6 @@
     <channel lang="en" xmltv_id="WFQXDT2.us" site_id="cw-wfqxtv2-traverse-citycadillac-mi/31612">CW (WFQX-DT2) Cadillac, MI</channel>
     <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV) Orlando, FL</channel>
     <channel lang="en" xmltv_id="WFTYDT1.us" site_id="unimas-wfty-smithtown-ny/1961">UniMás (WFTY) Smithtown, NY</channel>
-    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WFTYDT4.us" site_id="ion-mystery-wftydt4-smithtown-ny/19460">ION Mystery (WFTY-DT4) Smithtown, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT2.us" site_id="true-crime-network-wfutdt2-newark-nj/16472">True Crime Network (WFUT-DT2) Newark, NJ</channel>
     <channel lang="en" xmltv_id="WFUTDT3.us" site_id="gettv-wfutdt3-newark-nj/16429">GetTV (WFUT-DT3) Newark, NJ</channel>
@@ -352,10 +345,8 @@
     <channel lang="en" xmltv_id="WKARDT1.us" site_id="pbs-wkar-east-lansing-mi/13241">PBS (WKAR-TV) East Lansing, MI</channel>
     <channel lang="en" xmltv_id="WKBWDT1.us" site_id="abc-wkbw-buffalo-ny/89">ABC (WKBW) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD1.us" site_id="azteca-wkob-new-york-ny/5096">Azteca (WKOB) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD3.us" site_id="peace-tv-wkobld3-new-york-ny/11085">Peace TV (WKOB-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD5.us" site_id="sonlife-network-wkobld5-new-york-ny/11087">SonLife Network (WKOB-LD5) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD7.us" site_id="shop-lc-wkobdt7-new-york-ny/16454">Shop LC (WKOB-DT7) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD8.us" site_id="ontv4u-wkobdt8-new-york-ny/17491">ONTV4U (WKOB-DT8) New York, NY</channel>
     <channel lang="en" xmltv_id="WKRNDT1.us" site_id="abc-wkrn-nashville-tn/1886">ABC (WKRN) Nashville, TN</channel>
@@ -379,7 +370,6 @@
     <channel lang="en" xmltv_id="WMARDT5.us" site_id="court-tv-wmartv5-baltimore-md/34056">Court TV (WMAR-DT5) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WMBCDT2.us" site_id="quest-wmbctv2-newton-nj/16467">Quest (WMBC-TV2) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="new-tang-dynasty-tv-wmbcdt5-newton-nj/15033">New Tang Dynasty TV (WMBC-DT5) Newton, NJ</channel>
-    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBQCD1.us" site_id="biztv-wmbqcd-new-york-ny/16459">Biz-TV (WMBQ-CD) New York, NY</channel>
     <channel lang="en" xmltv_id="WMBQCD2.us" site_id="hope-channel-wmbqcd2-new-york-ny/16460">Hope Channel (WMBQ-CD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WMEUCD1.us" site_id="the-u-wmeucd-chicago-il/12512">The U (WMEU-CD) Chicago, IL</channel>
@@ -389,20 +379,16 @@
     <channel lang="en" xmltv_id="WNDTCD1.us" site_id="fnx-wndtcd-manhattan-ny/34515">FNX (WNDT-CD) Manhattan, NY</channel>
     <channel lang="en" xmltv_id="WNETDT1.us" site_id="pbs-wnet-new-york-ny/1774">PBS (WNET) New York, NY</channel>
     <channel lang="en" xmltv_id="WNETDT2.us" site_id="pbs-kids-wnetdt2-new-york-ny/2088">PBS Kids (WNET-DT2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNJBDT1.us" site_id="nj-pbs-wnjb-new-brunswick-nj/2124">NJ PBS (WNJB) New Brunswick, NJ</channel>
     <channel lang="en" xmltv_id="WNJNDT1.us" site_id="nj-pbs-wnjn-montclair-nj/2574">NJ PBS (WNJN) Montclair, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT1.us" site_id="nj-pbs-wnjt-trenton-nj/2564">NJ PBS (WNJT) Trenton, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT2.us" site_id="nhk-world-wnjttv2-trenton-nj/32845">NHK World (WNJT-TV2) Trenton, NJ</channel>
-    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
-    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
     <channel lang="en" xmltv_id="WNMFLD1.us" site_id="infomercials-wnmf-new-york-ny/17860">Infomercials (WNMF) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMFLD2.us" site_id="jewelry-tv-wnmfld2-new-york-ny/17861">Jewelry TV (WNMF-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMUDT1.us" site_id="pbs-wnmu-marquette-mi/481">PBS (WNMU) Marquette, MI</channel>
     <channel lang="en" xmltv_id="WNWODT1.us" site_id="nbc-wnwo-toledo-oh/259">NBC (WNWO-TV) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WNXYLD1.us" site_id="cgtn-wnxyld-new-york-ny/16456">CGTN (WNXY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNXYLD2.us" site_id="cctv4-wnxyld2-new-york-ny/16457">CCTV-4 (WNXY-LD2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT1.us" site_id="nyc-life-wnyedt1-new-york-ny/10011">NYC Life (WNYE-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT2.us" site_id="nyc-gov-wnyedt2-new-york-ny/11074">NYC Gov (WNYE-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT3.us" site_id="cuny-wnyedt3-new-york-ny/11075">CUNY (WNYE-DT3) New York, NY</channel>
@@ -416,7 +402,6 @@
     <channel lang="en" xmltv_id="WNYWDT5.us" site_id="decades-wnyw5-new-york-ny/34342">Decades (WNYW5) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD1.us" site_id="cgtn-wnyxld-new-york-ny/16441">CGTN (WNYX-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD2.us" site_id="cctv4-wnyxld2-new-york-ny/16442">CCTV-4 (WNYX-LD2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD4.us" site_id="revn-wnyxld4-new-york-ny/16447">REV&apos;N (WNYX-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD5.us" site_id="retro-tv-wnyxld5-new-york-ny/17849">Retro TV (WNYX-LD5) New York, NY</channel>
     <channel lang="en" xmltv_id="WOIDT1.us" site_id="abc-woi-des-moines-ia/1245">ABC (WOI) Des Moines, IA</channel>
@@ -452,7 +437,6 @@
     <channel lang="en" xmltv_id="WTATDT1.us" site_id="fox-wtat-charleston-sc/1097">FOX (WTAT) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WTBYDT1.us" site_id="tbn-wtby-new-york-ny/2575">TBN (WTBY) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT2.us" site_id="smile-wtbytv2-new-york-ny/11093">Smile (WTBY-TV2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT4.us" site_id="positiv-wtbytv4-new-york-ny/11095">PosiTiV (WTBY-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WTLVDT1.us" site_id="nbc-wtlv-jacksonville-fl/1435">NBC (WTLV) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WTNHDT1.us" site_id="abc-wtnh-sd-new-haven-ct/17476">ABC (WTNH) SD New Haven, CT</channel>
@@ -473,10 +457,8 @@
     <channel lang="en" xmltv_id="WXINDT1.us" site_id="fox-wxin-indianapolis-in/1374">FOX (WXIN) Indianapolis, IN</channel>
     <channel lang="en" xmltv_id="WXNYLD1.us" site_id="cgtn-wxnyld-new-york-ny/11078">CGTN (WXNY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD2.us" site_id="cctv4-wxnyld2-new-york-ny/16443">CCTV-4 (WXNY-LD2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD4.us" site_id="retro-tv-wxnyld4-new-york-ny/16446">Retro TV (WXNY-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD5.us" site_id="retro-tv-wxnyld5-new-york-ny/17346">Retro TV (WXNY-LD5) New York, NY</channel>
-    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT2.us" site_id="bounce-wxtvdt2-paterson-nj/16452">Bounce (WXTV-DT2) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT3.us" site_id="twist-wxtvdt3-paterson-nj/16450">Twist (WXTV-DT3) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT4.us" site_id="grit-tv-wxtvdt4-paterson-nj/16451">Grit TV (WXTV-DT4) Paterson, NJ</channel>
@@ -485,5 +467,23 @@
     <channel lang="en" xmltv_id="WZMQDT2.us" site_id="cbs-wzmq2-marquette-mi/17308">CBS (WZMQ-DT2) Marquette, MI</channel>
     <channel lang="en" xmltv_id="YesNetwork.us" site_id="yes-network/1953">YES Network</channel>
     <channel lang="en" xmltv_id="YTATV.us" site_id="youtoo-america-network/5463">Youtoo America - Network</channel> 
+    <channel lang="es" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
+    <channel lang="es" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
+    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
+    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
+    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
+    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
+    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
+    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
+    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
+    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
+    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
   </channels>
 </site>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -5,12 +5,12 @@
     <channel lang="en" xmltv_id="5StarMaxEast.us" site_id="5-star-max-eastern/636">5 StarMax East</channel>
     <channel lang="en" xmltv_id="5StarMaxWest.us" site_id="5-star-max-pacific/2627">5StarMax West</channel>
     <channel lang="en" xmltv_id="ABCEast.us" site_id="abc-eastern/1224">ABC Eastern</channel>
-    <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
-    <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
-    <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
     <channel lang="en" xmltv_id="ABCNewsLive.us" site_id="abc-news-live/36224">ABC News Live</channel>
     <channel lang="en" xmltv_id="ABCSpark.ca" site_id="abc-spark/10281">ABC Spark</channel>
+    <channel lang="en" xmltv_id="AccuWeatherNOW.us" site_id="accuweather/6140">AccuWeather</channel>
     <channel lang="en" xmltv_id="ActionMaxWest.us" site_id="actionmax-pacific-hd/8473">Actionmax Pacific HD</channel>
+    <channel lang="en" xmltv_id="AEEast.us" site_id="ae-us-eastern-feed/2">A&amp;E East</channel>
+    <channel lang="en" xmltv_id="AEWest.us" site_id="ae-us-pacific-feed/1202">A&amp;E West</channel>
     <channel lang="en" xmltv_id="AMCPlus.us" site_id="amc/35317">AMC+</channel>
     <channel lang="en" xmltv_id="AMCWest.us" site_id="amc-pacific-feed/1262">AMC West</channel>
     <channel lang="en" xmltv_id="AnimalPlanetWest.us" site_id="animal-planet-us-hd-west/11524">Animal Planet West</channel>
@@ -28,13 +28,13 @@
     <channel lang="en" xmltv_id="BallySportsNewOrleans.us" site_id="bally-sports-new-orleans/12558">Bally Sports New Orleans</channel>
     <channel lang="en" xmltv_id="BallySportsNorth.us" site_id="bally-sports-north/1234">Bally Sports North</channel>
     <channel lang="en" xmltv_id="BallySportsOhio.us" site_id="bally-sports-ohio/1089">Bally Sports Ohio</channel>
+    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
     <channel lang="en" xmltv_id="BallySportsSanDiego.us" site_id="bally-sports-san-diego/10272">Bally Sports San Diego</channel>
     <channel lang="en" xmltv_id="BallySportsSoCal.us" site_id="bally-sports-socal/2592">Bally Sports SoCal</channel>
     <channel lang="en" xmltv_id="BallySportsSouth.us" site_id="bally-sports-south-hd/4520">Bally Sports South</channel>
     <channel lang="en" xmltv_id="BallySportsSoutheast.us" site_id="bally-sports-southeast/1352">Bally Sports Southeast</channel>
-    <channel lang="en" xmltv_id="BallySportsSouthwest.us" site_id="bally-sports-southwest/1106">Bally Sports Southwest</channel>
-    <channel lang="en" xmltv_id="BallySportsOklahoma.us" site_id="bally-sports-oklahoma-hd/11520">Bally Sports Oklahoma</channel>
     <channel lang="en" xmltv_id="BallySportsSouthSouthCarolinas.us" site_id="bally-sports-south-carolinas/4531">Bally Sports South South Carolinas</channel>
+    <channel lang="en" xmltv_id="BallySportsSouthwest.us" site_id="bally-sports-southwest/1106">Bally Sports Southwest</channel>
     <channel lang="en" xmltv_id="BallySportsWisconsin.us" site_id="bally-sports-wisconsin/6760">Bally Sports Wisconsin</channel>
     <channel lang="en" xmltv_id="BBCAmericaEast.us" site_id="bbc-america-east/615">BBC America East</channel>
     <channel lang="en" xmltv_id="BBCWorldNewsNorthAmerica.uk" site_id="bbc-world-north-america/527">BBC World News North America</channel>
@@ -59,10 +59,10 @@
     <channel lang="en" xmltv_id="CBUTDT.ca" site_id="cbc-cbut-vancouver-bc/180">CBC (CBUT) Vancouver, BC</channel>
     <channel lang="en" xmltv_id="CBWTDT.ca" site_id="cbc-cbwt-winnipeg-mb/110">CBC (CBWT) Winnipeg, MB</channel>
     <channel lang="en" xmltv_id="CBXTDT.ca" site_id="cbc-cbxt-edmonton-ab/146">CBC (CBXT) Edmonton, AB</channel>
-    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="CMTEast.us" site_id="cmt-us-eastern-feed-hd/6344">CMT East</channel>
     <channel lang="en" xmltv_id="CNBC.us" site_id="cnbc-usa/201">CNBC</channel>
     <channel lang="en" xmltv_id="CNN.us" site_id="cnn/70">CNN</channel>
+    <channel lang="en" xmltv_id="ComedyCentralWest.us" site_id="comedy-central-us-pacific-feed/1212">Comedy Central West</channel>
     <channel lang="en" xmltv_id="Crave1.ca" site_id="crave1-east/72">Crave 1</channel>
     <channel lang="en" xmltv_id="Crave2.ca" site_id="crave2-east/86">Crave 2</channel>
     <channel lang="en" xmltv_id="Crave3.ca" site_id="crave3-east/85">Crave 3</channel>
@@ -74,15 +74,15 @@
     <channel lang="en" xmltv_id="ESPN2.us" site_id="espn2/650">ESPN 2</channel>
     <channel lang="en" xmltv_id="EWest.us" site_id="e-entertainment-usa-pacific-feed/1213">E! West</channel>
     <channel lang="en" xmltv_id="FlixWest.us" site_id="flix-pacific/3387">Flix West</channel>
+    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxBusiness.us" site_id="fox-business/4656">Fox Business</channel>
     <channel lang="en" xmltv_id="FoxEast.us" site_id="fox-eastern/1229">FOX Eastern</channel>
-    <channel lang="en" xmltv_id="FoodNetworkWest.us" site_id="food-network-usa-pacific-feed/2032">Food Network West</channel>
     <channel lang="en" xmltv_id="FoxNewsChannel.us" site_id="fox-news/1083">FOX News</channel>
     <channel lang="en" xmltv_id="FreeformEast.us" site_id="freeform-east-feed/1011">Freeform</channel>
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
     <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
     <channel lang="en" xmltv_id="FXXWest.us" site_id="fxx-usa-pacific/19080">FXX West</channel>
-    <channel lang="es" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
+    <channel lang="en" xmltv_id="GalavisionWest.us" site_id="galavision-pacific-feed/1573">Galavision West</channel>
     <channel lang="en" xmltv_id="GreatAmericanLiving.us" site_id="gac-living/16158">Great American Living</channel>
     <channel lang="en" xmltv_id="Grit.us" site_id="grit-network/14377">Grit</channel>
     <channel lang="en" xmltv_id="HallmarkChannelEast.us" site_id="hallmark-channel-hd-eastern/6213">Hallmark Channel East</channel>
@@ -126,12 +126,12 @@
     <channel lang="en" xmltv_id="KCNCDT1.us" site_id="cbs-kcnc-denver-co/1566">CBS (KCNC-TV) Denver, CO</channel>
     <channel lang="en" xmltv_id="KCOPDT1.us" site_id="mnt-kcop-los-angeles-ca/1811">KCOP (KCOP) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KCPQDT1.us" site_id="fox-kcpq-tacoma-wa/32824">FOX (KCPQ) Tacoma, WA</channel>
+    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
+    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
+    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KEYTDT1.us" site_id="abc-keyt-santa-barbara-ca/2308">ABC (KEYT) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT2.us" site_id="cbs-keytdt2-my-rtn-santa-barbara-ca/5877">CBS (KEYT-DT2) Santa Barbara, CA</channel>
     <channel lang="en" xmltv_id="KEYTDT3.us" site_id="mnt-keyttv3-santa-barbara-ca/33700">MNT (KEYT-DT3) Santa Barbara, CA</channel>
-    <channel lang="en" xmltv_id="KDVRDT1.us" site_id="fox-kdvr-denver-co/1572">FOX (KDVR) Denver, CO</channel>
-    <channel lang="en" xmltv_id="KDLTDT2.us" site_id="fox-kdlt2-odlt-sioux-falls-sd/1063">FOX (KDLT-DT2) Sioux Falls, SD</channel>
-    <channel lang="en" xmltv_id="KECIDT1.us" site_id="nbc-keci-missoula-mt/5053">NBC (KECI-TV) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KFJXDT1.us" site_id="fox-kfjx-pittsburg-ks/2426">FOX (KFJX) Pittsburg, KS</channel>
     <channel lang="en" xmltv_id="KFNBDT1.us" site_id="fox-kfnb-casper-wy/9916">FOX (KFNB) Casper, WY</channel>
     <channel lang="en" xmltv_id="KFSNDT1.us" site_id="abc-kfsn-fresno-ca/2686">ABC (KFSN) Fresno, CA</channel>
@@ -147,8 +147,8 @@
     <channel lang="en" xmltv_id="KLCSDT3.us" site_id="create-klcs3-los-angeles-ca/11230">Create (KLCS3) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMBCDT1.us" site_id="abc-kmbc-kansas-city-mo/2453">ABC (KMBC) Kansas City, MO</channel>
     <channel lang="en" xmltv_id="KMBCDT2.us" site_id="metv-kmbctv2-kansas-city-mo/7267">MeTV (KMBC-DT2) Kansas City, MO</channel>
-    <channel lang="es" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
-    <channel lang="es" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
+    <channel lang="en" xmltv_id="KMEXDT1.us" site_id="uni-kmex-los-angeles-ca/2602">Univision (KMEX) Los Angeles, CA</channel>
+    <channel lang="en" xmltv_id="KMEXDT2.us" site_id="unimas-kftr-ontario-ca/11261">UniMás (KMEX-DT2) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KMGHDT1.us" site_id="abc-kmgh-denver-co/1568">ABC (KMGH) Denver, CO</channel>
     <channel lang="en" xmltv_id="KNBCDT1.us" site_id="nbc-knbc-los-angeles-ca/2588">NBC (KNBC) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KNTVDT1.us" site_id="nbc-kntv-san-francisco-ca/3262">NBC (KNTV) San Francisco, CA</channel>
@@ -175,14 +175,14 @@
     <channel lang="en" xmltv_id="KTMFDT1.us" site_id="abc-ktmf-missoula-mt/4940">ABC (KTMF) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT2.us" site_id="fox-ktmf2-missoula-mt/8933">FOX (KTMF-DT2) Missoula, MT</channel>
     <channel lang="en" xmltv_id="KTMFDT3.us" site_id="swx-right-now-ktmf3-missoula-mt/35958">SWX (KTMF-DT3) Missoula, MT</channel>
-    <channel lang="es" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
+    <channel lang="en" xmltv_id="KTRKDT1.us" site_id="abc-ktrk-houston-tx/2394">ABC (KTRK) Houston, TX</channel>
     <channel lang="en" xmltv_id="KTTVDT1.us" site_id="fox-kttv-los-angeles-ca/1949">FOX (KTTV) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KTVDDT1.us" site_id="mnt-ktvd-denver-co/1565">MNT (KTVD) Denver, CO</channel>
     <channel lang="en" xmltv_id="KTVFDT1.us" site_id="nbc-ktvf-fairbanks-ak/5121">NBC (KTVF) Fairbanks, AK</channel>
     <channel lang="en" xmltv_id="KTVQDT2.us" site_id="cw-ktvq2-billings-mt/8943">CW (KTVQ-DT2) Billings, MT</channel>
     <channel lang="en" xmltv_id="KTVUDT1.us" site_id="fox-ktvu-san-francisco-ca/2145">FOX (KTVU) San Francisco, CA</channel>
     <channel lang="en" xmltv_id="KUFMDT1.us" site_id="pbs-kufm-missoula-mt/13228">PBS (KUFM-TV) Missoula, MT</channel>
-    <channel lang="es" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
+    <channel lang="en" xmltv_id="KVEADT1.us" site_id="telemundo-kvea-los-angeles-ca/2611">Telemundo (KVEA) Los Angeles, CA</channel>
     <channel lang="en" xmltv_id="KWCHDT1.us" site_id="cbs-kwch-wichita-ks/1546">CBS (KWCH) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KWCHDT4.us" site_id="circle-kwchdt4-hutchinsonm-ks/34557">Circle (KWCH-DT4) Wichita, KS</channel>
     <channel lang="en" xmltv_id="KXDFCD1.us" site_id="cbs-k13xd-fairbanks-ak/4960">CBS (KXDF-CD) Fairbanks, AK</channel>
@@ -191,17 +191,17 @@
     <channel lang="en" xmltv_id="LogoEast.us" site_id="logo-east/2091">Logo East</channel>
     <channel lang="en" xmltv_id="LogoWest.us" site_id="logo-pacific/13460">Logo West</channel>
     <channel lang="en" xmltv_id="MeTV.us" site_id="metv-network/16325">MeTV Network</channel>
-    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusDriveIn.us" site_id="epix-drivein/11487">MGM+ Drive-In</channel>
     <channel lang="en" xmltv_id="MGMPlusEast.us" site_id="epix-hd-east/7610">MGM+ East</channel>
+    <channel lang="en" xmltv_id="MGMPlusHitsEast.us" site_id="epix2-east/11485">MGM+ Hits East</channel>
     <channel lang="en" xmltv_id="MGMPlusMarquee.us" site_id="epix-hits/11486">MGM+ Marquee</channel>
     <channel lang="en" xmltv_id="MGMPlusWest.us" site_id="epix-pacific/13443">MGM+ Pacific</channel>
     <channel lang="en" xmltv_id="MoreMaxWest.us" site_id="moremax-pacific-hd/8472">Moremax Pacific HD</channel>
     <channel lang="en" xmltv_id="MovieMaxWest.us" site_id="moviemax-pacific/2625">MovieMax West</channel>
     <channel lang="en" xmltv_id="MoviePlexEast.us" site_id="movieplex-eastern/1066">MoviePlex East</channel>
     <channel lang="en" xmltv_id="MoviePlexWest.us" site_id="movieplex-pacific/1220">MoviePlex West</channel>
-    <channel lang="en" xmltv_id="MSNBC.us" site_id="msnbc-usa/655">MSNBC</channel>
     <channel lang="en" xmltv_id="MSG.us" site_id="msg-madison-square-gardens-hd/4695">MSG</channel>
+    <channel lang="en" xmltv_id="MSNBC.us" site_id="msnbc-usa/655">MSNBC</channel>
     <channel lang="en" xmltv_id="NBCEast.us" site_id="nbc-network-eastern/1227">NBC Network Eastern</channel>
     <channel lang="en" xmltv_id="NBCSportsBoston.us" site_id="nbc-sports-boston/4529">NBC Sports Boston</channel>
     <channel lang="en" xmltv_id="News12Conneticut.us" site_id="news-12-connecticut/20178">News12 Conneticut</channel>
@@ -246,12 +246,12 @@
     <channel lang="en" xmltv_id="TCMEast.us" site_id="turner-classic-movies-usa/176">Turner Classic Movies USA</channel>
     <channel lang="en" xmltv_id="TelemundoEast.us" site_id="telemundo-east-hd/33284">Telemundo East</channel>
     <channel lang="en" xmltv_id="TelemundoWest.us" site_id="telemundo-pacific-feed/2013">Telemundo West</channel>
-    <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
-    <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
-    <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>
     <channel lang="en" xmltv_id="TheMovieChannelEast.us" site_id="tmc-hd-eastern/4352">The Movie Channel East</channel>
     <channel lang="en" xmltv_id="TheMovieChannelXtraEast.us" site_id="tmc-xtra-hd-eastern/7113">The Movie Channel Xtra East</channel>
     <channel lang="en" xmltv_id="TheWeatherChannel.us" site_id="the-weather-channel-hd/5599">The Weather Channel</channel>
+    <channel lang="en" xmltv_id="ThrillerMaxWest.us" site_id="thrillermax-pacific/2595">Thrillermax Pacific</channel>
+    <channel lang="en" xmltv_id="TLCEast.us" site_id="tlc-usa-eastern/5005">TLC East</channel>
+    <channel lang="en" xmltv_id="TLCWest.us" site_id="tlc-usa-hd-pacific/13492">TLC USA HD Pacific</channel>
     <channel lang="en" xmltv_id="TNTWest.us" site_id="tnt-pacific-feed/2252">TNT West</channel>
     <channel lang="en" xmltv_id="TravelChannelEast.us" site_id="travel-us-east/662">Travel Channel East</channel>
     <channel lang="en" xmltv_id="truTVWest.us" site_id="trutv-usa-pacific-hd/18808">truTV USA Pacific HD</channel>
@@ -260,17 +260,19 @@
     <channel lang="en" xmltv_id="TSN3.ca" site_id="tsn3/13719">TSN3</channel>
     <channel lang="en" xmltv_id="TSN4.ca" site_id="tsn4/279">TSN4</channel>
     <channel lang="en" xmltv_id="TSN5.ca" site_id="tsn5/278">TSN5</channel>
-    <channel lang="en" xmltv_id="TVOne.us" site_id="tv-one/2287">TV One</channel>	  
     <channel lang="en" xmltv_id="TVLandWest.us" site_id="tv-land-pacific/210">TV Land West</channel>
+    <channel lang="en" xmltv_id="TVOne.us" site_id="tv-one/2287">TV One</channel>	  
     <channel lang="en" xmltv_id="USANetworkWest.us" site_id="usa-network-pacific/2144">USA Network West</channel>
     <channel lang="en" xmltv_id="VH1West.us" site_id="vh1-pacific-feed/1270">VH1 West</channel>
     <channel lang="en" xmltv_id="VICETV.us" site_id="vice/624">Vice</channel>
     <channel lang="en" xmltv_id="W20CQD1.us" site_id="hope-channel-w20cqd-hempstead-ny/16436">Hope Channel (W20CQ-D) Hempstead, NY</channel>
+    <channel lang="en" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
     <channel lang="en" xmltv_id="WABCDT1.us" site_id="abc-wabc-new-york-ny/1769">ABC (WABC) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT2.us" site_id="localish-wabcdt2-new-york-ny/10497">Localish (WABC-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT3.us" site_id="this-wabctv3-new-york-ny/11049">THIS (WABC-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WABCDT4.us" site_id="hsn-wabctv4-new-york-ny/36168">HSN (WABC-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WADLDT1.us" site_id="wadl-tv-detroit-mi/10217">MNT (WADL) Mount Clemens, MI</channel>
+    <channel lang="en" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
     <channel lang="en" xmltv_id="WBALDT1.us" site_id="nbc-wbal-baltimore-md/3236">NBC (WBAL-TV) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT2.us" site_id="metv-wbaltv2-baltimore-md/11796">MeTV (WBAL-DT2) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WBALDT4.us" site_id="the-grio-wbaltv4-baltimore-md/36930">The Grio (WBAL-DT4) Baltimore, MD</channel>
@@ -288,10 +290,10 @@
     <channel lang="en" xmltv_id="WCBSDT1.us" site_id="cbs-wcbs-new-york-ny/1766">CBS (WCBS) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT2.us" site_id="start-tv-wcbstv2-new-york-ny/11045">Start TV (WCBS-TV2) New York, NY</channel>
     <channel lang="en" xmltv_id="WCBSDT3.us" site_id="dabl-wcbstv3-new-york-ny/34131">DABL (WCBS-TV3) New York, NY</channel>
-    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCIUDT1.us" site_id="cw26-wciu-chicago-il/1834">CW (WCIU) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCIUDT5.us" site_id="story-wciutv5-chicago-il/11342">Story (WCIU-DT5) Chicago, IL</channel>
     <channel lang="en" xmltv_id="WCMUDT1.us" site_id="pbs-wcmu-mt-pleasant-mi/9304">PBS (WCMU-TV) Mount Pleasant, MI</channel>
+    <channel lang="en" xmltv_id="WCSCDT1.us" site_id="cbs-wcsc-charleston-sc/1092">CBS (WCSC) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WCVBDT1.us" site_id="abc-wcvb-boston-ma/133">ABC (WCVB-TV) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCVBDT2.us" site_id="metv-wcvbdt2-boston/10773">MeTV (WCVB-DT2) Boston, MA</channel>
     <channel lang="en" xmltv_id="WCWJDT1.us" site_id="cw-wcwj-jacksonville-fl/2046">CW (WCWJ) Jacksonville, FL</channel>
@@ -316,6 +318,7 @@
     <channel lang="en" xmltv_id="WFQXDT2.us" site_id="cw-wfqxtv2-traverse-citycadillac-mi/31612">CW (WFQX-DT2) Cadillac, MI</channel>
     <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV) Orlando, FL</channel>
     <channel lang="en" xmltv_id="WFTYDT1.us" site_id="unimas-wfty-smithtown-ny/1961">UniMás (WFTY) Smithtown, NY</channel>
+    <channel lang="en" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WFTYDT4.us" site_id="ion-mystery-wftydt4-smithtown-ny/19460">ION Mystery (WFTY-DT4) Smithtown, NY</channel>
     <channel lang="en" xmltv_id="WFUTDT2.us" site_id="true-crime-network-wfutdt2-newark-nj/16472">True Crime Network (WFUT-DT2) Newark, NJ</channel>
     <channel lang="en" xmltv_id="WFUTDT3.us" site_id="gettv-wfutdt3-newark-nj/16429">GetTV (WFUT-DT3) Newark, NJ</channel>
@@ -328,6 +331,7 @@
     <channel lang="en" xmltv_id="WHDHDT2.us" site_id="this-whdh2-hudson-nh/8041">THIS (WHDH) Boston, MA</channel>
     <channel lang="en" xmltv_id="WHNELD9.us" site_id="newsnet-whneld9-flint-mi/35849">NewsNet (WHNE-LD9) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WIVBDT1.us" site_id="cbs-wivb-buffalo-ny/88">CBS (WIVB) Buffalo, NY</channel>
+    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
     <channel lang="en" xmltv_id="WJAXDT1.us" site_id="cbs-wjax-jacksonville-fl/2048">CBS (WJAX) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WJLADT1.us" site_id="abc-wjla-district-of-columbia/1555">ABC (WJLA) District of Columbia</channel>
     <channel lang="en" xmltv_id="WJLPDT1.us" site_id="metv-wjlp-new-jerseynew-york/5138">MeTV (WJLP) New Jersey</channel>
@@ -348,8 +352,10 @@
     <channel lang="en" xmltv_id="WKARDT1.us" site_id="pbs-wkar-east-lansing-mi/13241">PBS (WKAR-TV) East Lansing, MI</channel>
     <channel lang="en" xmltv_id="WKBWDT1.us" site_id="abc-wkbw-buffalo-ny/89">ABC (WKBW) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD1.us" site_id="azteca-wkob-new-york-ny/5096">Azteca (WKOB) New York, NY</channel>
+    <channel lang="en" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD3.us" site_id="peace-tv-wkobld3-new-york-ny/11085">Peace TV (WKOB-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD5.us" site_id="sonlife-network-wkobld5-new-york-ny/11087">SonLife Network (WKOB-LD5) New York, NY</channel>
+    <channel lang="en" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD7.us" site_id="shop-lc-wkobdt7-new-york-ny/16454">Shop LC (WKOB-DT7) New York, NY</channel>
     <channel lang="en" xmltv_id="WKOBLD8.us" site_id="ontv4u-wkobdt8-new-york-ny/17491">ONTV4U (WKOB-DT8) New York, NY</channel>
     <channel lang="en" xmltv_id="WKRNDT1.us" site_id="abc-wkrn-nashville-tn/1886">ABC (WKRN) Nashville, TN</channel>
@@ -373,6 +379,7 @@
     <channel lang="en" xmltv_id="WMARDT5.us" site_id="court-tv-wmartv5-baltimore-md/34056">Court TV (WMAR-DT5) Baltimore, MD</channel>
     <channel lang="en" xmltv_id="WMBCDT2.us" site_id="quest-wmbctv2-newton-nj/16467">Quest (WMBC-TV2) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBCDT5.us" site_id="new-tang-dynasty-tv-wmbcdt5-newton-nj/15033">New Tang Dynasty TV (WMBC-DT5) Newton, NJ</channel>
+    <channel lang="en" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
     <channel lang="en" xmltv_id="WMBQCD1.us" site_id="biztv-wmbqcd-new-york-ny/16459">Biz-TV (WMBQ-CD) New York, NY</channel>
     <channel lang="en" xmltv_id="WMBQCD2.us" site_id="hope-channel-wmbqcd2-new-york-ny/16460">Hope Channel (WMBQ-CD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WMEUCD1.us" site_id="the-u-wmeucd-chicago-il/12512">The U (WMEU-CD) Chicago, IL</channel>
@@ -382,16 +389,20 @@
     <channel lang="en" xmltv_id="WNDTCD1.us" site_id="fnx-wndtcd-manhattan-ny/34515">FNX (WNDT-CD) Manhattan, NY</channel>
     <channel lang="en" xmltv_id="WNETDT1.us" site_id="pbs-wnet-new-york-ny/1774">PBS (WNET) New York, NY</channel>
     <channel lang="en" xmltv_id="WNETDT2.us" site_id="pbs-kids-wnetdt2-new-york-ny/2088">PBS Kids (WNET-DT2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNJBDT1.us" site_id="nj-pbs-wnjb-new-brunswick-nj/2124">NJ PBS (WNJB) New Brunswick, NJ</channel>
     <channel lang="en" xmltv_id="WNJNDT1.us" site_id="nj-pbs-wnjn-montclair-nj/2574">NJ PBS (WNJN) Montclair, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT1.us" site_id="nj-pbs-wnjt-trenton-nj/2564">NJ PBS (WNJT) Trenton, NJ</channel>
     <channel lang="en" xmltv_id="WNJTDT2.us" site_id="nhk-world-wnjttv2-trenton-nj/32845">NHK World (WNJT-TV2) Trenton, NJ</channel>
+    <channel lang="en" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
+    <channel lang="en" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
     <channel lang="en" xmltv_id="WNMFLD1.us" site_id="infomercials-wnmf-new-york-ny/17860">Infomercials (WNMF) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMFLD2.us" site_id="jewelry-tv-wnmfld2-new-york-ny/17861">Jewelry TV (WNMF-LD2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNMUDT1.us" site_id="pbs-wnmu-marquette-mi/481">PBS (WNMU) Marquette, MI</channel>
     <channel lang="en" xmltv_id="WNWODT1.us" site_id="nbc-wnwo-toledo-oh/259">NBC (WNWO-TV) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WNXYLD1.us" site_id="cgtn-wnxyld-new-york-ny/16456">CGTN (WNXY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNXYLD2.us" site_id="cctv4-wnxyld2-new-york-ny/16457">CCTV-4 (WNXY-LD2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT1.us" site_id="nyc-life-wnyedt1-new-york-ny/10011">NYC Life (WNYE-DT1) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT2.us" site_id="nyc-gov-wnyedt2-new-york-ny/11074">NYC Gov (WNYE-DT2) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYEDT3.us" site_id="cuny-wnyedt3-new-york-ny/11075">CUNY (WNYE-DT3) New York, NY</channel>
@@ -405,15 +416,17 @@
     <channel lang="en" xmltv_id="WNYWDT5.us" site_id="decades-wnyw5-new-york-ny/34342">Decades (WNYW5) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD1.us" site_id="cgtn-wnyxld-new-york-ny/16441">CGTN (WNYX-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD2.us" site_id="cctv4-wnyxld2-new-york-ny/16442">CCTV-4 (WNYX-LD2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD4.us" site_id="revn-wnyxld4-new-york-ny/16447">REV&apos;N (WNYX-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WNYXLD5.us" site_id="retro-tv-wnyxld5-new-york-ny/17849">Retro TV (WNYX-LD5) New York, NY</channel>
     <channel lang="en" xmltv_id="WOIDT1.us" site_id="abc-woi-des-moines-ia/1245">ABC (WOI) Des Moines, IA</channel>
+    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="WPCWDT1.us" site_id="cw-wpcw-pittsburgh-pa/3187">CW (WPCW) Jeannette, PA</channel>
     <channel lang="en" xmltv_id="WPIXDT1.us" site_id="wpix-new-york-superstation/63">CW (WPIX) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT2.us" site_id="antenna-wpix2-new-york-ny/10745">Antenna (WPIX2) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT3.us" site_id="court-tv-wpix3-new-york-ny/9723">Court TV (WPIX3) New York, NY</channel>
     <channel lang="en" xmltv_id="WPIXDT4.us" site_id="rewind-tv-us-wpix4-new-york-ny/32844">Rewind TV US (WPIX4) New York, NY</channel>
-    <channel lang="es" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
+    <channel lang="en" xmltv_id="WPLGDT1.us" site_id="abc-wplg-miami-fl/3358">ABC (WPLG) Miami, FL</channel>
     <channel lang="en" xmltv_id="WPVIDT2.us" site_id="localish-wpvidt2-philadelphia-pa/8852">Localish (WPVI-DT2) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPVIDT3.us" site_id="this-wpvitv3-philadelphia-pa/14662">THIS (WPVI-TV3) Philadelphia, PA</channel>
     <channel lang="en" xmltv_id="WPXNDT1.us" site_id="ion-wpxn-new-york-ny/1778">ION (WPXN) New York, NY</channel>
@@ -439,6 +452,7 @@
     <channel lang="en" xmltv_id="WTATDT1.us" site_id="fox-wtat-charleston-sc/1097">FOX (WTAT) Charleston, SC</channel>
     <channel lang="en" xmltv_id="WTBYDT1.us" site_id="tbn-wtby-new-york-ny/2575">TBN (WTBY) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT2.us" site_id="smile-wtbytv2-new-york-ny/11093">Smile (WTBY-TV2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
     <channel lang="en" xmltv_id="WTBYDT4.us" site_id="positiv-wtbytv4-new-york-ny/11095">PosiTiV (WTBY-TV4) New York, NY</channel>
     <channel lang="en" xmltv_id="WTLVDT1.us" site_id="nbc-wtlv-jacksonville-fl/1435">NBC (WTLV) Jacksonville, FL</channel>
     <channel lang="en" xmltv_id="WTNHDT1.us" site_id="abc-wtnh-sd-new-haven-ct/17476">ABC (WTNH) SD New Haven, CT</channel>
@@ -448,6 +462,7 @@
     <channel lang="en" xmltv_id="WTVGDT2.us" site_id="cw-wtvgdt2-toledo-oh/10390">CW (WTVG-DT2) Toledo, OH</channel>
     <channel lang="en" xmltv_id="WTVSDT5.us" site_id="mlc-wtvsdt5-detroit-mi/36121">Michigan Learning Channel (WTVS-DT5) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WTVTDT1.us" site_id="fox-wtvt-tampa-bay-fl/2552">FOX (WTVT) Tampa Bay, FL</channel>
+    <channel lang="en" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
     <channel lang="en" xmltv_id="WVUEDT1.us" site_id="fox-wvue-new-orleans-la/1745">FOX (WVUE) New Orleans, LA</channel>
     <channel lang="en" xmltv_id="WWAYDT2.us" site_id="cbs-wway2-wilmington-nc/7209">CBS (WWAY2) Wilmington, NC</channel>
     <channel lang="en" xmltv_id="WWJDT4.us" site_id="fave-tv-wwjtv4-detroit-mi/35971">Fave TV (WWJ-DT4) Detroit, MI</channel>
@@ -458,31 +473,16 @@
     <channel lang="en" xmltv_id="WXINDT1.us" site_id="fox-wxin-indianapolis-in/1374">FOX (WXIN) Indianapolis, IN</channel>
     <channel lang="en" xmltv_id="WXNYLD1.us" site_id="cgtn-wxnyld-new-york-ny/11078">CGTN (WXNY-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD2.us" site_id="cctv4-wxnyld2-new-york-ny/16443">CCTV-4 (WXNY-LD2) New York, NY</channel>
+    <channel lang="en" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD4.us" site_id="retro-tv-wxnyld4-new-york-ny/16446">Retro TV (WXNY-LD4) New York, NY</channel>
     <channel lang="en" xmltv_id="WXNYLD5.us" site_id="retro-tv-wxnyld5-new-york-ny/17346">Retro TV (WXNY-LD5) New York, NY</channel>
+    <channel lang="en" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT2.us" site_id="bounce-wxtvdt2-paterson-nj/16452">Bounce (WXTV-DT2) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT3.us" site_id="twist-wxtvdt3-paterson-nj/16450">Twist (WXTV-DT3) Paterson, NJ</channel>
     <channel lang="en" xmltv_id="WXTVDT4.us" site_id="grit-tv-wxtvdt4-paterson-nj/16451">Grit TV (WXTV-DT4) Paterson, NJ</channel>
+    <channel lang="en" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
     <channel lang="en" xmltv_id="WYXNLD1.us" site_id="cgtn-wyxnld-new-york-ny/29736">CGTN (WYXN-LD) New York, NY</channel>
     <channel lang="en" xmltv_id="WZMQDT2.us" site_id="cbs-wzmq2-marquette-mi/17308">CBS (WZMQ-DT2) Marquette, MI</channel>
-    <channel lang="es" xmltv_id="W20CQD2.us" site_id="esperanza-w20cqd2-hempstead-ny/16437">Esperanza (W20CQ-D2) Hempstead, NY</channel>
-    <channel lang="es" xmltv_id="WASALD1.us" site_id="estrella-wasald-port-jervis-ny/11071">Estrella (WASA-LD) Port Jervis, NY</channel>
-    <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UNI (WFTY-DT2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD2.us" site_id="daystar-wkobld2-new-york-ny/11083">Daystar (WKOB-LD2) New York, NY</channel>
-    <channel lang="es" xmltv_id="WKOBLD6.us" site_id="estrella-wkobdt6-new-york-ny/16453">Estrella (WKOB-DT6) New York, NY</channel>
-    <channel lang="es" xmltv_id="WMBCDT7.us" site_id="aliento-vision-wmbctv7-newton-nj/16468">Aliento Vision (WMBC-TV7) Newton, NJ</channel>
-    <channel lang="es" xmltv_id="WNETDT3.us" site_id="vme-wnetdt3-new-york-ny/7291">V-Me (WNET-DT3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNJUDT1.us" site_id="telemundo-wnju-teterboro-nj/1772">Telemundo (WNJU) Teterboro, NJ</channel>
-    <channel lang="es" xmltv_id="WNJUDT2.us" site_id="telexitos-wnju2-teterboro-nj/10749">TeleXitos (WNJU2) Teterboro, NJ</channel>
-    <channel lang="es" xmltv_id="WNXYLD3.us" site_id="cgtn-spanish-wnxyld3-new-york-ny/16458">CGTN Spanish (WNXY-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WNYXLD3.us" site_id="cgtn-spanish-wnyxld3-new-york-ny/16445">CGTN Spanish (WNYX-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WTBYDT3.us" site_id="enlace-wtbytv3-new-york-ny/11094">Enlace (WTBY-TV3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WUTVDT1.us" site_id="fox-wutv-buffalo-ny/45">FOX (WUTV) Buffalo, NY</channel>
-    <channel lang="es" xmltv_id="WXNYLD3.us" site_id="cgtn-spanish-wxnyld3-new-york-ny/16444">CGTN Spanish (WXNY-LD3) New York, NY</channel>
-    <channel lang="es" xmltv_id="WXTVDT1.us" site_id="uni-wxtv-teaneck-nj/1771">UNI (WXTV) Teaneck, NJ</channel>
-    <channel lang="es" xmltv_id="WXYZDT1.us" site_id="abc-wxyz-detroit-mi/11155">ABC (WXYZ) Detroit, MI</channel>
-    <channel lang="en" xmltv_id="WJACDT4.us" site_id="cw-wjactv4-johnstown-pa/15113">CW+ (WJAC-TV4) Johnstown, PA</channel>
-    <channel lang="en" xmltv_id="WorldFishingNetwork.us" site_id="wfnworld-fishing-network/2414">World Fishing Network</channel>
     <channel lang="en" xmltv_id="YesNetwork.us" site_id="yes-network/1953">YES Network</channel>
     <channel lang="en" xmltv_id="YTATV.us" site_id="youtoo-america-network/5463">Youtoo America - Network</channel>
   </channels>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -90,8 +90,8 @@
     <channel lang="en" xmltv_id="FreeformWest.us" site_id="freeform-pacific-feed/1197">Freeform West</channel>
     <channel lang="en" xmltv_id="FuseEast.us" site_id="fuse-tv-hd-eastern/6221">Fuse East</channel>
     <channel lang="en" xmltv_id="FXEast.us" site_id="fx-networks-east-coast-hd/6111">FX East</channel>
-    <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
     <channel lang="en" xmltv_id="FXMovieChannel.us" site_id="fx-movie-channel-hd/8463">FX Movie Channel</channel>
+    <channel lang="en" xmltv_id="FXWest.us" site_id="fx-networks-west-coast/1449">FX West</channel>
     <channel lang="en" xmltv_id="FXXEast.us" site_id="fxx-usa-hd-eastern/7506">FXX East</channel>
     <channel lang="en" xmltv_id="FXXWest.us" site_id="fxx-usa-pacific/19080">FXX West</channel>
     <channel lang="en" xmltv_id="FYIEast.us" site_id="fyi-usa-hd-eastern/6211">FYI East</channel>
@@ -200,8 +200,8 @@
     <channel lang="en" xmltv_id="KYAZDT2.us" site_id="metv-plus-kyazdt2-houston-tx/15499">MeTV Plus (KYAZ-DT2) Houston TX</channel>
     <channel lang="en" xmltv_id="LogoEast.us" site_id="logo-east/2091">Logo East</channel>
     <channel lang="en" xmltv_id="LogoWest.us" site_id="logo-pacific/13460">Logo West</channel>
-    <channel lang="en" xmltv_id="MagnoliaNetwork.us" site_id="magnolia-hd-east/8114">Magnolia Network</channel>
     <channel lang="en" xmltv_id="MagnoliaNetworEast.us" site_id="magnolia-hd-east/8114">Magnolia East</channel>
+    <channel lang="en" xmltv_id="MagnoliaNetwork.us" site_id="magnolia-hd-east/8114">Magnolia Network</channel>
     <channel lang="en" xmltv_id="MeTV.us" site_id="metv-network/16325">MeTV Network</channel>
     <channel lang="en" xmltv_id="MGMPlusDriveIn.us" site_id="epix-drivein/11487">MGM+ Drive-In</channel>
     <channel lang="en" xmltv_id="MGMPlusEast.us" site_id="epix-hd-east/7610">MGM+ East</channel>


### PR DESCRIPTION
Sorted alphabetically.
Language fix on two stations.
Added ActionMaxEast #1791
Added CinemaxEast #1793
Added CinemaxWest #1794
Added MoreMaxEast #1796
Added MovieMaxEast #1798
Added ThrillerMaxEast #1799
Added DiscoveryChannelEast #1800
Added DiscoveryFamily #1801
Added DisneyChannelEast #1802
Added DisneyJuniorEast #1803
Added DisneyXDEast #1804
Added Magnolia Network #1806
Added FYIEast #1808
Added GolTV #1809
Added FuseEast #1810
Added FXEast #1811
Added FXXEast #1812
Added FXMovieChannel #1813