### PR TITLE
Use www.mncvision.id as TV guide source.

### DIFF
--- a/sites/mncvision.id/mncvision.id.config.js
+++ b/sites/mncvision.id/mncvision.id.config.js
@@ -13,7 +13,7 @@ dayjs.extend(customParseFormat)
 module.exports = {
   site: 'mncvision.id',
   days: 2,
-  url: 'https://mncvision.id/schedule/table',
+  url: 'https://www.mncvision.id/schedule/table',
   request: {
     method: 'POST',
     data: function ({ channel, date }) {

--- a/sites/mncvision.id/mncvision.id.test.js
+++ b/sites/mncvision.id/mncvision.id.test.js
@@ -26,7 +26,7 @@ const headers = {
 }
 
 it('can generate valid url', () => {
-  expect(url).toBe('https://mncvision.id/schedule/table')
+  expect(url).toBe('https://www.mncvision.id/schedule/table')
 })
 
 it('can generate valid request method', () => {


### PR DESCRIPTION
Guide for mncvision.id expects to be POST request. The first POST request indeed routed to https://mncvision.id/schedule/table, but this site will then redirect it to https://www.mncvision.id/schedule/table. The redirection will use GET request, so the schedule POST data will never be received by the site.