### PR TITLE
Update channel config

### DIFF
--- a/sites/tvgids.nl/tvgids.nl.channels.xml
+++ b/sites/tvgids.nl/tvgids.nl.channels.xml
@@ -93,7 +93,7 @@
   <channel site="tvgids.nl" lang="nl" xmltv_id="RTVRijnmond.nl" site_id="rtvrijnmond">RTV Rijnmond</channel>
   <channel site="tvgids.nl" lang="nl" xmltv_id="RTVUtrecht.nl" site_id="rtvutrecht">RTV Utrecht</channel>
   <channel site="tvgids.nl" lang="nl" xmltv_id="SBS6.nl" site_id="sbs6">SBS 6</channel>
-  <channel site="tvgids.nl" lang="nl" xmltv_id="SBS9.nl" site_id="sbs9">SBS 9</channel>
+  <channel site="tvgids.nl" lang="nl" xmltv_id="ViaplayTv.nl" site_id="viaplaytv">Viaplay TV</channel>
   <channel site="tvgids.nl" lang="nl" xmltv_id="ShortsTV.uk" site_id="shortstv">ShortsTV</channel>
   <channel site="tvgids.nl" lang="nl" xmltv_id="StingrayClassica.ca" site_id="stingrayclassica">Stingray Classica</channel>
   <channel site="tvgids.nl" lang="nl" xmltv_id="Tipik.be" site_id="rtbfla2">RTBF La 2</channel>


### PR DESCRIPTION
The SBS9 channel renamed as Viaplay TV as result from some corporate merger.
I tried to get the icon to parse but I'm not seeing how the icon is being parsed.

I've tried to change the following in the config.js

```
function parseIcon($item) {
  let icon =  $item('.program__thumbnail').data('src');

  if(icon === null || icon == undefined)
  {
    icon = $item('img').data('src');
  }

  return icon;
}
```

I've tested this code outside and it seemed to work however the icon is not parsed.