### PR TITLE
Update tvpassport.com.config.js

### DIFF
--- a/sites/tvpassport.com/tvpassport.com.config.js
+++ b/sites/tvpassport.com/tvpassport.com.config.js
@@ -11,7 +11,7 @@ dayjs.extend(customParseFormat)
 
 module.exports = {
   site: 'tvpassport.com',
-  days: 2,
+  days: 3,
   url({ channel, date }) {
     return `https://www.tvpassport.com/tv-listings/stations/${channel.site_id}/${date.format(
       'YYYY-MM-DD'


### PR DESCRIPTION
The guide data is currently 18.3 mb today. (https://github.com/iptv-org/epg/blob/gh-pages/guides/en/tvpassport.com.xml)

I believe extending the guide data to 3 days will remain under the 50mb limit.

This PR does that. :)