### PR TITLE
update pickx provider

### DIFF
--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -132,7 +132,11 @@ module.exports = {
 function fetchApiVersion() {
   return new Promise(async (resolve, reject) => {
     try {
-      const response = await axios.get('https://px-epg.azureedge.net/version', {
+
+      // https://px-epg.azureedge.net/version is deprecated
+      // probably the version url will be changed around over time
+      const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
+      const response = await axios.get(versionUrl, {
         headers: {
           'Origin': 'https://www.pickx.be',
           'Referer': 'https://www.pickx.be/'

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -142,10 +142,10 @@ function fetchApiVersion() {
       //const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
       //const versionUrl = 'https://www.pickx.be/api/s-8546c5fd136241d42aab714d2fe3ccc5671fd899035efae07cd0b8f4eb23994e'
       //const versionUrl = 'https://www.pickx.be/api/s-64464ad9a3bc117af5dca620027216ecade6a51c230135a0f134c0ee042ff407';
-
+      //const versionUrl = 'https://www.pickx.be/api/s-626d8fdabfb1d44e5a614cd69f4b45d6843fdb63566fc80ea4f97f40e4ea3152';
       //the new strategy to break the provider is to leave old version url's available and to return invalid results on those endpoints
 
-      const versionUrl = 'https://www.pickx.be/api/s-626d8fdabfb1d44e5a614cd69f4b45d6843fdb63566fc80ea4f97f40e4ea3152';
+      const versionUrl = 'https://www.pickx.be//api/s-cefaf96e249e53648c4895c279e7a621233c50b4357d62b0bdf6bff45f31b5c0';
 
       const response = await axios.get(versionUrl, {
         headers: {

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -141,10 +141,11 @@ function fetchApiVersion() {
       //const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
       //const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
       //const versionUrl = 'https://www.pickx.be/api/s-8546c5fd136241d42aab714d2fe3ccc5671fd899035efae07cd0b8f4eb23994e'
+      //const versionUrl = 'https://www.pickx.be/api/s-64464ad9a3bc117af5dca620027216ecade6a51c230135a0f134c0ee042ff407';
 
       //the new strategy to break the provider is to leave old version url's available and to return invalid results on those endpoints
 
-      const versionUrl = 'https://www.pickx.be/api/s-64464ad9a3bc117af5dca620027216ecade6a51c230135a0f134c0ee042ff407';
+      const versionUrl = 'https://www.pickx.be/api/s-626d8fdabfb1d44e5a614cd69f4b45d6843fdb63566fc80ea4f97f40e4ea3152';
 
       const response = await axios.get(versionUrl, {
         headers: {

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -140,10 +140,11 @@ function fetchApiVersion() {
       //const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
       //const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
       //const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
+      //const versionUrl = 'https://www.pickx.be/api/s-8546c5fd136241d42aab714d2fe3ccc5671fd899035efae07cd0b8f4eb23994e'
 
       //the new strategy to break the provider is to leave old version url's available and to return invalid results on those endpoints
 
-      const versionUrl = 'https://www.pickx.be/api/s-8546c5fd136241d42aab714d2fe3ccc5671fd899035efae07cd0b8f4eb23994e'
+      const versionUrl = 'https://www.pickx.be/api/s-64464ad9a3bc117af5dca620027216ecade6a51c230135a0f134c0ee042ff407';
 
       const response = await axios.get(versionUrl, {
         headers: {

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -135,7 +135,11 @@ function fetchApiVersion() {
 
       // https://px-epg.azureedge.net/version is deprecated
       // probably the version url will be changed around over time
-      const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
+
+      //history of used version urls
+      //const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
+
+      const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
       const response = await axios.get(versionUrl, {
         headers: {
           'Origin': 'https://www.pickx.be',

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -139,10 +139,12 @@ function fetchApiVersion() {
       //history of used version urls
       //const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
       //const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
+      //const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
 
       //the new strategy to break the provider is to leave old version url's available and to return invalid results on those endpoints
 
-      const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
+      const versionUrl = 'https://www.pickx.be/api/s-8546c5fd136241d42aab714d2fe3ccc5671fd899035efae07cd0b8f4eb23994e'
+
       const response = await axios.get(versionUrl, {
         headers: {
           'Origin': 'https://www.pickx.be',

--- a/sites/pickx.be/pickx.be.config.js
+++ b/sites/pickx.be/pickx.be.config.js
@@ -138,8 +138,11 @@ function fetchApiVersion() {
 
       //history of used version urls
       //const versionUrl = 'https://www.pickx.be/api/s-3b36540f3cef64510112f3f95c2c0cdca321997ed2b1042ad778523235e155eb'
+      //const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
 
-      const versionUrl = 'https://www.pickx.be/api/s-671f172425e1bc74cd0440fd67aaa6cbe68b582f3f401186c2f46ae97e80516b'
+      //the new strategy to break the provider is to leave old version url's available and to return invalid results on those endpoints
+
+      const versionUrl = 'https://www.pickx.be/api/s-a6b4b4fefaa20e438523a6167e63b8504d96b9df8303473349763c4418cffe30'
       const response = await axios.get(versionUrl, {
         headers: {
           'Origin': 'https://www.pickx.be',


### PR DESCRIPTION
Pickx.be decided to update the version path.
The url is updated to the new value.
Some effort is needed to study the mechanism that is used in order to generate this url.