### PR TITLE
#2555 Fix Site web.magentatv.de

### DIFF
--- a/sites/web.magentatv.de/web.magentatv.de.config.js
+++ b/sites/web.magentatv.de/web.magentatv.de.config.js
@@ -2,8 +2,7 @@ const axios = require('axios')
 const dayjs = require('dayjs')
 const utc = require('dayjs/plugin/utc')
 const customParseFormat = require('dayjs/plugin/customParseFormat')
-const fetch = require('node-fetch')
-const { upperCase } = require('lodash')
+const { upperCase, method, head } = require('lodash')
 
 let X_CSRFTOKEN
 let COOKIE
@@ -165,11 +164,10 @@ function parseItems(content) {
   return data.playbilllist
 }
 
-// Function to try to fetch COOKIE and X_CSRFTOKEN
-function fetchCookieAndToken() {
-  return fetch(
-    'https://api.prod.sngtv.magentatv.de/EPG/JSON/Authenticate?SID=firstup&T=Windows_chrome_118',
-    {
+async function fetchCookieAndToken() {
+  try {
+    const response = await axios.request({
+      url: 'https://api.prod.sngtv.magentatv.de/EPG/JSON/Authenticate',
       headers: {
         accept: 'application/json, text/javascript, */*; q=0.01',
         'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
@@ -180,51 +178,48 @@ function fetchCookieAndToken() {
         Referer: 'https://web.magentatv.de/',
         'Referrer-Policy': 'strict-origin-when-cross-origin'
       },
-      body: '{"terminalid":"00:00:00:00:00:00","mac":"00:00:00:00:00:00","terminaltype":"WEBTV","utcEnable":1,"timezone":"Etc/GMT0","userType":3,"terminalvendor":"Unknown"}',
-      method: 'POST'
+      params: {
+        SID: 'firstup',
+        T: 'Windows_chrome_118'
+      },
+      method: 'POST',
+      data: '{"terminalid":"00:00:00:00:00:00","mac":"00:00:00:00:00:00","terminaltype":"WEBTV","utcEnable":1,"timezone":"Etc/GMT0","userType":3,"terminalvendor":"Unknown"}',
+    })
+
+
+    // Extract the cookies specified in cookiesToExtract
+    const setCookieHeader = response.headers['set-cookie'] || []
+    let extractedCookies = []
+    cookiesToExtract.forEach(cookieName => {
+      const regex = new RegExp(`${cookieName}=(.+?)(;|$)`)
+      const match = setCookieHeader.find(header => regex.test(header))
+
+      if (match) {
+        const cookieString = regex.exec(match)[0]
+        extractedCookies.push(cookieString)
+      }
+    })
+
+
+    // check if we recieved a csrfToken only then store the values
+    if (!response.data.csrfToken) {
+      console.log('csrfToken not found in the response.')
+      return
     }
-  )
-    .then(response => {
-      // Check if the response status is OK (2xx)
-      if (!response.ok) {
-        throw new Error('HTTP request failed')
-      }
 
-      // Extract the set-cookie header
-      const setCookieHeader = response.headers.raw()['set-cookie']
+    X_CSRFTOKEN = response.data.csrfToken
+    COOKIE = extractedCookies.join(' ')
 
-      // Extract the cookies specified in cookiesToExtract
-      cookiesToExtract.forEach(cookieName => {
-        const regex = new RegExp(`${cookieName}=(.+?)(;|$)`)
-        const match = setCookieHeader.find(header => regex.test(header))
-
-        if (match) {
-          const cookieValue = regex.exec(match)[1]
-          extractedCookies[cookieName] = cookieValue
-        }
-      })
-
-      return response.json()
-    })
-    .then(data => {
-      if (data.csrfToken) {
-        X_CSRFTOKEN = data.csrfToken
-        COOKIE = `JSESSIONID=${extractedCookies.JSESSIONID}; CSESSIONID=${extractedCookies.CSESSIONID}; CSRFSESSION=${extractedCookies.CSRFSESSION}; JSESSIONID=${extractedCookies.JSESSIONID};`
-      } else {
-        console.log('csrfToken not found in the response.')
-      }
-    })
-    .catch(error => {
-      console.error(error)
-    })
+  } catch(error) {
+    console.error(error)
+  }
 }
 
-function setHeaders() {
-  return fetchCookieAndToken().then(() => {
-    return {
-      X_CSRFTOKEN: X_CSRFTOKEN,
-      'Content-Type': 'application/json',
-      Cookie: COOKIE
-    }
-  })
+async function setHeaders() {
+  await fetchCookieAndToken()
+  return {
+    X_CSRFTOKEN: X_CSRFTOKEN,
+    'Content-Type': 'application/json',
+    Cookie: COOKIE
+  }
 }


### PR DESCRIPTION
The currently used module `fetch` is not available as `node-fetch` anymore since Node JS 18. Thus running this site will throw an error 
```
Cannot find module 'node-fetch' from 'sites/web.magentatv.de/web.magentatv.de.config.js'
```
Closes https://github.com/iptv-org/epg/issues/2555

This PR removes the dependency for `fetch` and relies only on `axios` for fetching the needed cookies and token. I additionally added a change to load this tokens only once which speeds up the fetching a lot (at least on my machine)
I tested on Nodejs 16 and 20 