### PR TITLE
Fix firstmedia.com schedule api start time.

### DIFF
--- a/sites/firstmedia.com/firstmedia.com.config.js
+++ b/sites/firstmedia.com/firstmedia.com.config.js
@@ -11,7 +11,7 @@ module.exports = {
   url({ channel, date }) {
     return `https://api.firstmedia.com/api/content/tv-guide/list?date=${date.format(
       'DD/MM/YYYY'
-    )}&channel=${channel.site_id}&startTime=0&endTime=24`
+    )}&channel=${channel.site_id}&startTime=1&endTime=24`
   },
   parser({ content, channel, date }) {
     if (!content || !channel || !date) return []

--- a/sites/firstmedia.com/firstmedia.com.test.js
+++ b/sites/firstmedia.com/firstmedia.com.test.js
@@ -8,7 +8,7 @@ const channel = { site_id: '243', xmltv_id: 'AlJazeeraEnglish.qa', lang: 'id' }
 
 it('can generate valid url', () => {
   expect(url({ channel, date })).toBe(
-    'https://api.firstmedia.com/api/content/tv-guide/list?date=08/11/2023&channel=243&startTime=0&endTime=24'
+    'https://api.firstmedia.com/api/content/tv-guide/list?date=08/11/2023&channel=243&startTime=1&endTime=24'
   )
 })
 


### PR DESCRIPTION
The correct start time for schedule is 1. Settings start time to 0 will mix the schedules from next day.