### PR TITLE
Update i.mjh.nz

### DIFF
--- a/sites/i.mjh.nz/i.mjh.nz.config.js
+++ b/sites/i.mjh.nz/i.mjh.nz.config.js
@@ -160,7 +160,7 @@ function getCategories(item) {
 }
 
 function getIcon(item) {
-  return item.icon && item.icon.length ? item.icon[0] : null
+  return item.icon && item.icon.length ? item.icon[0].src : null
 }
 
 function parseItems(content, channel, date) {


### PR DESCRIPTION
Fixes https://github.com/iptv-org/epg/issues/2556

```sh
npm test --- i.mjh.nz

> test
> run-script-os i.mjh.nz


> test:default
> TZ=Pacific/Nauru npx jest --runInBand i.mjh.nz

 PASS  sites/i.mjh.nz/i.mjh.nz.test.js
  ✓ can generate valid url (3 ms)
  ✓ can parse response (3073 ms)
  ✓ can handle empty guide (1 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.518 s, estimated 4 s
Ran all test suites matching /i.mjh.nz/i.
```

```sh
npm run grab --- --channels=sites/i.mjh.nz/i.mjh.nz_pbs.channels.xml

> grab
> npx tsx scripts/commands/epg/grab.ts --channels=sites/i.mjh.nz/i.mjh.nz_pbs.channels.xml

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  channels: sites/i.mjh.nz/i.mjh.nz_pbs.channels.xml
loading channels...
  found 149 channel(s)
run #1:
  [1/298] i.mjh.nz (en) - KACVDT1.us - Jan 11, 2025 (33 programs)
  [2/298] i.mjh.nz (en) - KACVDT1.us - Jan 12, 2025 (34 programs)
  [3/298] i.mjh.nz (en) - KAETDT1.us - Jan 12, 2025 (27 programs)
  [4/298] i.mjh.nz (en) - KAKMDT1.us - Jan 12, 2025 (35 programs)
  [5/298] i.mjh.nz (en) - KBTCDT1.us - Jan 12, 2025 (32 programs)
...
```