### PR TITLE
Patch 2023.05.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "commander": "^8.2.0",
         "csv-parser": "^3.0.0",
         "dayjs": "^1.10.8",
-        "epg-grabber": "^0.30.2",
+        "epg-grabber": "^0.31.0",
         "epg-parser": "^0.2.0",
         "form-data": "^4.0.0",
         "fs-extra": "^10.0.1",
@@ -1990,6 +1990,11 @@
         }
       ]
     },
+    "node_modules/cdata": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/cdata/-/cdata-0.1.3.tgz",
+      "integrity": "sha512-z0R4cT5357OEAVkP1CEFTHz1egpu2gYiWm2WJOY/sQDhojEXUYL4m3v2kYi5wER3PkMRL+GgfDhed2kGzrHSZA=="
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2438,6 +2443,14 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/cwait": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cwait/-/cwait-1.1.2.tgz",
+      "integrity": "sha512-kIx8zE5jJ1iBgZytTr01aj57HdC+thPsg8W9Tw0gbf30/F7wfRRUS+BiXT90Dn+A0oGtF0xLT5293Ua4w/ZsNA==",
+      "dependencies": {
+        "cdata": "^0.1.1"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -2724,9 +2737,9 @@
       }
     },
     "node_modules/epg-grabber": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.30.2.tgz",
-      "integrity": "sha512-Ao8hM1yizk5tuNeskER0YmU3IWRFzBCjgKnRpCHpLNKCkst28AmicN/Bzi32EXE06hl8yXQnKKwKnp7/PCI/Xw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.31.0.tgz",
+      "integrity": "sha512-DT58SsA9QOBB1qC4uKDabRdbOohUeO4jwUCXEDk9jvI8NVvk3lypnB2JUkwYv3Q1kQeFs+522E8pbcZLEa5oFQ==",
       "dependencies": {
         "axios": "^0.21.1",
         "axios-cache-interceptor": "^0.10.3",
@@ -2734,6 +2747,7 @@
         "axios-mock-adapter": "^1.20.0",
         "commander": "^7.1.0",
         "curl-generator": "^0.2.0",
+        "cwait": "^1.1.2",
         "dayjs": "^1.10.4",
         "epg-parser": "^0.1.6",
         "fs-extra": "^11.1.1",
@@ -8446,6 +8460,11 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
       "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
     },
+    "cdata": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/cdata/-/cdata-0.1.3.tgz",
+      "integrity": "sha512-z0R4cT5357OEAVkP1CEFTHz1egpu2gYiWm2WJOY/sQDhojEXUYL4m3v2kYi5wER3PkMRL+GgfDhed2kGzrHSZA=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8796,6 +8815,14 @@
         "ms": "^2.0.0"
       }
     },
+    "cwait": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cwait/-/cwait-1.1.2.tgz",
+      "integrity": "sha512-kIx8zE5jJ1iBgZytTr01aj57HdC+thPsg8W9Tw0gbf30/F7wfRRUS+BiXT90Dn+A0oGtF0xLT5293Ua4w/ZsNA==",
+      "requires": {
+        "cdata": "^0.1.1"
+      }
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -9005,9 +9032,9 @@
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "epg-grabber": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.30.2.tgz",
-      "integrity": "sha512-Ao8hM1yizk5tuNeskER0YmU3IWRFzBCjgKnRpCHpLNKCkst28AmicN/Bzi32EXE06hl8yXQnKKwKnp7/PCI/Xw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.31.0.tgz",
+      "integrity": "sha512-DT58SsA9QOBB1qC4uKDabRdbOohUeO4jwUCXEDk9jvI8NVvk3lypnB2JUkwYv3Q1kQeFs+522E8pbcZLEa5oFQ==",
       "requires": {
         "axios": "^0.21.1",
         "axios-cache-interceptor": "^0.10.3",
@@ -9015,6 +9042,7 @@
         "axios-mock-adapter": "^1.20.0",
         "commander": "^7.1.0",
         "curl-generator": "^0.2.0",
+        "cwait": "^1.1.2",
         "dayjs": "^1.10.4",
         "epg-parser": "^0.1.6",
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Arhey",
   "license": "MIT",
   "jest": {
-    "testPathIgnorePatterns": [
-      ".jenkins"
+    "modulePathIgnorePatterns": [
+      "<rootDir>/.jenkins/"
     ],
     "testRegex": "(sites|tests)/(.*?/)?.*test.js$",
     "setupFilesAfterEnv": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commander": "^8.2.0",
     "csv-parser": "^3.0.0",
     "dayjs": "^1.10.8",
-    "epg-grabber": "^0.30.2",
+    "epg-grabber": "^0.31.0",
     "epg-parser": "^0.2.0",
     "form-data": "^4.0.0",
     "fs-extra": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,6 +1250,11 @@
   "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
   "version" "1.0.30001434"
 
+"cdata@^0.1.1":
+  "integrity" "sha512-z0R4cT5357OEAVkP1CEFTHz1egpu2gYiWm2WJOY/sQDhojEXUYL4m3v2kYi5wER3PkMRL+GgfDhed2kGzrHSZA=="
+  "resolved" "https://registry.npmjs.org/cdata/-/cdata-0.1.3.tgz"
+  "version" "0.1.3"
+
 "chalk-template@0.4.0":
   "integrity" "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg=="
   "resolved" "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz"
@@ -1588,6 +1593,13 @@
   dependencies:
     "ms" "^2.0.0"
 
+"cwait@^1.1.2":
+  "integrity" "sha512-kIx8zE5jJ1iBgZytTr01aj57HdC+thPsg8W9Tw0gbf30/F7wfRRUS+BiXT90Dn+A0oGtF0xLT5293Ua4w/ZsNA=="
+  "resolved" "https://registry.npmjs.org/cwait/-/cwait-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "cdata" "^0.1.1"
+
 "data-urls@^2.0.0":
   "integrity" "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ=="
   "resolved" "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz"
@@ -1783,10 +1795,10 @@
   "resolved" "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz"
   "version" "4.4.0"
 
-"epg-grabber@^0.30.2":
-  "integrity" "sha512-Ao8hM1yizk5tuNeskER0YmU3IWRFzBCjgKnRpCHpLNKCkst28AmicN/Bzi32EXE06hl8yXQnKKwKnp7/PCI/Xw=="
-  "resolved" "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.30.2.tgz"
-  "version" "0.30.2"
+"epg-grabber@^0.31.0":
+  "integrity" "sha512-DT58SsA9QOBB1qC4uKDabRdbOohUeO4jwUCXEDk9jvI8NVvk3lypnB2JUkwYv3Q1kQeFs+522E8pbcZLEa5oFQ=="
+  "resolved" "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.31.0.tgz"
+  "version" "0.31.0"
   dependencies:
     "axios" "^0.21.1"
     "axios-cache-interceptor" "^0.10.3"
@@ -1794,6 +1806,7 @@
     "axios-mock-adapter" "^1.20.0"
     "commander" "^7.1.0"
     "curl-generator" "^0.2.0"
+    "cwait" "^1.1.2"
     "dayjs" "^1.10.4"
     "epg-parser" "^0.1.6"
     "fs-extra" "^11.1.1"


### PR DESCRIPTION
The update adds the ability to send multiple requests to the same site simultaneously. 

To do this in the config you just need to specify the maximum allowed number of connections for a given site, like this:

```js
module.exports = {
  site: 'tv.nu',
  maxConnections: 200,
  //...
}
```

This parameter should be set separately for each site to avoid server overload or blocking.

Resolves #2054