### PR TITLE
AXN Germany re-brand

### DIFF
--- a/sites/hd-plus.de/hd-plus.de.channels.xml
+++ b/sites/hd-plus.de/hd-plus.de.channels.xml
@@ -11,7 +11,7 @@
     <channel lang="de" xmltv_id="ATV.at" site_id="atv-hd">ATV</channel>
     <channel lang="de" xmltv_id="ATV2.at" site_id="atv2">ATV 2</channel>
     <channel lang="de" xmltv_id="AugsburgTV.de" site_id="a-tv">Augsburg TV</channel>
-    <channel lang="de" xmltv_id="AXNGermany.de" site_id="axn-hd">AXN Deutschland</channel>
+    <channel lang="de" xmltv_id="SonyAXN.de" site_id="axn-hd">Sony AXN</channel>
     <channel lang="de" xmltv_id="BRFernsehenNord.de" site_id="bayerisches-fernsehen-hd">Bayerisches Fernsehen Nord</channel>
     <channel lang="de" xmltv_id="BibelTV.de" site_id="bibel-tv-hd">Bibel TV</channel>
     <channel lang="de" xmltv_id="BloombergTVEurope.uk" site_id="bloomberg-tv-europe">Bloomberg TV Europe</channel>

--- a/sites/tv.post.lu/tv.post.lu.channels.xml
+++ b/sites/tv.post.lu/tv.post.lu.channels.xml
@@ -6,7 +6,7 @@
     <channel lang="de" xmltv_id="AnimalPlanetGermany.de" site_id="fcaabf30-77e7-11e9-b5ca-f345a2ed0fbe">Animal Planet</channel>
     <channel lang="de" xmltv_id="ARDalpha.de" site_id="067f0c30-8096-11e9-b5ca-f345a2ed0fbe">ARD-Alpha</channel>
     <channel lang="de" xmltv_id="AutoMotorundSport.de" site_id="da694da0-7199-11e9-a762-3be38d7f533c">Auto Motor Sport</channel>
-    <channel lang="de" xmltv_id="AXNGermany.de" site_id="5524fb20-719a-11e9-a762-3be38d7f533c">AXN</channel>
+    <channel lang="de" xmltv_id="SonyAXN.de" site_id="5524fb20-719a-11e9-a762-3be38d7f533c">Sony AXN</channel>
     <channel lang="de" xmltv_id="Bergblick.de" site_id="eae06590-1ec4-11eb-953f-eb0eedf1f375">Bergblick TV</channel>
     <channel lang="de" xmltv_id="BibelTV.de" site_id="39dd1270-8096-11e9-b5ca-f345a2ed0fbe">Bibel TV</channel>
     <channel lang="de" xmltv_id="BoomerangGermany.de" site_id="53424560-81d5-11e9-b43b-9d7b168e6372">Boomerang</channel>


### PR DESCRIPTION
Change AXNGermany.de to SonyAXN.de
#1940

Will pick up tv.blue.ch in a separate PR as there are more changes to be done