### PR TITLE
Update osn.com TV guide api.

### DIFF
--- a/sites/osn.com/osn.com.config.js
+++ b/sites/osn.com/osn.com.config.js
@@ -8,26 +8,19 @@ dayjs.extend(timezone)
 module.exports = {
   site: 'osn.com',
   days: 2,
-  url: 'https://www.osn.com/CMSPages/TVScheduleWebService.asmx/GetTVChannelsProgramTimeTable',
-  request: {
-    method: 'POST',
-    headers: {
+  headers({ channel }) {
+    return {
       'Content-Type': 'application/json; charset=UTF-8',
-      Referer: 'https://www.osn.com'
-    },
-    data({ channel, date }) {
-      return {
-        newDate: date.format('MM/DD/YYYY'),
-        selectedCountry: 'AE',
-        channelCode: channel.site_id,
-        isMobile: false,
-        hoursForMobile: 0
-      }
-    },
-    jar: null
+      Referer: `https://www.osn.com/${channel.lang}-ae/watch/tv-schedule`,
+    }
   },
-  parser: function ({ content, channel }) {
-    let programs = []
+  url({ channel, date }) {
+    return `https://www.osn.com/api/TVScheduleWebService.asmx/GetTVChannelsProgramTimeTable?newDate=${
+      encodeURIComponent(date.format('MM/DD/YYYY'))
+    }&selectedCountry=AE&channelCode=${channel.site_id}&isMobile=false&hoursForMobile=6`
+  },
+  parser({ content, channel }) {
+    const programs = []
     const items = parseItems(content)
     items.forEach(item => {
       const start = parseStart(item, channel)
@@ -64,8 +57,5 @@ function parseStart(item) {
 }
 
 function parseItems(content) {
-  if (!content) return []
-  const json = JSON.parse(content)
-
-  return json.d ? JSON.parse(json.d) : []
+  return content ? JSON.parse(content) : []
 }

--- a/sites/osn.com/osn.com.test.js
+++ b/sites/osn.com/osn.com.test.js
@@ -1,6 +1,6 @@
 // NODE_OPTIONS=--insecure-http-parser npx epg-grabber --config=sites/osn.com/osn.com.config.js --channels=sites/osn.com/osn.com.channels.xml --output=guide.xml --days=2
 
-const { parser, url, request } = require('./osn.com.config.js')
+const { parser, url, headers } = require('./osn.com.config.js')
 const dayjs = require('dayjs')
 const utc = require('dayjs/plugin/utc')
 const customParseFormat = require('dayjs/plugin/customParseFormat')
@@ -10,32 +10,20 @@ dayjs.extend(utc)
 const date = dayjs.utc('2021-10-24', 'YYYY-MM-DD').startOf('d')
 const channelAR = { site_id: 'AAN', xmltv_id: 'AlAanTV.ae', lang: 'ar' }
 const channelEN = { site_id: 'AAN', xmltv_id: 'AlAanTV.ae', lang: 'en' }
-const content = JSON.stringify({
-  d: '[{"IsPlaying":"0","Durationtime":null,"StartMinute":0,"EndMinute":0,"EmptyDivWidth":1152,"TotalDivWidth":576,"IsTodayDate":false,"IsLastRow":false,"StartDateTime":"24 Oct 2021, 22:00","EndDateTime":"\\/Date(-62135596800000)\\/","Title":"Al Aan TV","Arab_Title":"تلفزيون الآن","GenreEnglishName":null,"GenreArabicName":null,"ChannelNumber":140,"ChannelCode":"AAN","Duration":"\\/Date(-62135596800000)\\/","Showtime":"\\/Date(-62135596800000)\\/","EpisodeId":738257,"ProgramType":null,"EPGUNIQID":"AAN202110271800738257"}]'
-})
-
-it('can generate valid request data', () => {
-  const result = request.data({ channel: channelAR, date })
-  expect(result).toMatchObject({
-    newDate: '10/24/2021',
-    selectedCountry: 'AE',
-    channelCode: 'AAN',
-    isMobile: false,
-    hoursForMobile: 0
-  })
-})
+const content = '[{"IsPlaying":"0","Durationtime":null,"StartMinute":0,"EndMinute":0,"EmptyDivWidth":1152,"TotalDivWidth":576,"IsTodayDate":false,"IsLastRow":false,"StartDateTime":"24 Oct 2021, 22:00","EndDateTime":"\\/Date(-62135596800000)\\/","Title":"Al Aan TV","Arab_Title":"تلفزيون الآن","GenreEnglishName":null,"GenreArabicName":null,"ChannelNumber":140,"ChannelCode":"AAN","Duration":"\\/Date(-62135596800000)\\/","Showtime":"\\/Date(-62135596800000)\\/","EpisodeId":738257,"ProgramType":null,"EPGUNIQID":"AAN202110271800738257"}]'
 
 it('can generate valid request headers', () => {
-  const result = request.headers
+  const result = headers({ channel: channelAR, date })
   expect(result).toMatchObject({
     'Content-Type': 'application/json; charset=UTF-8',
-    Referer: 'https://www.osn.com'
+    Referer: 'https://www.osn.com/ar-ae/watch/tv-schedule'
   })
 })
 
 it('can generate valid url', () => {
-  expect(url).toBe(
-    'https://www.osn.com/CMSPages/TVScheduleWebService.asmx/GetTVChannelsProgramTimeTable'
+  const result = url({ channel: channelAR, date })
+  expect(result).toBe(
+    'https://www.osn.com/api/TVScheduleWebService.asmx/GetTVChannelsProgramTimeTable?newDate=10%2F24%2F2021&selectedCountry=AE&channelCode=AAN&isMobile=false&hoursForMobile=6'
   )
 })
 
@@ -64,6 +52,6 @@ it('can parse response (en)', () => {
 })
 
 it('can handle empty guide', () => {
-  const result = parser({ date, channel: channelAR, content: JSON.stringify({ d: '[]' }) })
+  const result = parser({ date, channel: channelAR, content: '[]' })
   expect(result).toMatchObject([])
 })


### PR DESCRIPTION
The guide now uses GET request and the language returned by api is detected by the referrer.