### PR TITLE
Adding more channels using `tvguide.myjcom.jp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /channels.xml
 /guide.xml
 /guide.xml.gz
+
+# macOS
+.DS_Store

--- a/sites/tvguide.myjcom.jp/tvguide.myjcom.jp.channels.xml
+++ b/sites/tvguide.myjcom.jp/tvguide.myjcom.jp.channels.xml
@@ -134,4 +134,19 @@
   <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="" site_id="120_415_65527">JSPORTS4 (4K)</channel>
   <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="" site_id="120_416_65527">ショップチャンネル ４Ｋ</channel>
   <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="" site_id="120_417_65527">4Ｋ QVC</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="NHKBSP4K.jp" site_id="5_101_11">ＮＨＫ　ＢＳＰ４Ｋ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="NHKBS.jp" site_id="3_101_4">ＮＨＫ　ＢＳ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="MTV.jp" site_id="120_150_65406">MTV HD</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOAKDTV.jp" site_id="2_1024_32736">NHK東京　総合</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOABDTV.jp" site_id="2_1032_32737">NHK東京　教育</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="TokyoMX1.jp" site_id="2_23608_32391">TOKYO　MX</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOOKDTV.jp" site_id="2_41984_32096">NHK京都　総合</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOBKDTV.jp" site_id="2_40960_32112">NHK大阪　総合</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOBHDTV.jp" site_id="2_41008_32118">テレビ大阪</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOOYDTV.jp" site_id="2_2064_32722">毎日テレビ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JODXDTV.jp" site_id="2_2080_32724">関西テレビ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOAYDTV.jp" site_id="2_2072_32723">ABCテレビ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOBRDTV.jp" site_id="2_42032_32102">KBS京都</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOIXDTV.jp" site_id="2_2088_32725">読売テレビ</channel>
+  <channel site="tvguide.myjcom.jp" lang="ja" xmltv_id="JOUHDTV.jp" site_id="2_43056_32086">サンテレビ</channel>
 </channels>


### PR DESCRIPTION
I added the following japanese channels, which were on the JCOM website :

- NHKBSP4K.jp
- NHKBS.jp
- MTV.jp
- JOAKDTV.jp
- JOABDTV.jp
- TokyoMX1.jp
- JOOKDTV.jp
- JOBKDTV.jp
- JOBHDTV.jp
- JOOYDTV.jp
- JODXDTV.jp
- JOAYDTV.jp
- JOBRDTV.jp
- JOIXDTV.jp
- JOUHDTV.jp