### PR TITLE
Added --days control to npm grab script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Now choose one of the sources (their complete list can be found in the [/sites](
 
 ```sh
 # Windows
-set SITE=example.com&& npm run grab
+set SITE=example.com && set DAYS=2 && npm run grab
 
 # Linux/macOS
-SITE=example.com npm run grab
+SITE=example.com DAYS=2 npm run grab
 ```
 
 After the download is completed in the current directory will appear a new folder `guides`, which will store all XML files:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:commands": "npx jest --runInBand -- commands",
     "test:sites": "TZ=Pacific/Nauru npx jest --runInBand -- sites",
     "check": "npm run api:load && npm run channels:lint sites/**/*.js && npm run channels:validate sites/**/*.xml",
-    "grab": "cross-var epg-grabber --config=sites/$SITE/$SITE.config.js --channels=sites/$SITE/$SITE.channels.xml --output=guides/{lang}/{site}.xml",
+    "grab": "cross-var epg-grabber --config=sites/$SITE/$SITE.config.js --channels=sites/$SITE/$SITE.channels.xml --output=guides/{lang}/{site}.xml --days=$DAYS",
     "serve": "npx serve"
   },
   "private": true,


### PR DESCRIPTION
Answering half of my own [question](https://github.com/orgs/iptv-org/discussions/441) by adding `--days` control to the npm `grab` script that invokes `epg-grabber`.