### PR TITLE
Update Vidio Scripts and Channels

### DIFF
--- a/sites/vidio.com/vidio.com.channels.xml
+++ b/sites/vidio.com/vidio.com.channels.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7004">Prambors On Air</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7055">TRAX</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7169">ELGANGGA</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7216">Geronimo</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7283">SWARA SEMARANG</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7284">GAJAHMADA</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="7619">MUSICA</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="8815">Metro Globe Network</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="9430">World Cup 1</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="" site_id="9431">World Cup 2</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ABCAustralia.au" site_id="7150">ABC Australia</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="AfricanewsEnglish.fr" site_id="12784">AFRICANEWS TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="AjwaTV.id" site_id="7464">AJWA TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="AlJazeeraEnglish.qa" site_id="6410">Aljazeera</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ANTV.id" site_id="782">ANTV</channel>
@@ -18,16 +9,17 @@
   <channel site="vidio.com" lang="id" xmltv_id="beINSports1.id" site_id="6299">Bein 1</channel>
   <channel site="vidio.com" lang="id" xmltv_id="beINSports3.id" site_id="6317">Bein 3</channel>
   <channel site="vidio.com" lang="id" xmltv_id="BTV.id" site_id="6165">BTV</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV1.id" site_id="6685">CTV 1</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV2.id" site_id="6686">CTV 2</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV3.id" site_id="6786">CTV 3</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV5.id" site_id="9182">CTV 5</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV6.id" site_id="9183">CTV 6</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV1.id" site_id="6685">Champions TV 1</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV2.id" site_id="6686">Champions TV 2</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV3.id" site_id="6786">Champions TV 3</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV5.id" site_id="9182">Champions TV 5</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="ChampionsTV6.id" site_id="9183">Champions TV 6</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ChampionsTVEPL.id" site_id="9353">Premier League TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="CNA.sg" site_id="6411">News Asia</channel>
   <channel site="vidio.com" lang="id" xmltv_id="DAAITV.id" site_id="6482">DAAI TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="DWEnglish.de" site_id="5075">DW English</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ElshintaTV.id" site_id="10975">Elshinta TV</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="EuronewsEnglish.fr" site_id="6412">Euro News</channel>
   <channel site="vidio.com" lang="id" xmltv_id="FashionTVAsia.fr" site_id="6511">Fashion TV - Global</channel>
   <channel site="vidio.com" lang="id" xmltv_id="FashionTVLOriginal.fr" site_id="6507">FashionTV L&apos;Original</channel>
   <channel site="vidio.com" lang="id" xmltv_id="FashionTVMidnightSecrets.fr" site_id="6504">Fashion TV Midnight Secrets</channel>
@@ -35,13 +27,13 @@
   <channel site="vidio.com" lang="id" xmltv_id="Horee.id" site_id="6397">Horee</channel>
   <channel site="vidio.com" lang="id" xmltv_id="Indosiar.id" site_id="205">Indosiar</channel>
   <channel site="vidio.com" lang="id" xmltv_id="JakTV.id" site_id="5415">Jaktv</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="JPMTV.id" site_id="9714">JPM TV</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="JPMTV.id" site_id="9714">jawaposTV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="JTV.id" site_id="9713">JTV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="KompasTV.id" site_id="874">Kompas TV</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="LFCTV.uk" site_id="7916">Liverpool TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="MagnaChannel.id" site_id="7230">Magna TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="MakkahTV.sa" site_id="6852">Makkah TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="MentariTV.id" site_id="8237">Mentari TV</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="MetroGlobeNetwork.id" site_id="8815">Metro Globe Network</channel>
   <channel site="vidio.com" lang="id" xmltv_id="MetroTV.id" site_id="777">Metro TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="Moji.id" site_id="206">Moji</channel>
   <channel site="vidio.com" lang="id" xmltv_id="NBATV.us" site_id="6717">NBA TV</channel>
@@ -54,15 +46,17 @@
   <channel site="vidio.com" lang="id" xmltv_id="ROCKEntertainment.sg" site_id="8120">ROCK Entertainment</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ROCKExtreme.sg" site_id="8121">Rock Action</channel>
   <channel site="vidio.com" lang="id" xmltv_id="SCTV.id" site_id="204">SCTV</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="SPOTV.id" site_id="17139">SPOTV</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="SEAToday.id" site_id="7687">SEA TODAY</channel>
   <channel site="vidio.com" lang="id" xmltv_id="SPOTV2.id" site_id="17140">SPOTV 2</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="SPOTV.id" site_id="17139">SPOTV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="TawafTV.id" site_id="12607">Tawaf TV</channel>
   <channel site="vidio.com" lang="id" xmltv_id="Trans7.id" site_id="734">Trans7</channel>
   <channel site="vidio.com" lang="id" xmltv_id="TransTV.id" site_id="733">TRANS TV</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="TV5MondeAsia.fr" site_id="17278">TV5Monde</channel>
   <channel site="vidio.com" lang="id" xmltv_id="tvNAsia.hk" site_id="6362">TVN</channel>
   <channel site="vidio.com" lang="id" xmltv_id="tvOne.id" site_id="783">TVOne</channel>
   <channel site="vidio.com" lang="id" xmltv_id="TVRINasional.id" site_id="6441">TVRI</channel>
+  <channel site="vidio.com" lang="id" xmltv_id="TVTempo.id" site_id="7946">TV Tempo</channel>
   <channel site="vidio.com" lang="id" xmltv_id="UChannel.id" site_id="6898">U-Channel TV</channel>
-  <channel site="vidio.com" lang="id" xmltv_id="ZeeBioskop.id" site_id="6399">Zee Bioskop</channel>
   <channel site="vidio.com" lang="id" xmltv_id="ZooMoo.sg" site_id="6533">Zoomoo</channel>
 </channels>

--- a/sites/vidio.com/vidio.com.config.js
+++ b/sites/vidio.com/vidio.com.config.js
@@ -41,23 +41,30 @@ module.exports = {
       .catch(console.error)
 
     const $ = cheerio.load(result)
-    const items = $('.home-content a').toArray()
+    const itemGroups = $('.home-content').toArray()
     const channels = []
-    items.forEach(item => {
-      const $item = $(item)
+    const processedIds = []
 
-      const name = $item.find('p').text()
-      if (name.toUpperCase().indexOf('FM') < 0 && name.toUpperCase().indexOf('RADIO') < 0) {
-        channels.push({
-          lang: 'id',
-          site_id: $item.attr('href').substr($item.attr('href').lastIndexOf('/') + 1).split('-')[0],
-          name
-        })
+    itemGroups.forEach(group => {
+      const $group = $(group)
+      const props = $group.data('ahoy-props')
+      const name = props.content_title
+      const siteId = props.content_id
+
+      if (props.section.includes('Radio') || processedIds.includes(siteId)) {
+        return
       }
+
+      channels.push({
+        lang: 'id',
+        site_id: siteId,
+        name: name
+      })
+      processedIds.push(siteId)
     })
 
     return channels
-  }  
+  }
 }
 
 function parseStart($item, date) {


### PR DESCRIPTION
Changes in this PR:
- Updated the scripts for Vidio to skip all radio channels.
- Added a fix to stop duplicate channels from being processed.
- Updated the `channels.xml` file with the latest version for Vidio.