### PR TITLE
Patch 2023.09.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ To download a guide in a specific language pass its [ISO 639-1](https://en.wikip
 npm run grab -- --site=example.com --lang=fr
 ```
 
+To override the number of days for which the program will be loaded use the `--days` argument (the default is the value specified in the site config):
+
+```sh
+npm run grab -- --site=example.com --days=3
+```
+
 To also create a compressed version of the guide, add the `--gzip` flag:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test:commands": "npx jest --runInBand -- commands",
     "test:sites": "TZ=Pacific/Nauru npx jest --runInBand -- sites",
     "check": "npm run api:load && npm run channels:lint sites/**/*.js && npm run channels:validate sites/**/*.xml",
-    "grab": "npm run api:load && node scripts/commands/epg/grab.js",
-    "serve": "npx serve"
+    "grab": "node scripts/commands/epg/grab.js",
+    "serve": "npx serve",
+    "postinstall": "npm run api:load"
   },
   "private": true,
   "author": "Arhey",

--- a/tests/__data__/expected/guides/en/example.com.xml
+++ b/tests/__data__/expected/guides/en/example.com.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?><tv date="20221020">
 <channel id="Channel1.us"><display-name>Channel 1</display-name><url>https://example.com</url></channel>
+<channel id="Channel2.us"><display-name>Channel 2</display-name><url>https://example.com</url></channel>
 <programme start="20220306043000 +0000" stop="20220306071000 +0000" channel="Channel1.us"><title lang="en">Program1</title></programme>
 </tv>

--- a/tests/__data__/input/sites/epg-grab/epg-grab.channels.xml
+++ b/tests/__data__/input/sites/epg-grab/epg-grab.channels.xml
@@ -2,6 +2,7 @@
 <site site="example.com">
   <channels>
     <channel lang="en" xmltv_id="Channel1.us" site_id="140">Channel 1</channel>
+    <channel lang="en" xmltv_id="Channel2.us" site_id="142">Channel 2</channel>
     <channel lang="fr" xmltv_id="Channel1.us" site_id="140">Channel 1</channel>
   </channels>
 </site>

--- a/tests/__data__/input/sites/epg-grab/epg-grab.config.js
+++ b/tests/__data__/input/sites/epg-grab/epg-grab.config.js
@@ -1,10 +1,15 @@
 module.exports = {
   site: 'example.com',
-  days: 2,
+  days: 1,
+  request: {
+    timeout: 1000
+  },
   url() {
     return `https://example.com`
   },
-  parser() {
+  parser({ channel }) {
+    if (channel.xmltv_id === 'Channel2.us') return []
+
     return [
       {
         title: 'Program1',


### PR DESCRIPTION
Changes:

- fixes "Error: ENOENT: no such file or directory, open 'epg/scripts/tmp/data/channels.json'" (#2159, #2165)
- fixes `npm audit` issues (#2159)
- fixes "Only first channel fetched" (#2166)
- adds `--days` argument to `grab` script