### PR TITLE
fix: remove logo attribute to avoid error

### DIFF
--- a/sites/nhk.or.jp/nhk.or.jp.channels.xml
+++ b/sites/nhk.or.jp/nhk.or.jp.channels.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <site site="nhk.or.jp">
   <channels>
-    <channel lang="en" xmltv_id="NHKWorldJapan.jp" site_id="0"
-      logo="https://www3.nhk.or.jp/nhkworld/common/site_images/nw_webapp_1024x1024.png">NHK
-      World-Japan</channel>
+    <channel lang="en" xmltv_id="NHKWorldJapan.jp" site_id="0">NHK World-Japan</channel>
   </channels>
 </site>


### PR DESCRIPTION
"logo" attribute is not allowed on _channel_ tag, it triggers the following error :

> Element 'channel', attribute 'logo': The attribute 'logo' is not allowed.