### PR TITLE
Update tvguide.com.config.js

### DIFF
--- a/sites/tvguide.com/tvguide.com.config.js
+++ b/sites/tvguide.com/tvguide.com.config.js
@@ -11,7 +11,7 @@ module.exports = {
   days: 2,
   url: function ({ date, channel }) {
     const [providerId, channelSourceIds] = channel.site_id.split('#')
-    const url = `https://fandom-prod.apigee.net/v1/xapi/tvschedules/tvguide/${providerId}/web?start=${date
+    const url = `https://internal-prod.apigee.fandom.net/v1/xapi/tvschedules/tvguide/${providerId}/web?start=${date
       .startOf('d')
       .unix()}&duration=1440&channelSourceIds=${channelSourceIds}`
 
@@ -44,7 +44,7 @@ module.exports = {
     for (let providerId of providers) {
       const data = await axios
         .get(
-          `https://fandom-prod.apigee.net/v1/xapi/tvschedules/tvguide/serviceprovider/${providerId}/sources/web`
+          `https://internal-prod.apigee.fandom.net/v1/xapi/tvschedules/tvguide/serviceprovider/${providerId}/sources/web`
         )
         .then(r => r.data)
         .catch(console.log)
@@ -82,6 +82,7 @@ function parseItems(content) {
 }
 
 async function loadProgramDetails(item) {
+  item.programDetails = item.programDetails.replace('player1-backend-prod-internal.apigee.net', 'internal-prod.apigee.fandom.net')
   const data = await axios
     .get(item.programDetails)
     .then(r => r.data)


### PR DESCRIPTION
Resolves https://github.com/iptv-org/epg/issues/2327

It seems like tvguide has changed the server url where they store the api, and also the programDetails internal url they use throws 404, that's why i've added a simple replace to the production url they seem to be using.