### PR TITLE
Fix firstmedia.com schedule mislead.

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -94,7 +94,7 @@
 | nowplayer.now.com          | 🟢     |                                                                     |
 | nuevosiglo.com.uy          | 🟢     |                                                                     |
 | ontvtonight.com            | 🟢     |                                                                     |
-| osn.com                    | 🟡     | https://github.com/iptv-org/epg/issues/2157                         |
+| osn.com                    | 🟢     |                                                                     |
 | pbsguam.org                | 🟢     |                                                                     |
 | plex.tv                    | 🟢     |                                                                     |
 | programacion-tv.elpais.com | 🟢     |                                                                     |


### PR DESCRIPTION
The retrieved schedules from firstmedia.com api indeed confusing. Taken for example the following snippet:

```
{
  channelNo: '245',
  title: 'News Bulletin',
  date: '2023-11-07 17:00:00',
  startTime: '2023-11-07 17:00:00',
  endTime: '2023-11-07 17:30:00',
  description: 'News Bulletin',
  long_description: 'Hourly update of international news with an emphasis on the Arab world.'
}
```

Neither `startTime` nor `endTime` is an actual time but an offset from `date`. If its an actual time then it would overlap with each others.

The workaround is to calculate the start and stop time offset, sort the schedules based on those offset, and last skip overlapped schedules.