### PR TITLE
Update nzxmltv.com

### DIFF
--- a/sites/nzxmltv.com/nzxmltv.com.config.js
+++ b/sites/nzxmltv.com/nzxmltv.com.config.js
@@ -20,7 +20,7 @@ module.exports = {
       const program = {
         title: item.title?.[0]?.value,
         description: item.desc?.[0]?.value,
-        icon: item.icon?.[0],
+        icon: item.icon?.[0]?.src,
         start: item.start,
         stop: item.stop
       }


### PR DESCRIPTION
Fixes https://github.com/iptv-org/epg/issues/2557

```sh
npm test --- nzxmltv.com

> test
> run-script-os nzxmltv.com


> test:default
> TZ=Pacific/Nauru npx jest --runInBand nzxmltv.com

 PASS  sites/nzxmltv.com/nzxmltv.com.test.js
  ✓ can generate valid url (5 ms)
  ✓ can parse response (18 ms)
  ✓ can handle empty guide (2 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.687 s, estimated 1 s
Ran all test suites matching /nzxmltv.com/i.
```

```sh
npm run grab --- --channels=sites/nzxmltv.com/nzxmltv.com_freeview.channels.xml

> grab
> npx tsx scripts/commands/epg/grab.ts --channels=sites/nzxmltv.com/nzxmltv.com_freeview.channels.xml

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  channels: sites/nzxmltv.com/nzxmltv.com_freeview.channels.xml
loading channels...
  found 35 channel(s)
run #1:
  [1/70] nzxmltv.com (en) - xmltv/guide#28 - Jan 11, 2025 (0 programs)
  [2/70] nzxmltv.com (en) - xmltv/guide#28 - Jan 12, 2025 (0 programs)
  [3/70] nzxmltv.com (en) - WhakaataMaori.nz - Jan 12, 2025 (25 programs)
  [4/70] nzxmltv.com (en) - WhakaataMaori.nz - Jan 11, 2025 (35 programs)
  [5/70] nzxmltv.com (en) - WairarapaTV.nz - Jan 12, 2025 (23 programs)
  [6/70] nzxmltv.com (en) - WairarapaTV.nz - Jan 11, 2025 (23 programs)
...
```