### PR TITLE
Add tv.sfr.fr

### DIFF
--- a/sites/tv.sfr.fr/readme.md
+++ b/sites/tv.sfr.fr/readme.md
@@ -1,0 +1,21 @@
+# tv.sfr.fr
+
+https://tv.sfr.fr/programme-tv
+
+### Download the guide
+
+```sh
+npm run grab --- --site=tv.sfr.fr
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/tv.sfr.fr/tv.sfr.fr.config.js --output=./sites/tv.sfr.fr/tv.sfr.fr.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- tv.sfr.fr
+```

--- a/sites/tv.sfr.fr/tv.sfr.fr.channels.xml
+++ b/sites/tv.sfr.fr/tv.sfr.fr.channels.xml
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2">13ème rue</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4">France 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="5">AB1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="6">Mangas</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="7">Toute l&apos;histoire</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="10">Action</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="12">Animaux</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="13">Das Erste</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="15">Auto Moto</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="19">BBC NEWS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="32">Canal J</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="34">CANAL+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="36">Cartoon Network</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="38">Chasse et Pêche</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="47">France 5</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="49">SERIE CLUB</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="51">CNBC Europe</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="53">CNN International</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="58">DISNEY CHANNEL</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="60">SPORT 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="61">DW-TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="63">Science et Vie TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="64">Equidia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="71">ETB1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="72">ETB2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="76">EUROSPORT 1 HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="78">France 4</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="80">France 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="87">Game One</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="88">Histoire TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="110">KTO</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="111">Arte</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="112">LCI</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="115">RTL9</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="116">BFM Lyon</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="118">M6</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="119">W9</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="121">MCM</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="124">LA CHAINE METEO</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="125">Mezzo</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="128">MTV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="140">Euronews Fra</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="145">Paris Première</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="154">Rai Due</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="155">Rai Tre</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="156">Rai Uno</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="166">RTL Television</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="169">RTPI</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="173">SEASONS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="182">SWR</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="185">TCM Cinéma</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="191">Téva</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="192">TF1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="195">TMC</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="203">TV3 Catalunya</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="205">TV5 Monde</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="208">TVE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="218">XXL</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="219">ZDF</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="225">TV Breizh</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="226">CNews</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="229">Tiji</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="234">LCP-Public Sénat</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="241">RFM TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="243">NATIONAL GEAOGRAPHIC HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="265">Melody TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="273">TV7 Bordeaux</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="282">OCS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="283">CINE+ émotion</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="284">CINE+ frisson</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="285">CINE+ festival</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="287">CINE+ classic</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="299">DISNEY CHANNEL +1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="300">DISNEY JUNIOR HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="308">France 3 via Stella</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="318">CGTN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="321">Boomerang</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="325">Trace Urban</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="340">2M Maroc</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="345">Al Jazeera</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="346">Canal Algérie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="356">Al Masriya</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="357">Fashion TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="366">Sat 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="368">Sky News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="369">Phoenix Infonews</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="371">Tunisia 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="393">Vià MATÉLÉ</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="394">Astrocenter.tv</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="400">Discovery Channel</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="401">CINE+ family</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="405">E! Entertainment</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="406">Pink TV / Pink X</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="410">Bloomberg</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="416">Hustler TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="421">8 Mont-Blanc</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="439">EUROSPORT 2 HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="444">NRJ12</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="445">C8</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="446">TFX</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="451">Ushuaia TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="453">M6 Music</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="458">CStar</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="463">OLPLAY</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="473">Nickelodeon</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="479">Syfy</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="481">BFM TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="482">Gulli</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="491">Télé Nantes</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="525">Al Jazeera English</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="526">Zee TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="529">France 24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="531">Luxe TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="534">Canal 32</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="535">LMtv Sarthe</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="537">Télé Grenoble</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="538">vià30</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="539">TV Rennes 35</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="540">TV Tours</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="558">Private TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="560">Dorcel TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="561">Africa 24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="571">CRTV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="573">2STV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="574">Berbère TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="579">ART AFLAM 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="583">Distrito Comedia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="585">De pelicula</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="586">Shangaï Dragon TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="588">Las Estrellas</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="589">Dubaï TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="592">etb basque</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="593">Euro D</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="594">Euro Star</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="603">Jordan Satellite Channel</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="605">NRJ Hits</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="608">Beur TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="609">Canal 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="619">TV Romania International</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="624">Habertürk</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="625">ART CINEMA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="665">Medi 1 TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="671">France 24 ENG</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="683">Man-X</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="697">ORTM</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="701">20 Minutes TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="703">Canal 21</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="704">vià34</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="713">24 Horas</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="719">NATIONAL GEO WILD HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="724">Armenia 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="753">TRACE CARIBBEAN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="769">Al Aoula</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="771">Beijing TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="772">CCTV-4</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="773">CCTV YULE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="774">CGTN-Français</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="781">i24 News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="782">Hunan TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="789">RAI SCUOLA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="790">RAI STORIA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="793">Record News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="795">Rotana Cinema</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="805">TV Record</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="807">SIC Internacional</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="809">Wéo TV, La voix du nord</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="814">France 24 ARA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="829">My Zen TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="830">NHK WORLD-JAPAN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="843">RMS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="846">RTI 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="847">RTS 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="848">RTV Pink Extra</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="849">RTV Pink Film</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="850">RTV Pink Music</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="851">RTV Pink Plus</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="854">Show Turk</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="858">TV Congo</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="859">Telehit</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="860">tlnovelas</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="863">Figaro TV IDF</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="864">The Israeli Network</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="871">TVN24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="875">TVP Polonia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="876">GRT GBA Satellite TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="880">Great Wall Elite</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="882">ZTV World (Zhejiang Star TV)</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="888">Nickelodeon Junior</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="907">Mezzo Live</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="928">Boomerang+1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="930">BFM Grand Lille</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="944">KBS World</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="945">Murr TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="950">Geo TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="951">Geo News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="952">B4U Movies</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="953">PENTHOUSE HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="956">Arryadia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="957">Al Maghribia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="958">Arrabiâ</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="959">Assadissa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="960">3 SAT</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="964">Pro Sieben</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="966">RTL2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="971">Vox</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="981">KABEL EINS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="982">KIKA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="984">Equinoxe TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="985">Gabon 1ère</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="992">LCP-AN 24/24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1003">ORTB</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1010">iTVN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1019">Rotana Music</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1022">Al Resalah</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1023">TV78</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1026">Antenna 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1031">N-TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1041">TVM</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1042">ORTC</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1045">vià Mirabelle</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1061">Lucky Jack</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1071">RTG</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1072">MUSEUM TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1073">BFM Business</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1077">BFM PARIS ILE-DE-FRANCE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1095">vià Vosges</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1096">Nessma</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1097">RTNC</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1111">Télé Bocal</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1112">Berbère Musique</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1113">Berbère Jeunesse</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1115">NTD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1124">SFR ACTU</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1125">CGTN-Documentary</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1128">Phoenix CNE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1129">Rai News 24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1133">Vox Africa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1138">China Movie Channel (CMC)</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1145">Utsav Plus</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1151">TL7 Saint Etienne</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1154">TFM</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1167">Game One+1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1179">Trace Africa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1180">Colors</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1185">Maritima TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1189">Arte Allemande</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1196">JSBC International</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1197">Lyon Capitale TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1199">Zouk TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1268">TV Vendée</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1275">NBN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1283">Al Jadeed</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1285">OTV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1288">Mediaset Italia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1290">beIN SPORTS 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1295">GOLF+ HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1304">beIN SPORTS 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1307">BBlack Classic</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1321">Tébéo</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1335">beIN SPORTS 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1336">beIN SPORTS MAX 4</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1337">beIN SPORTS MAX 5</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1338">beIN SPORTS MAX 6</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1339">beIN SPORTS MAX 7</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1340">beIN SPORTS MAX 8</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1341">beIN SPORTS MAX 9</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1342">beIN SPORTS MAX 10</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1374">TLC</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1399">Chérie 25</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1400">RMC Découverte</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1401">L&apos;équipe</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1402">RMC Story</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1403">6ter</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1404">TF1 Séries-Films</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1452">Men&apos;s Up TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1457">L&apos;actu des jeux vidéo</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1461">Nollywood TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1472">Hot vidéo TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1474">Dorcel XXX</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1538">Sony Max</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1540">Al Arabiya</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1550">Echorouk TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1551">Ennahar TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1555">SIC Noticias</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1562">Paramount Channel</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1585">J-One</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1601">BBlack Africa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1613">Panorama Film</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1614">Panorama Drama</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1615">Angers Télé</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1623">Benfica TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1637">TVI Internacional</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1638">TV8 Moselle-Est</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1640">SEN TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1654">A3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1698">Al Majd Holy Quran</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1700">Mosaik Cristal</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1702">Antena 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1704">TVG EUROPA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1717">i24 News Anglais</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1718">i24 News Arabe</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1719">7A Limoges</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1721">ASTV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1723">ETB3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1724">ILTV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1726">WELT</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1729">RTL NITRO TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1733">Saudi Channel 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1735">Télé Schiltigheim</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1737">TELEGOHELLE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1738">vià93</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1746">Nickelodeon Teen</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1750">Télé Paese</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1760">VIVA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1761">Atres Series</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1763">Rotana Drama</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1765">Netflix</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1776">TREK</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1854">Super RTL</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1921">France 3 Alpes</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1922">France 3 Alsace</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1923">France 3 Aquitaine</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1924">France 3 Auvergne</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1925">France 3 Basse-Normandie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1926">France 3 Bourgogne</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1927">France 3 Bretagne</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1928">France 3 Centre</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1929">France 3 Champagne-Ardenne</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1931">France 3 Côte d&apos;Azur</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1932">France 3 Franche-Comté</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1933">France 3 Haute-Normandie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1934">France 3 Languedoc</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1935">France 3 Limousin</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1936">France 3 Lorraine</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1937">France 3 Midi-Pyrénées</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1938">France 3 Nord-Pas-de-Calais</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1939">France 3 Paris IDF</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1940">France 3 Pays de la Loire</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1941">France 3 Picardie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1942">France 3 Poitou-Charentes</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1943">France 3 Provence-Alpes</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1944">France 3 Rhône-Alpes</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1948">Trace Toca</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1949">TV8 International</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1960">BET</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1973">Rishtey</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1974">Utsav Bharat</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1975">iTVN Extra</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="1990">A+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2006">MTV Hits</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2011">+ d’Afrique</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2013">Public Sénat 24/24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2022">Trace Gospel</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2037">Crime District</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2040">Warner TV Next</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2046">Canal Q</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2050">Porto Canal</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2064">El Hiwar Ettounsi</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2065">Nickelodeon+1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2072">Paramount Channel décalé</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2095">RMC Sport Access</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2111">franceinfo:</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2166">BBlack Caribbean</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2168">Boomerang Anglais</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2169">TCM Anglais</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2184">Discovery Investigation</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2218">LBC Sat</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2274">TGCOM24</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2275">TVPI (TV Biarritz)</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2292">STAR TVE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2299">Samira TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2302">vià31</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2303">vià66</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2313">RTP 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2317">BFM Grand Littoral</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2321">Melody d&apos;Afrique</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2334">WARNER TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2337">Portail des chaînes locales</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2343">Nollywood TV Epic</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2345">A BOLA TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2347">Local Visao</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2353">MGG TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2369">Grosbliederstroff</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2372">TRESSANGE TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2373">TV2COM</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2376">Union TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2444">DocuBox HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2445">FashionBox HD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2446">FilmBox Arthouse</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2530">ANDALUCIA TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2665">RMC Sport 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2666">RMC Sport Live 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2730">France 3 Nouvelle Aquitaine</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2752">Comedy Central</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2756">BEIN MOVIES</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2777">KANAL 7 AVRUPA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2778">SHOW MAX</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2784">CHERIFLA TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2804">ATV Avrupa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2832">Echorouk News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2837">Sport en France</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2838">DORCEL TV AFRICA</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2878">Rotana Classic</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2908">SUNU YEUF</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2913">NCI</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2941">Amazon Prime Vidéo</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2942">TECH &amp; CO</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2957">El Bilad TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2974">Disney+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="2977">Trace Vanilla</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3020">Alaraby 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3075">ALL FLAMENCO_</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3106">Top Santé TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3137">MAURIENNE TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3164">BFM DICI HAUTE-PROVENCE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3165">BFM DICI ALPES DU SUD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3169">VIXEN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3171">RMC Sport Live 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3172">RMC Sport Live 4</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3273">CDIRECT</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3287">Auto Plus TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3289">BFM MARSEILLE PROVENCE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3290">BFM TOULON VAR</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3291">BFM NICE COTE D&apos;AZUR</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3347">CANAL+ DOCS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3348">CANAL+ KIDS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3349">CANAL+ GRAND ECRAN</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3360">Maison &amp; Travaux TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3372">Maboke TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3376">Carthage+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3380">Télé Maroc</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3381">Fix et Foxy</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3386">Marmiton TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3425">TF1 4K</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3460">BFM ALSACE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3501">CANAL+ FOOT</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3504">CANAL+ SPORT 360</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3537">DMC</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3538">ON TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3539">Rotana Cinéma+ FR</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3540">Rotana Aflam+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3541">ART AFLAM 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3542">AL HEKAYAT 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3543">AL HEKAYAT 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3544">DMC Drama</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3548">Rotana Kids</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3549">Iqraa International</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3550">Iqraa TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3551">HANNIBAL TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3557">BFM Normandie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3562">France 24 Espanol</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3563">KANALDUDE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3572">TELE MADRID</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3574">Helwa</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3597">DREAMWORKS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3600">REAL MADRID TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3629">Journal du Golf TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3725">Sky News Arabia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3726">Asharq News</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3727">Bahia</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3728">Watania 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3736">Dizi</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3738">Cartoonito</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3760">NA TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3761">Canal 11</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3769">NOVELAS</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3770">Cannes Lérins TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3771">Puissance TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3774">CHADA TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3778">Wéo Picardie</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3779">CANAL+ BOX OFFICE</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3786">TVMonaco</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3795">DAZN 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3797">CRESPIN TELEVISION</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3799">NHK World Premium</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3800">Lana TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3810">Rotana M+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3902">Rotana Comedy</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3946">RMC Talk Sport</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3947">RMC Talk Info</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3948">BFM Grands Reportages</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3949">RMC Alerte Secours</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3950">RMC WOW</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3951">J&apos;irai dormir chez vous</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3952">RMC Mystère</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3953">RMC Mecanic</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3970">Pulaagu</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3993">TinyTeen</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="3994">MEN TV</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4003">Lang Lab</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4004">Lingo Toons</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4012">France 2 UHD</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4068">CANAL+LIVE 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4069">CANAL+LIVE 2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4070">CANAL+LIVE 3</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4071">CANAL+LIVE 4</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4072">CANAL+LIVE 5</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4073">CANAL+LIVE 6</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4074">CANAL+LIVE 7</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4092">BFM2</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4093">Alaraby 1</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4100">V+</channel>
+  <channel site="tv.sfr.fr" lang="fr" xmltv_id="" site_id="4101">INSOMNIA</channel>
+</channels>

--- a/sites/tv.sfr.fr/tv.sfr.fr.config.js
+++ b/sites/tv.sfr.fr/tv.sfr.fr.config.js
@@ -1,0 +1,65 @@
+const axios = require('axios')
+const dayjs = require('dayjs')
+
+module.exports = {
+  site: 'tv.sfr.fr',
+  days: 2,
+  url({ date }) {
+    return `https://static-cdn.tv.sfr.net/data/epg/gen8/guide_web_${date.format('YYYYMMDD')}.json`
+  },
+  request: {
+    maxContentLength: 10 * 1024 * 1024, // 10Mb
+    cache: {
+      ttl: 24 * 60 * 60 * 1000 // 1 day
+    }
+  },
+  parser({ content, channel }) {
+    let programs = []
+    let items = parseItems(content, channel)
+    items.forEach(item => {
+      programs.push({
+        start: dayjs(item.startDate),
+        stop: dayjs(item.endDate),
+        title: item.title,
+        subtitle: item.subTitle || null,
+        category: item.genre,
+        description: item.longSynopsis,
+        images: item.images.map(img => img.url),
+        season: item.seasonNumber || null,
+        episode: item.episodeNumber || null
+      })
+    })
+
+    return programs
+  },
+  async channels() {
+    const data = await axios
+      .get('https://api.sfr.fr/service-channel/api/rest/v2/channels')
+      .then(r => r.data)
+      .catch(console.error)
+
+    let channels = {}
+    Object.values(data.data.chaines).forEach(channel => {
+      if (!channels[channel.epg_id]) {
+        channels[channel.epg_id] = {
+          lang: 'fr',
+          site_id: channel.epg_id,
+          name: channel.nom_chaine
+        }
+      }
+    })
+
+    return Object.values(channels)
+  }
+}
+
+function parseItems(content, channel) {
+  try {
+    const data = JSON.parse(content)
+    if (!data || !data.epg || !Array.isArray(data.epg[channel.site_id])) return []
+
+    return data.epg[channel.site_id]
+  } catch {
+    return []
+  }
+}

--- a/sites/tv.sfr.fr/tv.sfr.fr.test.js
+++ b/sites/tv.sfr.fr/tv.sfr.fr.test.js
@@ -1,0 +1,71 @@
+const { parser, url } = require('./tv.sfr.fr.config.js')
+const fs = require('fs')
+const path = require('path')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2025-01-18', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: '192',
+  xmltv_id: 'TF1.fr'
+}
+
+it('can generate valid url', () => {
+  expect(url({ date, channel })).toBe(
+    'https://static-cdn.tv.sfr.net/data/epg/gen8/guide_web_20250118.json'
+  )
+})
+
+it('can parse response', () => {
+  const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.json'), 'utf8')
+  let results = parser({ content, channel })
+  results = results.map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(results.length).toBe(23)
+  expect(results[0]).toMatchObject({
+    start: '2025-01-18T02:05:00.000Z',
+    stop: '2025-01-18T05:00:00.000Z',
+    title: 'Programmes de la nuit',
+    subtitle: null,
+    category: 'Programme indéterminé',
+    description: 'Retrouvez tous vos programmes de nuit.',
+    images: [
+      'http://static-cdn.tv.sfr.net/data/img/pl/3/6/9/5757963.jpg',
+      'http://static-cdn.tv.sfr.net/data/img/pl/5/0/8/7616805.jpg'
+    ],
+    season: null,
+    episode: null
+  })
+  expect(results[22]).toMatchObject({
+    start: '2025-01-18T22:40:00.000Z',
+    stop: '2025-01-19T00:00:00.000Z',
+    title: 'Star Academy',
+    subtitle: 'Retour au château',
+    category: 'Téléréalité',
+    description:
+      "C'est en direct du plateau que Nikos Aliagas revient sur les prestations des différents académiciens en compagnie du corps professoral. L'occasion de revenir en détails sur le déroulement du prime avec les aspects positifs mais également les éléments sur lesquels les élèves doivent progresser pour espérer faire la différence sur cette fin d'aventure.",
+    images: [
+      'http://static-cdn.tv.sfr.net/data/img/pl/1/0/0/9517001.jpg',
+      'http://static-cdn.tv.sfr.net/data/img/pl/6/7/2/9992276.jpg',
+      'http://static-cdn.tv.sfr.net/data/img/pl/9/0/1/9985109.jpg',
+      'http://static-cdn.tv.sfr.net/data/img/pl/6/7/5/9491576.jpg'
+    ],
+    season: 12,
+    episode: 15
+  })
+})
+
+it('can handle empty guide', () => {
+  const results = parser({
+    content: ''
+  })
+
+  expect(results).toMatchObject([])
+})


### PR DESCRIPTION
Closes https://github.com/iptv-org/epg/issues/2484

```sh
npm test --- tv.sfr.fr

> test
> run-script-os tv.sfr.fr


> test:default
> TZ=Pacific/Nauru npx jest --runInBand tv.sfr.fr

 PASS  sites/tv.sfr.fr/tv.sfr.fr.test.js
  ✓ can generate valid url (5 ms)
  ✓ can parse response (124 ms)
  ✓ can handle empty guide (1 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.869 s, estimated 1 s
Ran all test suites matching /tv.sfr.fr/i.
```

```sh
npm run grab --- --site=tv.sfr.fr --maxConnections=100

> grab
> npx tsx scripts/commands/epg/grab.ts --site=tv.sfr.fr --maxConnections=100

starting...
config:
  output: guide.xml
  maxConnections: 100
  gzip: false
  site: tv.sfr.fr
loading channels...
  found 503 channel(s)
run #1:
  [1/1006] tv.sfr.fr (fr) - 2 - Jan 15, 2025 (26 programs)
  [2/1006] tv.sfr.fr (fr) - 4 - Jan 15, 2025 (38 programs)
  [3/1006] tv.sfr.fr (fr) - 5 - Jan 15, 2025 (41 programs)
  [4/1006] tv.sfr.fr (fr) - 6 - Jan 15, 2025 (62 programs)
  [5/1006] tv.sfr.fr (fr) - 7 - Jan 15, 2025 (23 programs)
  [6/1006] tv.sfr.fr (fr) - 10 - Jan 15, 2025 (16 programs)
  [7/1006] tv.sfr.fr (fr) - 12 - Jan 15, 2025 (32 programs)
  [8/1006] tv.sfr.fr (fr) - 13 - Jan 15, 2025 (30 programs)
  [9/1006] tv.sfr.fr (fr) - 15 - Jan 15, 2025 (23 programs)
...
  [1006/1006] tv.sfr.fr (fr) - 4068 - Jan 16, 2025 (0 programs)
  saving to "guide.xml"...
  done in 00h 01m 25s
```