### PR TITLE
The UK version and the Swiss version don't play the same program

### DIFF
--- a/sites/tv.blue.ch/tv.blue.ch.channels.xml
+++ b/sites/tv.blue.ch/tv.blue.ch.channels.xml
@@ -489,7 +489,7 @@
   <channel site="tv.blue.ch" lang="en" xmltv_id="DubaiTV.ae" site_id="138">Dubai TV</channel>
   <channel site="tv.blue.ch" lang="en" xmltv_id="DWEnglish.de" site_id="142">DW Englisch</channel>
   <channel site="tv.blue.ch" lang="en" xmltv_id="E4.uk" site_id="146">E4</channel>
-  <channel site="tv.blue.ch" lang="en" xmltv_id="EDGEsport.uk" site_id="1722">MySports EDGE</channel>
+  <channel site="tv.blue.ch" lang="en" xmltv_id="" site_id="1722">MySports EDGE</channel>
   <channel site="tv.blue.ch" lang="en" xmltv_id="EEurope.nl" site_id="145">E! Entertainment Europe</channel>
   <channel site="tv.blue.ch" lang="en" xmltv_id="EnglishClubTV.uk" site_id="1398">English Club TV</channel>
   <channel site="tv.blue.ch" lang="en" xmltv_id="EuronewsEnglish.fr" site_id="164">Euronews E</channel>


### PR DESCRIPTION
The UK version and the Swiss version don't play the same program, so this is linking to the wrong one.

Removed the ID since I don't believe there is a MySportsEDGE.ch or similar.