### PR TITLE
Added Orlando Channels to TVPassport

### DIFF
--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -640,7 +640,13 @@
     <channel lang="en" xmltv_id="WFSBDT2.us" site_id="ion-mystery-wfsb2-hartford-ct/15686">ION Mystery (WFSB-DT2) Hartford, CT</channel>
     <channel lang="en" xmltv_id="WFSBDT3.us" site_id="laff-wfsb3-hartford-ct/16153">Laff (WFSB-DT3) Hartford, CT</channel>
     <channel lang="en" xmltv_id="WFSBDT4.us" site_id="cbs-wfsb4-fairfield-county-hartfod-ct/14723">CBS (WFSB-DT4) Fairfield County, CT</channel>
-    <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WFTVDT1.us" site_id="abc-wftv-orlando-fl/2494">ABC (WFTV-DT1) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WKMGDT1.us" site_id="cbs-wkmg-orlando-fl/2492">CBS (WKMG-DT1) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WKCFDT1.us" site_id="cw-wkcf-orlando-fl/2515">CW (WKCF-DT1) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WOFLDT1.us" site_id="fox-wofl-orlando-fl/2491">FOX (WOFL-DT1) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WRBWDT1.us" site_id="fox-35-plus-wrbw-orlando-fl/2493">My TV 65 / FOX 35 Plus (WRBW-DT1) Orlando, FL</channel>
+    <channel lang="en" xmltv_id="WESHDT1.us" site_id="nbc-wesh-daytona-beach-fl/2490">NBC (WESH-DT1) Daytona Beach, FL</channel>
+    <channel lang="en" xmltv_id="WRDQDT3.us" site_id="telemundo-wrdqdt3-orlando-fl/17603">Telemundo (WRDQ-DT3) Orlando, FL</channel>    
     <channel lang="en" xmltv_id="WFTYDT1.us" site_id="unimas-wfty-smithtown-ny/1961">True Crime Network (WFTY) Smithtown, NY</channel>
     <channel lang="es" xmltv_id="WFTYDT2.us" site_id="uni-wftydt2-new-york-ny/1962">UniMás (WFTY-DT2) New York, NY</channel>
     <channel lang="es" xmltv_id="WFTYDT3.us" site_id="gettv-wftydt3-los-angeles-ca/13521">GetTV (WFTY-DT3) Los Angeles, CA</channel>


### PR DESCRIPTION
Added six Orlando channels. Corrected station name for ABC.