### PR TITLE
chore: upgrade epg-grabber to 0.37.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "csv-parser": "^3.0.0",
         "cwait": "^1.1.2",
         "dayjs": "^1.11.10",
-        "epg-grabber": "^0.37.1",
+        "epg-grabber": "^0.37.2",
         "epg-parser": "^0.2.0",
         "eslint": "^8.17.0",
         "eslint-config-prettier": "^9.0.0",
@@ -3936,9 +3936,9 @@
       }
     },
     "node_modules/epg-grabber": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.1.tgz",
-      "integrity": "sha512-Q5gFLhrQGe+ou97Rs/VBRLgtYxSsnwzUEXs/V0cVmJhwpQedwMlG4VyEcc1TUDm53A+61T5fTtpmCsNUVb9N3g==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.2.tgz",
+      "integrity": "sha512-nW0LREl8pX0rEp7IMKqgbqQizvH/hqagCyv5ixwj7Pwdja7u8Kl2OpSicKr2iMt0ysO9cjqaSsWFWHHGgmVYtQ==",
       "dependencies": {
         "axios": "^1.6.1",
         "axios-cache-interceptor": "^0.10.3",
@@ -11321,9 +11321,9 @@
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "epg-grabber": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.1.tgz",
-      "integrity": "sha512-Q5gFLhrQGe+ou97Rs/VBRLgtYxSsnwzUEXs/V0cVmJhwpQedwMlG4VyEcc1TUDm53A+61T5fTtpmCsNUVb9N3g==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.2.tgz",
+      "integrity": "sha512-nW0LREl8pX0rEp7IMKqgbqQizvH/hqagCyv5ixwj7Pwdja7u8Kl2OpSicKr2iMt0ysO9cjqaSsWFWHHGgmVYtQ==",
       "requires": {
         "axios": "^1.6.1",
         "axios-cache-interceptor": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "csv-parser": "^3.0.0",
     "cwait": "^1.1.2",
     "dayjs": "^1.11.10",
-    "epg-grabber": "^0.37.1",
+    "epg-grabber": "^0.37.2",
     "epg-parser": "^0.2.0",
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,10 +2137,10 @@ entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
   resolved "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
-epg-grabber@^0.37.1:
-  version "0.37.1"
-  resolved "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.1.tgz"
-  integrity sha512-Q5gFLhrQGe+ou97Rs/VBRLgtYxSsnwzUEXs/V0cVmJhwpQedwMlG4VyEcc1TUDm53A+61T5fTtpmCsNUVb9N3g==
+epg-grabber@^0.37.2:
+  version "0.37.2"
+  resolved "https://registry.npmjs.org/epg-grabber/-/epg-grabber-0.37.2.tgz"
+  integrity sha512-nW0LREl8pX0rEp7IMKqgbqQizvH/hqagCyv5ixwj7Pwdja7u8Kl2OpSicKr2iMt0ysO9cjqaSsWFWHHGgmVYtQ==
   dependencies:
     axios "^1.6.1"
     axios-cache-interceptor "^0.10.3"


### PR DESCRIPTION
This fixes an issue with image URLs not being escaped and therefore resulting in invalid XML.

See https://github.com/freearhey/epg-grabber/pull/21

Closes https://github.com/iptv-org/epg/issues/2464, #2436