### PR TITLE
`tvpassport.com` works again

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -172,7 +172,7 @@
 | [tvireland.ie](sites/tvireland.ie)                                 | 🟢     |                                                                                          |
 | [tvmi.mt](sites/tvmi.mt)                                           | 🟢     |                                                                                          |
 | [tvmusor.hu](sites/tvmusor.hu)                                     | 🟢     |                                                                                          |
-| [tvpassport.com](sites/tvpassport.com)                             | 🔴     | https://github.com/iptv-org/epg/issues/2349                                              |
+| [tvpassport.com](sites/tvpassport.com)                             | 🟢     |                                                                                          |
 | [tvplus.com.tr](sites/tvplus.com.tr)                               | 🔴     | https://github.com/iptv-org/epg/issues/2377                                              |
 | [tvprofil.com](sites/tvprofil.com)                                 | 🟡     | https://github.com/iptv-org/epg/issues/2399                                              |
 | [tvtv.us](sites/tvtv.us)                                           | 🟡     | https://github.com/iptv-org/epg/issues/2357, https://github.com/iptv-org/epg/issues/2353 |


### PR DESCRIPTION
I don't know why you indicated that `tvpassport.com` is not working

![image](https://github.com/user-attachments/assets/faf2e64e-cb60-4e7c-addf-bf9fc589ac60)
