### PR TITLE
Update chaines-tv.orange.fr.config.js

### DIFF
--- a/sites/chaines-tv.orange.fr/chaines-tv.orange.fr.config.js
+++ b/sites/chaines-tv.orange.fr/chaines-tv.orange.fr.config.js
@@ -16,7 +16,7 @@ module.exports = {
       const start = parseStart(item)
       const stop = parseStop(item, start)
       programs.push({
-        title: item.title,
+        title: item.season?.serie?.title ? item.season.serie.title : item.title,
         category: item.genreDetailed,
         description: item.synopsis,
         icon: parseIcon(item),


### PR DESCRIPTION
On some occurences, item.title can be the name of the episode instead of the name of the show.