### PR TITLE
Resolves issue reported in #2301

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -174,7 +174,7 @@
 | [tvpassport.com](sites/tvpassport.com)                             | 🟢     |                                             |
 | [tvplus.com.tr](sites/tvplus.com.tr)                               | 🟢     |                                             |
 | [tvprofil.com](sites/tvprofil.com)                                 | 🟢     |                                             |
-| [tvtv.us](sites/tvtv.us)                                           | 🔴     | https://github.com/iptv-org/epg/issues/2176 |
+| [tvtv.us](sites/tvtv.us)                                           | 🟢     |                                             |
 | [vidio.com](sites/vidio.com)                                       | 🟢     |                                             |
 | [virginmediatelevision.ie](sites/virginmediatelevision.ie)         | 🟢     |                                             |
 | [virgintvgo.virginmedia.com](sites/virgintvgo.virginmedia.com)     | 🟢     |                                             |

--- a/sites/tvtv.us/tvtv.us.config.js
+++ b/sites/tvtv.us/tvtv.us.config.js
@@ -8,7 +8,7 @@ module.exports = {
   delay: 1500, // 1500 ms (otherwise the server returns error 429: https://github.com/iptv-org/epg/issues/2176)
   days: 2,
   url: function ({ date, channel }) {
-    return `https://www.tvtv.us/api/v1/lineup/USA-NY71652-DEFAULT/grid/${date.toJSON()}/${date
+    return `https://www.tvtv.us/api/v1/lineup/USA-NY71652-X/grid/${date.toJSON()}/${date
       .add(1, 'd')
       .toJSON()}/${channel.site_id}`
   },

--- a/sites/tvtv.us/tvtv.us.test.js
+++ b/sites/tvtv.us/tvtv.us.test.js
@@ -14,7 +14,7 @@ const channel = {
 
 it('can generate valid url', () => {
   expect(url({ channel, date })).toBe(
-    'https://www.tvtv.us/api/v1/lineup/USA-NY71652-DEFAULT/grid/2022-09-20T00:00:00.000Z/2022-09-21T00:00:00.000Z/62670'
+    'https://www.tvtv.us/api/v1/lineup/USA-NY71652-X/grid/2022-09-20T00:00:00.000Z/2022-09-21T00:00:00.000Z/62670'
   )
 })
 


### PR DESCRIPTION
Updated URL for tvtv.us since the -DEFAULT no longer exists.
Should resolve issue reported in #2301 