### PR TITLE
Update tvpassport.com channels languages

### DIFF
--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -5768,9 +5768,9 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation-discovery-usa--pacific/19949">Investigation Discovery USA - Pacific</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation-discovery-usa-hd--eastern/6997">Investigation Discovery USA HD - Eastern</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation-discovery-usa-hd--pacific/19950">Investigation Discovery USA HD - Pacific</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation-hd/11345">Investigation HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation-sur-demande/15115">Investigation Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="investigation/11344">Investigation</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="investigation-hd/11345">Investigation HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="investigation-sur-demande/15115">Investigation Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="investigation/11344">Investigation</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ion--central-hd/17251">ION - Central HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ion--central/1706">ION - Central</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ion--eastern-feed-hd/8534">ION - Eastern Feed HD</channel>
@@ -6588,8 +6588,8 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="matv--saguenay/7428">MATV - Saguenay</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mavtv-usa-hd/6981">MavTV USA HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mavtv-usa/6610">MavTV USA</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="max-hd/9112">MAX HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="max/306">MAX</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="max-hd/9112">MAX HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="max/306">MAX</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="may-we-suggest/7691">May We Suggest</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mbc-ktsf-dt3-san-francisco-ca/10663">KBS World (KTSF-DT3) San Francisco, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mcaet--media-center-for-art-education--technolo/12630">MCAET - Media Center for Art, Education &amp; Technolo</channel>
@@ -12362,6 +12362,7 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="CanalM.ca" site_id="canal-m/5955">Canal M</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="CanalVie.ca" site_id="canal-vie/307">Canal Vie</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Casa.ca" site_id="casa/5484">CASA</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="elle-fictions/101">ELLE Fictions</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="CBAFTDT.ca" site_id="src-cbaft-moncton-nb/118">ICI (CBAFT) Moncton, NB</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="CBFTDT.ca" site_id="src-cbft-montreal-qc/196">ICI (CBFT) Montreal, QC</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="CBLFTDT.ca" site_id="src-cblft-toronto-hd/3626">ICI (CBLFT) Toronto HD</channel>
@@ -12371,6 +12372,7 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="Cinepop.ca" site_id="cinepop/2325">Cinépop</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="CPACFrench.ca" site_id="cpac-francais/429">CPAC (Francais)</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="DorcelTVCanada.ca" site_id="vivid-tv-canada-francais/8519">Dorcel TV (Français)</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="frissons-tv/32125">Frissons TV</channel>
   <channel site="tvpassport.com" lang="pt" xmltv_id="FPTV.ca" site_id="fptv-festival-portuguese-tv/2465">FPTV (Festival Portuguese TV)</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Historia.ca" site_id="historia/345">Historia</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="IciARTV.ca" site_id="artv/459">ARTV</channel>
@@ -12401,9 +12403,11 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal/1140">Tele-Quebec (CIVM) Montreal</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal-hd/6464">Tele-Quebec (CIVM) Montreal HD</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="TVASports.ca" site_id="tva-sports/9823">TVA Sports</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="unis-est/13716">Unis - Est</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Vrak.ca" site_id="vrak/48">VRAK</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Z.ca" site_id="z/344">Z</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Zeste.ca" site_id="zeste/7508">Zeste</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="amitele/13775">AMI-télé</channel>
   <channel site="tvpassport.com" lang="hu" xmltv_id="ERTWorld.ca" site_id="ert-world-canada/3419">ERT World (Canada)</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="MediasetItalia.ca" site_id="mediaset-italia/8436">Mediaset Italia</channel>
 </channels>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -9805,10 +9805,10 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sec-network-hd/13712">SEC Network HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sec-network/13711">SEC Network</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="selection-xxx-sur-demande/7803">Sélection XXX Sur Demande</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--dv/8394">Series + DV</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--hd/3975">Series + HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--sur-demande/10898">Series + Sur Demande</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series-/341">Series +</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series-dv/8394">Series + DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series-hd/3975">Series + HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series-sur-demande/10898">Series + Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series/341">Series +</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="services-optimum/7692">Services Optimum</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="shaw-cable-events-1/16879">Shaw Cable Events 1</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="shaw-cable-events-2/16880">Shaw Cable Events 2</channel>
@@ -10173,67 +10173,67 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sportstime-ohio/3242">Bally Sports Great Lakes</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sprout-hd/8835">Universal Kids HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sprout/4349">Universal Kids</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbaft-moncton-nb-hd/6816">ICI (CBAFT) Moncton, NB HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbeft-windsor/3883">ICI (CBEFT) Windsor</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfj-st-johns-nf-hd/6818">ICI (CBFJ) St. John's, NF HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfj-st-johns-nf/5476">ICI (CBFJ) St. John's, NF</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfst-src-nord-qc-hd/9671">ICI (CBFST) SRC -Nord, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfst-src-nord/598">ICI (CBFST) SRC-Nord</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbft-montreal-qc-dv/5935">ICI (CBFT) Montreal, QC DV</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbft-montreal-qc-hd/2837">ICI (CBFT) Montreal, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbgat-gaspe-qc-hd/9670">ICI (CBGAT) Gaspé, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbgat-gaspe-qc/2167">ICI (CBGAT) Gaspé, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbhft-halifax-ns-hd/6817">ICI (CBHFT) Halifax, NS HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbhft-halifax-ns/3882">ICI (CBHFT) Halifax, NS</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbkft-regina-sk-hd/6819">ICI (CBKFT) Regina, SK HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbkft-regina-sk/287">ICI (CBKFT) Regina, SK</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cblft-toronto/14">ICI (CBLFT) Toronto</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on-dv/14158">ICI (CBOFT) Ottawa, ON DV</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on-hd/6768">ICI (CBOFT) Ottawa, ON HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on/463">ICI (CBOFT) Ottawa, ON</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab-dv/14160">ICI (CBRFT) Calgary, AB DV</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab-hd/9610">ICI (CBRFT) Calgary, AB HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab/3980">ICI (CBRFT) Calgary, AB</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbst-sept-iles-qc-hd/9673">ICI (CBST) Sept-Iles, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbst-sept-iles-qc/3299">ICI (CBST) Sept-Iles, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbuft-vancouver-bc-hd/6769">ICI (CBUFT) Vancouver, BC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc--digital/5948">ICI (CBVT) Quebec, QC - Digital</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc-hd/6820">ICI (CBVT) Quebec, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc/562">ICI (CBVT) Quebec, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbwft-winnipeg-mb-hd/6770">ICI (CBWFT) Winnipeg, MB HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbwft-winnipeg-mb/144">ICI (CBWFT) Winnipeg, MB</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab-dv/14159">ICI (CBXFT) Edmonton, AB DV</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab-hd/9609">ICI (CBXFT) Edmonton, AB HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab/174">ICI (CBXFT) Edmonton, AB</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjbr-rimouski-qc-hd/9668">ICI (CJBR) Rimouski, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjbr-rimouski-qc/2170">ICI (CJBR) Rimouski, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-dt-val-dor-qc/14060">ICI (CJDG-DT) Val D'Or, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-2-lebel-sur-quevillon-qc/14062">ICI (CJDG-TV-2) Lebel-Sur-Quevillon, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-3-joutel-qc/14064">ICI (CJDG-TV-3) Joutel, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc-hd/14067">ICI (CJDG-TV-4) Matagami, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc/14066">ICI (CJDG-TV-4) Matagami, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-rouyn-qc-hd/9669">ICI (CKRN) Rouyn, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-rouyn-qc/1036">ICI (CKRN) Rouyn, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-tv-2-ville-marie-qc/14056">ICI (CKRN-TV-2) Ville-Marie, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-tv-3-bearnfabre-qc/14058">ICI (CKRN-TV-3) Bearn/Fabre, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-1-baie-st-paul-qc/14050">ICI (CKRT-DT-1) Baie St-Paul, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-2-degelis-qc/14051">ICI (CKRT-DT-2) Dégelis, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-3-riviere-du-loup-qc/14052">ICI (CKRT-DT-3) Rivière-du-Loup, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-4-cabano-qc/14053">ICI (CKRT-DT-4) Cabano, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-5-st-urbain-qc/14054">ICI (CKRT-DT-5) St Urbain, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-6-trois-pistoles-qc/14055">ICI (CKRT-DT-6) Trois-Pistoles, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc-hd/10928">ICI (CKRT) Riviere-du-Loup, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc/499">ICI (CKRT) Riviere-du-Loup, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc--digital/5936">ICI (CKSH) Sherbrooke, QC - digital</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc-hd/9672">ICI (CKSH) Sherbrooke, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc/2169">ICI (CKSH) Sherbrooke, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc--digital/5946">ICI (CKTM) Trois-Rivières, QC - Digital</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc-hd/9674">ICI (CKTM) Trois-Rivières, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc/550">ICI (CKTM) Trois-Rivières, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-jonquiere-qc-hd/10968">ICI (CKTV) Jonquière, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-jonquiere-qc/606">ICI (CKTV) Jonquière, QC</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-saguenay-qc-hd/9667">ICI (CKTV) Saguenay, QC HD</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-saguenay-qc/564">ICI (CKTV) Saguenay, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbaft-moncton-nb-hd/6816">ICI (CBAFT) Moncton, NB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbeft-windsor/3883">ICI (CBEFT) Windsor</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbfj-st-johns-nf-hd/6818">ICI (CBFJ) St. John's, NF HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbfj-st-johns-nf/5476">ICI (CBFJ) St. John's, NF</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbfst-src-nord-qc-hd/9671">ICI (CBFST) SRC -Nord, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbfst-srcnord/598">ICI (CBFST) SRC-Nord</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbft-montreal-qc-dv/5935">ICI (CBFT) Montreal, QC DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbft-montreal-qc-hd/2837">ICI (CBFT) Montreal, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbgat-gaspe-qc-hd/9670">ICI (CBGAT) Gaspé, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbgat-gaspe-qc/2167">ICI (CBGAT) Gaspé, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbhft-halifax-ns-hd/6817">ICI (CBHFT) Halifax, NS HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbhft-halifax-ns/3882">ICI (CBHFT) Halifax, NS</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbkft-regina-sk-hd/6819">ICI (CBKFT) Regina, SK HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbkft-regina-sk/287">ICI (CBKFT) Regina, SK</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cblft-toronto/14">ICI (CBLFT) Toronto</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cboft-ottawa-on-dv/14158">ICI (CBOFT) Ottawa, ON DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cboft-ottawa-on-hd/6768">ICI (CBOFT) Ottawa, ON HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cboft-ottawa-on/463">ICI (CBOFT) Ottawa, ON</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbrft-calgary-ab-dv/14160">ICI (CBRFT) Calgary, AB DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbrft-calgary-ab-hd/9610">ICI (CBRFT) Calgary, AB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbrft-calgary-ab/3980">ICI (CBRFT) Calgary, AB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbst-sept-iles-qc-hd/9673">ICI (CBST) Sept-Iles, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbst-sept-iles-qc/3299">ICI (CBST) Sept-Iles, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbuft-vancouver-bc-hd/6769">ICI (CBUFT) Vancouver, BC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbvt-quebec-qc--digital/5948">ICI (CBVT) Quebec, QC - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbvt-quebec-qc-hd/6820">ICI (CBVT) Quebec, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbvt-quebec-qc/562">ICI (CBVT) Quebec, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbwft-winnipeg-mb-hd/6770">ICI (CBWFT) Winnipeg, MB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbwft-winnipeg-mb/144">ICI (CBWFT) Winnipeg, MB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbxft-edmonton-ab-dv/14159">ICI (CBXFT) Edmonton, AB DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbxft-edmonton-ab-hd/9609">ICI (CBXFT) Edmonton, AB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cbxft-edmonton-ab/174">ICI (CBXFT) Edmonton, AB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjbr-rimouski-qc-hd/9668">ICI (CJBR) Rimouski, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjbr-rimouski-qc/2170">ICI (CJBR) Rimouski, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjdg-dt-val-dor-qc/14060">ICI (CJDG-DT) Val D'Or, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjdg-tv-2-lebel-sur-quevillon-qc/14062">ICI (CJDG-TV-2) Lebel-Sur-Quevillon, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjdg-tv-3-joutel-qc/14064">ICI (CJDG-TV-3) Joutel, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjdg-tv-4-matagami-qc-hd/14067">ICI (CJDG-TV-4) Matagami, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cjdg-tv-4-matagami-qc/14066">ICI (CJDG-TV-4) Matagami, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrn-rouyn-qc-hd/9669">ICI (CKRN) Rouyn, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrn-rouyn-qc/1036">ICI (CKRN) Rouyn, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrn-tv-2-ville-marie-qc/14056">ICI (CKRN-TV-2) Ville-Marie, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrn-tv-3-bearnfabre-qc/14058">ICI (CKRN-TV-3) Bearn/Fabre, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-1-baie-st-paul-qc/14050">ICI (CKRT-DT-1) Baie St-Paul, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-2-degelis-qc/14051">ICI (CKRT-DT-2) Dégelis, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-3-riviere-du-loup-qc/14052">ICI (CKRT-DT-3) Rivière-du-Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-4-cabano-qc/14053">ICI (CKRT-DT-4) Cabano, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-5-st-urbain-qc/14054">ICI (CKRT-DT-5) St Urbain, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-dt-6-trois-pistoles-qc/14055">ICI (CKRT-DT-6) Trois-Pistoles, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-riviere-du-loup-qc-hd/10928">ICI (CKRT) Riviere-du-Loup, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-ckrt-riviere-du-loup-qc/499">ICI (CKRT) Riviere-du-Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cksh-sherbrooke-qc--digital/5936">ICI (CKSH) Sherbrooke, QC - digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cksh-sherbrooke-qc-hd/9672">ICI (CKSH) Sherbrooke, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cksh-sherbrooke-qc/2169">ICI (CKSH) Sherbrooke, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktm-trois-rivieres-qc--digital/5946">ICI (CKTM) Trois-Rivières, QC - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktm-trois-rivieres-qc-hd/9674">ICI (CKTM) Trois-Rivières, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktm-trois-rivieres-qc/550">ICI (CKTM) Trois-Rivières, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktv-jonquiere-qc-hd/10968">ICI (CKTV) Jonquière, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktv-jonquiere-qc/606">ICI (CKTV) Jonquière, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktv-saguenay-qc-hd/9667">ICI (CKTV) Saguenay, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-cktv-saguenay-qc/564">ICI (CKTV) Saguenay, QC</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ssptv-channel-13/18859">SSPTV Channel 13</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ssptv-channel-513hd/18860">SSPTV Channel 513HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sstn-kata-dallas-tx-hd/19947">SSTN (KATA) Dallas, TX HD</channel>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -7266,9 +7266,9 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mnt-xdtv-san-diego-ca/2622">Milenio (XDTV) San Diego, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mnt-xhdtv-tecate-mexico-hd/6947">MNT (XHDTV) Tecate, Mexico HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="mnt-xhdtv-tecate-mexico/4348">Milenio (XHDTV) Tecate, Mexico</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moi-et-compagnie-hd/9155">Moi et compagnie HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moi-et-compagnie-sur-demande/10360">Moi et compagnie Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moi-et-compagnie/9109">Moi et compagnie</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="temoin-hd/9155">Témoin HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="temoin-sur-demande/10360">Témoin Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="temoin/9109">Témoin</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moremax--eastern-hd/7097">MoreMax - Eastern HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moremax--pacific-hd/8472">MoreMax - Pacific HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="moremax--pacific/2581">MoreMax - Pacific</channel>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -529,7 +529,7 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="actionmax--eastern/1377">ActionMax - Eastern</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="actionmax--pacific-hd/8473">ActionMax - Pacific HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="actionmax--pacific/2582">ActionMax - Pacific</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="addik-tv-hd/6059">Addik TV HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="addik-tv-hd/6059">Addik TV HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="adult-on-demand-hd/7136">Adult On Demand HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="adult-on-demand/6480">Adult On Demand</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="adult-swin-on-demand/6664">Adult Swin On Demand</channel>
@@ -792,7 +792,7 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="arirang-tv-kxla-dt5-los-angeles-ca/11250">Arirang TV (KXLA5) Los Angeles, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="arirang-tv-wrnn-dt3-new-york-ny/11091">SHOPHQ (WRNN-DT3) New York, NY</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="arirang-tv/10575">Arirang TV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="artv-hd/5887">ARTV HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="artv-hd/5887">ARTV HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ary-qtv/13700">ARY QTV</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="asn-kmys-dt2-san-antonio-tx/10622">DABL (KMYS) San Antonio, TX</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="asn-wbma-dt3-birmingham-al/15263">The Nest (WBMA-LD3) Birmingham, AL</channel>
@@ -933,9 +933,9 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="baby-first-tv-hd/16414">Baby First TV HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="baby-first-tv-on-demand/14272">Baby First TV On Demand</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="baby-first-tv/4444">Baby First TV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="bandes-annonces-cogeco/3297">Tele Pub Cogeco</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="bandes-annonces-super-ecran--sogetel/5973">Bandes-annonces Super Ecran - Sogetel</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="bandes-annonces-super-ecran/5972">Bandes-annonces Super Ecran</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="bandes-annonces-cogeco/3297">Tele Pub Cogeco</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="bandes-annonces-super-ecran--sogetel/5973">Bandes-annonces Super Ecran - Sogetel</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="bandes-annonces-super-ecran/5972">Bandes-annonces Super Ecran</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="bandes-annonces-viewers-choice/568">Bandes-annonces (Viewer's Choice)</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="basin-pbs-kpbt-tv-odessa-tx-hd/8003">Basin PBS (KPBT-TV) Odessa, TX HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="basin-pbs-kpbt-tv-odessa-tx/8002">Basin PBS (KPBT-TV) Odessa, TX</channel>
@@ -1366,8 +1366,8 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="cable-14-hamilton/670">Cable 14 Hamilton</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-3-guatemala/8636">Canal 3 Guatemala</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-annonces/7766">Canal annonces</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-d-hd/3978">Canal D HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-d-sur-demande/10895">Canal D Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="canal-d-hd/3978">Canal D HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="canal-d-sur-demande/10895">Canal D Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-horaire-hd/6469">Canal horaire HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-horaire/580">Canal horaire</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-indigo-2/3273">Canal Indigo 2</channel>
@@ -1388,8 +1388,8 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-soi-kvea-dt3-los-angeles-ca/11219">Canal SOI (KVEA-DT3) Los Angeles, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-sur-hd/7323">Canal Sur HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-sur/2100">Canal Sur</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-vie-hd/3974">Canal Vie HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="canal-vie-sur-demande/10897">Canal Vie Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="canal-vie-hd/3974">Canal Vie HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="canal-vie-sur-demande/10897">Canal Vie Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="capital-networks-bnn--business-news-network/9860">Capital Networks: BNN Bloomberg</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="capital-networks-city-tv-toronto-on/13732">Capital Networks: CITY Toronto, ON</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="capital-networks-cmt-canada/9858">Capital Networks: CMT Canada</channel>
@@ -1437,8 +1437,8 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="cartoon-network-usa--pacific-feed/1209">Cartoon Network USA - Pacific Feed</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="cartoon-network-usa-hd--eastern/6917">Cartoon Network USA HD - Eastern</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="cartoon-network-usa-hd--pacific/8880">Cartoon Network USA HD - Pacific</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="casa-hd/10211">CASA HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="casa-sur-demande/10361">CASA Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="casa-hd/10211">CASA HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="casa-sur-demande/10361">CASA Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="catholic-television-of-the-diocese-of-scranton/1650">Catholic Television of the Diocese of Scranton</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="catv-12-bismarck-nd/1384">CATV 12 Bismarck, ND</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="cbc--mctv/25">CBC - MCTV</channel>
@@ -4081,10 +4081,10 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="euronews-kbid-lp-coalinga-ca/4201">Al Jazeera (KBID-LP) Coalinga, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="euronews-kmsg-ld-fresno-ca/18629">EuroNews (KMSG-LD3) Fresno, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="euronews/2121">EuroNews</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evasion-hd/6468">Evasion HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evasion-sur-demande/31477">Evasion Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evasion-sur-demande/9057">Evasion Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evasion/343">Evasion</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="evasion-hd/6468">Evasion HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="evasion-sur-demande/31477">Evasion Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="evasion-sur-demande/9057">Evasion Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="evasion/343">Evasion</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evine-hd/11284">SHOPHQ HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evine-kgbs-dt2-austin-tx/18547">Comet TV (KGBS-CD2) Austin, TX</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="evine-kzmm-cd2-fresno-ca/18301">SHOPHQ (KZMM-CD2) Fresno, CA</channel>
@@ -4098,7 +4098,7 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ewtn-usa-kjcs-colorado-springs-co/5642">EWTN USA (KJCS) Colorado Springs, CO</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ewtn-usa/620">EWTN USA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="exercise-ondemand/6843">Exercise OnDemand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="explora-hd/10299">Explora HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="explora-hd/10299">Explora HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="explore-w34dq-dt2-pittsburg-nh/14924">Explore (W34DQ-DT2) Pittsburg, NH</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="explore-w50dp-dt2-hanover-nh/14925">Explore (W50DP-DT2) Hanover, NH</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="explore-wekw-dt2-keene-nh/14922">Explore (WEKW-DT2) Keene, NH</channel>
@@ -5486,9 +5486,9 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="hillsong-wwrs-dt2-mayvolle-wi/15633">TBN Inspire (WWRS-TV2) Mayvolle, WI</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="hillsong-wwto-dt2-chicago-il/14448">Smile (WWTO-TV2) Chicago, IL</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="himnt-kcci-dt3-des-moines-ia/15768">H&amp;I/MNT (KCCI-DT3) Des Moines, IA</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="historia-dv/8390">Historia DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="historia-hd/3976">Historia HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="historia-sur-demande/10899">Historia Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="historia-dv/8390">Historia DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="historia-hd/3976">Historia HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="historia-sur-demande/10899">Historia Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="history-canada-hd-east/6822">History Canada HD East</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="history-canada-hd-west/3963">History Canada HD West</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="history-canada-on-demand-hd/10842">History Canada On Demand HD</channel>
@@ -5673,10 +5673,10 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="i-sat/9960">I-Sat</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="iavc-kffv-dt3-seattle-wa/16756">H&amp;I (KFFV3) Seattle, WA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="iavc-kxla-dt6-los-angeles-ca/11252">SonLife Network (KXLA6) Los Angeles, CA</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ici-explora-sur-demand/10767">Ici Explora sur Demand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ici-radio-canada-sur-demand/9059">Ici Radio Canada sur Demand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ici-television-hd/13786">ICI Television (CFHD-DT) Montréal, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ici-television/11385">ICI Television (CFHD-DT) Montréal, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-explora-sur-demand/10767">Ici Explora sur Demand</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-radio-canada-sur-demand/9059">Ici Radio Canada sur Demand</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-television-hd/13786">ICI Television (CFHD-DT) Montréal, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="ici-television/11385">ICI Television (CFHD-DT) Montréal, QC</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="impact-television-network-regional/11148">Impact Television Network (Regional)</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="impact-television-network/9018">Impact Television Network</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="impact-wlpc-ld-detroit-mi-hd/10235">Impact (WLPC-LD) Detroit, MI HD</channel>
@@ -6491,7 +6491,7 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="latv-wybn-dt7-albany-ny/17339">Action (WYBN-LD7) Albany, NY</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="latv-wzpa-dt4-philadelphia-pa/15246">LATV (WZPA-LD4) Philadelphia, PA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="latv-xhas-dt2-san-diego-ca/17303">LATV (XHAS-DT2) San Diego, CA</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="lcn-hd/7321">LCN HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="lcn-hd/7321">LCN HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="learn-kaid-dt3-boise-id/5567">Learn (KAID-DT3) Boise, ID</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="learn-kbin-dt2-council-bluffs-ia/14422">PBS Kids (KBIN-TV2) Council Bluffs, IA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="learn-kcdt-dt3-coeur-dalene-id/5566">Learn (KCDT-DT3) Coeur D'Alene, ID</channel>
@@ -9259,9 +9259,9 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="premium-services-on-demand/7740">Premium Services On Demand</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="primetime-ondemand-hd/7123">Primetime OnDemand HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="primetime-ondemand/6838">Primetime OnDemand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="prise-2-hd/10848">Prise 2 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="prise-2-sur-demande/10768">Prise 2 Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="productions-quebecois/7703">Productions Quebecois</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="prise-2-hd/10848">Prise 2 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="prise-2-sur-demande/10768">Prise 2 Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="productions-quebecois/7703">Productions Quebecois</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="pt-check-ch-tv-vancouver-island-bc-hd/2021">PT CHECK: CH TV Vancouver Island, BC HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="pt-check-city-tv-calgary-ab/2278">PT CHECK: CITY Calgary, AB</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="pt-check-city-tv-vancouver-bc/2028">PT CHECK: CITY Vancouver, BC</channel>
@@ -9519,10 +9519,10 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rai/2470">RAI</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rcn-tv-pennsylvania-hd/20037">Astound TV Network Pennsylvania HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rcn-tv-pennsylvania/13538">Astound TV Network Pennsylvania</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rdi-news-hd/5888">RDI (News) HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rds-2-hd/9970">RDS 2 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rds-info-hd/10849">RDS Info HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="rds-reseau-des-sports-hd/5582">RDS (Réseau des sports) HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="rdi-news-hd/5888">RDI (News) HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="rds-2-hd/9970">RDS 2 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="rds-info-hd/10849">RDS Info HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="rds-reseau-des-sports-hd/5582">RDS (Réseau des sports) HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="real-estate-channel/3298">Real Estate Channel</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="real-estate-khsc-dt2-fresno-ca/11658">Real Estate (KHSC-DT2) Fresno, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="real-estate-knee-ld-malaga-ect-wa/30058">Real Estate (KNEE-LD) Malaga, Ect, WA</channel>
@@ -10173,67 +10173,67 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sportstime-ohio/3242">Bally Sports Great Lakes</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sprout-hd/8835">Universal Kids HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sprout/4349">Universal Kids</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbaft-moncton-nb-hd/6816">ICI (CBAFT) Moncton, NB HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbeft-windsor/3883">ICI (CBEFT) Windsor</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbfj-st-johns-nf-hd/6818">ICI (CBFJ) St. John's, NF HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbfj-st-johns-nf/5476">ICI (CBFJ) St. John's, NF</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbfst-src-nord-qc-hd/9671">ICI (CBFST) SRC -Nord, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbfst-src-nord/598">ICI (CBFST) SRC-Nord</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbft-montreal-qc-dv/5935">ICI (CBFT) Montreal, QC DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbft-montreal-qc-hd/2837">ICI (CBFT) Montreal, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbgat-gaspe-qc-hd/9670">ICI (CBGAT) Gaspé, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbgat-gaspe-qc/2167">ICI (CBGAT) Gaspé, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbhft-halifax-ns-hd/6817">ICI (CBHFT) Halifax, NS HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbhft-halifax-ns/3882">ICI (CBHFT) Halifax, NS</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbkft-regina-sk-hd/6819">ICI (CBKFT) Regina, SK HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbkft-regina-sk/287">ICI (CBKFT) Regina, SK</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cblft-toronto/14">ICI (CBLFT) Toronto</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cboft-ottawa-on-dv/14158">ICI (CBOFT) Ottawa, ON DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cboft-ottawa-on-hd/6768">ICI (CBOFT) Ottawa, ON HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cboft-ottawa-on/463">ICI (CBOFT) Ottawa, ON</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbrft-calgary-ab-dv/14160">ICI (CBRFT) Calgary, AB DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbrft-calgary-ab-hd/9610">ICI (CBRFT) Calgary, AB HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbrft-calgary-ab/3980">ICI (CBRFT) Calgary, AB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbst-sept-iles-qc-hd/9673">ICI (CBST) Sept-Iles, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbst-sept-iles-qc/3299">ICI (CBST) Sept-Iles, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbuft-vancouver-bc-hd/6769">ICI (CBUFT) Vancouver, BC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbvt-quebec-qc--digital/5948">ICI (CBVT) Quebec, QC - Digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbvt-quebec-qc-hd/6820">ICI (CBVT) Quebec, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbvt-quebec-qc/562">ICI (CBVT) Quebec, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbwft-winnipeg-mb-hd/6770">ICI (CBWFT) Winnipeg, MB HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbwft-winnipeg-mb/144">ICI (CBWFT) Winnipeg, MB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbxft-edmonton-ab-dv/14159">ICI (CBXFT) Edmonton, AB DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbxft-edmonton-ab-hd/9609">ICI (CBXFT) Edmonton, AB HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cbxft-edmonton-ab/174">ICI (CBXFT) Edmonton, AB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjbr-rimouski-qc-hd/9668">ICI (CJBR) Rimouski, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjbr-rimouski-qc/2170">ICI (CJBR) Rimouski, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjdg-dt-val-dor-qc/14060">ICI (CJDG-DT) Val D'Or, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjdg-tv-2-lebel-sur-quevillon-qc/14062">ICI (CJDG-TV-2) Lebel-Sur-Quevillon, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjdg-tv-3-joutel-qc/14064">ICI (CJDG-TV-3) Joutel, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc-hd/14067">ICI (CJDG-TV-4) Matagami, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc/14066">ICI (CJDG-TV-4) Matagami, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrn-rouyn-qc-hd/9669">ICI (CKRN) Rouyn, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrn-rouyn-qc/1036">ICI (CKRN) Rouyn, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrn-tv-2-ville-marie-qc/14056">ICI (CKRN-TV-2) Ville-Marie, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrn-tv-3-bearnfabre-qc/14058">ICI (CKRN-TV-3) Bearn/Fabre, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-1-baie-st-paul-qc/14050">ICI (CKRT-DT-1) Baie St-Paul, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-2-degelis-qc/14051">ICI (CKRT-DT-2) Dégelis, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-3-riviere-du-loup-qc/14052">ICI (CKRT-DT-3) Rivière-du-Loup, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-4-cabano-qc/14053">ICI (CKRT-DT-4) Cabano, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-5-st-urbain-qc/14054">ICI (CKRT-DT-5) St Urbain, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-dt-6-trois-pistoles-qc/14055">ICI (CKRT-DT-6) Trois-Pistoles, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc-hd/10928">ICI (CKRT) Riviere-du-Loup, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc/499">ICI (CKRT) Riviere-du-Loup, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cksh-sherbrooke-qc--digital/5936">ICI (CKSH) Sherbrooke, QC - digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cksh-sherbrooke-qc-hd/9672">ICI (CKSH) Sherbrooke, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cksh-sherbrooke-qc/2169">ICI (CKSH) Sherbrooke, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktm-trois-rivieres-qc--digital/5946">ICI (CKTM) Trois-Rivières, QC - Digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktm-trois-rivieres-qc-hd/9674">ICI (CKTM) Trois-Rivières, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktm-trois-rivieres-qc/550">ICI (CKTM) Trois-Rivières, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktv-jonquiere-qc-hd/10968">ICI (CKTV) Jonquière, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktv-jonquiere-qc/606">ICI (CKTV) Jonquière, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktv-saguenay-qc-hd/9667">ICI (CKTV) Saguenay, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="src-cktv-saguenay-qc/564">ICI (CKTV) Saguenay, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbaft-moncton-nb-hd/6816">ICI (CBAFT) Moncton, NB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbeft-windsor/3883">ICI (CBEFT) Windsor</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfj-st-johns-nf-hd/6818">ICI (CBFJ) St. John's, NF HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfj-st-johns-nf/5476">ICI (CBFJ) St. John's, NF</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfst-src-nord-qc-hd/9671">ICI (CBFST) SRC -Nord, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbfst-src-nord/598">ICI (CBFST) SRC-Nord</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbft-montreal-qc-dv/5935">ICI (CBFT) Montreal, QC DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbft-montreal-qc-hd/2837">ICI (CBFT) Montreal, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbgat-gaspe-qc-hd/9670">ICI (CBGAT) Gaspé, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbgat-gaspe-qc/2167">ICI (CBGAT) Gaspé, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbhft-halifax-ns-hd/6817">ICI (CBHFT) Halifax, NS HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbhft-halifax-ns/3882">ICI (CBHFT) Halifax, NS</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbkft-regina-sk-hd/6819">ICI (CBKFT) Regina, SK HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbkft-regina-sk/287">ICI (CBKFT) Regina, SK</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cblft-toronto/14">ICI (CBLFT) Toronto</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on-dv/14158">ICI (CBOFT) Ottawa, ON DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on-hd/6768">ICI (CBOFT) Ottawa, ON HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cboft-ottawa-on/463">ICI (CBOFT) Ottawa, ON</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab-dv/14160">ICI (CBRFT) Calgary, AB DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab-hd/9610">ICI (CBRFT) Calgary, AB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbrft-calgary-ab/3980">ICI (CBRFT) Calgary, AB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbst-sept-iles-qc-hd/9673">ICI (CBST) Sept-Iles, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbst-sept-iles-qc/3299">ICI (CBST) Sept-Iles, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbuft-vancouver-bc-hd/6769">ICI (CBUFT) Vancouver, BC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc--digital/5948">ICI (CBVT) Quebec, QC - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc-hd/6820">ICI (CBVT) Quebec, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbvt-quebec-qc/562">ICI (CBVT) Quebec, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbwft-winnipeg-mb-hd/6770">ICI (CBWFT) Winnipeg, MB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbwft-winnipeg-mb/144">ICI (CBWFT) Winnipeg, MB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab-dv/14159">ICI (CBXFT) Edmonton, AB DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab-hd/9609">ICI (CBXFT) Edmonton, AB HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cbxft-edmonton-ab/174">ICI (CBXFT) Edmonton, AB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjbr-rimouski-qc-hd/9668">ICI (CJBR) Rimouski, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjbr-rimouski-qc/2170">ICI (CJBR) Rimouski, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-dt-val-dor-qc/14060">ICI (CJDG-DT) Val D'Or, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-2-lebel-sur-quevillon-qc/14062">ICI (CJDG-TV-2) Lebel-Sur-Quevillon, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-3-joutel-qc/14064">ICI (CJDG-TV-3) Joutel, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc-hd/14067">ICI (CJDG-TV-4) Matagami, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cjdg-tv-4-matagami-qc/14066">ICI (CJDG-TV-4) Matagami, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-rouyn-qc-hd/9669">ICI (CKRN) Rouyn, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-rouyn-qc/1036">ICI (CKRN) Rouyn, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-tv-2-ville-marie-qc/14056">ICI (CKRN-TV-2) Ville-Marie, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrn-tv-3-bearnfabre-qc/14058">ICI (CKRN-TV-3) Bearn/Fabre, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-1-baie-st-paul-qc/14050">ICI (CKRT-DT-1) Baie St-Paul, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-2-degelis-qc/14051">ICI (CKRT-DT-2) Dégelis, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-3-riviere-du-loup-qc/14052">ICI (CKRT-DT-3) Rivière-du-Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-4-cabano-qc/14053">ICI (CKRT-DT-4) Cabano, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-5-st-urbain-qc/14054">ICI (CKRT-DT-5) St Urbain, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-dt-6-trois-pistoles-qc/14055">ICI (CKRT-DT-6) Trois-Pistoles, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc-hd/10928">ICI (CKRT) Riviere-du-Loup, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-ckrt-riviere-du-loup-qc/499">ICI (CKRT) Riviere-du-Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc--digital/5936">ICI (CKSH) Sherbrooke, QC - digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc-hd/9672">ICI (CKSH) Sherbrooke, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cksh-sherbrooke-qc/2169">ICI (CKSH) Sherbrooke, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc--digital/5946">ICI (CKTM) Trois-Rivières, QC - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc-hd/9674">ICI (CKTM) Trois-Rivières, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktm-trois-rivieres-qc/550">ICI (CKTM) Trois-Rivières, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-jonquiere-qc-hd/10968">ICI (CKTV) Jonquière, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-jonquiere-qc/606">ICI (CKTV) Jonquière, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-saguenay-qc-hd/9667">ICI (CKTV) Saguenay, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="src-cktv-saguenay-qc/564">ICI (CKTV) Saguenay, QC</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ssptv-channel-13/18859">SSPTV Channel 13</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="ssptv-channel-513hd/18860">SSPTV Channel 513HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sstn-kata-dallas-tx-hd/19947">SSTN (KATA) Dallas, TX HD</channel>
@@ -10403,12 +10403,12 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-channel-hd-4/10894">Ginx eSports TV Canada HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-channel-on-demand-hd/10884">Super Channel on Demand HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-channel-on-demand/5598">Super Channel on Demand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-2-hd/8459">Super Ecran 2 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-3-hd/9822">Super Ecran 3 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-4-hd/9825">Super Ecran 4 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-hd-1-temp-for-tvguide/5930">Super Ecran HD 1 (temp for TVGuide)</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-hd-1/5898">Super Ecran HD 1</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-ecran-sur-demande/3426">Super Ecran Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-2-hd/8459">Super Ecran 2 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-3-hd/9822">Super Ecran 3 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-4-hd/9825">Super Ecran 4 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-hd-1-temp-for-tvguide/5930">Super Ecran HD 1 (temp for TVGuide)</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-hd-1/5898">Super Ecran HD 1</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="super-ecran-sur-demande/3426">Super Ecran Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-sports-pak-1/16938">Super Sports Pak 1</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-sports-pak-10/16941">Super Sports Pak 10</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="super-sports-pak-11/16942">Super Sports Pak 11</channel>
@@ -11293,56 +11293,56 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tv5-international-hd--east/6472">TV5 International HD - East</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tv5-monde-usa/2628">TV5 Monde USA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tv8-k45ie-d-vail-co/15354">TV8 (K45IE-D) Vail, CO</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfcm-quebec--digital/5931">TVA (CFCM) Quebec - Digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfcm-quebec-hd/11116">TVA (CFCM) Québec HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfcm-quebec/1031">TVA (CFCM) Québec</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfem-rouyn-hd/15399">TVA (CFEM) Rouyn HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfem-rouyn/2540">TVA (CFEM) Rouyn</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfer-rimouski-hd/31497">TVA (CFER) Rimouski HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cfer-rimouski/1034">TVA (CFER) Rimouski</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cftm-montreal-hd/5934">TVA (CFTM) Montreal HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cftm-west-feed/1753">TVA (CFTM) West Feed</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-carleton-hd/9976">TVA (CHAU) Carleton HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-carleton/141">TVA (CHAU) Carleton</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-1-ste-marguerite-marie-qc/13903">TVA (CHAU-DT-1) Ste-Marguerite-Marie, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-10-tracadie-nb/13904">TVA (CHAU-DT-10) Tracadie, NB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-11-kedgwick-nb/13905">TVA (CHAU-DT-11) Kedgwick, NB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-2-st-quentin-nb/13906">TVA (CHAU-DT-2) St-Quentin, NB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-3-port-daniel-qc/13907">TVA (CHAU-DT-3) Port-Daniel, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-4-chandler-qc/13908">TVA (CHAU-DT-4) Chandler, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-51-perce-qc/13902">TVA (CHAU-DT-5(1)) Percé, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-6-gaspe-qc/13909">TVA (CHAU-DT-6) Gaspé, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-7-riviere-au-renard-qc/13910">TVA (CHAU-DT-7) Rivière-au-Renard, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-8-cloridorme-qc/13911">TVA (CHAU-DT-8) Cloridorme, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chau-dt-9-lanse-a-valleau-qc/13912">TVA (CHAU-DT-9) L'Anse-a-Valleau, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chem-trois-rivieres-mauricie-hd/11118">TVA (CHEM) Trois-Rivières (Mauricie) HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chem-trois-rivieres/1033">TVA (CHEM) Trois-Rivieres</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chem-trois-riviers--digital/5933">TVA (CHEM) Trois-Riviers - Digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chlt-sherbrooke--digital/5932">TVA (CHLT) Sherbrooke - Digital</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chlt-sherbrooke-hd/11117">TVA (CHLT) Sherbrooke HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chlt-sherbrooke/1032">TVA (CHLT) Sherbrooke</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chot-hull-qc-hd/31494">TVA (CHOT) Gatineau, QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-chot-hull/4">TVA (CHOT) Gatineau, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-1-edmundston-nb/14069">TVA (CIMT-DT-1) Edmundston, NB</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-2-trois-pistoles-qc/14070">TVA (CIMT-DT-2) Trois-Pistoles, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-4-baie-st-paul-qc/14071">TVA (CIMT-DT-4) Baie St-Paul, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-5-st-urbain-qc/14072">TVA (CIMT-DT-5) St Urbain, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-6-riviere-du-loup-qc/14073">TVA (CIMT-DT-6) Rivière-du-Loup, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-7-les-escoumins-qc/14074">TVA (CIMT-DT-7) Les Escoumins, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-dt-8-cabano-qc/14075">TVA (CIMT-DT-8) Cabano, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-riviere-du-loup-hd/31589">TVA (CIMT) Rivière du Loup HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cimt-riviere-du-loup/317">TVA (CIMT) Rivière du Loup</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cjpm-saguenay-chicoutimi-qc-hd/31496">TVA (CJPM) Saguenay (Chicoutimi), QC HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-cjpm-saguenay-qc/1035">TVA (CJPM) Saguenay, QC</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-hd/4354">TVA HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-sports-2-hd/13778">TVA Sports 2 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-sports-2/13777">TVA Sports 2</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-sports-3-hd/15116">TVA Sports 3 HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-sports-3/14946">TVA Sports 3</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tva-sports-hd/9824">TVA Sports HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvcbf-television-communautaire-bois-francs/8578">TVCBF (Télévision communautaire Bois-Francs)</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfcm-quebec--digital/5931">TVA (CFCM) Quebec - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfcm-quebec-hd/11116">TVA (CFCM) Québec HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfcm-quebec/1031">TVA (CFCM) Québec</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfem-rouyn-hd/15399">TVA (CFEM) Rouyn HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfem-rouyn/2540">TVA (CFEM) Rouyn</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfer-rimouski-hd/31497">TVA (CFER) Rimouski HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cfer-rimouski/1034">TVA (CFER) Rimouski</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cftm-montreal-hd/5934">TVA (CFTM) Montreal HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cftm-west-feed/1753">TVA (CFTM) West Feed</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-carleton-hd/9976">TVA (CHAU) Carleton HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-carleton/141">TVA (CHAU) Carleton</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-1-ste-marguerite-marie-qc/13903">TVA (CHAU-DT-1) Ste-Marguerite-Marie, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-10-tracadie-nb/13904">TVA (CHAU-DT-10) Tracadie, NB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-11-kedgwick-nb/13905">TVA (CHAU-DT-11) Kedgwick, NB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-2-st-quentin-nb/13906">TVA (CHAU-DT-2) St-Quentin, NB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-3-port-daniel-qc/13907">TVA (CHAU-DT-3) Port-Daniel, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-4-chandler-qc/13908">TVA (CHAU-DT-4) Chandler, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-51-perce-qc/13902">TVA (CHAU-DT-5(1)) Percé, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-6-gaspe-qc/13909">TVA (CHAU-DT-6) Gaspé, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-7-riviere-au-renard-qc/13910">TVA (CHAU-DT-7) Rivière-au-Renard, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-8-cloridorme-qc/13911">TVA (CHAU-DT-8) Cloridorme, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chau-dt-9-lanse-a-valleau-qc/13912">TVA (CHAU-DT-9) L'Anse-a-Valleau, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chem-trois-rivieres-mauricie-hd/11118">TVA (CHEM) Trois-Rivières (Mauricie) HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chem-trois-rivieres/1033">TVA (CHEM) Trois-Rivieres</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chem-trois-riviers--digital/5933">TVA (CHEM) Trois-Riviers - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chlt-sherbrooke--digital/5932">TVA (CHLT) Sherbrooke - Digital</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chlt-sherbrooke-hd/11117">TVA (CHLT) Sherbrooke HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chlt-sherbrooke/1032">TVA (CHLT) Sherbrooke</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chot-hull-qc-hd/31494">TVA (CHOT) Gatineau, QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-chot-hull/4">TVA (CHOT) Gatineau, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-1-edmundston-nb/14069">TVA (CIMT-DT-1) Edmundston, NB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-2-trois-pistoles-qc/14070">TVA (CIMT-DT-2) Trois-Pistoles, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-4-baie-st-paul-qc/14071">TVA (CIMT-DT-4) Baie St-Paul, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-5-st-urbain-qc/14072">TVA (CIMT-DT-5) St Urbain, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-6-riviere-du-loup-qc/14073">TVA (CIMT-DT-6) Rivière-du-Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-7-les-escoumins-qc/14074">TVA (CIMT-DT-7) Les Escoumins, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-dt-8-cabano-qc/14075">TVA (CIMT-DT-8) Cabano, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-riviere-du-loup-hd/31589">TVA (CIMT) Rivière du Loup HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cimt-riviere-du-loup/317">TVA (CIMT) Rivière du Loup</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cjpm-saguenay-chicoutimi-qc-hd/31496">TVA (CJPM) Saguenay (Chicoutimi), QC HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-cjpm-saguenay-qc/1035">TVA (CJPM) Saguenay, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-hd/4354">TVA HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-sports-2-hd/13778">TVA Sports 2 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-sports-2/13777">TVA Sports 2</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-sports-3-hd/15116">TVA Sports 3 HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-sports-3/14946">TVA Sports 3</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tva-sports-hd/9824">TVA Sports HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tvcbf-television-communautaire-bois-francs/8578">TVCBF (Télévision communautaire Bois-Francs)</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvcogeco-on-demand/6786">TVCOGECO On Demand</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvcogeco-sur-demande/7794">TVCogeco Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="tvcogeco-sur-demande/7794">TVCogeco Sur Demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvg--television-games-network-hd/16422">TVG - Television Games Network HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvg--television-games-network/14986">FanDuel TV</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="tvg-2--horse-racing/535">FanDuel Racing</channel>
@@ -12378,6 +12378,16 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="IciRDI.ca" site_id="rdi-news/8">RDI (News)</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="LaChaineDisney.ca" site_id="la-chaine-disney/5981">La Chaine Disney</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="LCN.ca" site_id="lcn/432">LCN</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cftf-riviere-du-loup-qc/1272">Noovo (CFTF) Riviere du Loup, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfrs-saguenaylac-stjean-qc/2183">Noovo (CFRS) Saguenay/Lac St-Jean, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfks-sherbrooke-qc/2181">Noovo (CFKS) Sherbrooke, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfap-quebec-qc/2179">Noovo (CFAP) Québec, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfjp-montreal-qc/301">Noovo (CFJP) Montreal, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfkm-troisrivieres-qc/2180">Noovo (CFKM) Trois-Rivières, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfgs-gatineau-qc/5">Noovo (CFGS) Gatineau, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cfvs-valdor-qc/2184">Noovo (CFVS) Val-d'Or, QC</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-hd/4884">Noovo HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cftfdt6-riviereduloup-qc/14002">Noovo (CFTF-DT-6) Rivière-du-Loup, QC</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Prise2.ca" site_id="prise-2/2848">Prise 2</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="RDS.ca" site_id="rds-reseau-des-sports/47">RDS (Réseau des sports)</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="RDS2.ca" site_id="rds-2/9705">RDS 2</channel>
@@ -12388,7 +12398,6 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran4.ca" site_id="super-ecran-4/411">Super Ecran 4</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="TVASports.ca" site_id="tva-sports/9823">TVA Sports</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Vrak.ca" site_id="vrak/48">VRAK</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="Yoopa.ca" site_id="yoopa/7616">Yoopa</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Z.ca" site_id="z/344">Z</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Zeste.ca" site_id="zeste/7508">Zeste</channel>
   <channel site="tvpassport.com" lang="hu" xmltv_id="ERTWorld.ca" site_id="ert-world-canada/3419">ERT World (Canada)</channel>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -12398,8 +12398,8 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran2.ca" site_id="super-ecran-2/362">Super Ecran 2</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran3.ca" site_id="super-ecran-3/410">Super Ecran 3</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran4.ca" site_id="super-ecran-4/411">Super Ecran 4</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal">Tele-Quebec (CIVM) Montreal</channel>
-  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal-hd">Tele-Quebec (CIVM) Montreal HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal/1140">Tele-Quebec (CIVM) Montreal</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal-hd/6464">Tele-Quebec (CIVM) Montreal HD</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="TVASports.ca" site_id="tva-sports/9823">TVA Sports</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Vrak.ca" site_id="vrak/48">VRAK</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Z.ca" site_id="z/344">Z</channel>

--- a/sites/tvpassport.com/tvpassport.com.channels.xml
+++ b/sites/tvpassport.com/tvpassport.com.channels.xml
@@ -9805,10 +9805,10 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sec-network-hd/13712">SEC Network HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="sec-network/13711">SEC Network</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="selection-xxx-sur-demande/7803">Sélection XXX Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="series--dv/8394">Series + DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="series--hd/3975">Series + HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="series--sur-demande/10898">Series + Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="series-/341">Series +</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--dv/8394">Series + DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--hd/3975">Series + HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series--sur-demande/10898">Series + Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="series-/341">Series +</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="services-optimum/7692">Services Optimum</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="shaw-cable-events-1/16879">Shaw Cable Events 1</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="shaw-cable-events-2/16880">Shaw Cable Events 2</channel>
@@ -11973,11 +11973,11 @@
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="yur-view-ca--san-diego-ca-hd/6928">YurView CA - San Diego, CA HD</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="yur-view-ca--san-diego-ca/4347">YurView CA - San Diego, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="yurview-oklahoma/15157">YurView Tulsa</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="z-dv/8402">Z DV</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="z-hd/3979">Z HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="z-sur-demande/10896">Z Sur Demande</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="zeste-hd/7943">Zeste HD</channel>
-  <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="zeste-sur-demande/9058">Zeste Sur demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="z-dv/8402">Z DV</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="z-hd/3979">Z HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="z-sur-demande/10896">Z Sur Demande</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="zeste-hd/7943">Zeste HD</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="zeste-sur-demande/9058">Zeste Sur demande</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="zion-tv-kcio-dt4-ontario-ca/17530">Zion TV (KCIO-DT4) Ontario, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="zion-tv-kcio-ld3-ontario-ca/31475">Zion TV (KCIO-LD3) Ontario, CA</channel>
   <channel site="tvpassport.com" lang="en" xmltv_id="" site_id="zone-jeunesse-sur-demande/7497">Zone Jeunesse Sur Demande</channel>
@@ -12389,6 +12389,8 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-hd/4884">Noovo HD</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="noovo-cftfdt6-riviereduloup-qc/14002">Noovo (CFTF-DT-6) Rivière-du-Loup, QC</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Prise2.ca" site_id="prise-2/2848">Prise 2</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="qub/7616">QUB</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="qub-hd/7617">QUB HD</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="RDS.ca" site_id="rds-reseau-des-sports/47">RDS (Réseau des sports)</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="RDS2.ca" site_id="rds-2/9705">RDS 2</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="RDSInfo.ca" site_id="rds-info/3889">RDS Info</channel>
@@ -12396,6 +12398,8 @@
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran2.ca" site_id="super-ecran-2/362">Super Ecran 2</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran3.ca" site_id="super-ecran-3/410">Super Ecran 3</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="SuperEcran4.ca" site_id="super-ecran-4/411">Super Ecran 4</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal">Tele-Quebec (CIVM) Montreal</channel>
+  <channel site="tvpassport.com" lang="fr" xmltv_id="" site_id="telequebec-civm-montreal-hd">Tele-Quebec (CIVM) Montreal HD</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="TVASports.ca" site_id="tva-sports/9823">TVA Sports</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Vrak.ca" site_id="vrak/48">VRAK</channel>
   <channel site="tvpassport.com" lang="fr" xmltv_id="Z.ca" site_id="z/344">Z</channel>


### PR DESCRIPTION
I've updated a couple of channels under tvpassport.com.channels.xml to change the language to French to reflect the reality of those channels.

I've added Noovo, QUB, Télé-Québec channels since they were missing in the list.

I've removed Yoopa in the list of channels since it does not exist anymore and the website redirect to a completely different channel now:
https://www.tvpassport.com/tv-listings/stations/yoopa/7616 -> https://www.tvpassport.com/tv-listings/stations/qub/7616

Radio-Canada and Series + the ids were not the right one anymore and we were only able to fetch 2 days of guide. Updating the ids made it possible to fetch more days.