### PR TITLE
Add tv-spored.siol.net

### DIFF
--- a/sites/tv-spored.siol.net/__data__/content.html
+++ b/sites/tv-spored.siol.net/__data__/content.html
@@ -1,0 +1,3347 @@
+<!doctype html>
+<html lang="sl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="preload"
+      href="/_next/static/media/1cf13853095a62e2-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/38c28ef5d38c7945-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/52b660d6c1eb514f-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/68040411bbf3104a-s.p.ttf"
+      as="font"
+      crossorigin=""
+      type="font/ttf"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/71fc01820777da89-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/725d9bf62572528d-s.p.ttf"
+      as="font"
+      crossorigin=""
+      type="font/ttf"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/74691c6b533fc12d-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/8c279e41746278e3-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/d45d409d2fa42169-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/d79053dc2fa747e1-s.p.ttf"
+      as="font"
+      crossorigin=""
+      type="font/ttf"
+    />
+    <link
+      rel="preload"
+      href="/_next/static/media/f029807352456171-s.p.woff2"
+      as="font"
+      crossorigin=""
+      type="font/woff2"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://www.facebook.com/tr?id=101984190133976&amp;ev=PageView&amp;noscript=1"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/86/5c/30cad26c7f3db1193027.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/70/77/215ef27f31dc4cc3c2ff.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/b8/1d/9070934b6e8ab90955a5.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/a0/d2/402020c0d4e8c9634817.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/74/dc/a7b23a48ae5cf85a8179.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/c0/8b/35834ce15aeb7696cb09.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/be/55/a656568a2080893f004a.jpg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/ca/4c/d5fb440310620e2b02a8.jpeg"
+    />
+    <link rel="stylesheet" href="/_next/static/css/ccffdc6ea249bec6.css" data-precedence="next" />
+    <link rel="stylesheet" href="/_next/static/css/bca5ef303b452bcb.css" data-precedence="next" />
+    <link
+      rel="preload"
+      as="script"
+      fetchpriority="low"
+      href="/_next/static/chunks/webpack-d70776087c4d8a2e.js"
+    />
+    <script src="/_next/static/chunks/fd9d1056-ad668c23c89094e9.js" async=""></script>
+    <script src="/_next/static/chunks/69-f67a231268e5fceb.js" async=""></script>
+    <script src="/_next/static/chunks/main-app-f17598996d861a10.js" async=""></script>
+    <script src="/_next/static/chunks/647-1cfed450302421c4.js" async=""></script>
+    <script src="/_next/static/chunks/app/global-error-42518278c1c04387.js" async=""></script>
+    <script src="/_next/static/chunks/2626716e-1204952e0c2f13b3.js" async=""></script>
+    <script src="/_next/static/chunks/13b76428-ac16532e24d8aa3f.js" async=""></script>
+    <script src="/_next/static/chunks/935-56093c0b7187e483.js" async=""></script>
+    <script src="/_next/static/chunks/206-24cb2ebaaee1b406.js" async=""></script>
+    <script src="/_next/static/chunks/741-aec7b398fcc08cd7.js" async=""></script>
+    <script src="/_next/static/chunks/445-15372bec73978f69.js" async=""></script>
+    <script src="/_next/static/chunks/561-e598a824d42ca3f6.js" async=""></script>
+    <script
+      src="/_next/static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"
+      async=""
+    ></script>
+    <script src="/_next/static/chunks/457-aaf27fb26d066ad3.js" async=""></script>
+    <script src="/_next/static/chunks/208-2e235f84099ed6f3.js" async=""></script>
+    <script src="/_next/static/chunks/170-e928c32039c28157.js" async=""></script>
+    <script src="/_next/static/chunks/app/(content)/layout-3662790ffc082265.js" async=""></script>
+    <link rel="preload" href="//cdn.orangeclickmedia.com/tech/siol.net/ocm.js" as="script" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/e6/2d/78b773875a07b588d2a8-ts-pz-kv-december-banner-saj-v2-600x160.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/14/c5/9ad361fbfd93e79a6ecb-600x160-pz.jpeg"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://siol.net/media/img/45/07/6caf4e8909017ff18d16-ts-pz-kv-december-banner-saj-v2-brez-600x160.jpeg"
+    />
+    <title>TV spored za Exodus TV za 15. 1. 2025 na Siol.net</title>
+    <meta
+      name="description"
+      content="Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."
+    />
+    <link rel="manifest" href="/images/favicons/manifest.json" />
+    <meta name="keywords" content="tv spored,Exodus TV,program,oddaje" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
+    <meta name="msapplication-TileImage" content="/images/favicons/ms-icon-144x144.png" />
+    <link rel="canonical" href="https://tv-spored.siol.net/kanal/exodustv/datum/20250115" />
+    <meta property="og:title" content="TV spored za Exodus TV za 15. 1. 2025 na Siol.net" />
+    <meta
+      property="og:description"
+      content="Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."
+    />
+    <meta property="og:url" content="https://tv-spored.siol.net/" />
+    <meta property="og:locale" content="sl_SI" />
+    <meta property="og:image" content="https://tv-spored.siol.net/images/social_share.jpg" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@siolnews" />
+    <meta name="twitter:title" content="TV spored za Exodus TV za 15. 1. 2025 na Siol.net" />
+    <meta
+      name="twitter:description"
+      content="Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."
+    />
+    <meta name="twitter:image" content="https://tv-spored.siol.net/images/social_share.jpg" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-57x57.png" sizes="57x57" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-60x60.png" sizes="60x60" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-72x72.png" sizes="72x72" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-76x76.png" sizes="76x76" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-114x114.png" sizes="114x114" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-120x120.png" sizes="120x120" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-144x144.png" sizes="144x144" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-152x152.png" sizes="152x152" />
+    <link rel="apple-touch-icon" href="/images/favicons/apple-icon-180x180.png" sizes="180x180" />
+    <link rel="icon" href="/images/favicons/android-icon-192x192.png" sizes="192x192" />
+    <link rel="icon" href="/images/favicons/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" href="/images/favicons/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" href="/images/favicons/favicon-16x16.png" sizes="16x16" />
+    <meta name="next-size-adjust" />
+    <script src="/_next/static/chunks/polyfills-c67a75d1b6f99dc8.js" nomodule=""></script>
+  </head>
+  <body class="__variable_1b2967 __variable_d8bf44">
+    <div id="outofpage" data-ocm-ad="true" class="ad-zone"></div>
+    <div id="wallpaper_skin" data-ocm-ad="true" class="ad-zone"></div>
+    <!--$-->
+    <script type="didomi/javascript" data-vendor="didomi:google" src="/js/ga.js"></script>
+    <script
+      type="didomi/javascript"
+      id="smarttag_script"
+      data-vendor="c:at-internet"
+      src="//tag.aticdn.net/569027/smarttag.js"
+    ></script>
+    <script type="didomi/javascript" data-vendor="didomi:facebook" src="/js/fb.js"></script>
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        class="hidden"
+        src="https://www.facebook.com/tr?id=101984190133976&amp;ev=PageView&amp;noscript=1"
+    /></noscript>
+    <script
+      type="didomi/javascript"
+      src="/js/google_tag_manager.js"
+      data-vendor="didomi:google"
+      id="googletag-manager"
+    ></script>
+    <!--/$-->
+    <div class="fixed w-full z-10">
+      <div class="h-4 bg-white desktop:h-auto desktop:relative desktop:z-10 text-xs text-corpoline">
+        <div
+          class="hidden desktop:flex desktop:flex-row desktop:gap-4 desktop:container desktop:mx-auto my-auto desktop:py-1"
+        >
+          <a href="https://tv-spored.siol.net/">TV spored</a><a href="https://www.bizi.si/">Bizi</a
+          ><a href="https://www.najdi.si/">Najdi.si</a><a href="https://www.itis.si/">Itis.si</a
+          ><a href="https://www.1188.si/">1188</a>
+        </div>
+        <div class="desktop:hidden text-right h-full pr-2">
+          <button class="inline h-full">Telekom Slovenije</button>
+        </div>
+      </div>
+      <div class="bg-expose text-white pl-4 pr-2 desktop:p-0 desktop:relative desktop:z-10">
+        <div class="h-12 flex flex-row items-center desktop:container desktop:mx-auto desktop:h-14">
+          <div class="flex flex-row gap-2 h-4 desktop:gap-4 leading-none">
+            <button><i class="icon icon-burger"></i></button
+            ><a href="https://siol.net"><i class="icon icon-home"></i></a
+            ><a href="/"
+              ><img
+                alt="TV Spored logo"
+                loading="lazy"
+                width="93"
+                height="16"
+                decoding="async"
+                data-nimg="1"
+                class="ml-2 desktop:m-0"
+                style="color: transparent"
+                srcset="
+                  /_next/static/media/logo.54d100b8.svg?w=96  1x,
+                  /_next/static/media/logo.54d100b8.svg?w=256 2x
+                "
+                src="/_next/static/media/logo.54d100b8.svg?w=256"
+            /></a>
+          </div>
+          <div class="hidden desktop:flex flex-row text-white ml-[14px] py-5 gap-4">
+            <a class="uppercase text-xs" href="https://siol.net/novice">Novice</a
+            ><a class="uppercase text-xs" href="https://siol.net/sportal">Sportal</a
+            ><a class="uppercase text-xs" href="https://siol.net/trendi">Trendi</a
+            ><a class="uppercase text-xs" href="https://siol.net/avtomoto">Avtomoto</a
+            ><a class="uppercase text-xs" href="https://siol.net/mnenja">Kolumne</a
+            ><a
+              class="uppercase text-xs"
+              href="https://siol.net/kljucne-besede/spotkast-102419/articles"
+              >Spotkast</a
+            ><a class="uppercase text-xs" href="https://nepremicnine.siol.net/">S.Nepremičnine</a
+            ><a class="uppercase text-xs" href="https://videospot.siol.net/">VideoS.pot</a>
+          </div>
+          <div class="grow"></div>
+          <div class="flex-end flex flex-row gap-4 items-center desktop:mr-2 leading-none">
+            <div class="hidden desktop:flex flex-row bg-gray text-siol h-8 p-2 rounded-lg gap-4">
+              <span class="text-xs uppercase cursor-default">TELEKOM SLOVENIJE</span
+              ><a
+                href="https://www.telekom.si/etrgovina?utm_source=siolnet-eksnet&amp;utm_medium=zav-nav-ikona-etrgovina&amp;utm_term=naslovnica&amp;utm_campaign=zav-nav-ikona-etrgovina"
+                ><i class="icon icon-basket"></i></a
+              ><a
+                href="https://prijava.siol.net/posta/?utm_source=siolnet-eksnet&amp;utm_medium=zav-nav-ikona-posta&amp;utm_term=naslovnica&amp;utm_campaign=zav-nav-ikona-posta"
+                ><i class="icon icon-email-outline"></i></a
+              ><a
+                href="https://moj.telekom.si/sl/Profile/Login?utm_source=siolnet-eksnet&amp;utm_medium=zav-nav-ikona-mt&amp;utm_term=naslovnica&amp;utm_campaign=zav-nav-ikona-mt"
+                ><i class="icon icon-cog"></i
+              ></a>
+            </div>
+            <a href="https://siol.net/pregled-dneva"><i class="icon icon-timeline text-2xl"></i></a
+            ><a href="https://tv-spored.siol.net/"><i class="icon icon-tv-listing text-2xl"></i></a
+            ><a href="https://vreme.siol.net/"
+              ><img
+                alt="Vreme"
+                loading="lazy"
+                width="24"
+                height="25"
+                decoding="async"
+                data-nimg="1"
+                class="inline-block"
+                style="color: transparent"
+                srcset="
+                  /_next/static/media/vreme.6cf35697.svg?w=32 1x,
+                  /_next/static/media/vreme.6cf35697.svg?w=48 2x
+                "
+                src="/_next/static/media/vreme.6cf35697.svg?w=48"
+            /></a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="fixed w-screen pt-4 desktop:pt-20 bottom-full transition-transform pointer-events-none"
+      >
+        <div
+          class="bg-gray p-4 desktop:px-0 pointer-events-auto overflow-auto h-screen desktop:h-auto"
+        >
+          <div
+            class="desktop:container desktop:mx-auto flex flex-col desktop:flex-row justify-between gap-y-3 desktop:gap-0"
+          >
+            <div class="grid grid-cols-2 desktop:grid-cols-3 gap-2">
+              <a
+                class="block text-siol font-extrabold"
+                href="https://neo.io/?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=neo&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Spletna TV neo.io</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/neo?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=neo&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >NEO</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/mobilno?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=mobilni_paketi&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Mobilni paketi</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/internet?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=internet&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Internet</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/program-zvestobe?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=program_zvestobe&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Program zvestobe</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/e-trgovina?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=etrgovina&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >E-trgovina</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://moj.telekom.si/?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=moj_telekom&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Moj Telekom</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/mala-podjetja?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=poslovni_mala_podjetja&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Mala podjetja</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/velika-podjetja?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=poslovni_velika_podjetja&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Velika podjetja</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/e-oskrba?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=e_oskrba&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >E-oskrba</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://prijava.siol.net/posta?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=spletna_posta&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Spletna pošta</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/pomoc?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=pomoc&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Pomoč</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/info-in-obvestila?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=info_in_obvestila&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Info in obvestila</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/tehnik?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=tehnik&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Tehnik</a
+              ><a
+                class="block text-siol font-extrabold"
+                href="https://www.telekom.si/e-novice?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=enovice&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                >Želite prejemati e-novice?</a
+              >
+            </div>
+            <div class="bg-white p-2">
+              <a
+                href="https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet&amp;utm_medium=banner&amp;utm_campaign=digi_star%C5%A1_image_mc225&amp;utm_id=12082024_internal&amp;utm_content=380x247"
+                ><img
+                  class="desktop:h-[145px] desktop:w-[255px] object-cover"
+                  alt="Telekomov oglas"
+                  src="https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg"
+                /><span class="text-xs font-extrabold">Uživajmo pametno</span></a
+              >
+            </div>
+            <a
+              class="place-content-center mx-auto my-8 desktop:m-0"
+              href="https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet&amp;utm_medium=logo&amp;utm_campaign=telekom&amp;utm_term=ekskluziva&amp;utm_content=zavihek"
+              ><img
+                alt="Telekom"
+                loading="lazy"
+                width="206"
+                height="50"
+                decoding="async"
+                data-nimg="1"
+                style="color: transparent"
+                srcset="
+                  /_next/static/media/telekom_slovenije.d94a1399.svg?w=256 1x,
+                  /_next/static/media/telekom_slovenije.d94a1399.svg?w=640 2x
+                "
+                src="/_next/static/media/telekom_slovenije.d94a1399.svg?w=640"
+            /></a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="bg-white pl-4 h-9 border-b border-black flex flex-row flex-nowrap overflow-x-auto gap-2 items-center desktop:container desktop:mx-auto desktop:justify-center desktop:pl-0 desktop:pr-2 transition-transform false"
+      >
+        <a class="whitespace-nowrap text-xs" href="https://tv-spored.siol.net/kategorija/film"
+          ><span class="inline-block bg-expose h-2 w-2 rounded-lg mr-2"></span>Film</a
+        ><a class="whitespace-nowrap text-xs" href="https://tv-spored.siol.net/kategorija/sport"
+          ><span class="inline-block bg-expose h-2 w-2 rounded-lg mr-2"></span>Šport</a
+        ><a
+          class="whitespace-nowrap text-xs"
+          href="https://tv-spored.siol.net/kategorija/dokumentarni"
+          ><span class="inline-block bg-expose h-2 w-2 rounded-lg mr-2"></span>Dokumentarni</a
+        ><a
+          class="whitespace-nowrap text-xs"
+          href="https://tv-spored.siol.net/kategorija/otroski-in-mladinski"
+          ><span class="inline-block bg-expose h-2 w-2 rounded-lg mr-2"></span>Otroški</a
+        ><a
+          class="whitespace-nowrap text-xs"
+          href="https://tv-spored.siol.net/kategorija/nadaljevanka-nanizanka"
+          ><span class="inline-block bg-expose h-2 w-2 rounded-lg mr-2"></span
+          >Nadaljevanke-nanizanke</a
+        >
+      </div>
+    </div>
+    <div class="pt-[104px] desktop:pt-[112px]"></div>
+    <div
+      class="w-full fixed h-full bg-gray top-0 z-10 right-full false desktop:w-auto transition-transform"
+    >
+      <div class="max-w-[360px] mx-auto h-full p-6 flex flex-col gap-4 overflow-auto">
+        <div class="flex flex-row items-center">
+          <button><i class="icon icon-turn-off"></i></button
+          ><a class="ml-8 desktop:hidden" href="https://siol.net"
+            ><img
+              alt="Siol.net"
+              loading="lazy"
+              width="81"
+              height="16"
+              decoding="async"
+              data-nimg="1"
+              style="color: transparent"
+              srcset="
+                /_next/static/media/siol_logo.94091815.svg?w=96  1x,
+                /_next/static/media/siol_logo.94091815.svg?w=256 2x
+              "
+              src="/_next/static/media/siol_logo.94091815.svg?w=256"
+          /></a>
+        </div>
+        <form class="flex flex-row gap-2" action="https://siol.net/isci/">
+          <input
+            class="px-2 shadow-search-inner w-[200px] desktop:w-[220px]"
+            placeholder="Iskanje"
+            name="query"
+          /><button type="submit"><i class="icon icon-search text-2xl"></i></button>
+        </form>
+        <div
+          class="grid grid-cols-2 gap-y-2 gap-x-8 desktop:flex desktop:flex-col desktop:place-items-start"
+        >
+          <a
+            class="p-2 bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/carobni-december-90330/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Čarobni december</a
+          ><a
+            class="p-2 bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/energetika-2-0-103743/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Energetika 2.0</a
+          ><a
+            class="p-2 bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/trendi/ona-on"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Ona-On.com</a
+          ><a
+            class="p-2 bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://zgodbe.siol.net/licitacija-ilustracij/"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Dobrodelna
+            licitacija</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/odmrznimo-slovenijo-106577/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Odmrznimo
+            Slovenijo</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/trendi/zdravo-zivljenje/dober-vid"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Dober vid</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Nakup avtomobila</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/pravni-nasvet-60118/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Pravni nasvet</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/vizija-rasti-103625/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Vizija rasti</a
+          ><a
+            class="p-2 hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+            href="https://siol.net/kljucne-besede/gremo-v-nov-dom-106101/articles"
+            ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Gremo v nov dom</a
+          >
+        </div>
+        <div class="text-right desktop:text-left">
+          <button class=""><i class="icon icon-plus"></i></button>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://siol.net/novice">Novice</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://siol.net/novice/slovenija"
+                  >Slovenija</a
+                ><a class="hover:font-extrabold" href="https://siol.net/novice/svet"
+                  >Evropa in svet</a
+                ><a class="hover:font-extrabold" href="https://siol.net/novice/digisvet">Digisvet</a
+                ><a class="hover:font-extrabold" href="https://siol.net/novice/posel-danes"
+                  >Posel danes</a
+                ><a class="hover:font-extrabold" href="https://siol.net/novice/crna-kronika"
+                  >Kronika</a
+                >
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/aktivno-drzavljanstvo-102165/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Aktivno
+                  državljanstvo</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/novice/zdravje-za-jutri"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Zdravje za
+                  jutri</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/novice/financni-nasveti"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Finančni
+                  nasveti</a
+                ><button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://siol.net/sportal">Sportal</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://siol.net/sportal/nogomet">Nogomet</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/kosarka">Košarka</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/kolesarstvo"
+                  >Kolesarstvo</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/rokomet">Rokomet</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/zimski-sporti"
+                  >Zima</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/hokej">Hokej</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/tenis">Tenis</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/odbojka">Odbojka</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/atletika"
+                  >Atletika</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/avtomotosport"
+                  >Moto</a
+                ><a class="hover:font-extrabold" href="https://siol.net/sportal/drugi-sporti"
+                  >Drugo</a
+                >
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/luka-doncic-12996/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Luka Dončić</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/sportal/nogomet/prva-liga"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Prva liga</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/uefa-liga-prvakov-74204/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Liga prvakov</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/konferencna-liga-87031/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Konferenčna
+                  liga</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/sobotni-intervju-11361/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Sobotni
+                  intervju</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/druga-kariera-75383/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Druga
+                  kariera</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/prek-meja-104215/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Prek meja</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/sportal/naj-planinska-koca"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Naj planinska
+                  koča</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/sportal/rekreacija"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Rekreacija</a
+                ><button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://siol.net/trendi">Trendi</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://siol.net/trendi/glasba-in-film"
+                  >Glasba in film</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/zvezde-in-slavni"
+                  >Slavni</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/moda-in-lepota"
+                  >Moda in lepota</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/zdravo-zivljenje"
+                  >Zdravo življenje</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/kulinarika"
+                  >Kulinarika</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/dom">Dom</a
+                ><a class="hover:font-extrabold" href="https://siol.net/trendi/zanimivosti"
+                  >Zanimivosti</a
+                >
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/trendi/vedezevanje"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Vedeževanje</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/hisni-ljubljencki-29065/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Hišni
+                  ljubljenčki</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/trendi/ona-on"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Ona-On.com</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://tv-spored.siol.net/"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>TV-spored</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/trendi/potovanja"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Potovanja</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/horoskop/dnevni"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Horoskop</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/trajnost-19357/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Trajnost</a
+                ><button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://siol.net/avtomoto">Avtomoto</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://siol.net/avtomoto/novice">Novice</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/promet">Promet</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/e-avtomoto"
+                  >E-avtomoto</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/testi">Testi</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/prva-voznja"
+                  >Prva vožnja</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/nasveti">Nasveti</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/tehnika">Tehnika</a
+                ><a class="hover:font-extrabold" href="https://siol.net/avtomoto/zgodbe">Zgodbe</a>
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/e-mobilnost-66251/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>E-mobilnost</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Nakup
+                  avtomobila</a
+                ><button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://siol.net/mnenja">Kolumne</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://siol.net/mnenja/kolumne">Kolumne</a
+                ><a class="hover:font-extrabold" href="https://siol.net/mnenja/intervjuji"
+                  >Intervjuji</a
+                >
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a
+              class="uppercase hover:font-extrabold"
+              href="https://siol.net/kljucne-besede/spotkast-102419/articles"
+              >Spotkast</a
+            >
+          </div>
+          <div class="hidden"></div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://nepremicnine.siol.net/"
+              >S.Nepremičnine</a
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="grid grid-cols-2 border-b py-2 desktop:flex desktop:flex-col">
+              <div class="flex flex-col">
+                <a class="hover:font-extrabold" href="https://nepremicnine.siol.net/">Aktualno</a
+                ><a
+                  class="hover:font-extrabold"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja"
+                  >Iskanje</a
+                ><a class="hover:font-extrabold" href="https://nepremicnine.siol.net/novice"
+                  >Novice</a
+                ><a
+                  class="hover:font-extrabold"
+                  href="https://nepremicnine.siol.net/userarea/post-listing"
+                  >Objavi oglas</a
+                ><a class="hover:font-extrabold" href="https://nepremicnine.siol.net/novogradnje"
+                  >Novogradnje</a
+                >
+              </div>
+              <div class="flex flex-col gap-2 desktop:order-first desktop:place-items-start">
+                <a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja/ljubljana"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Ljubljana</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja/podravska/maribor"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Maribor</a
+                ><a
+                  class="px-2 desktop:py-2 false bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja/obala"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Obala</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja/savinjska/celje"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Celje</a
+                ><a
+                  class="px-2 desktop:py-2 desktop:hidden bg-white rounded-lg text-xs hover:bg-dark-gray transition-colors"
+                  href="https://nepremicnine.siol.net/iskanje/prodaja/gorenjska/kranj"
+                  ><span class="inline-block bg-siol h-2 w-2 rounded-lg mr-2"></span>Kranj</a
+                ><button class="hidden desktop:inline-block"><i class="icon icon-plus"></i></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <a class="uppercase hover:font-extrabold" href="https://videospot.siol.net/"
+              >VideoS.pot</a
+            >
+          </div>
+          <div class="hidden"></div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-row justify-between">
+            <button class="uppercase hover:font-extrabold">TELEKOM SLOVENIJE</button
+            ><button><i class="icon icon-chevron-down"></i></button>
+          </div>
+          <div class="hidden">
+            <div class="flex flex-col pt-4">
+              <div class="grid grid-cols-2 gap-y-2 gap-x-6 grow mb-4">
+                <a
+                  class="font-extrabold text-siol"
+                  href="https://neo.io/?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=neo&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Spletna TV neo.io</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/neo?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=neo&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >NEO</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/mobilno?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=mobilni_paketi&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Mobilni paketi</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/internet?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=internet&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Internet</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/program-zvestobe?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=program_zvestobe&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Program zvestobe</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/e-trgovina?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=etrgovina&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >E-trgovina</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://moj.telekom.si/?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=moj_telekom&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Moj Telekom</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/mala-podjetja?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=poslovni_mala_podjetja&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Mala podjetja</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/velika-podjetja?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=poslovni_velika_podjetja&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Velika podjetja</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/e-oskrba?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=e_oskrba&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >E-oskrba</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://prijava.siol.net/posta?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=spletna_posta&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Spletna pošta</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/pomoc?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=pomoc&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Pomoč</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/info-in-obvestila?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=info_in_obvestila&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Info in obvestila</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/tehnik?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=tehnik&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Tehnik</a
+                ><a
+                  class="font-extrabold text-siol"
+                  href="https://www.telekom.si/e-novice?utm_source=siolnet&amp;utm_medium=text&amp;utm_campaign=enovice&amp;utm_id=29112023_internal&amp;utm_term=ekskluziva&amp;utm_content=zgoraj"
+                  >Želite prejemati e-novice?</a
+                >
+              </div>
+              <div class="bg-white p-2">
+                <a
+                  href="https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet&amp;utm_medium=banner&amp;utm_campaign=digi_star%C5%A1_image_mc225&amp;utm_id=12082024_internal&amp;utm_content=380x247"
+                  ><img
+                    class="desktop:h-[145px] desktop:w-[255px] object-cover"
+                    alt="Telekomov oglas"
+                    src="https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg"
+                  /><span class="text-xs font-extrabold">Uživajmo pametno</span></a
+                >
+              </div>
+              <div class="py-10 text-center">
+                <a
+                  class="inline-block"
+                  target="_blank"
+                  href="https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet&amp;utm_medium=logo&amp;utm_campaign=telekom&amp;utm_term=ekskluziva&amp;utm_content=zavihek"
+                  ><img
+                    alt="Telekom"
+                    loading="lazy"
+                    width="206"
+                    height="50"
+                    decoding="async"
+                    data-nimg="1"
+                    style="color: transparent"
+                    srcset="
+                      /_next/static/media/telekom_slovenije.d94a1399.svg?w=256 1x,
+                      /_next/static/media/telekom_slovenije.d94a1399.svg?w=640 2x
+                    "
+                    src="/_next/static/media/telekom_slovenije.d94a1399.svg?w=640"
+                /></a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="border-y flex flex-col py-2">
+          <a class="hover:font-extrabold" href="https://siol.net/pregled-dneva">Zadnje novice</a
+          ><a class="hover:font-extrabold" href="https://tv-spored.siol.net/">TV spored</a
+          ><a class="hover:font-extrabold" href="https://siol.net/horoskop">Horoskop</a
+          ><a class="hover:font-extrabold" href="https://vreme.siol.net/">Vreme</a>
+          <div class="border-t my-2"></div>
+          <a class="hover:font-extrabold" href="https://www.bizi.si/">Bizi</a
+          ><a class="hover:font-extrabold" href="https://www.najdi.si/">Najdi.si</a
+          ><a class="hover:font-extrabold" href="https://www.itis.si/">Itis.si</a
+          ><a class="hover:font-extrabold" href="https://www.1188.si/">1188</a>
+        </div>
+        <div class="flex flex-row gap-2 desktop:grid desktop:grid-cols-3 place-self-start">
+          <a target="_blank" href="https://www.facebook.com/SiOL.net.Novice"
+            ><i class="icon icon-facebook text-2xl desktop:text-base"></i></a
+          ><a target="_blank" href="https://twitter.com/siolnews"
+            ><i class="icon icon-x text-2xl desktop:text-base"></i></a
+          ><a target="_blank" href="https://www.instagram.com/siol.net_novice/"
+            ><i class="icon icon-instagram text-2xl desktop:text-base"></i></a
+          ><a target="_blank" href="https://www.youtube.com/channel/UCoN9YgUHTqLBvVEFRH_HVaQ"
+            ><i class="icon icon-youtube text-2xl desktop:text-base"></i></a
+          ><a target="_blank" href="https://www.linkedin.com/company/tsmedia-d-o-o-/"
+            ><i class="icon icon-linkedin text-2xl desktop:text-base"></i></a
+          ><a target="_blank" href="https://www.pinterest.com/Siolnet/"
+            ><i class="icon icon-pinterest text-2xl desktop:text-base"></i
+          ></a>
+        </div>
+      </div>
+    </div>
+    <div class="inline desktop:block desktop:container desktop:mx-auto desktop:mb-4">
+      <form
+        class="p-2 mt-2 desktop:mt-4 gap-2 flex flex-col desktop:flex-row desktop:bg-darker-gray desktop:py-4 desktop:justify-center desktop:gap-6"
+      >
+        <style data-emotion="css b62m3t-container">
+          .css-b62m3t-container {
+            position: relative;
+            box-sizing: border-box;
+          }
+        </style>
+        <div class="desktop:w-[340px] css-b62m3t-container">
+          <style data-emotion="css 7pg0cj-a11yText">
+            .css-7pg0cj-a11yText {
+              z-index: 9999;
+              border: 0;
+              clip: rect(1px, 1px, 1px, 1px);
+              height: 1px;
+              width: 1px;
+              position: absolute;
+              overflow: hidden;
+              padding: 0;
+              white-space: nowrap;
+            }</style
+          ><span
+            id="react-select-react-select-Vpišite / Izberite program-live-region"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><span
+            aria-live="polite"
+            aria-atomic="false"
+            aria-relevant="additions text"
+            role="log"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><style data-emotion="css cp01gg-control">
+            .css-cp01gg-control {
+              -webkit-align-items: center;
+              -webkit-box-align: center;
+              -ms-flex-align: center;
+              align-items: center;
+              cursor: default;
+              display: -webkit-box;
+              display: -webkit-flex;
+              display: -ms-flexbox;
+              display: flex;
+              -webkit-box-flex-wrap: wrap;
+              -webkit-flex-wrap: wrap;
+              -ms-flex-wrap: wrap;
+              flex-wrap: wrap;
+              -webkit-box-pack: justify;
+              -webkit-justify-content: space-between;
+              justify-content: space-between;
+              min-height: 38px;
+              outline: 0 !important;
+              position: relative;
+              -webkit-transition: all 100ms;
+              transition: all 100ms;
+              box-sizing: border-box;
+            }
+          </style>
+          <div class="css-cp01gg-control">
+            <style data-emotion="css 14oxtc6">
+              .css-14oxtc6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                display: grid;
+                -webkit-flex: 1;
+                -ms-flex: 1;
+                flex: 1;
+                -webkit-box-flex-wrap: wrap;
+                -webkit-flex-wrap: wrap;
+                -ms-flex-wrap: wrap;
+                flex-wrap: wrap;
+                -webkit-overflow-scrolling: touch;
+                position: relative;
+                overflow: hidden;
+                box-sizing: border-box;
+              }
+            </style>
+            <div
+              class="bg-expose text-white font-extrabold shadow-search-inner pl-4 text-xs desktop:text-base h-8 desktop:h-10 css-14oxtc6"
+            >
+              <style data-emotion="css w54w9q-singleValue">
+                .css-w54w9q-singleValue {
+                  grid-area: 1/1/2/3;
+                  max-width: 100%;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div class="css-w54w9q-singleValue">Exodus TV</div>
+              <style data-emotion="css n9qnu9">
+                .css-n9qnu9 {
+                  visibility: visible;
+                  -webkit-flex: 1 1 auto;
+                  -ms-flex: 1 1 auto;
+                  flex: 1 1 auto;
+                  display: inline-grid;
+                  grid-area: 1/1/2/3;
+                  grid-template-columns: 0 min-content;
+                  box-sizing: border-box;
+                }
+                .css-n9qnu9:after {
+                  content: attr(data-value) ' ';
+                  visibility: hidden;
+                  white-space: pre;
+                  grid-area: 1/2;
+                  font: inherit;
+                  min-width: 2px;
+                  border: 0;
+                  margin: 0;
+                  outline: 0;
+                  padding: 0;
+                }
+              </style>
+              <div class="css-n9qnu9" data-value="">
+                <input
+                  class=""
+                  style="
+                    label: input;
+                    color: inherit;
+                    background: 0;
+                    opacity: 1;
+                    width: 100%;
+                    grid-area: 1 / 2;
+                    font: inherit;
+                    min-width: 2px;
+                    border: 0;
+                    margin: 0;
+                    outline: 0;
+                    padding: 0;
+                  "
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autoCorrect="off"
+                  id="react-select-react-select-Vpišite / Izberite program-input"
+                  spellcheck="false"
+                  tabindex="0"
+                  type="text"
+                  aria-autocomplete="list"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  role="combobox"
+                  aria-activedescendant=""
+                  value=""
+                />
+              </div>
+            </div>
+            <style data-emotion="css 1wy0on6">
+              .css-1wy0on6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-align-self: stretch;
+                -ms-flex-item-align: stretch;
+                align-self: stretch;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-flex-shrink: 0;
+                -ms-flex-negative: 0;
+                flex-shrink: 0;
+                box-sizing: border-box;
+              }
+            </style>
+            <div class="css-1wy0on6">
+              <style data-emotion="css g56vrd-indicatorContainer">
+                .css-g56vrd-indicatorContainer {
+                  display: -webkit-box;
+                  display: -webkit-flex;
+                  display: -ms-flexbox;
+                  display: flex;
+                  -webkit-transition: color 150ms;
+                  transition: color 150ms;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div
+                class="text-white absolute right-9 desktop:right-11 css-g56vrd-indicatorContainer"
+                aria-hidden="true"
+              >
+                <style data-emotion="css 8mmkcg">
+                  .css-8mmkcg {
+                    display: inline-block;
+                    fill: currentColor;
+                    line-height: 1;
+                    stroke: currentColor;
+                    stroke-width: 0;
+                  }</style
+                ><svg
+                  height="20"
+                  width="20"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                  focusable="false"
+                  class="css-8mmkcg"
+                >
+                  <path
+                    d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                  ></path>
+                </svg>
+              </div>
+              <style data-emotion="css j4w2j1-indicatorSeparator">
+                .css-j4w2j1-indicatorSeparator {
+                  -webkit-align-self: stretch;
+                  -ms-flex-item-align: stretch;
+                  align-self: stretch;
+                  width: 1px;
+                  box-sizing: border-box;
+                }</style
+              ><span class="hidden css-j4w2j1-indicatorSeparator"></span>
+              <div class="bg-expose text-white css-g56vrd-indicatorContainer" aria-hidden="true">
+                <i
+                  class="icon icon-chevron-down leading-8 h-8 w-8 desktop:h-10 desktop:w-10 desktop:leading-10 text-center"
+                ></i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <style data-emotion="css b62m3t-container">
+          .css-b62m3t-container {
+            position: relative;
+            box-sizing: border-box;
+          }
+        </style>
+        <div class="desktop:w-[340px] css-b62m3t-container">
+          <style data-emotion="css 7pg0cj-a11yText">
+            .css-7pg0cj-a11yText {
+              z-index: 9999;
+              border: 0;
+              clip: rect(1px, 1px, 1px, 1px);
+              height: 1px;
+              width: 1px;
+              position: absolute;
+              overflow: hidden;
+              padding: 0;
+              white-space: nowrap;
+            }</style
+          ><span
+            id="react-select-react-select-Vpišite / Izberite kategorijo-live-region"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><span
+            aria-live="polite"
+            aria-atomic="false"
+            aria-relevant="additions text"
+            role="log"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><style data-emotion="css cp01gg-control">
+            .css-cp01gg-control {
+              -webkit-align-items: center;
+              -webkit-box-align: center;
+              -ms-flex-align: center;
+              align-items: center;
+              cursor: default;
+              display: -webkit-box;
+              display: -webkit-flex;
+              display: -ms-flexbox;
+              display: flex;
+              -webkit-box-flex-wrap: wrap;
+              -webkit-flex-wrap: wrap;
+              -ms-flex-wrap: wrap;
+              flex-wrap: wrap;
+              -webkit-box-pack: justify;
+              -webkit-justify-content: space-between;
+              justify-content: space-between;
+              min-height: 38px;
+              outline: 0 !important;
+              position: relative;
+              -webkit-transition: all 100ms;
+              transition: all 100ms;
+              box-sizing: border-box;
+            }
+          </style>
+          <div class="css-cp01gg-control">
+            <style data-emotion="css 14oxtc6">
+              .css-14oxtc6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                display: grid;
+                -webkit-flex: 1;
+                -ms-flex: 1;
+                flex: 1;
+                -webkit-box-flex-wrap: wrap;
+                -webkit-flex-wrap: wrap;
+                -ms-flex-wrap: wrap;
+                flex-wrap: wrap;
+                -webkit-overflow-scrolling: touch;
+                position: relative;
+                overflow: hidden;
+                box-sizing: border-box;
+              }
+            </style>
+            <div
+              class="bg-gray desktop:bg-white shadow-search-inner pl-4 text-xs desktop:text-base h-8 desktop:h-10 css-14oxtc6"
+            >
+              <style data-emotion="css 1vlsb4t-placeholder">
+                .css-1vlsb4t-placeholder {
+                  grid-area: 1/1/2/3;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div
+                class="text-disabled css-1vlsb4t-placeholder"
+                id="react-select-react-select-Vpišite / Izberite kategorijo-placeholder"
+              >
+                Vpišite / Izberite kategorijo
+              </div>
+              <style data-emotion="css n9qnu9">
+                .css-n9qnu9 {
+                  visibility: visible;
+                  -webkit-flex: 1 1 auto;
+                  -ms-flex: 1 1 auto;
+                  flex: 1 1 auto;
+                  display: inline-grid;
+                  grid-area: 1/1/2/3;
+                  grid-template-columns: 0 min-content;
+                  box-sizing: border-box;
+                }
+                .css-n9qnu9:after {
+                  content: attr(data-value) ' ';
+                  visibility: hidden;
+                  white-space: pre;
+                  grid-area: 1/2;
+                  font: inherit;
+                  min-width: 2px;
+                  border: 0;
+                  margin: 0;
+                  outline: 0;
+                  padding: 0;
+                }
+              </style>
+              <div class="css-n9qnu9" data-value="">
+                <input
+                  class=""
+                  style="
+                    label: input;
+                    color: inherit;
+                    background: 0;
+                    opacity: 1;
+                    width: 100%;
+                    grid-area: 1 / 2;
+                    font: inherit;
+                    min-width: 2px;
+                    border: 0;
+                    margin: 0;
+                    outline: 0;
+                    padding: 0;
+                  "
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autoCorrect="off"
+                  id="react-select-react-select-Vpišite / Izberite kategorijo-input"
+                  spellcheck="false"
+                  tabindex="0"
+                  type="text"
+                  aria-autocomplete="list"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  role="combobox"
+                  aria-activedescendant=""
+                  aria-describedby="react-select-react-select-Vpišite / Izberite kategorijo-placeholder"
+                  value=""
+                />
+              </div>
+            </div>
+            <style data-emotion="css 1wy0on6">
+              .css-1wy0on6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-align-self: stretch;
+                -ms-flex-item-align: stretch;
+                align-self: stretch;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-flex-shrink: 0;
+                -ms-flex-negative: 0;
+                flex-shrink: 0;
+                box-sizing: border-box;
+              }
+            </style>
+            <div class="css-1wy0on6">
+              <style data-emotion="css j4w2j1-indicatorSeparator">
+                .css-j4w2j1-indicatorSeparator {
+                  -webkit-align-self: stretch;
+                  -ms-flex-item-align: stretch;
+                  align-self: stretch;
+                  width: 1px;
+                  box-sizing: border-box;
+                }</style
+              ><span class="hidden css-j4w2j1-indicatorSeparator"></span
+              ><style data-emotion="css g56vrd-indicatorContainer">
+                .css-g56vrd-indicatorContainer {
+                  display: -webkit-box;
+                  display: -webkit-flex;
+                  display: -ms-flexbox;
+                  display: flex;
+                  -webkit-transition: color 150ms;
+                  transition: color 150ms;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div class="bg-expose text-white css-g56vrd-indicatorContainer" aria-hidden="true">
+                <i
+                  class="icon icon-chevron-down leading-8 h-8 w-8 desktop:h-10 desktop:w-10 desktop:leading-10 text-center"
+                ></i>
+              </div>
+            </div>
+          </div>
+        </div>
+        <style data-emotion="css b62m3t-container">
+          .css-b62m3t-container {
+            position: relative;
+            box-sizing: border-box;
+          }
+        </style>
+        <div class="desktop:w-[340px] css-b62m3t-container">
+          <style data-emotion="css 7pg0cj-a11yText">
+            .css-7pg0cj-a11yText {
+              z-index: 9999;
+              border: 0;
+              clip: rect(1px, 1px, 1px, 1px);
+              height: 1px;
+              width: 1px;
+              position: absolute;
+              overflow: hidden;
+              padding: 0;
+              white-space: nowrap;
+            }</style
+          ><span
+            id="react-select-react-select-Vpišite / Izberite podkategorijo-live-region"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><span
+            aria-live="polite"
+            aria-atomic="false"
+            aria-relevant="additions text"
+            role="log"
+            class="css-7pg0cj-a11yText"
+          ></span
+          ><style data-emotion="css cp01gg-control">
+            .css-cp01gg-control {
+              -webkit-align-items: center;
+              -webkit-box-align: center;
+              -ms-flex-align: center;
+              align-items: center;
+              cursor: default;
+              display: -webkit-box;
+              display: -webkit-flex;
+              display: -ms-flexbox;
+              display: flex;
+              -webkit-box-flex-wrap: wrap;
+              -webkit-flex-wrap: wrap;
+              -ms-flex-wrap: wrap;
+              flex-wrap: wrap;
+              -webkit-box-pack: justify;
+              -webkit-justify-content: space-between;
+              justify-content: space-between;
+              min-height: 38px;
+              outline: 0 !important;
+              position: relative;
+              -webkit-transition: all 100ms;
+              transition: all 100ms;
+              box-sizing: border-box;
+            }
+          </style>
+          <div class="css-cp01gg-control">
+            <style data-emotion="css 14oxtc6">
+              .css-14oxtc6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                display: grid;
+                -webkit-flex: 1;
+                -ms-flex: 1;
+                flex: 1;
+                -webkit-box-flex-wrap: wrap;
+                -webkit-flex-wrap: wrap;
+                -ms-flex-wrap: wrap;
+                flex-wrap: wrap;
+                -webkit-overflow-scrolling: touch;
+                position: relative;
+                overflow: hidden;
+                box-sizing: border-box;
+              }
+            </style>
+            <div
+              class="bg-gray desktop:bg-white shadow-search-inner pl-4 text-xs desktop:text-base h-8 desktop:h-10 css-14oxtc6"
+            >
+              <style data-emotion="css 1vlsb4t-placeholder">
+                .css-1vlsb4t-placeholder {
+                  grid-area: 1/1/2/3;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div
+                class="text-disabled css-1vlsb4t-placeholder"
+                id="react-select-react-select-Vpišite / Izberite podkategorijo-placeholder"
+              >
+                Vpišite / Izberite podkategorijo
+              </div>
+              <style data-emotion="css n9qnu9">
+                .css-n9qnu9 {
+                  visibility: visible;
+                  -webkit-flex: 1 1 auto;
+                  -ms-flex: 1 1 auto;
+                  flex: 1 1 auto;
+                  display: inline-grid;
+                  grid-area: 1/1/2/3;
+                  grid-template-columns: 0 min-content;
+                  box-sizing: border-box;
+                }
+                .css-n9qnu9:after {
+                  content: attr(data-value) ' ';
+                  visibility: hidden;
+                  white-space: pre;
+                  grid-area: 1/2;
+                  font: inherit;
+                  min-width: 2px;
+                  border: 0;
+                  margin: 0;
+                  outline: 0;
+                  padding: 0;
+                }
+              </style>
+              <div class="css-n9qnu9" data-value="">
+                <input
+                  class=""
+                  style="
+                    label: input;
+                    color: inherit;
+                    background: 0;
+                    opacity: 1;
+                    width: 100%;
+                    grid-area: 1 / 2;
+                    font: inherit;
+                    min-width: 2px;
+                    border: 0;
+                    margin: 0;
+                    outline: 0;
+                    padding: 0;
+                  "
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autoCorrect="off"
+                  id="react-select-react-select-Vpišite / Izberite podkategorijo-input"
+                  spellcheck="false"
+                  tabindex="0"
+                  type="text"
+                  aria-autocomplete="list"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  role="combobox"
+                  aria-activedescendant=""
+                  aria-describedby="react-select-react-select-Vpišite / Izberite podkategorijo-placeholder"
+                  value=""
+                />
+              </div>
+            </div>
+            <style data-emotion="css 1wy0on6">
+              .css-1wy0on6 {
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-align-self: stretch;
+                -ms-flex-item-align: stretch;
+                align-self: stretch;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-flex-shrink: 0;
+                -ms-flex-negative: 0;
+                flex-shrink: 0;
+                box-sizing: border-box;
+              }
+            </style>
+            <div class="css-1wy0on6">
+              <style data-emotion="css j4w2j1-indicatorSeparator">
+                .css-j4w2j1-indicatorSeparator {
+                  -webkit-align-self: stretch;
+                  -ms-flex-item-align: stretch;
+                  align-self: stretch;
+                  width: 1px;
+                  box-sizing: border-box;
+                }</style
+              ><span class="hidden css-j4w2j1-indicatorSeparator"></span
+              ><style data-emotion="css g56vrd-indicatorContainer">
+                .css-g56vrd-indicatorContainer {
+                  display: -webkit-box;
+                  display: -webkit-flex;
+                  display: -ms-flexbox;
+                  display: flex;
+                  -webkit-transition: color 150ms;
+                  transition: color 150ms;
+                  box-sizing: border-box;
+                }
+              </style>
+              <div class="bg-expose text-white css-g56vrd-indicatorContainer" aria-hidden="true">
+                <i
+                  class="icon icon-chevron-down leading-8 h-8 w-8 desktop:h-10 desktop:w-10 desktop:leading-10 text-center"
+                ></i>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+      <div class="bg-expose gap-2 text-white text-xs desktop:text-base px-2 py-4 relative">
+        <button class="absolute top-4 desktop:top-5 z-[1] cursor-pointer leading-none">
+          <i class="icon icon-chevron-left font-bold h-4 w-4"></i></button
+        ><button class="absolute top-4 desktop:top-5 z-[1] cursor-pointer leading-none right-4">
+          <i class="icon icon-chevron-right font-bold h-4 w-4"></i>
+        </button>
+        <div class="splide mx-6">
+          <div class="splide__track">
+            <ul class="splide__list">
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250107"
+                  ><span class="font-extrabold">Tor</span>  7. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250108"
+                  ><span class="font-extrabold">Sre</span>  8. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250109"
+                  ><span class="font-extrabold">Čet</span>  9. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250110"
+                  ><span class="font-extrabold">Pet</span>  10. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250111"
+                  ><span class="font-extrabold">Sob</span>  11. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250112"
+                  ><span class="font-extrabold">Včeraj</span></a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250113"
+                  ><span class="font-extrabold">Danes</span></a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250114"
+                  ><span class="font-extrabold">Jutri</span></a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li
+                class="splide__slide border-b-white box-border h-4 desktop:h-6 is-current border-b"
+              >
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250115"
+                  ><span class="font-extrabold">Sre</span>  15. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250116"
+                  ><span class="font-extrabold">Čet</span>  16. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250117"
+                  ><span class="font-extrabold">Pet</span>  17. 1.</a
+                >
+              </li>
+              <li class="splide__slide">
+                <div class="border-l border-white h-2 my-1 desktop:my-2"></div>
+              </li>
+              <li class="splide__slide border-b-white box-border h-4 desktop:h-6 false">
+                <a class="uppercase whitespace-nowrap" href="/kanal/exodustv/datum/20250118"
+                  ><span class="font-extrabold">Sob</span>  18. 1.</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-row h-[0px]">
+        <div
+          class="relative bg-gradient-to-r from-expose w-[88px] h-[48px] bottom-[48px] pointer-events-none desktop:h-[56px] desktop:bottom-[56px]"
+        ></div>
+        <div class="grow"></div>
+        <div
+          class="relative bg-gradient-to-l from-expose w-[88px] h-[48px] bottom-[48px] pointer-events-none desktop:h-[56px] desktop:bottom-[56px]"
+        ></div>
+      </div>
+    </div>
+    <div class="text-text desktop:container px-2 desktop:mx-auto desktop:p-0">
+      <div id="billboard1" data-ocm-ad="true" class="ad-zone text-center"></div>
+      <div id="page_sponsors"></div>
+      <div class="p-2 desktop:p-0"><div class="border-b border-b-text desktop:hidden"></div></div>
+      <div class="bg-gray mt-4">
+        <h1 class="text-2xl font-extrabold p-2">TV spored za Exodus TV za 15. 1. 2025</h1>
+      </div>
+      <div class="inline desktop:flex desktop:flex-row">
+        <div class="desktop:w-[942px]">
+          <div
+            id="infeed1"
+            data-ocm-ad="true"
+            class="ad-zone tablet:hidden mt-2"
+            style="min-height: 250px"
+          ></div>
+          <div>
+            <div class="flex flex-row gap-7 mt-4">
+              <a
+                class="relative inline-block h-[70px] w-[70px]"
+                target="_self"
+                href="/kanal/exodustv"
+                ><img
+                  alt="Exodus TV"
+                  loading="lazy"
+                  decoding="async"
+                  data-nimg="fill"
+                  class="object-contain Exodus TV"
+                  style="
+                    position: absolute;
+                    height: 100%;
+                    width: 100%;
+                    left: 0;
+                    top: 0;
+                    right: 0;
+                    bottom: 0;
+                    color: transparent;
+                  "
+                  sizes="70px"
+                  srcset="
+                    /slika/kanal/exodustv?w=16     16w,
+                    /slika/kanal/exodustv?w=32     32w,
+                    /slika/kanal/exodustv?w=48     48w,
+                    /slika/kanal/exodustv?w=64     64w,
+                    /slika/kanal/exodustv?w=96     96w,
+                    /slika/kanal/exodustv?w=128   128w,
+                    /slika/kanal/exodustv?w=256   256w,
+                    /slika/kanal/exodustv?w=384   384w,
+                    /slika/kanal/exodustv?w=640   640w,
+                    /slika/kanal/exodustv?w=750   750w,
+                    /slika/kanal/exodustv?w=828   828w,
+                    /slika/kanal/exodustv?w=1080 1080w,
+                    /slika/kanal/exodustv?w=1200 1200w,
+                    /slika/kanal/exodustv?w=1920 1920w,
+                    /slika/kanal/exodustv?w=2048 2048w,
+                    /slika/kanal/exodustv?w=3840 3840w
+                  "
+                  src="/slika/kanal/exodustv?w=3840"
+              /></a>
+              <div
+                class="flex flex-col gap-2 desktop:flex-row desktop:flex-grow desktop:justify-between desktop:items-center justify-center"
+              >
+                <a class="text-2xl font-extrabold" href="/kanal/exodustv">Exodus TV</a>
+              </div>
+            </div>
+            <div class="flex flex-col gap-2 mt-2">
+              <a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/vecernice-molitveno-bogosluzje/80091620292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">0.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Večernice, Molitveno bogoslužje"
+                  >
+                    Večernice, Molitveno bogoslužje
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-svete-dezele/80091621292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">1.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Novice iz Svete dežele"
+                  >
+                    Novice iz Svete dežele
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-vatikana/80091622292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">1.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Novice iz Vatikana">
+                    Novice iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/svetnik-dneva/80091623292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">1.50</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Svetnik dneva">
+                    Svetnik dneva
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/ucitelji-cerkve/80092189292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">2.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Učitelji Cerkve (E2)"
+                  >
+                    Učitelji Cerkve<span class="font-normal"> (E2)</span>
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/na-robu-znanega-ob-izidu-knjige-menih-v-vrtincu-sirske-vojne/80092190292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">2.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne"
+                  >
+                    Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-marija-goretti/80092249292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">3.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Sveta Marija Goretti"
+                  >
+                    Sveta Marija Goretti
+                  </div>
+                  <div class="desktop:order-last">Dokumentarni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-radia-vatikan/80092194292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">3.25</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Novice Radia Vatikan"
+                  >
+                    Novice Radia Vatikan
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/iz-tega-razloga/80092215292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">3.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Iz tega razloga">
+                    Iz tega razloga
+                  </div>
+                  <div class="desktop:order-last">Film</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/rozni-venec-castitljivi-del/80091627292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">5.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Rožni venec, častitljivi del"
+                  >
+                    Rožni venec, častitljivi del
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-masa/80092306292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">6.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Sveta maša">
+                    Sveta maša
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/hvalnice-molitveno-bogosluzje/80092307292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">6.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Hvalnice, Molitveno bogoslužje"
+                  >
+                    Hvalnice, Molitveno bogoslužje
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-svete-dezele/80092815292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">7.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Novice iz Svete dežele"
+                  >
+                    Novice iz Svete dežele
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-vatikana/80092878292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">7.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Novice iz Vatikana">
+                    Novice iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/svetnik-dneva/80092906292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">7.50</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Svetnik dneva">
+                    Svetnik dneva
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/za-skupno-dobro-resitev-ali-usodna-prevara-splav-evtanazija/80092309292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">8.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Za skupno dobro: Rešitev ali usodna prevara, splav, evtanazija"
+                  >
+                    Za skupno dobro: Rešitev ali usodna prevara, splav, evtanazija
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/avdienca-in-kateheza-papeza-franciska/80092343292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">9.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Avdienca in kateheza papeža Frančiška"
+                  >
+                    Avdienca in kateheza papeža Frančiška
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/elena-privalova-orgelski-koncert-v-koprski-stolnici/80092383292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">10.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Elena Privalova: orgelski koncert v Koprski stolnici"
+                  >
+                    Elena Privalova: orgelski koncert v Koprski stolnici
+                  </div>
+                  <div class="desktop:order-last">Kultura-umetnost</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/zaupam-v-tebe/80092385292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">11.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Zaupam v Tebe (E2)">
+                    Zaupam v Tebe<span class="font-normal"> (E2)</span>
+                  </div>
+                  <div class="desktop:order-last">Film</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/rozni-venec-castitljivi-del/80092313292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">11.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Rožni venec, častitljivi del"
+                  >
+                    Rožni venec, častitljivi del
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-masa-v-zivo-iz-studijske-kapele/80092314292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">12.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Sveta maša, v živo iz studijske kapele"
+                  >
+                    Sveta maša, v živo iz studijske kapele
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/dnevna-molitvena-ura-molitveno-bogosluzje/80092315292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">12.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Dnevna molitvena ura, Molitveno bogoslužje"
+                  >
+                    Dnevna molitvena ura, Molitveno bogoslužje
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/porocilo-iz-vatikana/80092316292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">13.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Poročilo iz Vatikana"
+                  >
+                    Poročilo iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-vatikana/80092317292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">13.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Novice iz Vatikana">
+                    Novice iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/svetnik-dneva/80092318292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">13.50</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Svetnik dneva">
+                    Svetnik dneva
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/ucitelji-cerkve/80092388292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">14.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Učitelji Cerkve (E2)"
+                  >
+                    Učitelji Cerkve<span class="font-normal"> (E2)</span>
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/na-robu-znanega-ob-izidu-knjige-menih-v-vrtincu-sirske-vojne/80092391292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">14.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne"
+                  >
+                    Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-marija-goretti/80092427292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">15.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Sveta Marija Goretti"
+                  >
+                    Sveta Marija Goretti
+                  </div>
+                  <div class="desktop:order-last">Dokumentarni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-radia-vatikan/80092431292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">15.25</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Novice Radia Vatikan"
+                  >
+                    Novice Radia Vatikan
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/iz-tega-razloga/80092464292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">15.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Iz tega razloga">
+                    Iz tega razloga
+                  </div>
+                  <div class="desktop:order-last">Film</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/rozni-venec-castitljivi-del/80092322292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">17.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Rožni venec, častitljivi del"
+                  >
+                    Rožni venec, častitljivi del
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-masa/80092323292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">18.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Sveta maša">
+                    Sveta maša
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/vecernice-molitveno-bogosluzje/80092324292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">18.45</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Večernice, Molitveno bogoslužje"
+                  >
+                    Večernice, Molitveno bogoslužje
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/porocilo-iz-vatikana/80092325292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">19.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Poročilo iz Vatikana"
+                  >
+                    Poročilo iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-iz-vatikana/80092326292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">19.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Novice iz Vatikana">
+                    Novice iz Vatikana
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/svetnik-dneva/80092327292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">19.50</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Svetnik dneva">
+                    Svetnik dneva
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/pri-vidi-kreacija-ali-evolucija/80092470292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">20.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="PriVidi: Kreacija ali evolucija?"
+                  >
+                    PriVidi: Kreacija ali evolucija?
+                  </div>
+                  <div class="desktop:order-last">Informativni</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/avdienca-in-kateheza-papeza-franciska/80092344292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">21.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Avdienca in kateheza papeža Frančiška"
+                  >
+                    Avdienca in kateheza papeža Frančiška
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/novice-radia-vatikan/80092575292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">22.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Novice Radia Vatikan"
+                  >
+                    Novice Radia Vatikan
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/draga-2024/80092633292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">22.20</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Draga 2024 (E2)">
+                    Draga 2024<span class="font-normal"> (E2)</span>
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/rozni-venec-castitljivi-del/80092332292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">23.30</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div
+                    class="font-extrabold desktop:grow line-clamp-1"
+                    title="Rožni venec, častitljivi del"
+                  >
+                    Rožni venec, častitljivi del
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              ><a
+                class="bg-gray p-2 pl-0 flex flex-row gap-7 items-center"
+                href="/kanal/exodustv/oddaja/sveta-masa/80092333292/datum/20250115"
+                ><div class="w-[70px] text-center flex-none">0.00</div>
+                <div
+                  class="flex-initial desktop:flex desktop:flex-row desktop:flex-1 desktop:gap-2"
+                >
+                  <div class="font-extrabold desktop:grow line-clamp-1" title="Sveta maša">
+                    Sveta maša
+                  </div>
+                  <div class="desktop:order-last">Ostalo</div>
+                </div></a
+              >
+            </div>
+          </div>
+          <div
+            id="infeed2"
+            data-ocm-ad="true"
+            class="ad-zone tablet:hidden mt-2"
+            style="min-height: 250px"
+          ></div>
+          <div class="flex flex-row gap-2 mt-4 justify-stretch desktop:gap-28">
+            <a
+              class="bg-siol text-white rounded p-2 grow uppercase text-left"
+              href="/kanal/exodustv/datum/20250114"
+              >Jutri, 14. 1.</a
+            ><a
+              class="bg-siol text-white rounded p-2 grow uppercase text-right"
+              href="/kanal/exodustv/datum/20250116"
+              >Čet, 16. 1.</a
+            >
+          </div>
+          <div
+            class="text-2xl py-3 flex flex-row justify-between desktop:justify-normal mt-6 desktop:gap-6"
+          >
+            <a
+              target="_blank"
+              title="Deli preko Facebook"
+              class="order-1 desktop:order-1"
+              href="https://www.facebook.com/sharer/sharer.php?u=https://tv-spored.siol.net/kanal/exodustv/datum/20250115"
+              ><i class="icon icon-facebook"></i></a
+            ><a
+              target="_blank"
+              title="Deli preko X"
+              class="order-2 desktop:order-2"
+              href="https://twitter.com/intent/tweet?text=TV spored za Exodus TV za 15. 1. 2025&amp;url=https://tv-spored.siol.net/kanal/exodustv/datum/20250115&amp;via=SiolTV-SPORED"
+              ><i class="icon icon-x"></i></a
+            ><a
+              target="_blank"
+              title="Deli preko Viber"
+              class="order-3 desktop:hidden"
+              href="viber://forward?text=TV spored za Exodus TV za 15. 1. 2025 https://tv-spored.siol.net/kanal/exodustv/datum/20250115"
+              ><i class="icon icon-viber"></i></a
+            ><a
+              target="_blank"
+              title="Deli preko WhatsApp"
+              class="order-4 desktop:hidden"
+              href="https://wa.me/?text=TV spored za Exodus TV za 15. 1. 2025 https://tv-spored.siol.net/kanal/exodustv/datum/20250115"
+              ><i class="icon icon-whats-app"></i></a
+            ><button
+              class="react-share__ShareButton order-5 desktop:order-4"
+              style="
+                background-color: transparent;
+                border: none;
+                padding: 0;
+                font: inherit;
+                color: inherit;
+                cursor: pointer;
+              "
+            >
+              <i class="icon icon-mesenger"></i></button
+            ><a
+              target="_blank"
+              title="Deli preko SMS"
+              class="order-6 desktop:hidden"
+              href="sms:&amp;body=TV spored za Exodus TV za 15. 1. 2025 https://tv-spored.siol.net/kanal/exodustv/datum/20250115"
+              ><i class="icon icon-sms"></i></a
+            ><a
+              target="_blank"
+              title="Deli preko e-pošte"
+              class="order-7 desktop:order-6"
+              href="mailto:?subject=TV spored za Exodus TV za 15. 1. 2025&amp;body=https://tv-spored.siol.net/kanal/exodustv/datum/20250115"
+              ><i class="icon icon-mail"></i></a
+            ><a class="cursor-pointer order-8 desktop:order-7" title="Kopiraj povezavo"
+              ><i class="icon icon-copy-link"></i></a
+            ><a
+              class="order-9 desktop:order-3"
+              href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://tv-spored.siol.net/kanal/exodustv/datum/20250115&amp;title=TV spored za Exodus TV za 15. 1. 2025&amp;source=Siol.net"
+              ><i class="icon icon-linkedin"></i></a
+            ><a
+              target="_blank"
+              title="Deli preko Telegram"
+              class="order-11 desktop:hidden"
+              href="https://t.me/share/url?url=https://tv-spored.siol.net/kanal/exodustv/datum/20250115&amp;text=TV spored za Exodus TV za 15. 1. 2025"
+              ><i class="icon icon-telegram"></i></a
+            ><a
+              class="hidden desktop:inline-block desktop:order-8"
+              target="_blank"
+              href="https://1-tv--spored-siol-net.translate.goog/kanal/exodustv/datum/20250115?_x_tr_enc=1&amp;_x_tr_sl=en&amp;_x_tr_tl=sl&amp;_x_tr_hl=sl&amp;_x_tr_pto=wapp"
+              ><i class="icon icon-translate"></i
+            ></a>
+          </div>
+          <div
+            class="border-t border-b border-text desktop:px-4 text-2xl my-2 py-2 font-serif font-extrabold desktop:my-4 desktop:py-4"
+          >
+            Aktualno
+          </div>
+          <div class="grid grid-cols-2 py-4 gap-2 desktop:pl-24 tablet:grid-cols-4 desktop:pr-0">
+            <a
+              class="relative"
+              title="Ti znaki horoskopa imajo največ sreče pri igranju lota"
+              href="https://siol.net/trendi/horoskop/ti-znaki-horoskopa-imajo-najvec-srece-pri-igranju-lota-652335"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Ti znaki horoskopa imajo največ sreče pri igranju lota"
+                src="https://siol.net/media/img/86/5c/30cad26c7f3db1193027.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Ti znaki horoskopa imajo največ sreče pri igranju lota</span
+              ></a
+            ><a
+              class="relative"
+              title="Netflix zaradi požarov preložil premiero oddaje z Meghan Markle"
+              href="https://siol.net/trendi/glasba-in-film/netflix-zaradi-pozarov-prelozil-premiero-oddaje-z-meghan-markle-652730"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Netflix zaradi požarov preložil premiero oddaje z Meghan Markle"
+                src="https://siol.net/media/img/70/77/215ef27f31dc4cc3c2ff.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Netflix zaradi požarov preložil premiero oddaje z Meghan Markle</span
+              ></a
+            ><a
+              class="relative"
+              title="Začnite dan z vadbo, ki osvaja Slovenijo"
+              href="https://siol.net/trendi/zdravo-zivljenje/zacnite-dan-z-vadbo-ki-osvaja-slovenijo-652541"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Začnite dan z vadbo, ki osvaja Slovenijo"
+                src="https://siol.net/media/img/b8/1d/9070934b6e8ab90955a5.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Začnite dan z vadbo, ki osvaja Slovenijo</span
+              ></a
+            ><a
+              class="relative"
+              title="Balkanska zvezdnica potrdila, da je noseča"
+              href="https://siol.net/trendi/zvezde-in-slavni/balkanska-zvezdnica-potrdila-da-je-noseca-652698"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Balkanska zvezdnica potrdila, da je noseča"
+                src="https://siol.net/media/img/a0/d2/402020c0d4e8c9634817.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Balkanska zvezdnica potrdila, da je noseča</span
+              ></a
+            ><a
+              class="relative"
+              title="Umrl legendarni fotograf Oliviero Toscani"
+              href="https://siol.net/trendi/zvezde-in-slavni/umrl-legendarni-fotograf-oliviero-toscani-652685"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Umrl legendarni fotograf Oliviero Toscani"
+                src="https://siol.net/media/img/74/dc/a7b23a48ae5cf85a8179.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Umrl legendarni fotograf Oliviero Toscani</span
+              ></a
+            ><a
+              class="relative"
+              title="To je nova mis Slovenije, prihaja s Krasa"
+              href="https://siol.net/trendi/moda-in-lepota/to-je-nova-mis-slovenije-prihaja-s-krasa-652680"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="To je nova mis Slovenije, prihaja s Krasa"
+                src="https://siol.net/media/img/c0/8b/35834ce15aeb7696cb09.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >To je nova mis Slovenije, prihaja s Krasa</span
+              ></a
+            ><a
+              class="relative"
+              title="Stoli, ki združujejo udobje in prestiž"
+              href="https://siol.net/trendi/dom/stoli-ki-zdruzujejo-udobje-in-prestiz-652436"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Stoli, ki združujejo udobje in prestiž"
+                src="https://siol.net/media/img/be/55/a656568a2080893f004a.jpg"
+              /><span class="font-serif line-clamp-3"
+                >Stoli, ki združujejo udobje in prestiž</span
+              ></a
+            ><a
+              class="relative"
+              title="Horoskop: kakšna je vaša tedenska napoved?"
+              href="https://siol.net/trendi/odnosi/horoskop-kaksna-je-vasa-tedenska-napoved-540773"
+              ><img
+                class="w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]"
+                alt="Horoskop: kakšna je vaša tedenska napoved?"
+                src="https://siol.net/media/img/ca/4c/d5fb440310620e2b02a8.jpeg"
+              /><span class="font-serif line-clamp-3"
+                >Horoskop: kakšna je vaša tedenska napoved?</span
+              ></a
+            >
+          </div>
+        </div>
+        <div
+          class="inline desktop:flex desktop:flex-col desktop:w-[300px] desktop:pt-4 desktop:ml-2"
+        >
+          <div
+            id="sidebar1"
+            data-ocm-ad="true"
+            class="ad-zone mb-4"
+            style="min-height: 250px"
+          ></div>
+          <div class="border-t border-b border-text desktop:px-4 text-2xl uppercase">
+            Zdaj na sporedu
+          </div>
+          <div class="flex flex-col mt-5 mb-4 gap-4 desktop:p-0">
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/slo1"
+                  ><img
+                    alt="TV SLO 1"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain TV SLO 1"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/slo1?w=16     16w,
+                      /slika/kanal/slo1?w=32     32w,
+                      /slika/kanal/slo1?w=48     48w,
+                      /slika/kanal/slo1?w=64     64w,
+                      /slika/kanal/slo1?w=96     96w,
+                      /slika/kanal/slo1?w=128   128w,
+                      /slika/kanal/slo1?w=256   256w,
+                      /slika/kanal/slo1?w=384   384w,
+                      /slika/kanal/slo1?w=640   640w,
+                      /slika/kanal/slo1?w=750   750w,
+                      /slika/kanal/slo1?w=828   828w,
+                      /slika/kanal/slo1?w=1080 1080w,
+                      /slika/kanal/slo1?w=1200 1200w,
+                      /slika/kanal/slo1?w=1920 1920w,
+                      /slika/kanal/slo1?w=2048 2048w,
+                      /slika/kanal/slo1?w=3840 3840w
+                    "
+                    src="/slika/kanal/slo1?w=3840"
+                /></a>
+              </div>
+              <a target="_self" href="/kanal/slo1/oddaja/dnevnik/800919631/datum/20250113"
+                ><p title="Dnevnik" class="font-extrabold line-clamp-1">Dnevnik</p>
+                <p class="text-light-gray">
+                  Dnevno-informativna oddaja<!-- -->
+                  (<!-- -->33<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.57–19.30</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/slo2"
+                  ><img
+                    alt="TV SLO 2"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain TV SLO 2"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/slo2?w=16     16w,
+                      /slika/kanal/slo2?w=32     32w,
+                      /slika/kanal/slo2?w=48     48w,
+                      /slika/kanal/slo2?w=64     64w,
+                      /slika/kanal/slo2?w=96     96w,
+                      /slika/kanal/slo2?w=128   128w,
+                      /slika/kanal/slo2?w=256   256w,
+                      /slika/kanal/slo2?w=384   384w,
+                      /slika/kanal/slo2?w=640   640w,
+                      /slika/kanal/slo2?w=750   750w,
+                      /slika/kanal/slo2?w=828   828w,
+                      /slika/kanal/slo2?w=1080 1080w,
+                      /slika/kanal/slo2?w=1200 1200w,
+                      /slika/kanal/slo2?w=1920 1920w,
+                      /slika/kanal/slo2?w=2048 2048w,
+                      /slika/kanal/slo2?w=3840 3840w
+                    "
+                    src="/slika/kanal/slo2?w=3840"
+                /></a>
+              </div>
+              <a target="_self" href="/kanal/slo2/oddaja/videotrak/800550922/datum/20250113"
+                ><p title="Videotrak" class="font-extrabold line-clamp-1">Videotrak</p>
+                <p class="text-light-gray">
+                  Glasba<!-- -->
+                  (<!-- -->65<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.55–20.00</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/poptv"
+                  ><img
+                    alt="POP TV"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain POP TV"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/poptv?w=16     16w,
+                      /slika/kanal/poptv?w=32     32w,
+                      /slika/kanal/poptv?w=48     48w,
+                      /slika/kanal/poptv?w=64     64w,
+                      /slika/kanal/poptv?w=96     96w,
+                      /slika/kanal/poptv?w=128   128w,
+                      /slika/kanal/poptv?w=256   256w,
+                      /slika/kanal/poptv?w=384   384w,
+                      /slika/kanal/poptv?w=640   640w,
+                      /slika/kanal/poptv?w=750   750w,
+                      /slika/kanal/poptv?w=828   828w,
+                      /slika/kanal/poptv?w=1080 1080w,
+                      /slika/kanal/poptv?w=1200 1200w,
+                      /slika/kanal/poptv?w=1920 1920w,
+                      /slika/kanal/poptv?w=2048 2048w,
+                      /slika/kanal/poptv?w=3840 3840w
+                    "
+                    src="/slika/kanal/poptv?w=3840"
+                /></a>
+              </div>
+              <a target="_self" href="/kanal/poptv/oddaja/24-ur/800345624/datum/20250113"
+                ><p title="24UR" class="font-extrabold line-clamp-1">24UR</p>
+                <p class="text-light-gray">
+                  Dnevno-informativna oddaja<!-- -->
+                  (<!-- -->65<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.55–20.00</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/akanal"
+                  ><img
+                    alt="Kanal A"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Kanal A"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/akanal?w=16     16w,
+                      /slika/kanal/akanal?w=32     32w,
+                      /slika/kanal/akanal?w=48     48w,
+                      /slika/kanal/akanal?w=64     64w,
+                      /slika/kanal/akanal?w=96     96w,
+                      /slika/kanal/akanal?w=128   128w,
+                      /slika/kanal/akanal?w=256   256w,
+                      /slika/kanal/akanal?w=384   384w,
+                      /slika/kanal/akanal?w=640   640w,
+                      /slika/kanal/akanal?w=750   750w,
+                      /slika/kanal/akanal?w=828   828w,
+                      /slika/kanal/akanal?w=1080 1080w,
+                      /slika/kanal/akanal?w=1200 1200w,
+                      /slika/kanal/akanal?w=1920 1920w,
+                      /slika/kanal/akanal?w=2048 2048w,
+                      /slika/kanal/akanal?w=3840 3840w
+                    "
+                    src="/slika/kanal/akanal?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/akanal/oddaja/lepo-je-biti-sosed/800348025/datum/20250113"
+                ><p title="Lepo je biti sosed" class="font-extrabold line-clamp-1">
+                  Lepo je biti sosed
+                </p>
+                <p class="text-light-gray">
+                  Humoristični<!-- -->
+                  (<!-- -->60<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.45–19.45</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/planettv"
+                  ><img
+                    alt="Planet"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Planet"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/planettv?w=16     16w,
+                      /slika/kanal/planettv?w=32     32w,
+                      /slika/kanal/planettv?w=48     48w,
+                      /slika/kanal/planettv?w=64     64w,
+                      /slika/kanal/planettv?w=96     96w,
+                      /slika/kanal/planettv?w=128   128w,
+                      /slika/kanal/planettv?w=256   256w,
+                      /slika/kanal/planettv?w=384   384w,
+                      /slika/kanal/planettv?w=640   640w,
+                      /slika/kanal/planettv?w=750   750w,
+                      /slika/kanal/planettv?w=828   828w,
+                      /slika/kanal/planettv?w=1080 1080w,
+                      /slika/kanal/planettv?w=1200 1200w,
+                      /slika/kanal/planettv?w=1920 1920w,
+                      /slika/kanal/planettv?w=2048 2048w,
+                      /slika/kanal/planettv?w=3840 3840w
+                    "
+                    src="/slika/kanal/planettv?w=3840"
+                /></a>
+              </div>
+              <a target="_self" href="/kanal/planettv/oddaja/1001-noc/800255353/datum/20250113"
+                ><p title="1001 noč" class="font-extrabold line-clamp-1">1001 noč</p>
+                <p class="text-light-gray">
+                  Telenovela<!-- -->
+                  (<!-- -->65<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.55–20.00</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a
+                  class="relative inline-block h-full w-full"
+                  target="_self"
+                  href="/kanal/arenapremium"
+                  ><img
+                    alt="Arena Sport 1 Premium"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Arena Sport 1 Premium"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/arenapremium?w=16     16w,
+                      /slika/kanal/arenapremium?w=32     32w,
+                      /slika/kanal/arenapremium?w=48     48w,
+                      /slika/kanal/arenapremium?w=64     64w,
+                      /slika/kanal/arenapremium?w=96     96w,
+                      /slika/kanal/arenapremium?w=128   128w,
+                      /slika/kanal/arenapremium?w=256   256w,
+                      /slika/kanal/arenapremium?w=384   384w,
+                      /slika/kanal/arenapremium?w=640   640w,
+                      /slika/kanal/arenapremium?w=750   750w,
+                      /slika/kanal/arenapremium?w=828   828w,
+                      /slika/kanal/arenapremium?w=1080 1080w,
+                      /slika/kanal/arenapremium?w=1200 1200w,
+                      /slika/kanal/arenapremium?w=1920 1920w,
+                      /slika/kanal/arenapremium?w=2048 2048w,
+                      /slika/kanal/arenapremium?w=3840 3840w
+                    "
+                    src="/slika/kanal/arenapremium?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/arenapremium/oddaja/fa-pokal-2024-25-3-krog-manchester-city-salford-city/80091565786/datum/20250113"
+                ><p
+                  title="FA Pokal 2024/25 - 3. krog: Manchester City - Salford City"
+                  class="font-extrabold line-clamp-1"
+                >
+                  FA Pokal 2024/25 - 3. krog: Manchester City - Salford City
+                </p>
+                <p class="text-light-gray">
+                  Nogomet<!-- -->
+                  (<!-- -->120<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.30–20.30</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a
+                  class="relative inline-block h-full w-full"
+                  target="_self"
+                  href="/kanal/arenaslo1"
+                  ><img
+                    alt="Arena Sport 1"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Arena Sport 1"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/arenaslo1?w=16     16w,
+                      /slika/kanal/arenaslo1?w=32     32w,
+                      /slika/kanal/arenaslo1?w=48     48w,
+                      /slika/kanal/arenaslo1?w=64     64w,
+                      /slika/kanal/arenaslo1?w=96     96w,
+                      /slika/kanal/arenaslo1?w=128   128w,
+                      /slika/kanal/arenaslo1?w=256   256w,
+                      /slika/kanal/arenaslo1?w=384   384w,
+                      /slika/kanal/arenaslo1?w=640   640w,
+                      /slika/kanal/arenaslo1?w=750   750w,
+                      /slika/kanal/arenaslo1?w=828   828w,
+                      /slika/kanal/arenaslo1?w=1080 1080w,
+                      /slika/kanal/arenaslo1?w=1200 1200w,
+                      /slika/kanal/arenaslo1?w=1920 1920w,
+                      /slika/kanal/arenaslo1?w=2048 2048w,
+                      /slika/kanal/arenaslo1?w=3840 3840w
+                    "
+                    src="/slika/kanal/arenaslo1?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/arenaslo1/oddaja/aba-liga-2024-25-cedevita-olimpija-fmp-soccerbet/80091702612/datum/20250113"
+                ><p
+                  title="ABA Liga 2024/25: Cedevita Olimpija - FMP Soccerbet"
+                  class="font-extrabold line-clamp-1"
+                >
+                  ABA Liga 2024/25: Cedevita Olimpija - FMP Soccerbet
+                </p>
+                <p class="text-light-gray">
+                  Košarka<!-- -->
+                  (<!-- -->115<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.15–20.10</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a
+                  class="relative inline-block h-full w-full"
+                  target="_self"
+                  href="/kanal/eurosport"
+                  ><img
+                    alt="Eurosport 1"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Eurosport 1"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/eurosport?w=16     16w,
+                      /slika/kanal/eurosport?w=32     32w,
+                      /slika/kanal/eurosport?w=48     48w,
+                      /slika/kanal/eurosport?w=64     64w,
+                      /slika/kanal/eurosport?w=96     96w,
+                      /slika/kanal/eurosport?w=128   128w,
+                      /slika/kanal/eurosport?w=256   256w,
+                      /slika/kanal/eurosport?w=384   384w,
+                      /slika/kanal/eurosport?w=640   640w,
+                      /slika/kanal/eurosport?w=750   750w,
+                      /slika/kanal/eurosport?w=828   828w,
+                      /slika/kanal/eurosport?w=1080 1080w,
+                      /slika/kanal/eurosport?w=1200 1200w,
+                      /slika/kanal/eurosport?w=1920 1920w,
+                      /slika/kanal/eurosport?w=2048 2048w,
+                      /slika/kanal/eurosport?w=3840 3840w
+                    "
+                    src="/slika/kanal/eurosport?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/eurosport/oddaja/alpsko-smucanje-m-slalom-2-voznja-svetovni-pokal-adelboden/8008743371/datum/20250113"
+                ><p
+                  title="Alpsko smučanje (M): Slalom, 2. vožnja, svetovni pokal, Adelboden"
+                  class="font-extrabold line-clamp-1"
+                >
+                  Alpsko smučanje (M): Slalom, 2. vožnja, svetovni pokal, Adelboden
+                </p>
+                <p class="text-light-gray">
+                  Smučanje<!-- -->
+                  (<!-- -->59<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">18.21–19.20</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a
+                  class="relative inline-block h-full w-full"
+                  target="_self"
+                  href="/kanal/discoveryhdd"
+                  ><img
+                    alt="Discovery Channel HD"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain Discovery Channel HD"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/discoveryhdd?w=16     16w,
+                      /slika/kanal/discoveryhdd?w=32     32w,
+                      /slika/kanal/discoveryhdd?w=48     48w,
+                      /slika/kanal/discoveryhdd?w=64     64w,
+                      /slika/kanal/discoveryhdd?w=96     96w,
+                      /slika/kanal/discoveryhdd?w=128   128w,
+                      /slika/kanal/discoveryhdd?w=256   256w,
+                      /slika/kanal/discoveryhdd?w=384   384w,
+                      /slika/kanal/discoveryhdd?w=640   640w,
+                      /slika/kanal/discoveryhdd?w=750   750w,
+                      /slika/kanal/discoveryhdd?w=828   828w,
+                      /slika/kanal/discoveryhdd?w=1080 1080w,
+                      /slika/kanal/discoveryhdd?w=1200 1200w,
+                      /slika/kanal/discoveryhdd?w=1920 1920w,
+                      /slika/kanal/discoveryhdd?w=2048 2048w,
+                      /slika/kanal/discoveryhdd?w=3840 3840w
+                    "
+                    src="/slika/kanal/discoveryhdd?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/discoveryhdd/oddaja/trgovec-z-rabljenimi-vozili/80084981549/datum/20250113"
+                ><p title="Trgovec z rabljenimi vozili" class="font-extrabold line-clamp-1">
+                  Trgovec z rabljenimi vozili
+                </p>
+                <p class="text-light-gray">
+                  Avto-moto šport<!-- -->
+                  (<!-- -->30<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">19.00–19.30</p></a
+              >
+            </div>
+            <div class="border-t border-darker-gray"></div>
+            <div class="flex flex-row gap-2 text-text">
+              <div class="h-[95px] w-[95px] p-4 bg-gray flex-none">
+                <a class="relative inline-block h-full w-full" target="_self" href="/kanal/natgeo"
+                  ><img
+                    alt="National Geographic"
+                    loading="lazy"
+                    decoding="async"
+                    data-nimg="fill"
+                    class="object-contain National Geographic"
+                    style="
+                      position: absolute;
+                      height: 100%;
+                      width: 100%;
+                      left: 0;
+                      top: 0;
+                      right: 0;
+                      bottom: 0;
+                      color: transparent;
+                    "
+                    sizes="63px"
+                    srcset="
+                      /slika/kanal/natgeo?w=16     16w,
+                      /slika/kanal/natgeo?w=32     32w,
+                      /slika/kanal/natgeo?w=48     48w,
+                      /slika/kanal/natgeo?w=64     64w,
+                      /slika/kanal/natgeo?w=96     96w,
+                      /slika/kanal/natgeo?w=128   128w,
+                      /slika/kanal/natgeo?w=256   256w,
+                      /slika/kanal/natgeo?w=384   384w,
+                      /slika/kanal/natgeo?w=640   640w,
+                      /slika/kanal/natgeo?w=750   750w,
+                      /slika/kanal/natgeo?w=828   828w,
+                      /slika/kanal/natgeo?w=1080 1080w,
+                      /slika/kanal/natgeo?w=1200 1200w,
+                      /slika/kanal/natgeo?w=1920 1920w,
+                      /slika/kanal/natgeo?w=2048 2048w,
+                      /slika/kanal/natgeo?w=3840 3840w
+                    "
+                    src="/slika/kanal/natgeo?w=3840"
+                /></a>
+              </div>
+              <a
+                target="_self"
+                href="/kanal/natgeo/oddaja/vrhunsko-dubajsko-letalisce-2019/7982135255/datum/20250113"
+                ><p title="Vrhunsko dubajsko letališče 2019" class="font-extrabold line-clamp-1">
+                  Vrhunsko dubajsko letališče 2019
+                </p>
+                <p class="text-light-gray">
+                  Reportaža<!-- -->
+                  (<!-- -->60<!-- -->
+                  min)
+                </p>
+                <p class="text-light-gray">19.00–20.00</p></a
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 tablet:grid tablet:grid-cols-3">
+        <a
+          class="text-center text-xs tablet:text-left"
+          target="_blank"
+          href="https://www.telekom.si/e-trgovina/posebna-ponudba/naj-darila?utm_source=siolnet&amp;utm_medium=banner&amp;utm_campaign=_&amp;utm_id=5122024_internal&amp;utm_content=600x160"
+          ><img
+            class="w-full h-[96px] mb-4 object-cover desktop:h-[109px]"
+            src="https://siol.net/media/img/e6/2d/78b773875a07b588d2a8-ts-pz-kv-december-banner-saj-v2-600x160.jpeg"
+            alt="NAI darila"
+          /><span class="font-bold">NAI darila</span>
+          <p>Izdelki po akcijskih cenah.</p></a
+        ><a
+          class="text-center text-xs tablet:text-left"
+          target="_blank"
+          href="https://www.telekom.si/program-zvestobe/ugodnosti-programa-zvestobe?utm_source=siolnet&amp;utm_medium=banner&amp;utm_campaign=pz_sept_mc214&amp;utm_id=4092024_internal&amp;utm_term=siol-ao&amp;utm_content=160x600"
+          ><img
+            class="w-full h-[96px] mb-4 object-cover desktop:h-[109px]"
+            src="https://siol.net/media/img/14/c5/9ad361fbfd93e79a6ecb-600x160-pz.jpeg"
+            alt="Točke zvestobe"
+          /><span class="font-bold">Točke zvestobe</span>
+          <p>Preveri ugodnosti.</p></a
+        ><a
+          class="text-center text-xs tablet:text-left"
+          target="_blank"
+          href="https://najdarilo.telekom.si/?utm_source=siolnet&amp;utm_medium=banner&amp;utm_campaign=_&amp;utm_id=5122024_internal&amp;utm_content=600x160"
+          ><img
+            class="w-full h-[96px] mb-4 object-cover desktop:h-[109px]"
+            src="https://siol.net/media/img/45/07/6caf4e8909017ff18d16-ts-pz-kv-december-banner-saj-v2-brez-600x160.jpeg"
+            alt="E-trgovina"
+          /><span class="font-bold">E-trgovina</span>
+          <p>NAI darila po akcijskih cenah.</p></a
+        >
+      </div>
+    </div>
+    <div class="bg-gray desktop:bg-darker-gray mt-8 desktop:mt-10">
+      <div
+        class="p-2 flex flex-row gap-4 justify-between desktop:justify-normal desktop:container desktop:mx-auto desktop:px-0"
+      >
+        <div class="flex flex-row items-center gap-2 text-sm desktop:text-base desktop:grow">
+          <a href="https://www.bizi.si/">Bizi</a><a href="https://www.najdi.si/">Najdi.si</a
+          ><a href="https://itis.siol.net/">Itis.si</a><a href="https://www.1188.si/">1188</a>
+        </div>
+        <div class="flex flex-row gap-2 items-center">
+          <a href="https://www.facebook.com/SiOL.net.Novice"
+            ><i class="icon icon-facebook desktop:text-2xl"></i></a
+          ><a href="https://www.instagram.com/siol.net_novice/"
+            ><i class="icon icon-instagram desktop:text-2xl"></i></a
+          ><a href="https://twitter.com/siolnews"><i class="icon icon-x desktop:text-2xl"></i></a>
+        </div>
+        <div class="flex flex-row pr-2">
+          <a class="desktop:flex desktop:flex-rot desktop:items-center desktop:gap-2" href="#top"
+            ><i class="icon icon-on-top text-2xl"></i
+            ><span class="hidden desktop:block text-xs">Na vrh</span></a
+          >
+        </div>
+      </div>
+    </div>
+    <div class="bg-siol text-white">
+      <div class="p-4 desktop:container desktop:mx-auto desktop:px-0 desktop:flex desktop:flex-row">
+        <div class="columns-2 desktop:ml-40 gap-20 text-xs leading-6">
+          <div><a href="https://www.tsmedia.si/">Podjetje</a></div>
+          <div><button>Upravljanje soglasij</button></div>
+          <div><a href="https://www.tsmedia.si/siol-net">Oglaševanje</a></div>
+          <div><a href="https://siol.net/pogoji-uporabe">Pogoji uporabe</a></div>
+          <div><a href="https://siol.net/mobilna-aplikacija">Mobilna aplikacija</a></div>
+          <div><a href="https://siol.net/kolofon">Kontakti uredništva</a></div>
+          <div>
+            <a href="https://siol.net/varstvo-osebnih-podatkov">Varstvo osebnih podatkov</a>
+          </div>
+          <div><a href="https://siol.net/e-novice">Prijava na E-novice</a></div>
+          <div><a href="https://siol.net/feeds/latest">RSS</a></div>
+        </div>
+        <div class="mt-16 text-xs text-center desktop:order-first desktop:mt-0 desktop:text-left">
+          <p class="hidden desktop:block mb-9">
+            TSmedia, medijske vsebine in storitve, d.o.o.,<br />Cigaletova 15, 1000 Ljubljana,<br />T:
+            +386 1 473 00 10
+          </p>
+          <p class="font-light">
+            © TSmedia, medijske vsebine in storitve, d. o. o.<br />Vse pravice pridržane 1997-2024.
+          </p>
+        </div>
+      </div>
+    </div>
+    <script src="/_next/static/chunks/webpack-d70776087c4d8a2e.js" async=""></script>
+    <script>
+      ;(self.__next_f = self.__next_f || []).push([0])
+      self.__next_f.push([2, null])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '1:HL["/_next/static/media/1cf13853095a62e2-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n2:HL["/_next/static/media/38c28ef5d38c7945-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n3:HL["/_next/static/media/52b660d6c1eb514f-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n4:HL["/_next/static/media/68040411bbf3104a-s.p.ttf","font",{"crossOrigin":"","type":"font/ttf"}]\n5:HL["/_next/static/media/71fc01820777da89-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n6:HL["/_nex'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        't/static/media/725d9bf62572528d-s.p.ttf","font",{"crossOrigin":"","type":"font/ttf"}]\n7:HL["/_next/static/media/74691c6b533fc12d-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n8:HL["/_next/static/media/8c279e41746278e3-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\n9:HL["/_next/static/media/d45d409d2fa42169-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\na:HL["/_next/static/media/d79053dc2fa747e1-s.p.ttf","font",{"crossOrigin":"","type":"font/ttf"}]\nb:HL["/_next/static/media/'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        'f029807352456171-s.p.woff2","font",{"crossOrigin":"","type":"font/woff2"}]\nc:HL["/_next/static/css/ccffdc6ea249bec6.css","style"]\n0:"$Ld"\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([1, 'e:HL["/_next/static/css/bca5ef303b452bcb.css","style"]\n'])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        'f:I[7690,[],""]\n12:I[5613,[],""]\n17:I[1778,[],""]\n1b:I[9386,["647","static/chunks/647-1cfed450302421c4.js","470","static/chunks/app/global-error-42518278c1c04387.js"],""]\n13:["channel","exodustv","d"]\n14:["category","vsi","d"]\n15:["subCategory","vsi","d"]\n16:["date","20250115","d"]\n1c:[]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        'd:[[["$","link","0",{"rel":"stylesheet","href":"/_next/static/css/ccffdc6ea249bec6.css","precedence":"next","crossOrigin":"$undefined"}]],["$","$Lf",null,{"buildId":"35LxaZmwsf59P0BNC3vrC","assetPrefix":"","initialCanonicalUrl":"/kanal/exodustv/datum/20250115","initialTree":["",{"children":["(content)",{"children":["kanal",{"children":[["channel","exodustv","d"],{"children":["kategorija",{"children":[["category","vsi","d"],{"children":["podkategorija",{"children":[["subCategory","vsi","d"],{"children":["datum",{"children":[["date","20250115","d"],{"children":["__PAGE__",{}]}]}]}]}]}]}]}]}]}]},"$undefined","$undefined",true],"initialSeedData":["",{"children":["(content)",{"children":["kanal",{"children":[["channel","exodustv","d"],{"children":["kategorija",{"children":[["category","vsi","d"],{"children":["podkategorija",{"children":[["subCategory","vsi","d"],{"children":["datum",{"children":[["date","20250115","d"],{"children":["__PAGE__",{},["$L10","$L11",null]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children","$14","children","podkategorija","children","$15","children","datum","children","$16","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children","$14","children","podkategorija","children","$15","children","datum","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children","$14","children","podkategorija","children","$15","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children","$14","children","podkategorija","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children","$14","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children","kategorija","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children","$13","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children","kanal","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}]]},[null,"$L18",null]]},[null,["$","html",null,{"lang":"sl","children":["$","body",null,{"className":"__variable_1b2967 __variable_d8bf44","children":["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$L19","notFoundStyles":[],"styles":[["$","link","0",{"rel":"stylesheet","href":"/_next/static/css/bca5ef303b452bcb.css","precedence":"next","crossOrigin":"$undefined"}]]}]}]}],null]],"initialHead":[false,"$L1a"],"globalErrorComponent":"$1b","missingSlots":"$W1c"}]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '1a:[["$","meta","0",{"name":"viewport","content":"width=device-width, initial-scale=1"}],["$","meta","1",{"charSet":"utf-8"}],["$","title","2",{"children":"TV spored za Exodus TV za 15. 1. 2025 na Siol.net"}],["$","meta","3",{"name":"description","content":"Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."}],["$","link","4",{"rel":"manifest","href":"/images/favicons/manifest.json"}],["$","meta","5",{"name":"keywords","content":"tv spored,Exodus TV,program,oddaje"}],["$","meta","6",{"name":"msapplication-TileColor","content":"#ffffff"}],["$","meta","7",{"name":"msapplication-TileImage","content":"/images/favicons/ms-icon-144x144.png"}],["$","link","8",{"rel":"canonical","href":"https://tv-spored.siol.net/kanal/exodustv/datum/20250115"}],["$","meta","9",{"property":"og:title","content":"TV spored za Exodus TV za 15. 1. 2025 na Siol.net"}],["$","meta","10",{"property":"og:description","content":"Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."}],["$","meta","11",{"property":"og:url","content":"https://tv-spored.siol.net/"}],["$","meta","12",{"property":"og:locale","content":"sl_SI"}],["$","meta","13",{"property":"og:image","content":"https://tv-spored.siol.net/images/social_share.jpg"}],["$","meta","14",{"property":"og:type","content":"website"}],["$","meta","15",{"name":"twitter:card","content":"summary"}],["$","meta","16",{"name":"twitter:site","content":"@siolnews"}],["$","meta","17",{"name":"twitter:title","content":"TV spored za Exodus TV za 15. 1. 2025 na Siol.net"}],["$","meta","18",{"name":"twitter:description","content":"Kaj je na sporedu na Exodus TV v sreda, 15. 1. 2025. Preverite opis in čas začetka posameznih oddaj."}],["$","meta","19",{"name":"twitter:image","content":"https://tv-spored.siol.net/images/social_share.jpg"}],["$","link","20",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-57x57.png","sizes":"57x57"}],["$","link","21",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-60x60.png","sizes":"60x60"}],["$","link","22",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-72x72.png","sizes":"72x72"}],["$","link","23",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-76x76.png","sizes":"76x76"}],["$","link","24",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-114x114.png","sizes":"114x114"}],["$","link","25",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-120x120.png","sizes":"120x120"}],["$","link","26",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-144x144.png","sizes":"144x144"}],["$","link","27",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-152x152.png","sizes":"152x152"}],["$","link","28",{"rel":"apple-touch-icon","href":"/images/favicons/apple-icon-180x180.png","sizes":"180x180"}],["$","link","29",{"rel":"icon","href":"/images/favicons/android-icon-192x192.png","sizes":"192x192"}],["$","link","30",{"rel":"icon","href":"/images/favicons/favicon-32x32.png","sizes":"32x32"}],["$","link","31",{"rel":"icon","href":"/images/favicons/favicon-96x96.png","sizes":"96x96"}],["$","link","32",{"rel":"icon","href":"/images/favicons/favicon-16x16.png","sizes":"16x16"}],["$","meta","33",{"name":"next-size-adjust"}]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([1, '10:null\n'])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '1d:I[4430,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],"EventsList"]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '1e:I[5718,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '1f:I[7394,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '20:I[5250,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '21:I[5332,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],"AdZone"]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '23:I[7170,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","457","static/chunks/457-aaf27fb26d066ad3.js","208","static/chunks/208-2e235f84099ed6f3.js","561","static/chunks/561-e598a824d42ca3f6.js","170","static/chunks/170-e928c32039c28157.js","948","static/chunks/app/(content)/layout-3662790ffc082265.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '11:[["$","div",null,{"className":"p-2 desktop:p-0","children":["$","div",null,{"className":"border-b border-b-text desktop:hidden"}]}],["$","div",null,{"className":"bg-gray mt-4","children":["$","h1",null,{"className":"text-2xl font-extrabold p-2","children":"TV spored za Exodus TV za 15. 1. 2025"}]}],["$","div",null,{"className":"inline desktop:flex desktop:flex-row","children":[["$","div",null,{"className":"desktop:w-[942px]","children":[[["$","$L1d",null,{"selectedDate":"$D2025-01-15T00:00:00.000Z","channelsAsJson":[{"externalId":"EXODUSTV","name":"Exodus TV","events":[{"externalId":"80091620292","title":"Večernice, Molitveno bogoslužje","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-14T23:45:00.000Z","stopDateTime":"2025-01-15T00:00:00.000Z","duration":15,"date":"2025-01-15"},{"externalId":"80091621292","title":"Novice iz Svete dežele","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","dokumentarec"],"startDateTime":"2025-01-15T00:00:00.000Z","stopDateTime":"2025-01-15T00:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80091622292","title":"Novice iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja"],"startDateTime":"2025-01-15T00:30:00.000Z","stopDateTime":"2025-01-15T00:50:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80091623292","title":"Svetnik dneva","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","verska oddaja"],"startDateTime":"2025-01-15T00:50:00.000Z","stopDateTime":"2025-01-15T01:00:00.000Z","duration":10,"date":"2025-01-15"},{"externalId":"80092189292","title":"Učitelji Cerkve","season":0,"episode":2,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T01:00:00.000Z","stopDateTime":"2025-01-15T01:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092190292","title":"Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T01:30:00.000Z","stopDateTime":"2025-01-15T02:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092249292","title":"Sveta Marija Goretti","season":null,"episode":null,"category":"dokumentarni","subCategories":["biografija"],"startDateTime":"2025-01-15T02:00:00.000Z","stopDateTime":"2025-01-15T02:25:00.000Z","duration":25,"date":"2025-01-15"},{"externalId":"80092194292","title":"Novice Radia Vatikan","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja","dnevno-informativna oddaja"],"startDateTime":"2025-01-15T02:25:00.000Z","stopDateTime":"2025-01-15T02:45:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092215292","title":"Iz tega razloga","season":null,"episode":null,"category":"film","subCategories":["drama"],"startDateTime":"2025-01-15T02:45:00.000Z","stopDateTime":"2025-01-15T04:30:00.000Z","duration":105,"date":"2025-01-15"},{"externalId":"80091627292","title":"Rožni venec, častitljivi del","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T04:30:00.000Z","stopDateTime":"2025-01-15T05:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092306292","title":"Sveta maša","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T05:00:00.000Z","stopDateTime":"2025-01-15T05:45:00.000Z","duration":45,"date":"2025-01-15"},{"externalId":"80092307292","title":"Hvalnice, Molitveno bogoslužje","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T05:45:00.000Z","stopDateTime":"2025-01-15T06:00:00.000Z","duration":15,"date":"2025-01-15"},{"externalId":"80092815292","title":"Novice iz Svete dežele","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","dokumentarec"],"startDateTime":"2025-01-15T06:00:00.000Z","stopDateTime":"2025-01-15T06:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092878292","title":"Novice iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja"],"startDateTime":"2025-01-15T06:30:00.000Z","stopDateTime":"2025-01-15T06:50:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092906292","title":"Svetnik dneva","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","verska oddaja"],"startDateTime":"2025-01-15T06:50:00.000Z","stopDateTime":"2025-01-15T07:00:00.000Z","duration":10,"date":"2025-01-15"},{"externalId":"80092309292","title":"Za skupno dobro: Rešitev ali usodna prevara, splav, evtanazija","season":null,"episode":null,"category":"ostalo","subCategories":[],"startDateTime":"2025-01-15T07:00:00.000Z","stopDateTime":"2025-01-15T08:00:00.000Z","duration":60,"date":"2025-01-15"},{"externalId":"80092343292","title":"Avdienca in kateheza papeža Frančiška","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T08:00:00.000Z","stopDateTime":"2025-01-15T09:00:00.000Z","duration":60,"date":"2025-01-15"},{"externalId":"80092383292","title":"Elena Privalova: orgelski koncert v Koprski stolnici","season":null,"episode":null,"category":"kultura-umetnost","subCategories":["koncert"],"startDateTime":"2025-01-15T09:00:00.000Z","stopDateTime":"2025-01-15T10:00:00.000Z","duration":60,"date":"2025-01-15"},{"externalId":"80092385292","title":"Zaupam v Tebe","season":0,"episode":2,"category":"film","subCategories":["dokumentarec"],"startDateTime":"2025-01-15T10:00:00.000Z","stopDateTime":"2025-01-15T10:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092313292","title":"Rožni venec, častitljivi del","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T10:30:00.000Z","stopDateTime":"2025-01-15T11:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092314292","title":"Sveta maša, v živo iz studijske kapele","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T11:00:00.000Z","stopDateTime":"2025-01-15T11:45:00.000Z","duration":45,"date":"2025-01-15"},{"externalId":"80092315292","title":"Dnevna molitvena ura, Molitveno bogoslužje","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T11:45:00.000Z","stopDateTime":"2025-01-15T12:00:00.000Z","duration":15,"date":"2025-01-15"},{"externalId":"80092316292","title":"Poročilo iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["informativna oddaja","dnevno-informativna oddaja"],"startDateTime":"2025-01-15T12:00:00.000Z","stopDateTime":"2025-01-15T12:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092317292","title":"Novice iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja"],"startDateTime":"2025-01-15T12:30:00.000Z","stopDateTime":"2025-01-15T12:50:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092318292","title":"Svetnik dneva","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","verska oddaja"],"startDateTime":"2025-01-15T12:50:00.000Z","stopDateTime":"2025-01-15T13:00:00.000Z","duration":10,"date":"2025-01-15"},{"externalId":"80092388292","title":"Učitelji Cerkve","season":0,"episode":2,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T13:00:00.000Z","stopDateTime":"2025-01-15T13:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092391292","title":"Na robu znanega: Ob izidu knjige, Menih v vrtincu sirske vojne","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T13:30:00.000Z","stopDateTime":"2025-01-15T14:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092427292","title":"Sveta Marija Goretti","season":null,"episode":null,"category":"dokumentarni","subCategories":["biografija"],"startDateTime":"2025-01-15T14:00:00.000Z","stopDateTime":"2025-01-15T14:25:00.000Z","duration":25,"date":"2025-01-15"},{"externalId":"80092431292","title":"Novice Radia Vatikan","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja","dnevno-informativna oddaja"],"startDateTime":"2025-01-15T14:25:00.000Z","stopDateTime":"2025-01-15T14:45:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092464292","title":"Iz tega razloga","season":null,"episode":null,"category":"film","subCategories":["drama"],"startDateTime":"2025-01-15T14:45:00.000Z","stopDateTime":"2025-01-15T16:30:00.000Z","duration":105,"date":"2025-01-15"},{"externalId":"80092322292","title":"Rožni venec, častitljivi del","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T16:30:00.000Z","stopDateTime":"2025-01-15T17:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092323292","title":"Sveta maša","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T17:00:00.000Z","stopDateTime":"2025-01-15T17:45:00.000Z","duration":45,"date":"2025-01-15"},{"externalId":"80092324292","title":"Večernice, Molitveno bogoslužje","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T17:45:00.000Z","stopDateTime":"2025-01-15T18:00:00.000Z","duration":15,"date":"2025-01-15"},{"externalId":"80092325292","title":"Poročilo iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["informativna oddaja","dnevno-informativna oddaja"],"startDateTime":"2025-01-15T18:00:00.000Z","stopDateTime":"2025-01-15T18:30:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092326292","title":"Novice iz Vatikana","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja"],"startDateTime":"2025-01-15T18:30:00.000Z","stopDateTime":"2025-01-15T18:50:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092327292","title":"Svetnik dneva","season":null,"episode":null,"category":"informativni","subCategories":["dnevno-informativna oddaja","verska oddaja"],"startDateTime":"2025-01-15T18:50:00.000Z","stopDateTime":"2025-01-15T19:00:00.000Z","duration":10,"date":"2025-01-15"},{"externalId":"80092470292","title":"PriVidi: Kreacija ali evolucija?","season":null,"episode":null,"category":"informativni","subCategories":["pogovorna oddaja"],"startDateTime":"2025-01-15T19:00:00.000Z","stopDateTime":"2025-01-15T20:00:00.000Z","duration":60,"date":"2025-01-15"},{"externalId":"80092344292","title":"Avdienca in kateheza papeža Frančiška","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja"],"startDateTime":"2025-01-15T20:00:00.000Z","stopDateTime":"2025-01-15T21:00:00.000Z","duration":60,"date":"2025-01-15"},{"externalId":"80092575292","title":"Novice Radia Vatikan","season":null,"episode":null,"category":"ostalo","subCategories":["verska oddaja","dnevno-informativna oddaja"],"startDateTime":"2025-01-15T21:00:00.000Z","stopDateTime":"2025-01-15T21:20:00.000Z","duration":20,"date":"2025-01-15"},{"externalId":"80092633292","title":"Draga 2024","season":0,"episode":2,"category":"ostalo","subCategories":[],"startDateTime":"2025-01-15T21:20:00.000Z","stopDateTime":"2025-01-15T22:30:00.000Z","duration":70,"date":"2025-01-15"},{"externalId":"80092332292","title":"Rožni venec, častitljivi del","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T22:30:00.000Z","stopDateTime":"2025-01-15T23:00:00.000Z","duration":30,"date":"2025-01-15"},{"externalId":"80092333292","title":"Sveta maša","season":null,"episode":null,"category":"ostalo","subCategories":["verski obred"],"startDateTime":"2025-01-15T23:00:00.000Z","stopDateTime":"2025-01-15T23:45:00.000Z","duration":45,"date":"2025-01-15"}]}]}],["$","div",null,{"className":"flex flex-row gap-2 mt-4 justify-stretch desktop:gap-28","children":[["$","$L1e",null,{"className":"text-left","date":"$D2025-01-14T00:00:00.000Z"}],["$","$L1e",null,{"className":"text-right","date":"$D2025-01-16T00:00:00.000Z"}]]}],["$","$L1f",null,{"className":"mt-6 desktop:gap-6","subject":"TV spored za Exodus TV za 15. 1. 2025"}]],[["$","div",null,{"className":"border-t border-b border-text desktop:px-4 text-2xl my-2 py-2 font-serif font-extrabold desktop:my-4 desktop:py-4","children":"Aktualno"}],["$","div",null,{"className":"grid grid-cols-2 py-4 gap-2 desktop:pl-24 tablet:grid-cols-4 desktop:pr-0","children":[["$","$L20","https://siol.net/trendi/horoskop/ti-znaki-horoskopa-imajo-najvec-srece-pri-igranju-lota-652335",{"href":"https://siol.net/trendi/horoskop/ti-znaki-horoskopa-imajo-najvec-srece-pri-igranju-lota-652335","className":"relative","title":"Ti znaki horoskopa imajo največ sreče pri igranju lota","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Ti znaki horoskopa imajo največ sreče pri igranju lota","src":"https://siol.net/media/img/86/5c/30cad26c7f3db1193027.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Ti znaki horoskopa imajo največ sreče pri igranju lota"}]]}],["$","$L20","https://siol.net/trendi/glasba-in-film/netflix-zaradi-pozarov-prelozil-premiero-oddaje-z-meghan-markle-652730",{"href":"https://siol.net/trendi/glasba-in-film/netflix-zaradi-pozarov-prelozil-premiero-oddaje-z-meghan-markle-652730","className":"relative","title":"Netflix zaradi požarov preložil premiero oddaje z Meghan Markle","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Netflix zaradi požarov preložil premiero oddaje z Meghan Markle","src":"https://siol.net/media/img/70/77/215ef27f31dc4cc3c2ff.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Netflix zaradi požarov preložil premiero oddaje z Meghan Markle"}]]}],["$","$L20","https://siol.net/trendi/zdravo-zivljenje/zacnite-dan-z-vadbo-ki-osvaja-slovenijo-652541",{"href":"https://siol.net/trendi/zdravo-zivljenje/zacnite-dan-z-vadbo-ki-osvaja-slovenijo-652541","className":"relative","title":"Začnite dan z vadbo, ki osvaja Slovenijo","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Začnite dan z vadbo, ki osvaja Slovenijo","src":"https://siol.net/media/img/b8/1d/9070934b6e8ab90955a5.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Začnite dan z vadbo, ki osvaja Slovenijo"}]]}],["$","$L20","https://siol.net/trendi/zvezde-in-slavni/balkanska-zvezdnica-potrdila-da-je-noseca-652698",{"href":"https://siol.net/trendi/zvezde-in-slavni/balkanska-zvezdnica-potrdila-da-je-noseca-652698","className":"relative","title":"Balkanska zvezdnica potrdila, da je noseča","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Balkanska zvezdnica potrdila, da je noseča","src":"https://siol.net/media/img/a0/d2/402020c0d4e8c9634817.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Balkanska zvezdnica potrdila, da je noseča"}]]}],["$","$L20","https://siol.net/trendi/zvezde-in-slavni/umrl-legendarni-fotograf-oliviero-toscani-652685",{"href":"https://siol.net/trendi/zvezde-in-slavni/umrl-legendarni-fotograf-oliviero-toscani-652685","className":"relative","title":"Umrl legendarni fotograf Oliviero Toscani","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Umrl legendarni fotograf Oliviero Toscani","src":"https://siol.net/media/img/74/dc/a7b23a48ae5cf85a8179.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Umrl legendarni fotograf Oliviero Toscani"}]]}],["$","$L20","https://siol.net/trendi/moda-in-lepota/to-je-nova-mis-slovenije-prihaja-s-krasa-652680",{"href":"https://siol.net/trendi/moda-in-lepota/to-je-nova-mis-slovenije-prihaja-s-krasa-652680","className":"relative","title":"To je nova mis Slovenije, prihaja s Krasa","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"To je nova mis Slovenije, prihaja s Krasa","src":"https://siol.net/media/img/c0/8b/35834ce15aeb7696cb09.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"To je nova mis Slovenije, prihaja s Krasa"}]]}],["$","$L20","https://siol.net/trendi/dom/stoli-ki-zdruzujejo-udobje-in-prestiz-652436",{"href":"https://siol.net/trendi/dom/stoli-ki-zdruzujejo-udobje-in-prestiz-652436","className":"relative","title":"Stoli, ki združujejo udobje in prestiž","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Stoli, ki združujejo udobje in prestiž","src":"https://siol.net/media/img/be/55/a656568a2080893f004a.jpg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Stoli, ki združujejo udobje in prestiž"}]]}],["$","$L20","https://siol.net/trendi/odnosi/horoskop-kaksna-je-vasa-tedenska-napoved-540773",{"href":"https://siol.net/trendi/odnosi/horoskop-kaksna-je-vasa-tedenska-napoved-540773","className":"relative","title":"Horoskop: kakšna je vaša tedenska napoved?","children":[false,["$","img",null,{"className":"w-[50vw] h-[30vw] tablet:w-[25vw] tablet:h-[15vw] object-cover desktop:w-[200px] desktop:h-[130px]","alt":"Horoskop: kakšna je vaša tedenska napoved?","src":"https://siol.net/media/img/ca/4c/d5fb440310620e2b02a8.jpeg"}],["$","span",null,{"className":"font-serif line-clamp-3","children":"Horoskop: kakšna je vaša tedenska napoved?"}]]}]]}]]]}],["$","div",null,{"className":"inline desktop:flex desktop:flex-col desktop:w-[300px] desktop:pt-4 desktop:ml-2","children":[["$","$L21",null,{"id":"sidebar1","className":"mb-4","style":{"minHeight":250}}],"$L22"]}]]}]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '19:[["$","$L23",null,{"externalContent":{"corpoline":[{"text":"TV spored","url":"https://tv-spored.siol.net/"},{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://www.itis.si/"},{"text":"1188","url":"https://www.1188.si/"}],"primary":[{"text":"Novice","url":"https://siol.net/novice"},{"text":"Sportal","url":"https://siol.net/sportal"},{"text":"Trendi","url":"https://siol.net/trendi"},{"text":"Avtomoto","url":"https://siol.net/avtomoto"},{"text":"Kolumne","url":"https://siol.net/mnenja"},{"text":"Spotkast","url":"https://siol.net/kljucne-besede/spotkast-102419/articles"},{"text":"S.Nepremičnine","url":"https://nepremicnine.siol.net/"},{"text":"VideoS.pot","url":"https://videospot.siol.net/"}],"secondary":[{"text":"Film","url":"https://tv-spored.siol.net/kategorija/film"},{"text":"Šport","url":"https://tv-spored.siol.net/kategorija/sport"},{"text":"Dokumentarni","url":"https://tv-spored.siol.net/kategorija/dokumentarni"},{"text":"Otroški","url":"https://tv-spored.siol.net/kategorija/otroski-in-mladinski"},{"text":"Nadaljevanke-nanizanke","url":"https://tv-spored.siol.net/kategorija/nadaljevanka-nanizanka"}],"telekom":{"title":"TELEKOM SLOVENIJE","icons":[{"icon":"basket","url":"https://www.telekom.si/etrgovina?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-etrgovina\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-etrgovina"},{"icon":"email","url":"https://prijava.siol.net/posta/?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-posta\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-posta"},{"icon":"cog","url":"https://moj.telekom.si/sl/Profile/Login?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-mt\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-mt"}],"links":[{"text":"Spletna TV neo.io","url":"https://neo.io/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"NEO","url":"https://www.telekom.si/neo?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mobilni paketi","url":"https://www.telekom.si/mobilno?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=mobilni_paketi\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Internet","url":"https://www.telekom.si/internet?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=internet\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Program zvestobe","url":"https://www.telekom.si/program-zvestobe?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=program_zvestobe\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-trgovina","url":"https://www.telekom.si/e-trgovina?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=etrgovina\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Moj Telekom","url":"https://moj.telekom.si/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=moj_telekom\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mala podjetja","url":"https://www.telekom.si/mala-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_mala_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Velika podjetja","url":"https://www.telekom.si/velika-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_velika_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-oskrba","url":"https://www.telekom.si/e-oskrba?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=e_oskrba\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Spletna pošta","url":"https://prijava.siol.net/posta?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=spletna_posta\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Pomoč","url":"https://www.telekom.si/pomoc?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=pomoc\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Info in obvestila","url":"https://www.telekom.si/info-in-obvestila?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=info_in_obvestila\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Tehnik","url":"https://www.telekom.si/tehnik?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=tehnik\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Želite prejemati e-novice?","url":"https://www.telekom.si/e-novice?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=enovice\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"}],"news":{"title":"","description":"Uživajmo pametno","image":"https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg","url":"https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=digi_star%C5%A1_image_mc225\u0026utm_id=12082024_internal\u0026utm_content=380x247"},"logo":{"url":"https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet\u0026utm_medium=logo\u0026utm_campaign=telekom\u0026utm_term=ekskluziva\u0026utm_content=zavihek"}},"icons":[{"icon":"timeline","url":"https://siol.net/pregled-dneva"},{"icon":"tv-listing","url":"https://tv-spored.siol.net/"},{"icon":"vreme","url":"https://vreme.siol.net/"}],"hamburger":{"projects":[{"text":"Čarobni december","url":"https://siol.net/kljucne-besede/carobni-december-90330/articles"},{"text":"Energetika 2.0","url":"https://siol.net/kljucne-besede/energetika-2-0-103743/articles"},{"text":"Ona-On.com","url":"https://siol.net/trendi/ona-on"},{"text":"Dobrodelna licitacija","url":"https://zgodbe.siol.net/licitacija-ilustracij/"},{"text":"Odmrznimo Slovenijo","url":"https://siol.net/kljucne-besede/odmrznimo-slovenijo-106577/articles"},{"text":"Dober vid","url":"https://siol.net/trendi/zdravo-zivljenje/dober-vid"},{"text":"Nakup avtomobila","url":"https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"},{"text":"Pravni nasvet","url":"https://siol.net/kljucne-besede/pravni-nasvet-60118/articles"},{"text":"Vizija rasti","url":"https://siol.net/kljucne-besede/vizija-rasti-103625/articles"},{"text":"Gremo v nov dom","url":"https://siol.net/kljucne-besede/gremo-v-nov-dom-106101/articles"}],"main":[{"title":"Novice","url":"https://siol.net/novice","links":[{"text":"Slovenija","url":"https://siol.net/novice/slovenija"},{"text":"Evropa in svet","url":"https://siol.net/novice/svet"},{"text":"Digisvet","url":"https://siol.net/novice/digisvet"},{"text":"Posel danes","url":"https://siol.net/novice/posel-danes"},{"text":"Kronika","url":"https://siol.net/novice/crna-kronika"}],"projects":[{"text":"Aktivno državljanstvo","url":"https://siol.net/kljucne-besede/aktivno-drzavljanstvo-102165/articles"},{"text":"Zdravje za jutri","url":"https://siol.net/novice/zdravje-za-jutri"},{"text":"Finančni nasveti","url":"https://siol.net/novice/financni-nasveti"}]},{"title":"Sportal","url":"https://siol.net/sportal","links":[{"text":"Nogomet","url":"https://siol.net/sportal/nogomet"},{"text":"Košarka","url":"https://siol.net/sportal/kosarka"},{"text":"Kolesarstvo","url":"https://siol.net/sportal/kolesarstvo"},{"text":"Rokomet","url":"https://siol.net/sportal/rokomet"},{"text":"Zima","url":"https://siol.net/sportal/zimski-sporti"},{"text":"Hokej","url":"https://siol.net/sportal/hokej"},{"text":"Tenis","url":"https://siol.net/sportal/tenis"},{"text":"Odbojka","url":"https://siol.net/sportal/odbojka"},{"text":"Atletika","url":"https://siol.net/sportal/atletika"},{"text":"Moto","url":"https://siol.net/sportal/avtomotosport"},{"text":"Drugo","url":"https://siol.net/sportal/drugi-sporti"}],"projects":[{"text":"Luka Dončić","url":"https://siol.net/kljucne-besede/luka-doncic-12996/articles"},{"text":"Prva liga","url":"https://siol.net/sportal/nogomet/prva-liga"},{"text":"Liga prvakov","url":"https://siol.net/kljucne-besede/uefa-liga-prvakov-74204/articles"},{"text":"Konferenčna liga","url":"https://siol.net/kljucne-besede/konferencna-liga-87031/articles"},{"text":"Sobotni intervju","url":"https://siol.net/kljucne-besede/sobotni-intervju-11361/articles"},{"text":"Druga kariera","url":"https://siol.net/kljucne-besede/druga-kariera-75383/articles"},{"text":"Prek meja","url":"https://siol.net/kljucne-besede/prek-meja-104215/articles"},{"text":"Naj planinska koča","url":"https://siol.net/sportal/naj-planinska-koca"},{"text":"Rekreacija","url":"https://siol.net/sportal/rekreacija"}]},{"title":"Trendi","url":"https://siol.net/trendi","links":[{"text":"Glasba in film","url":"https://siol.net/trendi/glasba-in-film"},{"text":"Slavni","url":"https://siol.net/trendi/zvezde-in-slavni"},{"text":"Moda in lepota","url":"https://siol.net/trendi/moda-in-lepota"},{"text":"Zdravo življenje","url":"https://siol.net/trendi/zdravo-zivljenje"},{"text":"Kulinarika","url":"https://siol.net/trendi/kulinarika"},{"text":"Dom","url":"https://siol.net/trendi/dom"},{"text":"Zanimivosti","url":"https://siol.net/trendi/zanimivosti"}],"projects":[{"text":"Vedeževanje","url":"https://siol.net/trendi/vedezevanje"},{"text":"Hišni ljubljenčki","url":"https://siol.net/kljucne-besede/hisni-ljubljencki-29065/articles"},{"text":"Ona-On.com","url":"https://siol.net/trendi/ona-on"},{"text":"TV-spored","url":"https://tv-spored.siol.net/"},{"text":"Potovanja","url":"https://siol.net/trendi/potovanja"},{"text":"Horoskop","url":"https://siol.net/horoskop/dnevni"},{"text":"Trajnost","url":"https://siol.net/kljucne-besede/trajnost-19357/articles"}]},{"title":"Avtomoto","url":"https://siol.net/avtomoto","links":[{"text":"Novice","url":"https://siol.net/avtomoto/novice"},{"text":"Promet","url":"https://siol.net/avtomoto/promet"},{"text":"E-avtomoto","url":"https://siol.net/avtomoto/e-avtomoto"},{"text":"Testi","url":"https://siol.net/avtomoto/testi"},{"text":"Prva vožnja","url":"https://siol.net/avtomoto/prva-voznja"},{"text":"Nasveti","url":"https://siol.net/avtomoto/nasveti"},{"text":"Tehnika","url":"https://siol.net/avtomoto/tehnika"},{"text":"Zgodbe","url":"https://siol.net/avtomoto/zgodbe"}],"projects":[{"text":"E-mobilnost","url":"https://siol.net/kljucne-besede/e-mobilnost-66251/articles"},{"text":"Nakup avtomobila","url":"https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"}]},{"title":"Kolumne","url":"https://siol.net/mnenja","links":[{"text":"Kolumne","url":"https://siol.net/mnenja/kolumne"},{"text":"Intervjuji","url":"https://siol.net/mnenja/intervjuji"}],"projects":[]},{"title":"Spotkast","url":"https://siol.net/kljucne-besede/spotkast-102419/articles","links":[],"projects":[]},{"title":"S.Nepremičnine","url":"https://nepremicnine.siol.net/","links":[{"text":"Aktualno","url":"https://nepremicnine.siol.net/"},{"text":"Iskanje","url":"https://nepremicnine.siol.net/iskanje/prodaja"},{"text":"Novice","url":"https://nepremicnine.siol.net/novice"},{"text":"Objavi oglas","url":"https://nepremicnine.siol.net/userarea/post-listing"},{"text":"Novogradnje","url":"https://nepremicnine.siol.net/novogradnje"}],"projects":[{"text":"Ljubljana","url":"https://nepremicnine.siol.net/iskanje/prodaja/ljubljana"},{"text":"Maribor","url":"https://nepremicnine.siol.net/iskanje/prodaja/podravska/maribor"},{"text":"Obala","url":"https://nepremicnine.siol.net/iskanje/prodaja/obala"},{"text":"Celje","url":"https://nepremicnine.siol.net/iskanje/prodaja/savinjska/celje"},{"text":"Kranj","url":"https://nepremicnine.siol.net/iskanje/prodaja/gorenjska/kranj"}]},{"title":"VideoS.pot","url":"https://videospot.siol.net/","links":[],"projects":[]}],"telekom":{"title":"TELEKOM SLOVENIJE","icons":[{"icon":"basket","url":"https://www.telekom.si/etrgovina?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-etrgovina\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-etrgovina"},{"icon":"email","url":"https://prijava.siol.net/posta/?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-posta\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-posta"},{"icon":"cog","url":"https://moj.telekom.si/sl/Profile/Login?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-mt\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-mt"}],"links":[{"text":"Spletna TV neo.io","url":"https://neo.io/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"NEO","url":"https://www.telekom.si/neo?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mobilni paketi","url":"https://www.telekom.si/mobilno?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=mobilni_paketi\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Internet","url":"https://www.telekom.si/internet?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=internet\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Program zvestobe","url":"https://www.telekom.si/program-zvestobe?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=program_zvestobe\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-trgovina","url":"https://www.telekom.si/e-trgovina?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=etrgovina\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Moj Telekom","url":"https://moj.telekom.si/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=moj_telekom\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mala podjetja","url":"https://www.telekom.si/mala-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_mala_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Velika podjetja","url":"https://www.telekom.si/velika-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_velika_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-oskrba","url":"https://www.telekom.si/e-oskrba?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=e_oskrba\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Spletna pošta","url":"https://prijava.siol.net/posta?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=spletna_posta\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Pomoč","url":"https://www.telekom.si/pomoc?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=pomoc\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Info in obvestila","url":"https://www.telekom.si/info-in-obvestila?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=info_in_obvestila\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Tehnik","url":"https://www.telekom.si/tehnik?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=tehnik\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Želite prejemati e-novice?","url":"https://www.telekom.si/e-novice?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=enovice\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"}],"news":{"title":"","description":"Uživajmo pametno","image":"https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg","url":"https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=digi_star%C5%A1_image_mc225\u0026utm_id=12082024_internal\u0026utm_content=380x247"},"logo":{"url":"https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet\u0026utm_medium=logo\u0026utm_campaign=telekom\u0026utm_term=ekskluziva\u0026utm_content=zavihek"}},"extra":[{"text":"Zadnje novice","url":"https://siol.net/pregled-dneva"},{"text":"TV spored","url":"https://tv-spored.siol.net/"},{"text":"Horoskop","url":"https://siol.net/horoskop"},{"text":"Vreme","url":"https://vreme.siol.net/"}],"corpo":[{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://www.itis.si/"},{"text":"1188","url":"https://www.1188.si/"}],"social":[{"icon":"facebook","url":"https://www.facebook.com/SiOL.net.Novice"},{"icon":"x","url":"https://twitter.com/siolnews"},{"icon":"instagram","url":"https://www.instagram.com/siol.net_novice/"},{"icon":"youtube","url":"https://www.youtube.com/channel/UCoN9YgUHTqLBvVEFRH_HVaQ"},{"icon":"linkedin","url":"https://www.linkedin.com/company/tsmedia-d-o-o-/"},{"icon":"pinterest","url":"https://www.pinterest.com/Siolnet/"}]},"articles":[{"image":"https://siol.net/media/img/86/5c/30cad26c7f3db1193027.jpeg","title":"Ti znaki horoskopa imajo največ sreče pri igranju lota","url":"https://siol.net/trendi/horoskop/ti-znaki-horoskopa-imajo-najvec-srece-pri-igranju-lota-652335","sponsor":0},{"image":"https://siol.net/media/img/70/77/215ef27f31dc4cc3c2ff.jpeg","title":"Netflix zaradi požarov preložil premiero oddaje z Meghan Markle","url":"https://siol.net/trendi/glasba-in-film/netflix-zaradi-pozarov-prelozil-premiero-oddaje-z-meghan-markle-652730","sponsor":0},{"image":"https://siol.net/media/img/b8/1d/9070934b6e8ab90955a5.jpeg","title":"Začnite dan z vadbo, ki osvaja Slovenijo","url":"https://siol.net/trendi/zdravo-zivljenje/zacnite-dan-z-vadbo-ki-osvaja-slovenijo-652541","sponsor":0},{"image":"https://siol.net/media/img/a0/d2/402020c0d4e8c9634817.jpeg","title":"Balkanska zvezdnica potrdila, da je noseča","url":"https://siol.net/trendi/zvezde-in-slavni/balkanska-zvezdnica-potrdila-da-je-noseca-652698","sponsor":0},{"image":"https://siol.net/media/img/74/dc/a7b23a48ae5cf85a8179.jpeg","title":"Umrl legendarni fotograf Oliviero Toscani","url":"https://siol.net/trendi/zvezde-in-slavni/umrl-legendarni-fotograf-oliviero-toscani-652685","sponsor":0},{"image":"https://siol.net/media/img/c0/8b/35834ce15aeb7696cb09.jpeg","title":"To je nova mis Slovenije, prihaja s Krasa","url":"https://siol.net/trendi/moda-in-lepota/to-je-nova-mis-slovenije-prihaja-s-krasa-652680","sponsor":0},{"image":"https://siol.net/media/img/be/55/a656568a2080893f004a.jpg","title":"Stoli, ki združujejo udobje in prestiž","url":"https://siol.net/trendi/dom/stoli-ki-zdruzujejo-udobje-in-prestiz-652436","sponsor":0},{"image":"https://siol.net/media/img/ca/4c/d5fb440310620e2b02a8.jpeg","title":"Horoskop: kakšna je vaša tedenska napoved?","url":"https://siol.net/trendi/odnosi/horoskop-kaksna-je-vasa-tedenska-napoved-540773","sponsor":0}],"telekom3":[{"title":"NAI darila","description":"Izdelki po akcijskih cenah.","image":"https://siol.net/media/img/e6/2d/78b773875a07b588d2a8-ts-pz-kv-december-banner-saj-v2-600x160.jpeg","url":"https://www.telekom.si/e-trgovina/posebna-ponudba/naj-darila?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160"},{"title":"Točke zvestobe","description":"Preveri ugodnosti.","image":"https://siol.net/media/img/14/c5/9ad361fbfd93e79a6ecb-600x160-pz.jpeg","url":"https://www.telekom.si/program-zvestobe/ugodnosti-programa-zvestobe?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=pz_sept_mc214\u0026utm_id=4092024_internal\u0026utm_term=siol-ao\u0026utm_content=160x600"},{"title":"E-trgovina","description":"NAI darila po akcijskih cenah.","image":"https://siol.net/media/img/45/07/6caf4e8909017ff18d16-ts-pz-kv-december-banner-saj-v2-brez-600x160.jpeg","url":"https://najdarilo.telekom.si/?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160"}],"footer":{"corpoline":[{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://itis.siol.net/"},{"text":"1188","url":"https://www.1188.si/"}],"social":[{"icon":"facebook","url":"https://www.facebook.com/SiOL.net.Novice"},{"icon":"instagram","url":"https://www.instagram.com/siol.net_novice/"},{"icon":"twitter","url":"https://twitter.com/siolnews"}],"company":"TSmedia, medijske vsebine in storitve, d.o.o.,\u003cbr\u003eCigaletova 15, 1000 Ljubljana,\u003cbr\u003eT: +386 1 473 00 10","copyright":"© TSmedia, medijske vsebine in storitve, d. o. o.\u003cbr\u003eVse pravice pridržane 1997-2024.","links":[{"text":"Podjetje","url":"https://www.tsmedia.si/"},{"text":"Upravljanje soglasij","url":"javascript:Didomi.preferences.show()"},{"text":"Oglaševanje","url":"https://www.tsmedia.si/siol-net"},{"text":"Pogoji uporabe","url":"https://siol.net/pogoji-uporabe"},{"text":"Mobilna aplikacija","url":"https://siol.net/mobilna-aplikacija"},{"text":"Kontakti uredništva","url":"https://siol.net/kolofon"},{"text":"Varstvo osebnih podatkov","url":"https://siol.net/varstvo-osebnih-podatkov"},{"text":"Prijava na E-novice","url":"https://siol.net/e-novice"},{"text":"RSS","url":"https://siol.net/feeds/latest"}]}}}],["$","div",null,{"className":"bg-error bg-center bg-cover bg-no-repeat h-[800px] pt-36 flex flex-col gap-6 font-bold","children":[["$","div",null,{"className":"bg-black text-white text-center mx-6 p-4 gap-3 flex flex-col desktop:w-[1177px] desktop:mx-auto","children":[["$","div",null,{"className":"text-3xl uppercase desktop:text-7xl","children":["Tokrat za vas na sporedu:",["$","br",null,{}],"Izlet v neznano"]}],["$","div",null,{"className":"desktop:text-4xl","children":"Že iščemo pravo pot do TV-sporeda. Kmalu se vrnemo."}]]}],["$","div",null,{"className":"text-center text-4xl","children":"Do takrat raziščite posebne programe:"}],["$","div",null,{"className":"bg-white opacity-70 py-3 uppercase mx-2 flex flex-row justify-center gap-10 desktop:px-40 desktop:mx-auto","children":[["$","$L20",null,{"href":"/","children":"Trendi"}],["$","$L20",null,{"href":"/","children":"Novice"}],["$","$L20",null,{"href":"/","children":"Sportal"}]]}]]}]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '24:I[8399,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","457","static/chunks/457-aaf27fb26d066ad3.js","208","static/chunks/208-2e235f84099ed6f3.js","561","static/chunks/561-e598a824d42ca3f6.js","170","static/chunks/170-e928c32039c28157.js","948","static/chunks/app/(content)/layout-3662790ffc082265.js"],"PageData"]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([1, '25:"$Sreact.suspense"\n'])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '26:I[8399,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","457","static/chunks/457-aaf27fb26d066ad3.js","208","static/chunks/208-2e235f84099ed6f3.js","561","static/chunks/561-e598a824d42ca3f6.js","170","static/chunks/170-e928c32039c28157.js","948","static/chunks/app/(content)/layout-3662790ffc082265.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '27:I[5332,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],"AdManager"]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '28:I[259,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","457","static/chunks/457-aaf27fb26d066ad3.js","208","static/chunks/208-2e235f84099ed6f3.js","561","static/chunks/561-e598a824d42ca3f6.js","170","static/chunks/170-e928c32039c28157.js","948","static/chunks/app/(content)/layout-3662790ffc082265.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '29:I[5952,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","457","static/chunks/457-aaf27fb26d066ad3.js","208","static/chunks/208-2e235f84099ed6f3.js","561","static/chunks/561-e598a824d42ca3f6.js","170","static/chunks/170-e928c32039c28157.js","948","static/chunks/app/(content)/layout-3662790ffc082265.js"],""]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '18:[["$","$L21",null,{"id":"outofpage"}],["$","$L21",null,{"id":"wallpaper_skin"}],["$","$L24",null,{"pageType":"tvguide"}],["$","$25",null,{"children":[["$","$L26",null,{}],["$","$L27",null,{}]]}],["$","$L23",null,{"externalContent":{"corpoline":[{"text":"TV spored","url":"https://tv-spored.siol.net/"},{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://www.itis.si/"},{"text":"1188","url":"https://www.1188.si/"}],"primary":[{"text":"Novice","url":"https://siol.net/novice"},{"text":"Sportal","url":"https://siol.net/sportal"},{"text":"Trendi","url":"https://siol.net/trendi"},{"text":"Avtomoto","url":"https://siol.net/avtomoto"},{"text":"Kolumne","url":"https://siol.net/mnenja"},{"text":"Spotkast","url":"https://siol.net/kljucne-besede/spotkast-102419/articles"},{"text":"S.Nepremičnine","url":"https://nepremicnine.siol.net/"},{"text":"VideoS.pot","url":"https://videospot.siol.net/"}],"secondary":[{"text":"Film","url":"https://tv-spored.siol.net/kategorija/film"},{"text":"Šport","url":"https://tv-spored.siol.net/kategorija/sport"},{"text":"Dokumentarni","url":"https://tv-spored.siol.net/kategorija/dokumentarni"},{"text":"Otroški","url":"https://tv-spored.siol.net/kategorija/otroski-in-mladinski"},{"text":"Nadaljevanke-nanizanke","url":"https://tv-spored.siol.net/kategorija/nadaljevanka-nanizanka"}],"telekom":{"title":"TELEKOM SLOVENIJE","icons":[{"icon":"basket","url":"https://www.telekom.si/etrgovina?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-etrgovina\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-etrgovina"},{"icon":"email","url":"https://prijava.siol.net/posta/?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-posta\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-posta"},{"icon":"cog","url":"https://moj.telekom.si/sl/Profile/Login?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-mt\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-mt"}],"links":[{"text":"Spletna TV neo.io","url":"https://neo.io/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"NEO","url":"https://www.telekom.si/neo?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mobilni paketi","url":"https://www.telekom.si/mobilno?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=mobilni_paketi\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Internet","url":"https://www.telekom.si/internet?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=internet\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Program zvestobe","url":"https://www.telekom.si/program-zvestobe?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=program_zvestobe\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-trgovina","url":"https://www.telekom.si/e-trgovina?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=etrgovina\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Moj Telekom","url":"https://moj.telekom.si/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=moj_telekom\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mala podjetja","url":"https://www.telekom.si/mala-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_mala_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Velika podjetja","url":"https://www.telekom.si/velika-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_velika_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-oskrba","url":"https://www.telekom.si/e-oskrba?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=e_oskrba\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Spletna pošta","url":"https://prijava.siol.net/posta?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=spletna_posta\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Pomoč","url":"https://www.telekom.si/pomoc?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=pomoc\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Info in obvestila","url":"https://www.telekom.si/info-in-obvestila?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=info_in_obvestila\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Tehnik","url":"https://www.telekom.si/tehnik?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=tehnik\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Želite prejemati e-novice?","url":"https://www.telekom.si/e-novice?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=enovice\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"}],"news":{"title":"","description":"Uživajmo pametno","image":"https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg","url":"https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=digi_star%C5%A1_image_mc225\u0026utm_id=12082024_internal\u0026utm_content=380x247"},"logo":{"url":"https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet\u0026utm_medium=logo\u0026utm_campaign=telekom\u0026utm_term=ekskluziva\u0026utm_content=zavihek"}},"icons":[{"icon":"timeline","url":"https://siol.net/pregled-dneva"},{"icon":"tv-listing","url":"https://tv-spored.siol.net/"},{"icon":"vreme","url":"https://vreme.siol.net/"}],"hamburger":{"projects":[{"text":"Čarobni december","url":"https://siol.net/kljucne-besede/carobni-december-90330/articles"},{"text":"Energetika 2.0","url":"https://siol.net/kljucne-besede/energetika-2-0-103743/articles"},{"text":"Ona-On.com","url":"https://siol.net/trendi/ona-on"},{"text":"Dobrodelna licitacija","url":"https://zgodbe.siol.net/licitacija-ilustracij/"},{"text":"Odmrznimo Slovenijo","url":"https://siol.net/kljucne-besede/odmrznimo-slovenijo-106577/articles"},{"text":"Dober vid","url":"https://siol.net/trendi/zdravo-zivljenje/dober-vid"},{"text":"Nakup avtomobila","url":"https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"},{"text":"Pravni nasvet","url":"https://siol.net/kljucne-besede/pravni-nasvet-60118/articles"},{"text":"Vizija rasti","url":"https://siol.net/kljucne-besede/vizija-rasti-103625/articles"},{"text":"Gremo v nov dom","url":"https://siol.net/kljucne-besede/gremo-v-nov-dom-106101/articles"}],"main":[{"title":"Novice","url":"https://siol.net/novice","links":[{"text":"Slovenija","url":"https://siol.net/novice/slovenija"},{"text":"Evropa in svet","url":"https://siol.net/novice/svet"},{"text":"Digisvet","url":"https://siol.net/novice/digisvet"},{"text":"Posel danes","url":"https://siol.net/novice/posel-danes"},{"text":"Kronika","url":"https://siol.net/novice/crna-kronika"}],"projects":[{"text":"Aktivno državljanstvo","url":"https://siol.net/kljucne-besede/aktivno-drzavljanstvo-102165/articles"},{"text":"Zdravje za jutri","url":"https://siol.net/novice/zdravje-za-jutri"},{"text":"Finančni nasveti","url":"https://siol.net/novice/financni-nasveti"}]},{"title":"Sportal","url":"https://siol.net/sportal","links":[{"text":"Nogomet","url":"https://siol.net/sportal/nogomet"},{"text":"Košarka","url":"https://siol.net/sportal/kosarka"},{"text":"Kolesarstvo","url":"https://siol.net/sportal/kolesarstvo"},{"text":"Rokomet","url":"https://siol.net/sportal/rokomet"},{"text":"Zima","url":"https://siol.net/sportal/zimski-sporti"},{"text":"Hokej","url":"https://siol.net/sportal/hokej"},{"text":"Tenis","url":"https://siol.net/sportal/tenis"},{"text":"Odbojka","url":"https://siol.net/sportal/odbojka"},{"text":"Atletika","url":"https://siol.net/sportal/atletika"},{"text":"Moto","url":"https://siol.net/sportal/avtomotosport"},{"text":"Drugo","url":"https://siol.net/sportal/drugi-sporti"}],"projects":[{"text":"Luka Dončić","url":"https://siol.net/kljucne-besede/luka-doncic-12996/articles"},{"text":"Prva liga","url":"https://siol.net/sportal/nogomet/prva-liga"},{"text":"Liga prvakov","url":"https://siol.net/kljucne-besede/uefa-liga-prvakov-74204/articles"},{"text":"Konferenčna liga","url":"https://siol.net/kljucne-besede/konferencna-liga-87031/articles"},{"text":"Sobotni intervju","url":"https://siol.net/kljucne-besede/sobotni-intervju-11361/articles"},{"text":"Druga kariera","url":"https://siol.net/kljucne-besede/druga-kariera-75383/articles"},{"text":"Prek meja","url":"https://siol.net/kljucne-besede/prek-meja-104215/articles"},{"text":"Naj planinska koča","url":"https://siol.net/sportal/naj-planinska-koca"},{"text":"Rekreacija","url":"https://siol.net/sportal/rekreacija"}]},{"title":"Trendi","url":"https://siol.net/trendi","links":[{"text":"Glasba in film","url":"https://siol.net/trendi/glasba-in-film"},{"text":"Slavni","url":"https://siol.net/trendi/zvezde-in-slavni"},{"text":"Moda in lepota","url":"https://siol.net/trendi/moda-in-lepota"},{"text":"Zdravo življenje","url":"https://siol.net/trendi/zdravo-zivljenje"},{"text":"Kulinarika","url":"https://siol.net/trendi/kulinarika"},{"text":"Dom","url":"https://siol.net/trendi/dom"},{"text":"Zanimivosti","url":"https://siol.net/trendi/zanimivosti"}],"projects":[{"text":"Vedeževanje","url":"https://siol.net/trendi/vedezevanje"},{"text":"Hišni ljubljenčki","url":"https://siol.net/kljucne-besede/hisni-ljubljencki-29065/articles"},{"text":"Ona-On.com","url":"https://siol.net/trendi/ona-on"},{"text":"TV-spored","url":"https://tv-spored.siol.net/"},{"text":"Potovanja","url":"https://siol.net/trendi/potovanja"},{"text":"Horoskop","url":"https://siol.net/horoskop/dnevni"},{"text":"Trajnost","url":"https://siol.net/kljucne-besede/trajnost-19357/articles"}]},{"title":"Avtomoto","url":"https://siol.net/avtomoto","links":[{"text":"Novice","url":"https://siol.net/avtomoto/novice"},{"text":"Promet","url":"https://siol.net/avtomoto/promet"},{"text":"E-avtomoto","url":"https://siol.net/avtomoto/e-avtomoto"},{"text":"Testi","url":"https://siol.net/avtomoto/testi"},{"text":"Prva vožnja","url":"https://siol.net/avtomoto/prva-voznja"},{"text":"Nasveti","url":"https://siol.net/avtomoto/nasveti"},{"text":"Tehnika","url":"https://siol.net/avtomoto/tehnika"},{"text":"Zgodbe","url":"https://siol.net/avtomoto/zgodbe"}],"projects":[{"text":"E-mobilnost","url":"https://siol.net/kljucne-besede/e-mobilnost-66251/articles"},{"text":"Nakup avtomobila","url":"https://siol.net/kljucne-besede/nakup-avtomobila-20084/articles"}]},{"title":"Kolumne","url":"https://siol.net/mnenja","links":[{"text":"Kolumne","url":"https://siol.net/mnenja/kolumne"},{"text":"Intervjuji","url":"https://siol.net/mnenja/intervjuji"}],"projects":[]},{"title":"Spotkast","url":"https://siol.net/kljucne-besede/spotkast-102419/articles","links":[],"projects":[]},{"title":"S.Nepremičnine","url":"https://nepremicnine.siol.net/","links":[{"text":"Aktualno","url":"https://nepremicnine.siol.net/"},{"text":"Iskanje","url":"https://nepremicnine.siol.net/iskanje/prodaja"},{"text":"Novice","url":"https://nepremicnine.siol.net/novice"},{"text":"Objavi oglas","url":"https://nepremicnine.siol.net/userarea/post-listing"},{"text":"Novogradnje","url":"https://nepremicnine.siol.net/novogradnje"}],"projects":[{"text":"Ljubljana","url":"https://nepremicnine.siol.net/iskanje/prodaja/ljubljana"},{"text":"Maribor","url":"https://nepremicnine.siol.net/iskanje/prodaja/podravska/maribor"},{"text":"Obala","url":"https://nepremicnine.siol.net/iskanje/prodaja/obala"},{"text":"Celje","url":"https://nepremicnine.siol.net/iskanje/prodaja/savinjska/celje"},{"text":"Kranj","url":"https://nepremicnine.siol.net/iskanje/prodaja/gorenjska/kranj"}]},{"title":"VideoS.pot","url":"https://videospot.siol.net/","links":[],"projects":[]}],"telekom":{"title":"TELEKOM SLOVENIJE","icons":[{"icon":"basket","url":"https://www.telekom.si/etrgovina?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-etrgovina\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-etrgovina"},{"icon":"email","url":"https://prijava.siol.net/posta/?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-posta\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-posta"},{"icon":"cog","url":"https://moj.telekom.si/sl/Profile/Login?utm_source=siolnet-eksnet\u0026utm_medium=zav-nav-ikona-mt\u0026utm_term=naslovnica\u0026utm_campaign=zav-nav-ikona-mt"}],"links":[{"text":"Spletna TV neo.io","url":"https://neo.io/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"NEO","url":"https://www.telekom.si/neo?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=neo\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mobilni paketi","url":"https://www.telekom.si/mobilno?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=mobilni_paketi\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Internet","url":"https://www.telekom.si/internet?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=internet\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Program zvestobe","url":"https://www.telekom.si/program-zvestobe?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=program_zvestobe\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-trgovina","url":"https://www.telekom.si/e-trgovina?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=etrgovina\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Moj Telekom","url":"https://moj.telekom.si/?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=moj_telekom\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Mala podjetja","url":"https://www.telekom.si/mala-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_mala_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Velika podjetja","url":"https://www.telekom.si/velika-podjetja?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=poslovni_velika_podjetja\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"E-oskrba","url":"https://www.telekom.si/e-oskrba?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=e_oskrba\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Spletna pošta","url":"https://prijava.siol.net/posta?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=spletna_posta\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Pomoč","url":"https://www.telekom.si/pomoc?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=pomoc\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Info in obvestila","url":"https://www.telekom.si/info-in-obvestila?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=info_in_obvestila\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Tehnik","url":"https://www.telekom.si/tehnik?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=tehnik\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"},{"text":"Želite prejemati e-novice?","url":"https://www.telekom.si/e-novice?utm_source=siolnet\u0026utm_medium=text\u0026utm_campaign=enovice\u0026utm_id=29112023_internal\u0026utm_term=ekskluziva\u0026utm_content=zgoraj"}],"news":{"title":"","description":"Uživajmo pametno","image":"https://siol.net/media/img/42/e7/8b2ee38d26be102d4040.jpeg","url":"https://www.telekom.si/uzivajmo-pametno?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=digi_star%C5%A1_image_mc225\u0026utm_id=12082024_internal\u0026utm_content=380x247"},"logo":{"url":"https://www.telekom.si/zasebni-uporabniki/?utm_source=siolnet\u0026utm_medium=logo\u0026utm_campaign=telekom\u0026utm_term=ekskluziva\u0026utm_content=zavihek"}},"extra":[{"text":"Zadnje novice","url":"https://siol.net/pregled-dneva"},{"text":"TV spored","url":"https://tv-spored.siol.net/"},{"text":"Horoskop","url":"https://siol.net/horoskop"},{"text":"Vreme","url":"https://vreme.siol.net/"}],"corpo":[{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://www.itis.si/"},{"text":"1188","url":"https://www.1188.si/"}],"social":[{"icon":"facebook","url":"https://www.facebook.com/SiOL.net.Novice"},{"icon":"x","url":"https://twitter.com/siolnews"},{"icon":"instagram","url":"https://www.instagram.com/siol.net_novice/"},{"icon":"youtube","url":"https://www.youtube.com/channel/UCoN9YgUHTqLBvVEFRH_HVaQ"},{"icon":"linkedin","url":"https://www.linkedin.com/company/tsmedia-d-o-o-/"},{"icon":"pinterest","url":"https://www.pinterest.com/Siolnet/"}]},"articles":[{"image":"https://siol.net/media/img/86/5c/30cad26c7f3db1193027.jpeg","title":"Ti znaki horoskopa imajo največ sreče pri igranju lota","url":"https://siol.net/trendi/horoskop/ti-znaki-horoskopa-imajo-najvec-srece-pri-igranju-lota-652335","sponsor":0},{"image":"https://siol.net/media/img/70/77/215ef27f31dc4cc3c2ff.jpeg","title":"Netflix zaradi požarov preložil premiero oddaje z Meghan Markle","url":"https://siol.net/trendi/glasba-in-film/netflix-zaradi-pozarov-prelozil-premiero-oddaje-z-meghan-markle-652730","sponsor":0},{"image":"https://siol.net/media/img/b8/1d/9070934b6e8ab90955a5.jpeg","title":"Začnite dan z vadbo, ki osvaja Slovenijo","url":"https://siol.net/trendi/zdravo-zivljenje/zacnite-dan-z-vadbo-ki-osvaja-slovenijo-652541","sponsor":0},{"image":"https://siol.net/media/img/a0/d2/402020c0d4e8c9634817.jpeg","title":"Balkanska zvezdnica potrdila, da je noseča","url":"https://siol.net/trendi/zvezde-in-slavni/balkanska-zvezdnica-potrdila-da-je-noseca-652698","sponsor":0},{"image":"https://siol.net/media/img/74/dc/a7b23a48ae5cf85a8179.jpeg","title":"Umrl legendarni fotograf Oliviero Toscani","url":"https://siol.net/trendi/zvezde-in-slavni/umrl-legendarni-fotograf-oliviero-toscani-652685","sponsor":0},{"image":"https://siol.net/media/img/c0/8b/35834ce15aeb7696cb09.jpeg","title":"To je nova mis Slovenije, prihaja s Krasa","url":"https://siol.net/trendi/moda-in-lepota/to-je-nova-mis-slovenije-prihaja-s-krasa-652680","sponsor":0},{"image":"https://siol.net/media/img/be/55/a656568a2080893f004a.jpg","title":"Stoli, ki združujejo udobje in prestiž","url":"https://siol.net/trendi/dom/stoli-ki-zdruzujejo-udobje-in-prestiz-652436","sponsor":0},{"image":"https://siol.net/media/img/ca/4c/d5fb440310620e2b02a8.jpeg","title":"Horoskop: kakšna je vaša tedenska napoved?","url":"https://siol.net/trendi/odnosi/horoskop-kaksna-je-vasa-tedenska-napoved-540773","sponsor":0}],"telekom3":[{"title":"NAI darila","description":"Izdelki po akcijskih cenah.","image":"https://siol.net/media/img/e6/2d/78b773875a07b588d2a8-ts-pz-kv-december-banner-saj-v2-600x160.jpeg","url":"https://www.telekom.si/e-trgovina/posebna-ponudba/naj-darila?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160"},{"title":"Točke zvestobe","description":"Preveri ugodnosti.","image":"https://siol.net/media/img/14/c5/9ad361fbfd93e79a6ecb-600x160-pz.jpeg","url":"https://www.telekom.si/program-zvestobe/ugodnosti-programa-zvestobe?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=pz_sept_mc214\u0026utm_id=4092024_internal\u0026utm_term=siol-ao\u0026utm_content=160x600"},{"title":"E-trgovina","description":"NAI darila po akcijskih cenah.","image":"https://siol.net/media/img/45/07/6caf4e8909017ff18d16-ts-pz-kv-december-banner-saj-v2-brez-600x160.jpeg","url":"https://najdarilo.telekom.si/?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160"}],"footer":{"corpoline":[{"text":"Bizi","url":"https://www.bizi.si/"},{"text":"Najdi.si","url":"https://www.najdi.si/"},{"text":"Itis.si","url":"https://itis.siol.net/"},{"text":"1188","url":"https://www.1188.si/"}],"social":[{"icon":"facebook","url":"https://www.facebook.com/SiOL.net.Novice"},{"icon":"instagram","url":"https://www.instagram.com/siol.net_novice/"},{"icon":"twitter","url":"https://twitter.com/siolnews"}],"company":"TSmedia, medijske vsebine in storitve, d.o.o.,\u003cbr\u003eCigaletova 15, 1000 Ljubljana,\u003cbr\u003eT: +386 1 473 00 10","copyright":"© TSmedia, medijske vsebine in storitve, d. o. o.\u003cbr\u003eVse pravice pridržane 1997-2024.","links":[{"text":"Podjetje","url":"https://www.tsmedia.si/"},{"text":"Upravljanje soglasij","url":"javascript:Didomi.preferences.show()"},{"text":"Oglaševanje","url":"https://www.tsmedia.si/siol-net"},{"text":"Pogoji uporabe","url":"https://siol.net/pogoji-uporabe"},{"text":"Mobilna aplikacija","url":"https://siol.net/mobilna-aplikacija"},{"text":"Kontakti uredništva","url":"https://siol.net/kolofon"},{"text":"Varstvo osebnih podatkov","url":"https://siol.net/varstvo-osebnih-podatkov"},{"text":"Prijava na E-novice","url":"https://siol.net/e-novice"},{"text":"RSS","url":"https://siol.net/feeds/latest"}]}}}],["$","$L28",null,{"tvChannelsAsJson":[{"externalId":"SLO1","name":"TV SLO 1","category":"Informational","description":null},{"externalId":"SLO2","name":"TV SLO 2","category":"Informational","description":null},{"externalId":"POPTV","name":"POP TV","category":"Informational","description":null},{"externalId":"AKANAL","name":"Kanal A","category":"Movie","description":null},{"externalId":"PLANETTV","name":"Planet","category":"Informational","description":null},{"externalId":"ARENAPREMIUM","name":"Arena Sport 1 Premium","category":"Sport","description":null},{"externalId":"ARENASLO1","name":"Arena Sport 1","category":"Sport","description":null},{"externalId":"EUROSPORT","name":"Eurosport 1","category":"Sport","description":null},{"externalId":"DISCOVERYHDD","name":"Discovery Channel HD","category":"Documentry","description":null},{"externalId":"NATGEO","name":"National Geographic","category":"Documentry","description":null},{"externalId":"FOX","name":"STAR Channel","category":"Movie","description":null},{"externalId":"FOXLIFE","name":"STAR Life","category":"Movie","description":null},{"externalId":"PLANET2","name":"Planet 2","category":"Fun","description":null},{"externalId":"HBO","name":"HBO","category":"Movie","description":null},{"externalId":"DIZI","name":"Dizi","category":"Fun","description":null},{"externalId":"CARLITV","name":"Veseljak Golica","category":"Fun","description":null},{"externalId":"GOLD","name":"Gold TV","category":"Fun","description":null},{"externalId":"ARENATV","name":"Arena TV","category":"Fun","description":null},{"externalId":"TVPETELIN","name":"AKTUAL TV","category":"Fun","description":null},{"externalId":"NATGEOW","name":"National Geographic Wild","category":"Documentry","description":null},{"externalId":"ANIMALHD","name":"Animal Planet HD","category":"Documentry","description":null},{"externalId":"DISCTLC","name":"Discovery TLC","category":"Documentry","description":null},{"externalId":"DISCIDX","name":"Discovery ID Xtra","category":"Documentry","description":null},{"externalId":"DOXTV","name":"DOX TV","category":"Documentry","description":null},{"externalId":"TRAVELXPHD","name":"Travelxp HD","category":"Documentry","description":null},{"externalId":"TRAVELXP4K","name":"Travelxp 4K","category":"Documentry","description":null},{"externalId":"PLANETEARTHSD","name":"Planet Earth","category":"Documentry","description":null},{"externalId":"DOCUBOX","name":"DocuBox","category":"Documentry","description":null},{"externalId":"HISTORY","name":"Viasat History","category":"Documentry","description":null},{"externalId":"BBCEARTH","name":"BBC Earth","category":"Documentry","description":null},{"externalId":"HISTORYCH","name":"History Channel","category":"Documentry","description":null},{"externalId":"H2","name":"H2","category":"Documentry","description":null},{"externalId":"DAVINCILEAR","name":"Da Vinci Learning","category":"Documentry","description":null},{"externalId":"TRAVEL","name":"Travel Channel","category":"Documentry","description":null},{"externalId":"VIANATURE","name":"Viasat Nature","category":"Documentry","description":null},{"externalId":"EXPLORE","name":"Viasat Explore","category":"Documentry","description":null},{"externalId":"CURIOSITY","name":"Curiosity Channel","category":"Documentry","description":null},{"externalId":"BALKANTRIP","name":"Balkan trip","category":"Documentry","description":null},{"externalId":"HBO2","name":"HBO 2","category":"Movie","description":null},{"externalId":"HBO3","name":"HBO 3","category":"Movie","description":null},{"externalId":"CINEMAX1","name":"Cinemax","category":"Movie","description":null},{"externalId":"CINEMAX2","name":"Cinemax 2","category":"Movie","description":null},{"externalId":"FOXCRIME","name":"STAR Crime","category":"Movie","description":null},{"externalId":"FOXMOVIES","name":"STAR Movies","category":"Movie","description":null},{"externalId":"PICKBOXTV","name":"Pickbox TV","category":"Movie","description":null},{"externalId":"TV1000","name":"TV 1000","category":"Movie","description":null},{"externalId":"POPKINO","name":"Kino","category":"Movie","description":null},{"externalId":"BRIO","name":"Brio","category":"Movie","description":null},{"externalId":"CINESTARTV","name":"Cinestar TV 1","category":"Movie","description":null},{"externalId":"CINESTARTV2","name":"Cinestar TV 2","category":"Movie","description":null},{"externalId":"CINESTARACTION","name":"CineStar TV Action \u0026 Thriller","category":"Movie","description":null},{"externalId":"CINESTARFANTASY","name":"Cinestar Fantasy","category":"Movie","description":null},{"externalId":"CINESTARPR1","name":"CineStar TV Premiere 1","category":"Movie","description":null},{"externalId":"CINESTARPR2","name":"CineStar TV Premiere 2","category":"Movie","description":null},{"externalId":"BBCFIRSTHD_","name":"BBC First HD","category":"Movie","description":null},{"externalId":"KLASIKTV","name":"Klasik","category":"Movie","description":null},{"externalId":"MGM","name":"AMC","category":"Movie","description":null},{"externalId":"HALLMARK","name":"Diva","category":"Movie","description":null},{"externalId":"PINKSERIJE","name":"Pink Serije","category":"Movie","description":null},{"externalId":"PINKFILM","name":"Pink Film","category":"Movie","description":null},{"externalId":"EPICDRAMA","name":"Epic Drama","category":"Movie","description":null},{"externalId":"SCIFI","name":"SciFi","category":"Movie","description":null},{"externalId":"FILMBOX_PREMIUM","name":"FilmBox Premium","category":"Movie","description":null},{"externalId":"FILMBOX_EXTRA","name":"FilmBox Extra","category":"Movie","description":null},{"externalId":"FILMBOX_STARS","name":"FilmBox Stars","category":"Movie","description":null},{"externalId":"DOQ","name":"24Kitchen","category":"Fun","description":null},{"externalId":"KITCHENTV","name":"Kitchen TV","category":"Fun","description":null},{"externalId":"EEUROPE","name":"E!","category":"Fun","description":null},{"externalId":"PLANETPLUS","name":"Planet Eva","category":"Fun","description":null},{"externalId":"PINKSI","name":"TV3","category":"Fun","description":null},{"externalId":"FASHIONHD","name":"Fashion HD","category":"Fun","description":null},{"externalId":"FASHION","name":"Fashion TV","category":"Fun","description":null},{"externalId":"DRFIT","name":"Dr. Fit","category":"Fun","description":null},{"externalId":"WOMAN","name":"Woman","category":"Fun","description":null},{"externalId":"ARTE","name":"Arte","category":"Fun","description":null},{"externalId":"RTL","name":"RTL","category":"Fun","description":null},{"externalId":"RTL2","name":"RTL II","category":"Fun","description":null},{"externalId":"SUPERRTL","name":"Super RTL","category":"Fun","description":null},{"externalId":"KABEL1","name":"Kabel 1","category":"Fun","description":null},{"externalId":"VOX","name":"VOX","category":"Fun","description":null},{"externalId":"SAT1","name":"SAT 1","category":"Fun","description":null},{"externalId":"PRO7","name":"Pro7","category":"Fun","description":null},{"externalId":"3SAT","name":"3sat","category":"Fun","description":null},{"externalId":"NTV","name":"n-tv","category":"Fun","description":null},{"externalId":"TVE","name":"TVE","category":"Fun","description":null},{"externalId":"TV5","name":"TV5MONDE","category":"Fun","description":null},{"externalId":"MEDIAINTER","name":"Mediaset Italia","category":"Fun","description":null},{"externalId":"INFOTV","name":"Top TV","category":"Fun","description":null},{"externalId":"PINKSLO","name":"PINK SI","category":"Fun","description":null},{"externalId":"EWTN","name":"EWTN","category":"Fun","description":null},{"externalId":"LHTV","name":"LH TV HD","category":"Fun","description":null},{"externalId":"PINK","name":"Pink Plus","category":"Fun","description":null},{"externalId":"PINKZABAVA","name":"Pink Zabava","category":"Fun","description":null},{"externalId":"PINKREALITY","name":"Pink Reality","category":"Fun","description":null},{"externalId":"PINKSHOW","name":"Pink Show","category":"Fun","description":null},{"externalId":"HGTV","name":"HGTV","category":"Fun","description":null},{"externalId":"HAPPY_PUPPY","name":"Happy Puppy","category":"Fun","description":null},{"externalId":"DOGTV","name":"Dog TV","category":"Fun","description":null},{"externalId":"FILMBOX_ARTHOUSE","name":"FilmBox Arthouse","category":"Fun","description":null},{"externalId":"FASHIONBOX","name":"FashionBox","category":"Fun","description":null},{"externalId":"FAST_AND_FUNBOX","name":"Fast and FunBox","category":"Fun","description":null},{"externalId":"FUNBOX","name":"FunBox","category":"Fun","description":null},{"externalId":"MUSEUMHD","name":"Museum HD","category":"Fun","description":null},{"externalId":"MINIMAX","name":"Minimax","category":"ForKids","description":null},{"externalId":"POPOTO","name":"OTO","category":"ForKids","description":null},{"externalId":"BABYTV","name":"Baby TV","category":"ForKids","description":null},{"externalId":"NICKLEODEON","name":"Nickelodeon","category":"ForKids","description":null},{"externalId":"CARTOON","name":"Cartoon","category":"ForKids","description":null},{"externalId":"BOOMERANG","name":"Cartoonito","category":"ForKids","description":null},{"externalId":"JIMJAM","name":"JimJam","category":"ForKids","description":null},{"externalId":"DISNEY","name":"Disney Channel","category":"ForKids","description":null},{"externalId":"DISNEYJR","name":"Disney Junior","category":"ForKids","description":null},{"externalId":"NICKJR1","name":"Nick Jr.","category":"ForKids","description":null},{"externalId":"NICKTOONS","name":"NickToons","category":"ForKids","description":null},{"externalId":"RTLKOCKICA_","name":"RTL Kockica","category":"ForKids","description":null},{"externalId":"ARENASLO2","name":"Arena Sport 2","category":"Sport","description":null},{"externalId":"ARENASLO3","name":"Arena Sport 3","category":"Sport","description":null},{"externalId":"ARENASLO4","name":"Arena Sport 4","category":"Sport","description":null},{"externalId":"SPORTTV","name":"Šport TV 1","category":"Sport","description":null},{"externalId":"SPORTTV2","name":"Šport TV 2","category":"Sport","description":null},{"externalId":"SPORTTV3","name":"Šport TV 3","category":"Sport","description":null},{"externalId":"EUROSPORT2","name":"Eurosport 2","category":"Sport","description":null},{"externalId":"ARENAFIGHT","name":"Arena Fight","category":"Sport","description":null},{"externalId":"TVARENAESPORT","name":"Arena eSport","category":"Sport","description":null},{"externalId":"GAMETOON","name":"Gametoon","category":"Sport","description":null},{"externalId":"FIGHTBOX","name":"FightBox","category":"Sport","description":null},{"externalId":"EXTREME","name":"Extreme TV","category":"Sport","description":null},{"externalId":"MOTORVISIONTV","name":"Motorvision+","category":"Sport","description":null},{"externalId":"TRACESPORT","name":"Trace Sport","category":"Sport","description":null},{"externalId":"YACHTSAIL","name":"Nautical Channel","category":"Sport","description":null},{"externalId":"PINKFOLK2","name":"Pink Folk 2","category":"Music","description":null},{"externalId":"PINKKONCERT","name":"Pink Koncert","category":"Music","description":null},{"externalId":"PINKNROLL","name":"Pink\'n\'Roll","category":"Music","description":null},{"externalId":"MTVLIVEHD","name":"MTV HD","category":"Music","description":null},{"externalId":"VH1","name":"MTV 00s","category":"Local","description":null},{"externalId":"CMC","name":"CMC","category":"Music","description":null},{"externalId":"JUGOTONTV","name":"Jugoton","category":"Music","description":null},{"externalId":"MTVH","name":"MTV Hits","category":"Music","description":null},{"externalId":"MTVDANCE","name":"Club MTV","category":"Music","description":null},{"externalId":"TRACE","name":"Trace Urban","category":"Music","description":null},{"externalId":"MTV2","name":"MTV 90s","category":"Music","description":null},{"externalId":"VH1CLA","name":"MTV 80s","category":"Local","description":null},{"externalId":"MEZZO","name":"Mezzo","category":"Music","description":null},{"externalId":"PINKMUSIC","name":"Pink Music","category":"Music","description":null},{"externalId":"DMTV","name":"DM SAT","category":"Music","description":null},{"externalId":"PINKEXTRA","name":"Pink Extra","category":"Music","description":null},{"externalId":"PINKFOLK","name":"Pink Folk","category":"Music","description":null},{"externalId":"ADRIA","name":"Adria","category":"Music","description":null},{"externalId":"FOLX","name":"Folx","category":"Music","description":null},{"externalId":"ONEADRIA","name":"One Adria","category":"Music","description":null},{"externalId":"MEZZOLIVEHD","name":"Mezzo Live HD","category":"Music","description":null},{"externalId":"TVGOLICA","name":"TV Zlati zvoki","category":"Music","description":null},{"externalId":"PRVATVHD","name":"PRVA TV","category":"Music","description":null},{"externalId":"PAPRIKA","name":"BEST TV","category":"Music","description":null},{"externalId":"360_TUNEBOX","name":"360 TuneBox","category":"Music","description":null},{"externalId":"TV8","name":"Tv8","category":"Local","description":null},{"externalId":"NET","name":"NET TV","category":"Local","description":null},{"externalId":"VASKANAL","name":"Vaš kanal","category":"Local","description":null},{"externalId":"PTUJTV","name":"Ptujska TV","category":"Local","description":null},{"externalId":"SIPTV","name":"SIP TV","category":"Local","description":null},{"externalId":"TVAS","name":"TV As","category":"Local","description":null},{"externalId":"RTSM","name":"RTS Maribor","category":"Local","description":null},{"externalId":"VTV","name":"VTV","category":"Local","description":null},{"externalId":"BKTV","name":"BK TV","category":"Local","description":null},{"externalId":"TVCELJE","name":"TV Celje","category":"Local","description":null},{"externalId":"IDEATV","name":"Kanal 10 / Idea TV","category":"Local","description":null},{"externalId":"GALEJATV","name":"TV Galeja HD","category":"Local","description":null},{"externalId":"ANSATTV","name":"ePosavje TV","category":"Local","description":null},{"externalId":"EXODUSTV","name":"Exodus TV","category":"Local","description":null},{"externalId":"MEGAFONTV","name":"Megafon TV HD","category":"Local","description":null},{"externalId":"KOROSKATV","name":"KOROŠKA TV","category":"Local","description":null},{"externalId":"ZDRAVATV","name":"Zdrava TV","category":"Local","description":null},{"externalId":"ATMTVKG","name":"ATM TV Kranjska Gora HD","category":"Local","description":null},{"externalId":"TVRADGONA","name":"TV Radgona","category":"Local","description":null},{"externalId":"GEATV","name":"Gea TV","category":"Local","description":null},{"externalId":"TVNAKUPIHD","name":"TV nakupi HD","category":"Local","description":null},{"externalId":"LJTV","name":"Ljubljana TV HD","category":"Local","description":null},{"externalId":"RKANALP","name":"R Kanal+","category":"Local","description":null},{"externalId":"ORONTV","name":"Oron TV","category":"Local","description":null},{"externalId":"TVORMOZ","name":"Tv Ormož HD","category":"Local","description":null},{"externalId":"TVMIKLAVZHD","name":"TV Miklavž HD","category":"Local","description":null},{"externalId":"TVBELTINCI","name":"TV Beltinci","category":"Local","description":null},{"externalId":"SAVINJSKATV","name":"Savinjska TV","category":"Local","description":null},{"externalId":"TVVASCOM","name":"TV Vascom","category":"Local","description":null},{"externalId":"ETV","name":"ETV HD","category":"Local","description":null},{"externalId":"VITEL","name":"Vitel","category":"Local","description":null},{"externalId":"KICTVHD","name":"KIC TV","category":"Local","description":null},{"externalId":"TRZICTV","name":"Tržič TV","category":"Local","description":null},{"externalId":"SLO3","name":"TV SLO 3","category":"Informational","description":null},{"externalId":"NOVA24TV","name":"Nova 24 TV","category":"Informational","description":null},{"externalId":"NOVA24TV2","name":"Nova 24 TV 2","category":"Informational","description":null},{"externalId":"KOPER","name":"TV Koper Capodistria","category":"Informational","description":null},{"externalId":"TELEM","name":"Tele Maribor","category":"Informational","description":null},{"externalId":"HRT1","name":"HRT 1","category":"Informational","description":null},{"externalId":"HRT2","name":"HRT 2","category":"Informational","description":null},{"externalId":"HRT3","name":"HRT 3","category":"Informational","description":null},{"externalId":"OBNBOSNA","name":"OBN","category":"Informational","description":null},{"externalId":"RTS","name":"RT Srbija HD","category":"Informational","description":null},{"externalId":"RTCG","name":"MNE","category":"Informational","description":null},{"externalId":"RTK","name":"RTK","category":"Informational","description":null},{"externalId":"ALJAZEERA","name":"Al Jazeera Balkans","category":"Informational","description":null},{"externalId":"HAYAT","name":"Hayat","category":"Informational","description":null},{"externalId":"ELTATV","name":"ELTA TV","category":"Informational","description":null},{"externalId":"BNTV","name":"BN TV 2","category":"Informational","description":null},{"externalId":"CNN","name":"CNN","category":"Informational","description":null},{"externalId":"BBCWORLD","name":"BBC News","category":"Informational","description":null},{"externalId":"SKYNEWS","name":"Sky News","category":"Informational","description":null},{"externalId":"BLOOMBERGADRIA","name":"Bloomberg Adria","category":"Informational","description":null},{"externalId":"RAI1","name":"RAI 1","category":"Informational","description":null},{"externalId":"FRANCE24","name":"France 24","category":"Informational","description":null},{"externalId":"ZDF","name":"ZDF","category":"Informational","description":null},{"externalId":"ARD","name":"ARD","category":"Informational","description":null},{"externalId":"FOXNEWS","name":"Fox News","category":"Informational","description":null},{"externalId":"ORF1","name":"ORF 1","category":"Informational","description":null},{"externalId":"ORF2","name":"ORF 2","category":"Informational","description":null},{"externalId":"RAI2","name":"RAI 2","category":"Informational","description":null},{"externalId":"RAI3","name":"RAI 3","category":"Informational","description":null},{"externalId":"DUNA","name":"Duna World","category":"Informational","description":null},{"externalId":"ENAPLUSENA","name":"1+1 International","category":"Informational","description":null},{"externalId":"DOMKINO","name":"Dom Kino","category":"Informational","description":null},{"externalId":"TELECAFE","name":"Telecafe","category":"Informational","description":null},{"externalId":"VREMYA","name":"Vremya","category":"Informational","description":null},{"externalId":"MUZPERVOGO","name":"Muzika Pervogo","category":"Informational","description":null},{"externalId":"KAROUSEL","name":"Karousel","category":"Informational","description":null},{"externalId":"ICT","name":"ICTbusiness TV","category":"Informational","description":null},{"externalId":"RTLHRVATSKA2","name":"RTL 2 Hrvaška","category":"Balkan","description":null},{"externalId":"RTLHRVATSKA","name":"RTL Hrvaška","category":"Balkan","description":null},{"externalId":"RTLLIVING","name":"RTL Living","category":"Balkan","description":null},{"externalId":"OTVV","name":"OTV Valentino","category":"Balkan","description":null},{"externalId":"TRING7","name":"Tring 7","category":"Balkan","description":null},{"externalId":"TRINGM","name":"Tring Max","category":"Balkan","description":null},{"externalId":"TRINGS","name":"Tring Shqip","category":"Balkan","description":null},{"externalId":"TRINGT","name":"Tring Tring","category":"Balkan","description":null},{"externalId":"TRINGVP","name":"Tring Vizion+","category":"Balkan","description":null},{"externalId":"PRVAMAX","name":"TV Prva Max","category":"Balkan","description":null},{"externalId":"PRVAWORLD","name":"TV Prva World","category":"Balkan","description":null},{"externalId":"ALTERNATIVA","name":"Elta 2","category":"Balkan","description":null},{"externalId":"FTV","name":"FTV","category":"Balkan","description":null},{"externalId":"KAKANJ","name":"NTV IC Kakanj","category":"Balkan","description":null},{"externalId":"FOLKP","name":"Folk Plus","category":"Balkan","description":null},{"externalId":"RTRS","name":"RTRS","category":"Balkan","description":null},{"externalId":"TV1","name":"O Kanal","category":"Balkan","description":null},{"externalId":"SARAJEVO","name":"TV Sarajevo","category":"Balkan","description":null},{"externalId":"ZDRAVA","name":"Zdrava Televizija","category":"Balkan","description":null},{"externalId":"PRVAFILES","name":"TV Prva Files","category":"Balkan","description":null},{"externalId":"PRVAKICK","name":"TV Prva Kick","category":"Balkan","description":null},{"externalId":"PRVAPLUS","name":"TV Prva Plus","category":"Balkan","description":null},{"externalId":"JABUKATV","name":"Jabuka (OTV)","category":"Balkan","description":null},{"externalId":"NARODNA","name":"Narodna TV","category":"Balkan","description":null},{"externalId":"ISTRA","name":"TV RI","category":"Balkan","description":null},{"externalId":"JADRAN","name":"TV Jadran","category":"Balkan","description":null},{"externalId":"Z1","name":"Z1 Televizija","category":"Balkan","description":null},{"externalId":"ALFA","name":"Alfa TV","category":"Balkan","description":null},{"externalId":"ALSATM","name":"Alsat Macedonia","category":"Balkan","description":null},{"externalId":"SONCETV","name":"Sonce TV","category":"Balkan","description":null},{"externalId":"HAPPYREALITY1","name":"Happy Reality 1","category":"Balkan","description":null},{"externalId":"MKTV1","name":"MTV 1","category":"Balkan","description":null},{"externalId":"MKTV2","name":"MTV 2","category":"Balkan","description":null},{"externalId":"MKTV3","name":"MTV 3","category":"Balkan","description":null},{"externalId":"NASATV","name":"NAŠA TV","category":"Balkan","description":null},{"externalId":"HAPPYREALITY2","name":"Happy Reality 2","category":"Balkan","description":null},{"externalId":"BIR","name":"BIR","category":"Balkan","description":null},{"externalId":"SITEL","name":"TV Sitel","category":"Balkan","description":null},{"externalId":"B92","name":"B92","category":"Balkan","description":null},{"externalId":"PRVALIFE","name":"TV Prva Life","category":"Balkan","description":null},{"externalId":"HAPPY","name":"Happy TV","category":"Balkan","description":null},{"externalId":"VIKOM","name":"Vikom","category":"Balkan","description":null},{"externalId":"KCN","name":"KCN 1","category":"Balkan","description":null},{"externalId":"KCNM","name":"KCN 2 (music)","category":"Balkan","description":null},{"externalId":"PRVASRB","name":"PRVA Srbska TV","category":"Balkan","description":null},{"externalId":"RTS1","name":"RTS 1","category":"Balkan","description":null},{"externalId":"RTS2","name":"RTS 2","category":"Balkan","description":null},{"externalId":"DUGANS","name":"TV Duga Novi sad","category":"Balkan","description":null},{"externalId":"SPBEOGRAD","name":"KCN 3 (svet+)","category":"Balkan","description":null},{"externalId":"BHT1_","name":"BHT1","category":"Balkan","description":null},{"externalId":"ELTAHD","name":"ELTA HD","category":"Balkan","description":null},{"externalId":"HEMA","name":"Hema","category":"Balkan","description":null},{"externalId":"RTCG2","name":"RTCG 2","category":"Balkan","description":null},{"externalId":"SLONTV","name":"SLON TV extra","category":"Balkan","description":null},{"externalId":"24VESTI","name":"TV Vijesti","category":"Balkan","description":null},{"externalId":"24URM","name":"Televizija 24","category":"Balkan","description":null},{"externalId":"GLAMHD","name":"Glam HD","category":"Adult","description":null},{"externalId":"FOXYDOLLSHD","name":"Foxy Dolls HD","category":"Adult","description":null},{"externalId":"EXTREMEDE","name":"Extrem","category":"Adult","description":null},{"externalId":"HOTPLEASURE","name":"Hot Pleasure","category":"Adult","description":null},{"externalId":"BALKAN","name":"Balkan Erotic","category":"Adult","description":null},{"externalId":"PLAYBOYTV","name":"Playboy TV","category":"Adult","description":null},{"externalId":"SPICE","name":"Brazzers TV Europe","category":"Adult","description":null},{"externalId":"DORCEL","name":"Dorcel TV HD","category":"Adult","description":null},{"externalId":"DORCELHD","name":"Dorcel XXX HD","category":"Adult","description":null},{"externalId":"HUSTLERHD","name":"Hustler TV HD","category":"Adult","description":null},{"externalId":"PRIVATE","name":"Private TV","category":"Adult","description":null},{"externalId":"SUPERONEHD","name":"Super One HD","category":"Adult","description":null},{"externalId":"DUSKTV","name":"Dusk TV","category":"Adult","description":null},{"externalId":"SATISFACTIONITALY","name":"Redlight HD","category":"Adult","description":null},{"externalId":"SCTPRIVE","name":"CentoXCento","category":"Adult","description":null},{"externalId":"SCT","name":"Vivid Red HD","category":"Adult","description":null},{"externalId":"FREEX","name":"Pinko club","category":"Adult","description":null},{"externalId":"VIVIDTOUCH","name":"Vivid Touch","category":"Adult","description":null},{"externalId":"SEXATION","name":"Sexation","category":"Adult","description":null},{"externalId":"RKINGS","name":"Reality Kings TV","category":"Adult","description":null},{"externalId":"HUSTLER","name":"Hustler TV","category":"Adult","description":null},{"externalId":"HOTXXL","name":"Hot XXL","category":"Adult","description":null},{"externalId":"PASSIONXXXHD","name":"Passion XXX HD","category":"Adult","description":null},{"externalId":"EROX","name":"Erox","category":"Adult","description":null},{"externalId":"EROXXX","name":"Eroxxx","category":"Adult","description":null},{"externalId":"DEVILSHOMEHD","name":"Devils Home HD","category":"Adult","description":null},{"externalId":"CAPABLEHOLEHD","name":"Capable Hole HD","category":"Adult","description":null},{"externalId":"BOOBHD","name":"BooB HD","category":"Adult","description":null},{"externalId":"ANGELSHD","name":"Angels HD","category":"Adult","description":null},{"externalId":"MIXXXHD","name":"MIXXX HD","category":"Adult","description":null},{"externalId":"XXXTAZYHD","name":"XXXTAZY HD","category":"Adult","description":null}],"categoriesAsJson":[{"name":"dokumentarni","slug":"dokumentarni","subCategories":["akcija","animirani","avto-moto šport","biografija","dokumentarec","domišljijski","drama","družboslovje","družinski","fantazijski","glasba","gospodarstvo","informativna oddaja","intervju","komedija","koncert","kratki","kriminalka","kuharska oddaja","kultura","magazin","misterij","nadnaravno","narava","naravoslovje","otroška oddaja","pogovorna oddaja","politika","poljudnoznanstvena oddaja","potopis","predstava","prireditev","pustolovščina","reportaža","resničnostna oddaja","romantični","svetovalna oddaja","tehnika","triler","umetnost","verska oddaja","vojni","vzgojna oddaja","zabavna oddaja","zdravstvena vsebina","zgodovina","znanost","znanstvena fantastika","šport"],"subCategorySlugs":["akcija","animirani","avto-moto-sport","biografija","dokumentarec","domisljijski","drama","druzboslovje","druzinski","fantazijski","glasba","gospodarstvo","informativna-oddaja","intervju","komedija","koncert","kratki","kriminalka","kuharska-oddaja","kultura","magazin","misterij","nadnaravno","narava","naravoslovje","otroska-oddaja","pogovorna-oddaja","politika","poljudnoznanstvena-oddaja","potopis","predstava","prireditev","pustolovscina","reportaza","resnicnostna-oddaja","romanticni","sport","svetovalna-oddaja","tehnika","triler","umetnost","verska-oddaja","vojni","vzgojna-oddaja","zabavna-oddaja","zdravstvena-vsebina","zgodovina","znanost","znanstvena-fantastika"]},{"name":"film","slug":"film","subCategories":["akcija","amaterji","analni seks","animirani","biografija","dokumentarec","domišljijski","drama","družba","družboslovje","družinski","ekstremno","erotični","fantazijski","fetiš","glasba","grozljivka","humoristični","informativna oddaja","javni seks","komedija","koncert","kontaktna oddaja","kratki","kriminalka","kuharska oddaja","kultura","lepotice","m.i.l.f.","magazin","medrasno","misterij","moda","muzikal","nadnaravno","najstnice 18+","napovednik","narava","naravoslovje","orgije","otroška oddaja","otroški ali mladinski","ples","pogovorna oddaja","poljudnoznanstvena oddaja","potopis","predstava","prireditev","pustolovščina","reportaža","risanka","romantična komedija","romantični","samo dekleta","srhljivka","superheroji","tabu","triler","umetnost","verska oddaja","vestern","vojni","vzgojna oddaja","zabavna oddaja","zgodovina","znani in slavni","znanstvena fantastika","šport"],"subCategorySlugs":["akcija","amaterji","analni-seks","animirani","biografija","dokumentarec","domisljijski","drama","druzba","druzboslovje","druzinski","ekstremno","eroticni","fantazijski","fetis","glasba","grozljivka","humoristicni","informativna-oddaja","javni-seks","komedija","koncert","kontaktna-oddaja","kratki","kriminalka","kuharska-oddaja","kultura","lepotice","m.i.l.f.","magazin","medrasno","misterij","moda","muzikal","nadnaravno","najstnice-18","napovednik","narava","naravoslovje","orgije","otroska-oddaja","otroski-ali-mladinski","ples","pogovorna-oddaja","poljudnoznanstvena-oddaja","potopis","predstava","prireditev","pustolovscina","reportaza","risanka","romanticna-komedija","romanticni","samo-dekleta","sport","srhljivka","superheroji","tabu","triler","umetnost","verska-oddaja","vestern","vojni","vzgojna-oddaja","zabavna-oddaja","zgodovina","znani-in-slavni","znanstvena-fantastika"]},{"name":"informativni","slug":"informativni","subCategories":["animirani","biografija","dnevno-informativna oddaja","dokumentarec","domišljijski","drama","družboslovje","fantazijski","glasba","gospodarstvo","grozljivka","infokanal","informativna oddaja","intervju","komedija","kratki","kriminalka","kultura","magazin","misterij","naravoslovje","oglas","otroška oddaja","pogovorna oddaja","politika","potopis","prireditev","promet","reportaža","svetovalna oddaja","tehnika","triler","tv-prodaja","umetnost","verska oddaja","vreme","vzgojna oddaja","zabavna oddaja","zgodovina","šolska oddaja","šport"],"subCategorySlugs":["animirani","biografija","dnevno-informativna-oddaja","dokumentarec","domisljijski","drama","druzboslovje","fantazijski","glasba","gospodarstvo","grozljivka","infokanal","informativna-oddaja","intervju","komedija","kratki","kriminalka","kultura","magazin","misterij","naravoslovje","oglas","otroska-oddaja","pogovorna-oddaja","politika","potopis","prireditev","promet","reportaza","solska-oddaja","sport","svetovalna-oddaja","tehnika","triler","tv-prodaja","umetnost","verska-oddaja","vreme","vzgojna-oddaja","zabavna-oddaja","zgodovina"]},{"name":"izobraževalni","slug":"izobrazevalni","subCategories":["dokumentarec","družboslovje","glasba","gospodarstvo","informativna oddaja","komedija","kratki","kuharska oddaja","magazin","naravoslovje","otroška oddaja","pogovorna oddaja","potopis","pustolovščina","reportaža","resničnostna oddaja","romantični","svetovalna oddaja","tv-prodaja","verska oddaja","vzgojna oddaja","zabavna oddaja","zgodovina"],"subCategorySlugs":["dokumentarec","druzboslovje","glasba","gospodarstvo","informativna-oddaja","komedija","kratki","kuharska-oddaja","magazin","naravoslovje","otroska-oddaja","pogovorna-oddaja","potopis","pustolovscina","reportaza","resnicnostna-oddaja","romanticni","svetovalna-oddaja","tv-prodaja","verska-oddaja","vzgojna-oddaja","zabavna-oddaja","zgodovina"]},{"name":"kultura-umetnost","slug":"kultura-umetnost","subCategories":["dokumentarec","domišljijski","drama","družba","fantazijski","glasba","humoristični","izobraževalna oddaja","književnost","komedija","koncert","kratki","kultura","kviz","magazin","moda","opera","otroška oddaja","otroški ali mladinski","ples","predstava","prireditev","proslava","reportaža","risanka","romantični","umetnost","zabavna oddaja","šport"],"subCategorySlugs":["dokumentarec","domisljijski","drama","druzba","fantazijski","glasba","humoristicni","izobrazevalna-oddaja","knjizevnost","komedija","koncert","kratki","kultura","kviz","magazin","moda","opera","otroska-oddaja","otroski-ali-mladinski","ples","predstava","prireditev","proslava","reportaza","risanka","romanticni","sport","umetnost","zabavna-oddaja"]},{"name":"nadaljevanka-nanizanka","slug":"nadaljevanka-nanizanka","subCategories":["akcija","animirani","avto-moto šport","biografija","dokumentarec","domišljijski","drama","družboslovje","družinski","fantazijski","glasba","grozljivka","hbo produkcija","humoristični","informativna oddaja","komedija","kratki","kriminalka","kuharska oddaja","kultura","misterij","nadaljevanka","nadnaravno","nanizanka","narava","naravoslovje","otroška oddaja","otroški ali mladinski","politika","poljudnoznanstvena oddaja","potopis","pravna vsebina","pustolovščina","reportaža","resničnostna oddaja","risanka","romantični","srhljivka","superheroji","tehnika","telenovela","triler","vestern","vojni","vzgojna oddaja","zabavna oddaja","zdravstvena vsebina","zgodovina","znani in slavni","znanost","znanstvena fantastika","šport","življenjski slog"],"subCategorySlugs":["akcija","animirani","avto-moto-sport","biografija","dokumentarec","domisljijski","drama","druzboslovje","druzinski","fantazijski","glasba","grozljivka","hbo-produkcija","humoristicni","informativna-oddaja","komedija","kratki","kriminalka","kuharska-oddaja","kultura","misterij","nadaljevanka","nadnaravno","nanizanka","narava","naravoslovje","otroska-oddaja","otroski-ali-mladinski","politika","poljudnoznanstvena-oddaja","potopis","pravna-vsebina","pustolovscina","reportaza","resnicnostna-oddaja","risanka","romanticni","sport","srhljivka","superheroji","tehnika","telenovela","triler","vestern","vojni","vzgojna-oddaja","zabavna-oddaja","zdravstvena-vsebina","zgodovina","zivljenjski-slog","znani-in-slavni","znanost","znanstvena-fantastika"]},{"name":"ostalo","slug":"ostalo","subCategories":["amaterji","analni seks","animirani","dnevno-informativna oddaja","dokumentarec","drama","družboslovje","fetiš","glasba","grozljivka","humoristični","informativna oddaja","komedija","kosmatinke","kratki","lepotice","m.i.l.f.","magazin","misterij","moda","najstnice 18+","napovednik","oglas","orgije","politika","prireditev","romantični","stari \u0026 mladi","svetovalna oddaja","tabu","telenovela","triler","tv-prodaja","verska oddaja","verski obred","zabavna oddaja","zgodovina","znanstvena fantastika"],"subCategorySlugs":["amaterji","analni-seks","animirani","dnevno-informativna-oddaja","dokumentarec","drama","druzboslovje","fetis","glasba","grozljivka","humoristicni","informativna-oddaja","komedija","kosmatinke","kratki","lepotice","m.i.l.f.","magazin","misterij","moda","najstnice-18","napovednik","oglas","orgije","politika","prireditev","romanticni","stari-mladi","svetovalna-oddaja","tabu","telenovela","triler","tv-prodaja","verska-oddaja","verski-obred","zabavna-oddaja","zgodovina","znanstvena-fantastika"]},{"name":"otroški-mladinski","slug":"otroski-mladinski","subCategories":["akcija","animirani","dnevno-informativna oddaja","dokumentarec","domišljijski","drama","družboslovje","družinski","fantazijski","glasba","grozljivka","humoristični","informativna oddaja","izobraževalna oddaja","komedija","koncert","kontaktna oddaja","kratki","kriminalka","kuharska oddaja","kviz","magazin","misterij","nadnaravno","naravoslovje","naredi sam","otroška oddaja","otroški ali mladinski","ples","potopis","predstava","pustolovščina","resničnostna oddaja","risanka","romantični","triler","vojni","vzgojna oddaja","zabavna oddaja","zdravstvena vsebina","zgodovina","znanstvena fantastika","šolska oddaja","šport"],"subCategorySlugs":["akcija","animirani","dnevno-informativna-oddaja","dokumentarec","domisljijski","drama","druzboslovje","druzinski","fantazijski","glasba","grozljivka","humoristicni","informativna-oddaja","izobrazevalna-oddaja","komedija","koncert","kontaktna-oddaja","kratki","kriminalka","kuharska-oddaja","kviz","magazin","misterij","nadnaravno","naravoslovje","naredi-sam","otroska-oddaja","otroski-ali-mladinski","ples","potopis","predstava","pustolovscina","resnicnostna-oddaja","risanka","romanticni","solska-oddaja","sport","triler","vojni","vzgojna-oddaja","zabavna-oddaja","zdravstvena-vsebina","zgodovina","znanstvena-fantastika"]},{"name":"razvedrilni","slug":"razvedrilni","subCategories":["akcija","animirani","biografija","dnevno-informativna oddaja","dokumentarec","domišljijski","drama","družba","družboslovje","družinski","fantazijski","glasba","grozljivka","humoristični","igra na srečo","infokanal","informativna oddaja","književnost","komedija","koncert","kontaktna oddaja","kratki","kriminalka","kuharska oddaja","kultura","kviz","magazin","moda","nanizanka","narava","naravoslovje","naredi sam","otroška oddaja","otroški ali mladinski","ples","pogovorna oddaja","potopis","predstava","prireditev","pustolovščina","reportaža","resničnostna oddaja","romantični","svetovalna oddaja","tehnika","triler","tv-prodaja","umetnost","verska oddaja","vestern","zabavna oddaja","zdravstvena vsebina","zgodovina","znanstvena fantastika","šport","življenjski slog"],"subCategorySlugs":["akcija","animirani","biografija","dnevno-informativna-oddaja","dokumentarec","domisljijski","drama","druzba","druzboslovje","druzinski","fantazijski","glasba","grozljivka","humoristicni","igra-na-sreco","infokanal","informativna-oddaja","knjizevnost","komedija","koncert","kontaktna-oddaja","kratki","kriminalka","kuharska-oddaja","kultura","kviz","magazin","moda","nanizanka","narava","naravoslovje","naredi-sam","otroska-oddaja","otroski-ali-mladinski","ples","pogovorna-oddaja","potopis","predstava","prireditev","pustolovscina","reportaza","resnicnostna-oddaja","romanticni","sport","svetovalna-oddaja","tehnika","triler","tv-prodaja","umetnost","verska-oddaja","vestern","zabavna-oddaja","zdravstvena-vsebina","zgodovina","zivljenjski-slog","znanstvena-fantastika"]},{"name":"šport","slug":"sport","subCategories":["ameriški nogomet","avto-moto šport","biatlon","biljard","boks","borilni šport","deskanje na snegu","dnevno-informativna oddaja","dokumentarec","drama","drsanje","družinski","e-šport","ekstremni šport","golf","grozljivka","hokej","informativna oddaja","jadranje","kolesarstvo","konjeništvo","košarka","kratki","motokros","nogomet","odbojka","poker","reportaža","rokomet","smučanje","smučarski skoki","smučarski tek","tehnika","tenis","vaterpolo","šport"],"subCategorySlugs":["ameriski-nogomet","avto-moto-sport","biatlon","biljard","boks","borilni-sport","deskanje-na-snegu","dnevno-informativna-oddaja","dokumentarec","drama","drsanje","druzinski","e-sport","ekstremni-sport","golf","grozljivka","hokej","informativna-oddaja","jadranje","kolesarstvo","konjenistvo","kosarka","kratki","motokros","nogomet","odbojka","poker","reportaza","rokomet","smucanje","smucarski-skoki","smucarski-tek","sport","tehnika","tenis","vaterpolo"]},{"name":"za odrasle","slug":"za-odrasle","subCategories":["akcija","amaterji","analni seks","biografija","dokumentarec","domišljijski","drama","družinski","ekstremno","fantazijski","fetiš","g.i.l.f.","gej \u0026 trans","glasba","grozljivka","komedija","kosmatinke","kratki","kriminalka","lepotice","m.i.l.f.","magazin","malo mešano","medrasno","misterij","najstnice 18+","nanizanka","orgije","pustolovščina","romantični","samo dekleta","stari \u0026 mladi","tabu","triler","veliki joški","znanstvena fantastika"],"subCategorySlugs":["akcija","amaterji","analni-seks","biografija","dokumentarec","domisljijski","drama","druzinski","ekstremno","fantazijski","fetis","g.i.l.f.","gej-trans","glasba","grozljivka","komedija","kosmatinke","kratki","kriminalka","lepotice","m.i.l.f.","magazin","malo-mesano","medrasno","misterij","najstnice-18","nanizanka","orgije","pustolovscina","romanticni","samo-dekleta","stari-mladi","tabu","triler","veliki-joski","znanstvena-fantastika"]}]}],["$","div",null,{"className":"text-text desktop:container px-2 desktop:mx-auto desktop:p-0","children":[["$","$L21",null,{"id":"billboard1","className":"text-center"}],["$","div",null,{"id":"page_sponsors"}],["$","$L12",null,{"parallelRouterKey":"children","segmentPath":["children","(content)","children"],"loading":"$undefined","loadingStyles":"$undefined","loadingScripts":"$undefined","hasLoading":false,"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L17",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined","styles":null}],["$","div",null,{"className":"flex flex-col gap-2 tablet:grid tablet:grid-cols-3","children":[["$","$L20","https://www.telekom.si/e-trgovina/posebna-ponudba/naj-darila?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160",{"href":"https://www.telekom.si/e-trgovina/posebna-ponudba/naj-darila?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160","className":"text-center text-xs tablet:text-left","target":"_blank","children":[["$","img",null,{"className":"w-full h-[96px] mb-4 object-cover desktop:h-[109px]","src":"https://siol.net/media/img/e6/2d/78b773875a07b588d2a8-ts-pz-kv-december-banner-saj-v2-600x160.jpeg","alt":"NAI darila"}],["$","span",null,{"className":"font-bold","children":"NAI darila"}],["$","p",null,{"children":"Izdelki po akcijskih cenah."}]]}],["$","$L20","https://www.telekom.si/program-zvestobe/ugodnosti-programa-zvestobe?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=pz_sept_mc214\u0026utm_id=4092024_internal\u0026utm_term=siol-ao\u0026utm_content=160x600",{"href":"https://www.telekom.si/program-zvestobe/ugodnosti-programa-zvestobe?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=pz_sept_mc214\u0026utm_id=4092024_internal\u0026utm_term=siol-ao\u0026utm_content=160x600","className":"text-center text-xs tablet:text-left","target":"_blank","children":[["$","img",null,{"className":"w-full h-[96px] mb-4 object-cover desktop:h-[109px]","src":"https://siol.net/media/img/14/c5/9ad361fbfd93e79a6ecb-600x160-pz.jpeg","alt":"Točke zvestobe"}],["$","span",null,{"className":"font-bold","children":"Točke zvestobe"}],["$","p",null,{"children":"Preveri ugodnosti."}]]}],["$","$L20","https://najdarilo.telekom.si/?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160",{"href":"https://najdarilo.telekom.si/?utm_source=siolnet\u0026utm_medium=banner\u0026utm_campaign=_\u0026utm_id=5122024_internal\u0026utm_content=600x160","className":"text-center text-xs tablet:text-left","target":"_blank","children":[["$","img",null,{"className":"w-full h-[96px] mb-4 object-cover desktop:h-[109px]","src":"https://siol.net/media/img/45/07/6caf4e8909017ff18d16-ts-pz-kv-december-banner-saj-v2-brez-600x160.jpeg","alt":"E-trgovina"}],["$","span",null,{"className":"font-bold","children":"E-trgovina"}],["$","p",null,{"children":"NAI darila po akcijskih cenah."}]]}]]}]]}],[["$","div",null,{"className":"bg-gray desktop:bg-darker-gray mt-8 desktop:mt-10","children":["$","div",null,{"className":"p-2 flex flex-row gap-4 justify-between desktop:justify-normal desktop:container desktop:mx-auto desktop:px-0","children":[["$","div",null,{"className":"flex flex-row items-center gap-2 text-sm desktop:text-base desktop:grow","children":[["$","$L20","https://www.bizi.si/",{"href":"https://www.bizi.si/","children":"Bizi"}],["$","$L20","https://www.najdi.si/",{"href":"https://www.najdi.si/","children":"Najdi.si"}],["$","$L20","https://itis.siol.net/",{"href":"https://itis.siol.net/","children":"Itis.si"}],["$","$L20","https://www.1188.si/",{"href":"https://www.1188.si/","children":"1188"}]]}],["$","div",null,{"className":"flex flex-row gap-2 items-center","children":[["$","$L20","facebook",{"href":"https://www.facebook.com/SiOL.net.Novice","children":["$","i",null,{"className":"icon icon-facebook desktop:text-2xl"}]}],["$","$L20","instagram",{"href":"https://www.instagram.com/siol.net_novice/","children":["$","i",null,{"className":"icon icon-instagram desktop:text-2xl"}]}],["$","$L20","twitter",{"href":"https://twitter.com/siolnews","children":["$","i",null,{"className":"icon icon-x desktop:text-2xl"}]}]]}],["$","div",null,{"className":"flex flex-row pr-2","children":["$","$L20",null,{"className":"desktop:flex desktop:flex-rot desktop:items-center desktop:gap-2","href":"#top","children":[["$","i",null,{"className":"icon icon-on-top text-2xl"}],["$","span",null,{"className":"hidden desktop:block text-xs","children":"Na vrh"}]]}]}]]}]}],["$","div",null,{"className":"bg-siol text-white","children":["$","div",null,{"className":"p-4 desktop:container desktop:mx-auto desktop:px-0 desktop:flex desktop:flex-row","children":[["$","div",null,{"className":"columns-2 desktop:ml-40 gap-20 text-xs leading-6","children":[["$","$L29","https://www.tsmedia.si/",{"href":"https://www.tsmedia.si/","text":"Podjetje"}],["$","$L29","javascript:Didomi.preferences.show()",{"href":"javascript:Didomi.preferences.show()","text":"Upravljanje soglasij"}],["$","$L29","https://www.tsmedia.si/siol-net",{"href":"https://www.tsmedia.si/siol-net","text":"Oglaševanje"}],["$","$L29","https://siol.net/pogoji-uporabe",{"href":"https://siol.net/pogoji-uporabe","text":"Pogoji uporabe"}],["$","$L29","https://siol.net/mobilna-aplikacija",{"href":"https://siol.net/mobilna-aplikacija","text":"Mobilna aplikacija"}],["$","$L29","https://siol.net/kolofon",{"href":"https://siol.net/kolofon","text":"Kontakti uredništva"}],["$","$L29","https://siol.net/varstvo-osebnih-podatkov",{"href":"https://siol.net/varstvo-osebnih-podatkov","text":"Varstvo osebnih podatkov"}],["$","$L29","https://siol.net/e-novice",{"href":"https://siol.net/e-novice","text":"Prijava na E-novice"}],["$","$L29","https://siol.net/feeds/latest",{"href":"https://siol.net/feeds/latest","text":"RSS"}]]}],["$","div",null,{"className":"mt-16 text-xs text-center desktop:order-first desktop:mt-0 desktop:text-left","children":[["$","p",null,{"className":"hidden desktop:block mb-9","dangerouslySetInnerHTML":{"__html":"TSmedia, medijske vsebine in storitve, d.o.o.,\u003cbr\u003eCigaletova 15, 1000 Ljubljana,\u003cbr\u003eT: +386 1 473 00 10"}}],["$","p",null,{"className":"font-light","dangerouslySetInnerHTML":{"__html":"© TSmedia, medijske vsebine in storitve, d. o. o.\u003cbr\u003eVse pravice pridržane 1997-2024."}}]]}]]}]}]]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '2a:I[1749,["326","static/chunks/2626716e-1204952e0c2f13b3.js","990","static/chunks/13b76428-ac16532e24d8aa3f.js","647","static/chunks/647-1cfed450302421c4.js","935","static/chunks/935-56093c0b7187e483.js","206","static/chunks/206-24cb2ebaaee1b406.js","741","static/chunks/741-aec7b398fcc08cd7.js","445","static/chunks/445-15372bec73978f69.js","561","static/chunks/561-e598a824d42ca3f6.js","251","static/chunks/app/(content)/kanal/%5Bchannel%5D/kategorija/%5Bcategory%5D/podkategorija/%5BsubCategory%5D/datum/%5Bdate%5D/page-53d65ab90d5c555b.js"],"Image"]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([
+        1,
+        '22:[["$","div",null,{"className":"border-t border-b border-text desktop:px-4 text-2xl uppercase","children":"Zdaj na sporedu"}],["$","div",null,{"className":"flex flex-col mt-5 mb-4 gap-4 desktop:p-0","children":[[null,["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/slo1","target":"_self","children":["$","$L2a",null,{"className":"object-contain TV SLO 1 ","src":"/slika/kanal/slo1","alt":"TV SLO 1","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/slo1/oddaja/dnevnik/800919631/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Dnevnik","className":"font-extrabold line-clamp-1","children":"Dnevnik"}],["$","p",null,{"className":"text-light-gray","children":["Dnevno-informativna oddaja"," (",33," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.57–19.30"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/slo2","target":"_self","children":["$","$L2a",null,{"className":"object-contain TV SLO 2 ","src":"/slika/kanal/slo2","alt":"TV SLO 2","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/slo2/oddaja/videotrak/800550922/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Videotrak","className":"font-extrabold line-clamp-1","children":"Videotrak"}],["$","p",null,{"className":"text-light-gray","children":["Glasba"," (",65," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.55–20.00"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/poptv","target":"_self","children":["$","$L2a",null,{"className":"object-contain POP TV ","src":"/slika/kanal/poptv","alt":"POP TV","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/poptv/oddaja/24-ur/800345624/datum/20250113","target":"_self","children":[["$","p",null,{"title":"24UR","className":"font-extrabold line-clamp-1","children":"24UR"}],["$","p",null,{"className":"text-light-gray","children":["Dnevno-informativna oddaja"," (",65," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.55–20.00"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/akanal","target":"_self","children":["$","$L2a",null,{"className":"object-contain Kanal A ","src":"/slika/kanal/akanal","alt":"Kanal A","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/akanal/oddaja/lepo-je-biti-sosed/800348025/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Lepo je biti sosed","className":"font-extrabold line-clamp-1","children":"Lepo je biti sosed"}],["$","p",null,{"className":"text-light-gray","children":["Humoristični"," (",60," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.45–19.45"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/planettv","target":"_self","children":["$","$L2a",null,{"className":"object-contain Planet ","src":"/slika/kanal/planettv","alt":"Planet","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/planettv/oddaja/1001-noc/800255353/datum/20250113","target":"_self","children":[["$","p",null,{"title":"1001 noč","className":"font-extrabold line-clamp-1","children":"1001 noč"}],["$","p",null,{"className":"text-light-gray","children":["Telenovela"," (",65," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.55–20.00"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/arenapremium","target":"_self","children":["$","$L2a",null,{"className":"object-contain Arena Sport 1 Premium ","src":"/slika/kanal/arenapremium","alt":"Arena Sport 1 Premium","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/arenapremium/oddaja/fa-pokal-2024-25-3-krog-manchester-city-salford-city/80091565786/datum/20250113","target":"_self","children":[["$","p",null,{"title":"FA Pokal 2024/25 - 3. krog: Manchester City - Salford City","className":"font-extrabold line-clamp-1","children":"FA Pokal 2024/25 - 3. krog: Manchester City - Salford City"}],["$","p",null,{"className":"text-light-gray","children":["Nogomet"," (",120," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.30–20.30"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/arenaslo1","target":"_self","children":["$","$L2a",null,{"className":"object-contain Arena Sport 1 ","src":"/slika/kanal/arenaslo1","alt":"Arena Sport 1","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/arenaslo1/oddaja/aba-liga-2024-25-cedevita-olimpija-fmp-soccerbet/80091702612/datum/20250113","target":"_self","children":[["$","p",null,{"title":"ABA Liga 2024/25: Cedevita Olimpija - FMP Soccerbet","className":"font-extrabold line-clamp-1","children":"ABA Liga 2024/25: Cedevita Olimpija - FMP Soccerbet"}],["$","p",null,{"className":"text-light-gray","children":["Košarka"," (",115," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.15–20.10"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/eurosport","target":"_self","children":["$","$L2a",null,{"className":"object-contain Eurosport 1 ","src":"/slika/kanal/eurosport","alt":"Eurosport 1","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/eurosport/oddaja/alpsko-smucanje-m-slalom-2-voznja-svetovni-pokal-adelboden/8008743371/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Alpsko smučanje (M): Slalom, 2. vožnja, svetovni pokal, Adelboden","className":"font-extrabold line-clamp-1","children":"Alpsko smučanje (M): Slalom, 2. vožnja, svetovni pokal, Adelboden"}],["$","p",null,{"className":"text-light-gray","children":["Smučanje"," (",59," min)"]}],["$","p",null,{"className":"text-light-gray","children":"18.21–19.20"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/discoveryhdd","target":"_self","children":["$","$L2a",null,{"className":"object-contain Discovery Channel HD ","src":"/slika/kanal/discoveryhdd","alt":"Discovery Channel HD","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/discoveryhdd/oddaja/trgovec-z-rabljenimi-vozili/80084981549/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Trgovec z rabljenimi vozili","className":"font-extrabold line-clamp-1","children":"Trgovec z rabljenimi vozili"}],["$","p",null,{"className":"text-light-gray","children":["Avto-moto šport"," (",30," min)"]}],["$","p",null,{"className":"text-light-gray","children":"19.00–19.30"}]]}]]}]],[["$","div",null,{"className":"border-t border-darker-gray"}],["$","div",null,{"className":"flex flex-row gap-2 text-text","children":[["$","div",null,{"className":"h-[95px] w-[95px] p-4 bg-gray flex-none","children":["$","$L20",null,{"className":"relative inline-block h-full w-full","href":"/kanal/natgeo","target":"_self","children":["$","$L2a",null,{"className":"object-contain National Geographic ","src":"/slika/kanal/natgeo","alt":"National Geographic","sizes":"63px","fill":true}]}]}],["$","$L20",null,{"href":"/kanal/natgeo/oddaja/vrhunsko-dubajsko-letalisce-2019/7982135255/datum/20250113","target":"_self","children":[["$","p",null,{"title":"Vrhunsko dubajsko letališče 2019","className":"font-extrabold line-clamp-1","children":"Vrhunsko dubajsko letališče 2019"}],["$","p",null,{"className":"text-light-gray","children":["Reportaža"," (",60," min)"]}],["$","p",null,{"className":"text-light-gray","children":"19.00–20.00"}]]}]]}]]]}]]\n'
+      ])
+    </script>
+    <script>
+      self.__next_f.push([1, ''])
+    </script>
+  </body>
+</html>

--- a/sites/tv-spored.siol.net/readme.md
+++ b/sites/tv-spored.siol.net/readme.md
@@ -1,0 +1,21 @@
+# tv-spored.siol.net
+
+https://tv-spored.siol.net/
+
+### Download the guide
+
+```sh
+npm run grab --- --site=tv-spored.siol.net
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/tv-spored.siol.net/tv-spored.siol.net.config.js --output=./sites/tv-spored.siol.net/tv-spored.siol.net.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- tv-spored.siol.net
+```

--- a/sites/tv-spored.siol.net/tv-spored.siol.net.channels.xml
+++ b/sites/tv-spored.siol.net/tv-spored.siol.net.channels.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="3sat">3sat</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="24urm">Televizija 24</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="24vesti">TV Vijesti</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="360_tunebox">360 TuneBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="adria">Adria</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="akanal">Kanal A</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="alfa">Alfa TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="aljazeera">Al Jazeera Balkans</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="alsatm">Alsat Macedonia</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="alternativa">Elta 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="angelshd">Angels HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="animalhd">Animal Planet HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ansattv">ePosavje TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ard">ARD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenafight">Arena Fight</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenapremium">Arena Sport 1 Premium</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenaslo1">Arena Sport 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenaslo2">Arena Sport 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenaslo3">Arena Sport 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenaslo4">Arena Sport 4</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arenatv">Arena TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="arte">Arte</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="atmtvkg">ATM TV Kranjska Gora HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="b92">B92</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="babytv">Baby TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="balkan">Balkan Erotic</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="balkantrip">Balkan trip</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bbcearth">BBC Earth</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bbcfirsthd_">BBC First HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bbcworld">BBC News</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bht1_">BHT1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bir">BIR</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bktv">BK TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bloombergadria">Bloomberg Adria</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="bntv">BN TV 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="boobhd">BooB HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="boomerang">Cartoonito</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="brio">Brio</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="capableholehd">Capable Hole HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="carlitv">Veseljak Golica</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cartoon">Cartoon</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinemax1">Cinemax</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinemax2">Cinemax 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestaraction">CineStar TV Action &amp; Thriller</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestarfantasy">Cinestar Fantasy</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestarpr1">CineStar TV Premiere 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestarpr2">CineStar TV Premiere 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestartv">Cinestar TV 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cinestartv2">Cinestar TV 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cmc">CMC</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="cnn">CNN</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="curiosity">Curiosity Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="davincilear">Da Vinci Learning</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="devilshomehd">Devils Home HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="discidx">Discovery ID Xtra</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="discoveryhdd">Discovery Channel HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="disctlc">Discovery TLC</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="disney">Disney Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="disneyjr">Disney Junior</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dizi">Dizi</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dmtv">DM SAT</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="docubox">DocuBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dogtv">Dog TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="domkino">Dom Kino</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="doq">24Kitchen</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dorcel">Dorcel TV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dorcelhd">Dorcel XXX HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="doxtv">DOX TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="drfit">Dr. Fit</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dugans">TV Duga Novi sad</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="duna">Duna World</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="dusktv">Dusk TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eeurope">E!</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eltahd">ELTA HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eltatv">ELTA TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="enaplusena">1+1 International</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="epicdrama">Epic Drama</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="erox">Erox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eroxxx">Eroxxx</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="etv">ETV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eurosport">Eurosport 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="eurosport2">Eurosport 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ewtn">EWTN</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="exodustv">Exodus TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="explore">Viasat Explore</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="extreme">Extreme TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="extremede">Extrem</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fashion">Fashion TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fashionbox">FashionBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fashionhd">Fashion HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fast_and_funbox">Fast and FunBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fightbox">FightBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="filmbox_arthouse">FilmBox Arthouse</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="filmbox_extra">FilmBox Extra</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="filmbox_premium">FilmBox Premium</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="filmbox_stars">FilmBox Stars</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="folkp">Folk Plus</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="folx">Folx</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="fox">STAR Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="foxcrime">STAR Crime</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="foxlife">STAR Life</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="foxmovies">STAR Movies</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="foxnews">Fox News</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="foxydollshd">Foxy Dolls HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="france24">France 24</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="freex">Pinko club</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ftv">FTV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="funbox">FunBox</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="galejatv">TV Galeja HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="gametoon">Gametoon</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="geatv">Gea TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="glamhd">Glam HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="gold">Gold TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="h2">H2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hallmark">Diva</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="happy">Happy TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="happy_puppy">Happy Puppy</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="happyreality1">Happy Reality 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="happyreality2">Happy Reality 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hayat">Hayat</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hbo">HBO</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hbo2">HBO 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hbo3">HBO 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hema">Hema</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hgtv">HGTV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="history">Viasat History</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="historych">History Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hotpleasure">Hot Pleasure</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hotxxl">Hot XXL</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hrt1">HRT 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hrt2">HRT 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hrt3">HRT 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hustler">Hustler TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="hustlerhd">Hustler TV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ict">ICTbusiness TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ideatv">Kanal 10 / Idea TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="infotv">Top TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="istra">TV RI</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="jabukatv">Jabuka (OTV)</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="jadran">TV Jadran</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="jimjam">JimJam</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="jugotontv">Jugoton</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kabel1">Kabel 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kakanj">NTV IC Kakanj</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="karousel">Karousel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kcn">KCN 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kcnm">KCN 2 (music)</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kictvhd">KIC TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="kitchentv">Kitchen TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="klasiktv">Klasik</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="koper">TV Koper Capodistria</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="koroskatv">KOROŠKA TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="lhtv">LH TV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ljtv">Ljubljana TV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mediainter">Mediaset Italia</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="megafontv">Megafon TV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mezzo">Mezzo</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mezzolivehd">Mezzo Live HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mgm">AMC</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="minimax">Minimax</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mixxxhd">MIXXX HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mktv1">MTV 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mktv2">MTV 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mktv3">MTV 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="motorvisiontv">Motorvision+</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mtv2">MTV 90s</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mtvdance">Club MTV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mtvh">MTV Hits</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="mtvlivehd">MTV HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="museumhd">Museum HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="muzpervogo">Muzika Pervogo</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="narodna">Narodna TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nasatv">NAŠA TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="natgeo">National Geographic</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="natgeow">National Geographic Wild</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="net">NET TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nickjr1">Nick Jr.</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nickleodeon">Nickelodeon</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nicktoons">NickToons</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nova24tv">Nova 24 TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="nova24tv2">Nova 24 TV 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ntv">n-tv</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="obnbosna">OBN</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="oneadria">One Adria</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="orf1">ORF 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="orf2">ORF 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="orontv">Oron TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="otvv">OTV Valentino</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="paprika">BEST TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="passionxxxhd">Passion XXX HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pickboxtv">Pickbox TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pink">Pink Plus</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkextra">Pink Extra</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkfilm">Pink Film</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkfolk">Pink Folk</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkfolk2">Pink Folk 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkkoncert">Pink Koncert</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkmusic">Pink Music</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinknroll">Pink&apos;n&apos;Roll</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkreality">Pink Reality</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkserije">Pink Serije</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkshow">Pink Show</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinksi">TV3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkslo">PINK SI</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pinkzabava">Pink Zabava</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="planet2">Planet 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="planetearthsd">Planet Earth</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="planetplus">Planet Eva</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="planettv">Planet</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="playboytv">Playboy TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="popkino">Kino</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="popoto">OTO</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="poptv">POP TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="private">Private TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="pro7">Pro7</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvafiles">TV Prva Files</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvakick">TV Prva Kick</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvalife">TV Prva Life</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvamax">TV Prva Max</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvaplus">TV Prva Plus</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvasrb">PRVA Srbska TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvatvhd">PRVA TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="prvaworld">TV Prva World</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="ptujtv">Ptujska TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rai1">RAI 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rai2">RAI 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rai3">RAI 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rkanalp">R Kanal+</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rkings">Reality Kings TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtcg">MNE</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtcg2">RTCG 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtk">RTK</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtl">RTL</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtl2">RTL II</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtlhrvatska">RTL Hrvaška</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtlhrvatska2">RTL 2 Hrvaška</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtlkockica_">RTL Kockica</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtlliving">RTL Living</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtrs">RTRS</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rts">RT Srbija HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rts1">RTS 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rts2">RTS 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="rtsm">RTS Maribor</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sarajevo">TV Sarajevo</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sat1">SAT 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="satisfactionitaly">Redlight HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="savinjskatv">Savinjska TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="scifi">SciFi</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sct">Vivid Red HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sctprive">CentoXCento</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sexation">Sexation</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="siptv">SIP TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sitel">TV Sitel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="skynews">Sky News</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="slo1">TV SLO 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="slo2">TV SLO 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="slo3">TV SLO 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="slontv">SLON TV extra</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="soncetv">Sonce TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="spbeograd">KCN 3 (svet+)</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="spice">Brazzers TV Europe</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sporttv">Šport TV 1</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sporttv2">Šport TV 2</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="sporttv3">Šport TV 3</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="superonehd">Super One HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="superrtl">Super RTL</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="telecafe">Telecafe</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="telem">Tele Maribor</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="trace">Trace Urban</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tracesport">Trace Sport</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="travel">Travel Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="travelxp4k">Travelxp 4K</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="travelxphd">Travelxp HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tring7">Tring 7</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tringm">Tring Max</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="trings">Tring Shqip</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tringt">Tring Tring</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tringvp">Tring Vizion+</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="trzictv">Tržič TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tv1">O Kanal</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tv5">TV5MONDE</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tv8">Tv8</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tv1000">TV 1000</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvarenaesport">Arena eSport</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvas">TV As</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvbeltinci">TV Beltinci</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvcelje">TV Celje</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tve">TVE</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvgolica">TV Zlati zvoki</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvmiklavzhd">TV Miklavž HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvnakupihd">TV nakupi HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvormoz">Tv Ormož HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvpetelin">AKTUAL TV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvradgona">TV Radgona</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="tvvascom">TV Vascom</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vaskanal">Vaš kanal</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vh1">MTV 00s</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vh1cla">MTV 80s</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vianature">Viasat Nature</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vikom">Vikom</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vitel">Vitel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vividtouch">Vivid Touch</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vox">VOX</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vremya">Vremya</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="vtv">VTV</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="woman">Woman</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="xxxtazyhd">XXXTAZY HD</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="yachtsail">Nautical Channel</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="z1">Z1 Televizija</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="zdf">ZDF</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="zdrava">Zdrava Televizija</channel>
+  <channel site="tv-spored.siol.net" lang="sl" xmltv_id="" site_id="zdravatv">Zdrava TV</channel>
+</channels>

--- a/sites/tv-spored.siol.net/tv-spored.siol.net.config.js
+++ b/sites/tv-spored.siol.net/tv-spored.siol.net.config.js
@@ -1,0 +1,81 @@
+const axios = require('axios')
+const cheerio = require('cheerio')
+
+module.exports = {
+  site: 'tv-spored.siol.net',
+  days: 2,
+  url({ channel, date }) {
+    return `https://tv-spored.siol.net/kanal/${channel.site_id}/datum/${date.format('YYYYMMDD')}`
+  },
+  request: {
+    headers: {
+      Accept: 'text/html'
+    }
+  },
+  parser({ content, date }) {
+    const items = parseItems(content, date)
+
+    return items.map(item => ({
+      title: item.title,
+      category: item.category,
+      season: item.season,
+      episode: item.episode,
+      start: item.startDateTime,
+      stop: item.stopDateTime
+    }))
+  },
+  async channels() {
+    const content = await axios
+      .get('https://tv-spored.siol.net/', {
+        headers: {
+          Accept: 'text/html'
+        }
+      })
+      .then(r => r.data)
+      .catch(console.log)
+
+    const $ = cheerio.load(content)
+    const script = $('script:contains(tvChannelsAsJson)').text()
+    const func = new Function(`const self = { __next_f: [] };${script};return self.__next_f`)
+    const __next_f = func()
+    if (!__next_f[0] || !__next_f[0][1]) return []
+    const [, dataString] = __next_f[0][1].split(/:(.*)/s)
+    const data = JSON.parse(dataString)
+    const tvChannelsAsJson = findByKey(data, 'tvChannelsAsJson')
+
+    return tvChannelsAsJson.map(item => ({
+      name: item.name,
+      site_id: item.externalId.toLowerCase(),
+      lang: 'sl'
+    }))
+  }
+}
+
+function parseItems(content, date) {
+  try {
+    const $ = cheerio.load(content)
+    const script = $('script:contains(channelsAsJson)').text()
+    const func = new Function(`const self = { __next_f: [] };${script};return self.__next_f`)
+    const __next_f = func()
+    if (!__next_f[0] || !__next_f[0][1]) return []
+    const [, dataString] = __next_f[0][1].split(/:(.*)/s)
+    const data = JSON.parse(dataString)
+    const channelsAsJson = findByKey(data, 'channelsAsJson')
+
+    if (!channelsAsJson[0] || !Array.isArray(channelsAsJson[0].events)) return []
+
+    return channelsAsJson[0].events.filter(p => date.isSame(p.startDateTime, 'day'))
+  } catch {
+    return []
+  }
+}
+
+function findByKey(arr, key) {
+  if (!Array.isArray(arr)) return
+  return arr.reduce((a, item) => {
+    if (a) return a
+    if (item && item[key]) return item[key]
+    if (item && item.children) return findByKey(item.children, key)
+    if (Array.isArray(item)) return findByKey(item, key)
+  }, null)
+}

--- a/sites/tv-spored.siol.net/tv-spored.siol.net.test.js
+++ b/sites/tv-spored.siol.net/tv-spored.siol.net.test.js
@@ -1,0 +1,56 @@
+const { parser, url, request } = require('./tv-spored.siol.net.config.js')
+const fs = require('fs')
+const path = require('path')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2025-01-15', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: 'exodustv',
+  xmltv_id: 'ExodusTV.si'
+}
+
+it('can generate valid url', () => {
+  expect(url({ channel, date })).toBe('https://tv-spored.siol.net/kanal/exodustv/datum/20250115')
+})
+
+it('can generate request headers', () => {
+  expect(request.headers).toMatchObject({
+    Accept: 'text/html'
+  })
+})
+
+it('can parse response', () => {
+  const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.html'))
+  const results = parser({ content, date })
+
+  expect(results.length).toBe(41)
+  expect(results[0]).toMatchObject({
+    start: '2025-01-15T00:00:00.000Z',
+    stop: '2025-01-15T00:30:00.000Z',
+    title: 'Novice iz Svete dežele',
+    category: 'informativni',
+    season: null,
+    episode: null
+  })
+
+  expect(results[40]).toMatchObject({
+    start: '2025-01-15T23:00:00.000Z',
+    stop: '2025-01-15T23:45:00.000Z',
+    title: 'Sveta maša',
+    category: 'ostalo',
+    season: null,
+    episode: null
+  })
+})
+
+it('can handle empty guide', () => {
+  const result = parser({
+    date,
+    content: '<!DOCTYPE html><html><head></head><body></body></html>'
+  })
+  expect(result).toMatchObject([])
+})


### PR DESCRIPTION
Closes https://github.com/iptv-org/epg/issues/2232

```sh
npm test --- tv-spored.siol.net

> test
> run-script-os tv-spored.siol.net


> test:default
> TZ=Pacific/Nauru npx jest --runInBand tv-spored.siol.net

 PASS  sites/tv-spored.siol.net/tv-spored.siol.net.test.js
  ✓ can generate valid url (6 ms)
  ✓ can generate request headers (2 ms)
  ✓ can parse response (181 ms)
  ✓ can handle empty guide (1 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.025 s
Ran all test suites matching /tv-spored.siol.net/i.
```

```sh
npm run grab --- --site=tv-spored.siol.net

> grab
> npx tsx scripts/commands/epg/grab.ts --site=tv-spored.siol.net

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  site: tv-spored.siol.net
loading channels...
  found 312 channel(s)
run #1:
  [1/624] tv-spored.siol.net (sl) - 3sat - Jan 13, 2025 (41 programs)
  [2/624] tv-spored.siol.net (sl) - 3sat - Jan 14, 2025 (38 programs)
  [3/624] tv-spored.siol.net (sl) - 24urm - Jan 14, 2025 (19 programs)
  [4/624] tv-spored.siol.net (sl) - 360_tunebox - Jan 14, 2025 (23 programs)
  [5/624] tv-spored.siol.net (sl) - aljazeera - Jan 14, 2025 (36 programs)
  [6/624] tv-spored.siol.net (sl) - arenapremium - Jan 14, 2025 (14 programs)
  [7/624] tv-spored.siol.net (sl) - bir - Jan 14, 2025 (60 programs)
  [8/624] tv-spored.siol.net (sl) - domkino - Jan 14, 2025 (14 programs)
  [9/624] tv-spored.siol.net (sl) - domkino - Jan 13, 2025 (14 programs)
...
  [624/624] tv-spored.siol.net (sl) - rtcg - Jan 14, 2025 (44 programs)
  saving to "guide.xml"...
  done in 00h 03m 48s
```