### PR TITLE
Filter out repeated schedule events from sky.com.

### DIFF
--- a/sites/sky.com/sky.com.config.js
+++ b/sites/sky.com/sky.com.config.js
@@ -18,7 +18,7 @@ module.exports = {
       channel.site_id
     }`
   },
-  parser({ content, channel }) {
+  parser({ content, channel, date }) {
     const programs = []
     if (content) {
       const items = JSON.parse(content) || null
@@ -30,15 +30,16 @@ module.exports = {
               schedule.events
                 .forEach(event => {
                   const start = dayjs.utc(event.st * 1000)
-                  const stop = start.add(event.d, 's')
-                  programs.push({
-                    title: event.t,
-                    description: event.sy,
-                    season: event.seasonnumber,
-                    episode: event.episodenumber,
-                    start,
-                    stop
-                  })
+                  if (start.isSame(date, 'd')) {
+                    programs.push({
+                      title: event.t,
+                      description: event.sy,
+                      season: event.seasonnumber,
+                      episode: event.episodenumber,
+                      start,
+                      stop: start.add(event.d, 's')
+                    })
+                  }
                 })
             }
           })

--- a/sites/sky.com/sky.com.test.js
+++ b/sites/sky.com/sky.com.test.js
@@ -28,17 +28,17 @@ it('can parse response', () => {
     return p
   })
 
-  expect(result.length).toBe(33)
+  expect(result.length).toBe(31)
   expect(result[0]).toMatchObject({
-    start: '2024-12-13T22:00:00.000Z',
-    stop: '2024-12-13T23:00:00.000Z',
-    title: 'The UnXplained With...',
+    start: '2024-12-14T00:00:00.000Z',
+    stop: '2024-12-14T00:30:00.000Z',
+    title: 'Storage Wars',
     description:
-      'The Hunt for Jack the Ripper: Jack the Ripper\'s identity has eluded police, historians and armchair detectives for over a century. What do we know about the notorious killer? (S3, ep 21)',
-    season: 4,
-    episode: 14
+      'A Sale Of Two Cities: Emily brings her mother along with her to Walnut, and Darrell wastes no time finding an advantage. Ivy and Ivy jr clean up with their locker. (S12, ep 4)',
+    season: 12,
+    episode: 4
   })
-  expect(result[4]).toMatchObject({
+  expect(result[2]).toMatchObject({
     start: '2024-12-14T01:00:00.000Z',
     stop: '2024-12-14T01:30:00.000Z',
     title: 'Storage Wars',


### PR DESCRIPTION
Additional fix of #2516.