### PR TITLE
Fix mewatch.sg

### DIFF
--- a/sites/mewatch.sg/mewatch.sg.channels.xml
+++ b/sites/mewatch.sg/mewatch.sg.channels.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
+  <channel site="mewatch.sg" lang="en" xmltv_id="" site_id="98201">SPL02</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="AnimaxAsia.sg" site_id="242030">Animax</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="Channel5.sg" site_id="97098">Channel 5</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="Channel8.sg" site_id="97104">Channel 8</channel>
@@ -7,7 +8,6 @@
   <channel site="mewatch.sg" lang="en" xmltv_id="CinemaWorld.my" site_id="382872">CinemaWorld</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="CinemaxAsia.sg" site_id="97155">Cinemax</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="CNA.sg" site_id="97072">CNA</channel>
-  <channel site="mewatch.sg" lang="en" xmltv_id="GEM.sg" site_id="242036">GEM</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="GlobalTrekker.sg" site_id="158961">Global Trekker</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="HBOAsia.sg" site_id="97137">HBO</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="HBOFamilyAsia.sg" site_id="97147">HBO Family</channel>
@@ -15,12 +15,14 @@
   <channel site="mewatch.sg" lang="en" xmltv_id="HBOSignatureAsia.sg" site_id="97146">HBO Signature</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="meWATCHLIVE1.sg" site_id="97073">LIVE 1</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="meWATCHLIVE2.sg" site_id="97078">LIVE 2</channel>
-  <channel site="mewatch.sg" lang="en" xmltv_id="meWATCHLIVE5.sg" site_id="98202">LIVE 5</channel>
-  <channel site="mewatch.sg" lang="en" xmltv_id="meWATCHLIVEPlus1.sg" site_id="267994">LIVE+ 1</channel>
+  <channel site="mewatch.sg" lang="en" xmltv_id="Now70s.uk" site_id="158964">NOW 70s</channel>
+  <channel site="mewatch.sg" lang="en" xmltv_id="Now80s.uk" site_id="158965">NOW 80s</channel>
+  <channel site="mewatch.sg" lang="en" xmltv_id="NOWRock.uk" site_id="158963">NOW Rock</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="oktolidays.sg" site_id="186574">oktolidays</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="ROCKAction.sg" site_id="227349">ROCK Action</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="ROCKEntertainment.sg" site_id="227348">ROCK Entertainment</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="SPLCH01.sg" site_id="98200">SPL01</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="Suria.sg" site_id="97084">Suria</channel>
+  <channel site="mewatch.sg" lang="en" xmltv_id="TraceUrban.fr" site_id="158962">TRACE Urban</channel>
   <channel site="mewatch.sg" lang="en" xmltv_id="Vasantham.sg" site_id="97096">Vasantham</channel>
 </channels>

--- a/sites/mewatch.sg/mewatch.sg.config.js
+++ b/sites/mewatch.sg/mewatch.sg.config.js
@@ -1,12 +1,23 @@
 const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const timezone = require('dayjs/plugin/timezone')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
 
 module.exports = {
   site: 'mewatch.sg',
   days: 2,
   url: function ({ channel, date }) {
-    return `https://cdn.mewatch.sg/api/schedules?channels=${channel.site_id}&date=${date.format(
+    const utcDate = date.isUTC() ? date.tz(dayjs.tz.guess(), true).utc() : date.utc()
+
+    return `https://cdn.mewatch.sg/api/schedules?channels=${channel.site_id}&date=${utcDate.format(
       'YYYY-MM-DD'
-    )}&duration=24&ff=idp,ldp,rpt,cd&hour=21&intersect=true&lang=en&segments=all`
+    )}&duration=24&ff=idp,ldp,rpt,cd&hour=${utcDate.format(
+      'HH'
+    )}&intersect=true&lang=en&segments=all`
   },
   parser: function ({ content, channel }) {
     let programs = []

--- a/sites/mewatch.sg/mewatch.sg.config.js
+++ b/sites/mewatch.sg/mewatch.sg.config.js
@@ -40,7 +40,11 @@ module.exports = {
     $('#side-nav > div > div > div > nav:nth-child(1) > ul > li > ul > li').each((i, el) => {
       const name = $(el).find('a > span').text()
       const url = $(el).find('a').attr('href')
-      const [, site_id] = url.match(/\/(\d+)\?player-fullscreen/)
+      const [, site_id = null] = url.match(/\/(\d+)\?player-fullscreen/) ?? []
+
+      if (!site_id) {
+        return
+      }
 
       channels.push({
         lang: 'en',

--- a/sites/mewatch.sg/mewatch.sg.test.js
+++ b/sites/mewatch.sg/mewatch.sg.test.js
@@ -13,7 +13,7 @@ const channel = {
 
 it('can generate valid url', () => {
   expect(url({ channel, date })).toBe(
-    'https://cdn.mewatch.sg/api/schedules?channels=97098&date=2022-06-11&duration=24&ff=idp,ldp,rpt,cd&hour=21&intersect=true&lang=en&segments=all'
+    'https://cdn.mewatch.sg/api/schedules?channels=97098&date=2022-06-10&duration=24&ff=idp,ldp,rpt,cd&hour=12&intersect=true&lang=en&segments=all'
   )
 })
 


### PR DESCRIPTION
Changes in this PR:

- Fix error getting channel list when processing `https://www.mewatch.sg/paris2024/epg`.
- Dynamically set the date-time parameter to retrieve EPG list, so it always grabs a full day's schedule no matter what timezone the client's in.
- Updated the `channels.xml` file with the latest version from Mewatch.

---

**Update (09/23):**
One of the changes in this PR fixes an issue that occurred when processing the URL `https://www.mewatch.sg/paris2024/epg` from the channel list. Even though the Paris 2024 channels are no longer there, the fix is still useful to avoid similar errors in the future.