### PR TITLE
Add simple Docker integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 /node_modules/
-/temp
+/temp/
+/.git/
 /.github/
 /.tests/
 /.sites/
+/Dockerfile
+/.dockerignore
+/.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-node_modules
-.github
-.tests
+/node_modules/
+/temp
+/.github/
+/.tests/
+/.sites/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.github
+.tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 FROM node:lts-bookworm-slim
 
-RUN mkdir -p /build && chown node:node /build
+RUN install -d -g node -o node /build && \
+    npm install pm2 -g
 WORKDIR /build
+USER node
 
-COPY yarn.lock ./yarn.lock
-COPY package.json ./package.json
-COPY package-lock.json ./package-lock.json
+COPY --chown=node:node yarn.lock ./yarn.lock
+COPY --chown=node:node package.json ./package.json
+COPY --chown=node:node package-lock.json ./package-lock.json
 
 RUN npm ci --ignore-scripts
 
-COPY . .
-COPY docker/ecosystem.config.js ./ecosystem.config.js
-COPY docker/serve.json ./serve.json
-
-RUN npm install pm2 -g
-USER node
+COPY --chown=node:node . .
 RUN npm run postinstall
 
 # Set some application defaults
@@ -23,4 +20,4 @@ ENV NODE_ENV=production \
     GZIP=true
 
 EXPOSE 3000
-CMD [ "pm2-runtime", "ecosystem.config.js" ]
+CMD [ "pm2-runtime", "docker/ecosystem.config.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:lts-bookworm-slim
 
+RUN mkdir -p /build && chown node:node /build
 WORKDIR /build
 
 COPY yarn.lock ./yarn.lock
@@ -12,8 +13,9 @@ COPY . .
 COPY docker/ecosystem.config.js ./ecosystem.config.js
 COPY docker/serve.json ./serve.json
 
-RUN npm install pm2 -g && \
-    npm run postinstall
+RUN npm install pm2 -g
+USER node
+RUN npm run postinstall
 
 # Set some application defaults
 ENV NODE_ENV=production \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:lts-bookworm-slim AS build
+
+WORKDIR /build
+
+COPY yarn.lock ./yarn.lock
+COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
+
+RUN npm ci --ignore-scripts
+
+COPY . .
+COPY docker/ecosystem.config.js ./ecosystem.config.js
+COPY docker/serve.json ./serve.json
+
+RUN npm install pm2 -g \
+    npm run postinstall
+
+# Set some application defaults
+ENV NODE_ENV=production \
+    OUTPUT=/build/public/guide.xml \
+    GZIP=true
+
+EXPOSE 3000
+CMD [ "pm2-runtime", "ecosystem.config.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bookworm-slim AS build
+FROM node:lts-bookworm-slim
 
 WORKDIR /build
 
@@ -12,7 +12,7 @@ COPY . .
 COPY docker/ecosystem.config.js ./ecosystem.config.js
 COPY docker/serve.json ./serve.json
 
-RUN npm install pm2 -g \
+RUN npm install pm2 -g && \
     npm run postinstall
 
 # Set some application defaults

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tools for downloading the EPG (Electronic Program Guide) for thousands of TV cha
 - 📺 [Playlists](#playlists)
 - 🗄 [Database](#database)
 - 👨‍💻 [API](#api)
+- 🐋 [Docker](#docker)
 - 📚 [Resources](#resources)
 - 💬 [Discussions](#discussions)
 - 🛠 [Contribution](#contribution)
@@ -149,6 +150,47 @@ All channel data is taken from the [iptv-org/database](https://github.com/iptv-o
 ## API
 
 The API documentation can be found in the [iptv-org/api](https://github.com/iptv-org/api) repository.
+
+## Docker
+
+This repository provides a `Dockerfile` that you can use to build a Docker image. To do this, you need to have [Docker](https://docs.docker.com/get-docker/) installed on your computer.
+
+Build your image using the following command:
+
+```sh
+docker build -t epg .
+```
+You can then run the image. The container supports currently two modes:
+
+- If you supply an `CRON` environment variable, the container will start in cron-mode. The container will grab an initial set of EPG data according to your configuration, start a webserver on port 3000 and then run the cron job according to your `CRON` configuration.
+
+  Example:
+  ```sh
+  docker run -d -e CRON="0 0 * * *" -e SITE=example.com -p 3000:3000 --name epg epg
+  ```
+
+  This will grab the EPG data from `example.com` every day at midnight, store the file inside the container at `/build/public/guide.xml` and `/build/public/guide.xml.gz`, and start a webserver on port 3000 to serve the files via http.
+
+- If you don't supply a `CRON` environment variable, the container will start in an one-off mode. The container will grab an initial set of EPG data according to your configuration and then exit.
+
+  Example:
+  ```sh
+  docker run --rm -e SITE=example.com -v "${PWD}:/build/public" epg
+  ```
+
+  This will grab the EPG data from `example.com` and store the file in your current working directory.
+
+### Configuration
+
+You can configure the `grab` command by setting environment variables. All available options are listed in the [Usage](#usage) section with the corresponding environment variable names. Docker uses the same defaults of the options like the script with the execption of the `OUTPUT` and the `GZIP` option. The most important environment values are:
+
+| Environment variable | Default value | `npm run` option  |
+| -------------------- | ------------- | ----------------- |
+| `OUTPUT`             | `/build/public/guide.xml`   | `--output`        |
+| `GZIP`               | `true`        | `--gzip`          |
+| `SITE`               |               | `--site`          |
+| `CRON`               |               | `--cron`          |
+
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -51,18 +51,21 @@ And once the download is complete, the guide will be saved to the `guide.xml` fi
 Usage: npm run grab --- [options]
 
 Options:
-  -s, --site <name>             Name of the site to parse
+  -s, --site <name>             Name of the site to parse (env: SITE)
   -c, --channels <path>         Path to *.channels.xml file (required if the "--site" attribute is
-                                not specified)
-  -o, --output <path>           Path to output file (default: "guide.xml")
-  -l, --lang <code>             Filter channels by language (ISO 639-2 code)
-  -t, --timeout <milliseconds>  Override the default timeout for each request
-  -d, --delay <milliseconds>    Override the default delay between request
+                                not specified) (env: CHANNELS)
+  -o, --output <path>           Path to output file (default: "guide.xml", env: OUTPUT)
+  -l, --lang <code>             Filter channels by language (ISO 639-2 code) (env: LANG)
+  -t, --timeout <milliseconds>  Override the default timeout for each request (env: TIMEOUT)
+  -d, --delay <milliseconds>    Override the default delay between request (env: DELAY)
   --days <days>                 Override the number of days for which the program will be loaded
-                                (defaults to the value from the site config)
-  --maxConnections <number>     Limit on the number of concurrent requests (default: 1)
-  --cron <expression>           Schedule a script run (example: "0 0 * * *")
-  --gzip                        Create a compressed version of the guide as well (default: false)
+                                (defaults to the value from the site config) (env: DAYS)
+  --maxConnections <number>     Limit on the number of concurrent requests (default: 5, env:
+                                MAX_CONNECTIONS)
+  --cron <expression>           Schedule a script run (example: "0 0 * * *") (env: CRON)
+  --gzip                        Create a compressed version of the guide as well (default: false,
+                                env: GZIP)
+  -h, --help                    display help for command
 ```
 
 ### Access the guide by URL

--- a/docker/ecosystem.config.js
+++ b/docker/ecosystem.config.js
@@ -1,0 +1,32 @@
+// Docker startup configuration
+
+// first add the server app
+let apps = [{
+        name: "serve",
+        script: "npm run serve",
+    }
+]
+
+// if we run in cron-mode then add 2 jobs
+if (process.env.CRON) {
+    // run an initial grab at startup
+    apps.push({
+        name: "grab-startup",
+        script: "npm run grab",
+        autorestart: false,
+        filter_env: ["CRON"],
+    })
+    // run a grab according to the cron schedule
+    apps.push({
+        name: "grab-cron",
+        script: "npm run grab",
+    })
+} else {
+    // one time run only
+    apps.push({
+        name: "grab",
+        script: "npm run grab",
+    })
+}
+
+module.exports = { apps }

--- a/docker/ecosystem.config.js
+++ b/docker/ecosystem.config.js
@@ -16,7 +16,7 @@ if (process.env.CRON) {
         autorestart: false,
         filter_env: ["CRON"],
     })
-    // run a grab according to the cron schedule
+    // run a grab according to the cron schedule and let pm2 restart if it fails
     apps.push({
         name: "grab-cron",
         script: "npm run grab",
@@ -26,6 +26,7 @@ if (process.env.CRON) {
     apps.push({
         name: "grab",
         script: "npm run grab",
+        autorestart: false,
     })
 }
 

--- a/docker/ecosystem.config.js
+++ b/docker/ecosystem.config.js
@@ -1,33 +1,30 @@
 // Docker startup configuration
 
-// first add the server app
-let apps = [{
+let apps = []
+
+// if we run in cron-mode then start serve and cron
+if (process.env.CRON) {
+    apps = [{
         name: "serve",
         script: "npm run serve",
-    }
-]
-
-// if we run in cron-mode then add 2 jobs
-if (process.env.CRON) {
-    // run an initial grab at startup
-    apps.push({
+    },{
+        // run an initial grab at startup
         name: "grab-startup",
         script: "npm run grab",
         autorestart: false,
         filter_env: ["CRON"],
-    })
-    // run a grab according to the cron schedule and let pm2 restart if it fails
-    apps.push({
+    },{
+        // run a grab according to the cron schedule and let pm2 restart if it fails
         name: "grab-cron",
         script: "npm run grab",
-    })
+    }]
 } else {
     // one time run only
-    apps.push({
+    apps = [{
         name: "grab",
         script: "npm run grab",
         autorestart: false,
-    })
+    }]
 }
 
 module.exports = { apps }

--- a/docker/serve.json
+++ b/docker/serve.json
@@ -1,0 +1,3 @@
+{
+    "public": "./public"
+}

--- a/scripts/commands/epg/grab.ts
+++ b/scripts/commands/epg/grab.ts
@@ -1,5 +1,5 @@
 import { Logger, Timer, Storage, Collection } from '@freearhey/core'
-import { program } from 'commander'
+import { Option, program } from 'commander'
 import { CronJob } from 'cron'
 import { QueueCreator, Job, ChannelsParser } from '../../core'
 import { Channel } from 'epg-grabber'
@@ -7,28 +7,31 @@ import path from 'path'
 import { SITES_DIR } from '../../constants'
 
 program
-  .option('-s, --site <name>', 'Name of the site to parse')
-  .option(
+  .addOption(new Option('-s, --site <name>', 'Name of the site to parse').env('SITE'))
+  .addOption(new Option(
     '-c, --channels <path>',
     'Path to *.channels.xml file (required if the "--site" attribute is not specified)'
+    ).env('CHANNELS')
   )
-  .option('-o, --output <path>', 'Path to output file', 'guide.xml')
-  .option('-l, --lang <code>', 'Filter channels by language (ISO 639-2 code)')
-  .option('-t, --timeout <milliseconds>', 'Override the default timeout for each request')
-  .option('-d, --delay <milliseconds>', 'Override the default delay between request')
-  .option(
+  .addOption(new Option('-o, --output <path>', 'Path to output file').default('guide.xml').env('OUTPUT'))
+  .addOption(new Option('-l, --lang <code>', 'Filter channels by language (ISO 639-2 code)').env('LANG'))
+  .addOption(new Option('-t, --timeout <milliseconds>', 'Override the default timeout for each request').env('TIMEOUT'))
+  .addOption(new Option('-d, --delay <milliseconds>', 'Override the default delay between request').env('DELAY'))
+  .addOption(new Option(
     '--days <days>',
-    'Override the number of days for which the program will be loaded (defaults to the value from the site config)',
-    value => parseInt(value)
+    'Override the number of days for which the program will be loaded (defaults to the value from the site config)')
+    .argParser(value => parseInt(value))
+    .env('DAYS')
   )
-  .option(
+  .addOption(new Option(
     '--maxConnections <number>',
-    'Limit on the number of concurrent requests',
-    value => parseInt(value),
-    1
+    'Limit on the number of concurrent requests')
+    .argParser(value => parseInt(value))
+    .default(5)
+    .env('MAX_CONNECTIONS')
   )
-  .option('--cron <expression>', 'Schedule a script run (example: "0 0 * * *")')
-  .option('--gzip', 'Create a compressed version of the guide as well', false)
+  .addOption(new Option('--cron <expression>', 'Schedule a script run (example: "0 0 * * *")').env('CRON'))
+  .addOption(new Option('--gzip', 'Create a compressed version of the guide as well').default(false).env('GZIP'))
   .parse(process.argv)
 
 export type GrabOptions = {


### PR DESCRIPTION
Similar to https://github.com/iptv-org/epg/pull/2488/files this is a working, slim `Dockerfile` configuration to run the script inside docker. 
I made a small change on the script itself to accept also environment vars for the `grab` script instead of providing options. (e.g. you can use now `SITE=example.com npm run grab` instead of  `npm run grab --- --site=example.com`) This is not only a convenient feature but it helps also dramatically to configure the docker container accordingly.

I did not yet include some sort of GitHub Action to build and publish a ready-to-use image but if that's something that you guys want I can also add that (I will do it anyways in my fork of the repo) 