### PR TITLE
Add winplay.co

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -189,6 +189,7 @@
 | [wavve.com](sites/wavve.com)                                       | 🟢     |                                                                                          |
 | [web.magentatv.de](sites/web.magentatv.de)                         | 🟢     |                                                                                          |
 | [webtv.delta.nl](sites/webtv.delta.nl)                             | 🟢     |                                                                                          |
+| [winplay.co](sites/winplay.co)                                     | 🟢     |                                                                                          |
 | [worldfishingnetwork.com](sites/worldfishingnetwork.com)           | 🟢     |                                                                                          |
 | [xumo.tv](sites/xumo.tv)                                           | 🟢     |                                                                                          |
 | [zap.co.ao](sites/zap.co.ao)                                       | 🟢     |                                                                                          |

--- a/sites/winplay.co/__data__/content.json
+++ b/sites/winplay.co/__data__/content.json
@@ -1,0 +1,622 @@
+{
+  "data": {
+    "getLives": [
+      {
+        "_id": "529cff6f6bd2ea6b610000e0",
+        "logo": "https://platform-static.cdn.mdstrm.com/player/logo/s-live-529cff6f6bd2ea6b610000e0.png?c=20241223",
+        "name": "Win+ Fútbol",
+        "schedules": [
+          {
+            "_id": "67633cf2cd9263fa4fde8fd2",
+            "name": "Mejores partidos 2024: América vs. Nacional",
+            "date_start": "2024-12-23T22:30:00.000Z",
+            "date_end": "2024-12-24T00:30:00.000Z",
+            "current": true,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67633d28a1137afadc036ae7",
+            "name": "Los Disruptivos de Win",
+            "date_start": "2024-12-24T00:30:00.000Z",
+            "date_end": "2024-12-24T02:30:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67633ecd895d155a3913f983",
+            "name": "WIn Noticias",
+            "date_start": "2024-12-24T02:30:00.000Z",
+            "date_end": "2024-12-24T03:30:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67633ef7a449f4fa09408d69",
+            "name": "Repetición Programación Win",
+            "date_start": "2024-12-24T03:30:00.000Z",
+            "date_end": "2024-12-24T14:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6763402d863cc2faffa72beb",
+            "name": "Repetición Copa Win Sports Masc Sub 15 (Final)",
+            "date_start": "2024-12-24T14:00:00.000Z",
+            "date_end": "2024-12-24T16:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6763404ef696ae58fdb91b9e",
+            "name": "Win Noticias",
+            "date_start": "2024-12-24T16:00:00.000Z",
+            "date_end": "2024-12-24T17:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cc4c6c5458ca73ebe46f",
+            "name": "Repetición Copa BetPlay Dimayor 2017",
+            "date_start": "2024-12-24T17:00:00.000Z",
+            "date_end": "2024-12-24T19:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cc681e8e2bc9c8b91b96",
+            "name": "Detrás de la Gloria",
+            "date_start": "2024-12-24T19:00:00.000Z",
+            "date_end": "2024-12-24T20:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cca85fbec49a96d9735d",
+            "name": "Repetición Torneo BetPlay Dimayor 2024-I (Final Ida)",
+            "date_start": "2024-12-24T20:00:00.000Z",
+            "date_end": "2024-12-24T22:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765ccc8ef60d7ca50bf7f72",
+            "name": "Llaneros Campeón",
+            "date_start": "2024-12-24T22:00:00.000Z",
+            "date_end": "2024-12-24T23:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cd0d88e8c2fb6532ad9d",
+            "name": "Repetición Torneo BetPlay Dimayor 2024-I (Final Vuelta)",
+            "date_start": "2024-12-24T23:00:00.000Z",
+            "date_end": "2024-12-25T01:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cd3f7010a15941eee1f7",
+            "name": "Win Noticias",
+            "date_start": "2024-12-25T01:00:00.000Z",
+            "date_end": "2024-12-25T02:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cd73cf81e69c6f938fb7",
+            "name": "Repetición Programación Win",
+            "date_start": "2024-12-25T02:00:00.000Z",
+            "date_end": "2024-12-25T14:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cd9690f3e6c93ff24f88",
+            "name": "Repetición Copa Win Sports Fem Sub 13",
+            "date_start": "2024-12-25T14:00:00.000Z",
+            "date_end": "2024-12-25T16:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cdb9958caf9ad827b698",
+            "name": "Win Noticias",
+            "date_start": "2024-12-25T16:00:00.000Z",
+            "date_end": "2024-12-25T17:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cdde6c5458ca73ec0bb5",
+            "name": "Repetición Copa BetPlay Dimayor 2018",
+            "date_start": "2024-12-25T17:00:00.000Z",
+            "date_end": "2024-12-25T19:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765cdf63ac862cf29b0948f",
+            "name": "Detrás de la Gloria",
+            "date_start": "2024-12-25T19:00:00.000Z",
+            "date_end": "2024-12-25T20:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765ce19a449f4fa096d669f",
+            "name": "Liga BetPlay Dimayor 2024-I (Final Ida)",
+            "date_start": "2024-12-25T20:00:00.000Z",
+            "date_end": "2024-12-25T22:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6765ce3994a83798b6aaab0e",
+            "name": "Bucaramanga Campeón",
+            "date_start": "2024-12-25T22:00:00.000Z",
+            "date_end": "2024-12-25T23:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "529cff6f6bd2ea6b610000e0",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          }
+        ],
+        "__typename": "Live"
+      },
+      {
+        "_id": "5265a8f3af1ecb9d320000ee",
+        "logo": "https://platform-static.cdn.mdstrm.com/player/logo/s-live-5265a8f3af1ecb9d320000ee.png?c=20241223",
+        "name": "Win Sports",
+        "schedules": [
+          {
+            "_id": "6763030f777e099d5ee2869e",
+            "name": "Saque Largo",
+            "date_start": "2024-12-23T21:00:00.000Z",
+            "date_end": "2024-12-24T00:30:00.000Z",
+            "current": true,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6769957ef1d3bc4c15c374ad",
+            "name": "Repetición Liga BetPlay Dimayor 2024-II: Nacional vs Tolima (Final Vuelta)",
+            "date_start": "2024-12-24T00:30:00.000Z",
+            "date_end": "2024-12-24T02:30:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676995b4ce095c2598505dab",
+            "name": "Win Noticias",
+            "date_start": "2024-12-24T02:30:00.000Z",
+            "date_end": "2024-12-24T03:30:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67699621857fab2481285bb5",
+            "name": "Repetición Programación Win",
+            "date_start": "2024-12-24T03:30:00.000Z",
+            "date_end": "2024-12-24T14:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6769964e7d230225db2f0f78",
+            "name": "Repetición Evento 1995 - 2011",
+            "date_start": "2024-12-24T14:00:00.000Z",
+            "date_end": "2024-12-24T16:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67699689bd14cf50b8f0ec65",
+            "name": "Win Noticias",
+            "date_start": "2024-12-24T16:00:00.000Z",
+            "date_end": "2024-12-24T18:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676996b8c0036c5606f6b08f",
+            "name": "De Colección FPC",
+            "date_start": "2024-12-24T18:00:00.000Z",
+            "date_end": "2024-12-24T19:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676998e3857fab2481289303",
+            "name": "Mejor partido Colombia: Colombia vs. Gran Bretaña",
+            "date_start": "2024-12-24T19:00:00.000Z",
+            "date_end": "2024-12-24T21:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "67699907149eb85649e1694b",
+            "name": "Mejor partido Colombia: Colombia vs. Italia",
+            "date_start": "2024-12-24T21:00:00.000Z",
+            "date_end": "2024-12-24T23:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "6769993e07024c257874e517",
+            "name": "Creyentes: Siempre Adelante, ni un paso atrás",
+            "date_start": "2024-12-24T23:00:00.000Z",
+            "date_end": "2024-12-25T00:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676999729f609656290acf12",
+            "name": "Repetición Liga Betplay Dimayor 2024-I: Bucaramanga vs. Sata Fe",
+            "date_start": "2024-12-25T00:00:00.000Z",
+            "date_end": "2024-12-25T02:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676999918d38e9b76a940868",
+            "name": "Bucaramanga Campeón",
+            "date_start": "2024-12-25T02:00:00.000Z",
+            "date_end": "2024-12-25T03:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          },
+          {
+            "_id": "676999b5076f85b69b3593f5",
+            "name": "Repetición Programación Win",
+            "date_start": "2024-12-25T03:00:00.000Z",
+            "date_end": "2024-12-25T16:00:00.000Z",
+            "current": false,
+            "match": null,
+            "show": null,
+            "live": {
+              "_id": "5265a8f3af1ecb9d320000ee",
+              "dvr": true,
+              "type": "video",
+              "purchased": -1,
+              "__typename": "Live"
+            },
+            "__typename": "Schedule"
+          }
+        ],
+        "__typename": "Live"
+      },
+      {
+        "_id": "66bcd350d222a8a780862ec3",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Liga BetPlay de Baloncesto 2024 - II",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "64627247f7aaba0882296a20",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Señal Backup final Win básica",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "627c589eafdeb0082d4ea3de",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Rueda prensa FMS",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "61c3c92309dce808f216d778",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Liga BetPlay Dimayor 2024 - II: Pereira vs. Equidad",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "627c5650637d89088290fedf",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Premier 12",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "66195b77c7c13360bdaed72f",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Liga BetPlay de Baloncesto 2024 - II",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "662bd720450e3008a5f385d2",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Liga BetPlay Dimayor 2024 - II: Fortaleza vs. Águilas Doradas",
+        "schedules": [],
+        "__typename": "Live"
+      },
+      {
+        "_id": "66bcd3855e7418050351d810",
+        "logo": "https://ott-assets.mdstrm.com/526590f532b8fca13200005c/66563a476780f218bb74c7cc/assets/Logo_Play.png",
+        "name": "Liga BetPlay Dimayor 2024 - II: Alianza vs. Bucaramanga",
+        "schedules": [],
+        "__typename": "Live"
+      }
+    ]
+  }
+}

--- a/sites/winplay.co/readme.md
+++ b/sites/winplay.co/readme.md
@@ -1,0 +1,15 @@
+# winplay.co
+
+https://winplay.co/epg
+
+### Download the guide
+
+```sh
+npm run grab --- --site=winplay.co
+```
+
+### Test
+
+```sh
+npm test --- winplay.co
+```

--- a/sites/winplay.co/winplay.co.channels.xml
+++ b/sites/winplay.co/winplay.co.channels.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="winplay.co" lang="es" xmltv_id="WinPlusFutbol.co" site_id="529cff6f6bd2ea6b610000e0">Win+ Fútbol</channel>
+  <channel site="winplay.co" lang="es" xmltv_id="WinSports.co" site_id="5265a8f3af1ecb9d320000ee">Win Sports</channel>
+</channels>

--- a/sites/winplay.co/winplay.co.config.js
+++ b/sites/winplay.co/winplay.co.config.js
@@ -1,0 +1,46 @@
+const axios = require('axios')
+const dayjs = require('dayjs')
+
+module.exports = {
+  site: 'winplay.co',
+  days: 2,
+  url: 'https://next.platform.mediastre.am/graphql',
+  request: {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'x-client-id': 'a084524ea449c15dfe5e75636fb55ce6a9d0d7601aac946daa',
+      'x-ott-language': 'es'
+    },
+    data() {
+      return {
+        operationName: 'getLivesEpg',
+        variables: { page: 1, hours: 48 },
+        query:
+          'query getLivesEpg($page: Int = 1, $hours: Int, $ids: [String]) {\n getLives(ids: $ids) {\n _id\n logo\n name\n schedules(hours: $hours, page: {limit: 0, page: $page}) {\n _id\n name\n date_start\n date_end\n current\n match {\n matchDay\n __typename\n }\n show {\n _id\n title\n __typename\n }\n live {\n _id\n dvr\n type\n purchased\n __typename\n }\n __typename\n }\n __typename\n }\n}\n'
+      }
+    }
+  },
+  parser({ content, channel, date }) {
+    let programs = []
+    const items = parseItems(content, channel, date)
+    for (let item of items) {
+      programs.push({
+        title: item.name,
+        start: dayjs(item.date_start),
+        stop: dayjs(item.date_end)
+      })
+    }
+
+    return programs
+  }
+}
+
+function parseItems(content, channel, date) {
+  const data = JSON.parse(content)
+  if (!data || !data.data || !data.data.getLives) return []
+  const channelData = data.data.getLives.find(i => i._id === channel.site_id)
+  if (!Array.isArray(channelData.schedules)) return []
+
+  return channelData.schedules.filter(i => date.isSame(dayjs(i.date_start), 'd'))
+}

--- a/sites/winplay.co/winplay.co.test.js
+++ b/sites/winplay.co/winplay.co.test.js
@@ -1,0 +1,68 @@
+const { parser, url, request } = require('./winplay.co.config.js')
+const fs = require('fs')
+const path = require('path')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2024-12-24', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: '529cff6f6bd2ea6b610000e0',
+  xmltv_id: 'WinPlusFutbol.co'
+}
+
+it('can generate valid url', () => {
+  expect(url).toBe('https://next.platform.mediastre.am/graphql')
+})
+
+it('can generate valid request method', () => {
+  expect(request.method).toBe('POST')
+})
+
+it('can generate valid request headers', () => {
+  expect(request.headers).toMatchObject({
+    accept: 'application/json',
+    'x-client-id': 'a084524ea449c15dfe5e75636fb55ce6a9d0d7601aac946daa',
+    'x-ott-language': 'es'
+  })
+})
+
+it('can generate valid request data', () => {
+  expect(request.data()).toMatchObject({
+    operationName: 'getLivesEpg',
+    variables: { page: 1, hours: 48 },
+    query:
+      'query getLivesEpg($page: Int = 1, $hours: Int, $ids: [String]) {\n getLives(ids: $ids) {\n _id\n logo\n name\n schedules(hours: $hours, page: {limit: 0, page: $page}) {\n _id\n name\n date_start\n date_end\n current\n match {\n matchDay\n __typename\n }\n show {\n _id\n title\n __typename\n }\n live {\n _id\n dvr\n type\n purchased\n __typename\n }\n __typename\n }\n __typename\n }\n}\n'
+  })
+})
+
+it('can parse response', () => {
+  const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.json'), 'utf8')
+
+  const results = parser({ content, channel, date }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(results[0]).toMatchObject({
+    start: '2024-12-24T00:30:00.000Z',
+    stop: '2024-12-24T02:30:00.000Z',
+    title: 'Los Disruptivos de Win'
+  })
+
+  expect(results[1]).toMatchObject({
+    start: '2024-12-24T02:30:00.000Z',
+    stop: '2024-12-24T03:30:00.000Z',
+    title: 'WIn Noticias'
+  })
+})
+
+it('can handle empty guide', () => {
+  const content = '{"status":"ERROR","error":"UNAUTHORIZED_REQUEST"}'
+  const results = parser({ content, channel, date })
+
+  expect(results).toMatchObject([])
+})


### PR DESCRIPTION
Closes https://github.com/iptv-org/epg/issues/2251

Requires https://github.com/iptv-org/database/issues/14935

```sh
npm test -- winplay.co

> test
> run-script-os winplay.co


> test:default
> TZ=Pacific/Nauru npx jest --runInBand winplay.co

 PASS  sites/winplay.co/winplay.co.test.js
  ✓ can generate valid url (3 ms)
  ✓ can generate valid request method (1 ms)
  ✓ can generate valid request headers (2 ms)
  ✓ can generate valid request data (1 ms)
  ✓ can parse response (4 ms)
  ✓ can handle empty guide

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        2.761 s, estimated 3 s
Ran all test suites matching /winplay.co/i.
```

```sh
npm run grab --- --site=winplay.co

> grab
> npx tsx scripts/commands/epg/grab.ts --site=winplay.co

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  site: winplay.co
loading channels...
  found 2 channel(s)
run #1:
  [1/4] winplay.co (es) - WinPlayFutbol.co - Dec 23, 2024 (1 programs)
  [2/4] winplay.co (es) - WinPlayFutbol.co - Dec 24, 2024 (10 programs)
  [3/4] winplay.co (es) - WinSports.co - Dec 24, 2024 (9 programs)
  [4/4] winplay.co (es) - WinSports.co - Dec 23, 2024 (1 programs)
  saving to "guide.xml"...
  done in 00h 00m 04s
```