### PR TITLE
Add tvinsider.com

### DIFF
--- a/sites/tvinsider.com/__data__/content.html
+++ b/sites/tvinsider.com/__data__/content.html
@@ -1,0 +1,2128 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<link rel="preconnect" href="//ads.blogherads.com" crossorigin>
+<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2">
+<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2">
+<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="https://fonts.gstatic.com/s/ibmplexsanscondensed/v7/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7bvspYYnFBq4.woff2">
+<style>
+@font-face {
+  font-family: 'IBMPlexSans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('IBM Plex Sans'), local('IBMPlexSans'), url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'IBMPlexSans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local('IBM Plex Sans Medium'), local('IBMPlexSans-Medium'), url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjSL9AIFsdP3pBms.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'IBMPlexSans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'), url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'IBMPlexSansCondensed';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local('IBM Plex Sans Condensed Bold'), local('IBMPlexSansCond-Bold'), url(https://fonts.gstatic.com/s/ibmplexsanscondensed/v7/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7bvspYYnFBq4.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Objet';
+  font-display: swap;
+  src: url("https://www.tvinsider.com/wp-content/themes/tv/fonts/Objet-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Open Sans Regular'), local('Open-Sans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Open Sans Italic'), local('Open-Sans-Italic'), url(https://fonts.gstatic.com/s/opensans/v17/mem6YaGs126MiZpBA-UFUK0Zdc1GAK6b.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* actually using the semi-bold typeface in the url here */
+@font-face {
+  font-family: 'OpenSans';
+  font-style: normal;
+  font-weight: bold;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/opensans/v20/mem5YaGs126MiZpBA-UNirkOUuhpKKSTjw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'OpenSans';
+  font-style: italic;
+  font-weight: bold;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/opensans/v20/memnYaGs126MiZpBA-UFUKXGUdhrIqOxjaPX.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+</style>
+<link rel="shortcut icon" href="https://www.tvinsider.com/wp-content/themes/tv/images/favicon.ico" type="image/x-icon">
+<link rel="icon" href="https://www.tvinsider.com/wp-content/themes/tv/images/favicon.ico" type="image/x-icon">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google-site-verification" content="u5Ue-P2oV1f9Pq2AURnZ4gpuZ1Nrgcgwn09AmMPLgCE">
+<meta name="google-site-verification" content="it2r-MRipevefeCYWkPlW540pNwHDj9JpbST3-LAA-o">
+<meta name="pocket-site-verification" content="c2d9d3d73032bf0b0959f31688efb2">
+<meta name="google-site-verification" content="FsdlLOvbsiYf4t8sZFZgs9am050TrtgyydB9KbUhYvU">
+<meta property="fb:pages" content="112199118797264">
+<meta property="fb:app_id" content="2128917200700396">
+<meta property="og:site_name" content="TV Insider">
+<meta name="theme-color" content="#00aeef">
+<meta name="robots" content="max-image-preview:large">
+  <style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+  <link rel="alternate" type="application/rss+xml" title="TV Insider &raquo; Feed" href="https://www.tvinsider.com/feed/" />
+<script type="text/javascript" id="wpp-js" src="https://www.tvinsider.com/wp-content/plugins/wordpress-popular-posts/assets/js/wpp.min.js?ver=7.2.0" data-sampling="1" data-sampling-rate="100" data-api-url="https://www.tvinsider.com/wp-json/wordpress-popular-posts" data-post-id="0" data-token="5a661f22f8" data-lang="0" data-debug="0"></script>
+<link rel="alternate" type="application/rss+xml" title="TV Insider &raquo; MoviePlex Network Feed" href="https://www.tvinsider.com/network/movieplex/feed/" />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<link rel='stylesheet' id='sheknows-infuse-css' href='https://www.tvinsider.com/wp-content/plugins/sheknows-infuse/public/css/style.css?ver=1.0.42' type='text/css' media='all' />
+<link rel='stylesheet' id='base-style-css' href='https://www.tvinsider.com/wp-content/themes/tv/style.css?ver=1329' type='text/css' media='all' />
+<script>!(function(o,_name){o[_name]=o[_name]||function $(){($.q=$.q||[]).push(arguments)},o[_name].v=o[_name].v||2;!(function(o,t,e,n,c,a){function f(n,c){(n=(function(t,e){try{if(e=(t=o.localStorage).getItem("_aQS01ODhGOEZCQjAxRjgyQjdBMzk0MjhGMjItOTAx"))return JSON.parse(e).lgk||[];if((t.getItem(decodeURI(decodeURI('%25%37%36%34%61%256%33%31%2565%25%36%39%255%61%25%37%32%2530')))||"").split(",")[4]>0)return[[_name+"-engaged","true"]]}catch(n){}})())&&typeof n.forEach===e&&(c=o[t].pubads())&&n.forEach((function(o){o&&o[0]&&c.setTargeting(o[0],o[1]||"")}))}try{(a=o[t]=o[t]||{}).cmd=a.cmd||[],typeof a.pubads===e?f():typeof a.cmd.unshift===e?a.cmd.unshift(f):a.cmd.push(f)}catch(i){}})(window,"googletag","function");;})(window,decodeURI(decodeURI('a%25%36%34%256d%2569%2572a%25%36%63')));!(function(t,c,i){i=t.createElement(c),t=t.getElementsByTagName(c)[0],i.async=1,i.src="https://absentairport.com/chunks/39e8d6d4b4/a216c1cf9d948c6d545180ca42bee3d3b6a0a1.js",t.parentNode.insertBefore(i,t)})(document,"script");</script><script type="text/javascript" src="https://www.tvinsider.com/wp-content/plugins/she-media-cli-script/inc/connatix-player.js?ver=1736958701" id="connatix-js"></script>
+<!-- Begin Boomerang header tag -->
+<script type="text/javascript">
+  var blogherads = blogherads || {};
+  blogherads.adq = blogherads.adq || [];
+
+  blogherads.adq.push(function () {
+                        blogherads.setTargeting("ci", "term-45245");
+                blogherads.setTargeting("pt", "landing");
+            if (blogherads.setADmantXData) {
+            blogherads.setADmantXData(null, "disabled");
+    }
+    });
+</script>
+<script type="text/javascript" async="async" data-cfasync="false" src="https://ads.blogherads.com/static/blogherads.js"></script>
+<script type="text/javascript" async="async" data-cfasync="false" src="https://ads.blogherads.com/sk/12/122/1228136/26554/header.js"></script>
+<!-- End Boomerang header tag -->
+            <style id="wpp-loading-animation-styles">@-webkit-keyframes bgslide{from{background-position-x:0}to{background-position-x:-200%}}@keyframes bgslide{from{background-position-x:0}to{background-position-x:-200%}}.wpp-widget-block-placeholder,.wpp-shortcode-placeholder{margin:0 auto;width:60px;height:3px;background:#dd3737;background:linear-gradient(90deg,#dd3737 0%,#571313 10%,#dd3737 100%);background-size:200% auto;border-radius:3px;-webkit-animation:bgslide 1s infinite linear;animation:bgslide 1s infinite linear}</style>
+            
+
+<title>MoviePlex - TV Schedule & Listings Guide</title>
+<meta name="title" content="MoviePlex - TV Schedule & Listings Guide">
+<meta name="description" content="A live TV schedule for MoviePlex, with local listings of all upcoming programming.">
+<meta property="og:description" content="A live TV schedule for MoviePlex, with local listings of all upcoming programming.">
+<meta property="og:url" content="https://www.tvinsider.com/network/movieplex/schedule/">
+<meta property="og:title" content="MoviePlex - TV Schedule & Listings Guide">
+<meta property="og:type" content="article:tag">
+<meta property="og:image" content="https://www.tvinsider.com/wp-content/uploads/2023/08/movieplex.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@tvinsider">
+<meta name="twitter:creator" content="@tvinsider">
+<meta name="twitter:title" content="MoviePlex">
+<meta name="twitter:description" content="A live TV schedule for MoviePlex, with local listings of all upcoming programming.">
+<meta name="twitter:image" content="https://www.tvinsider.com/wp-content/uploads/2023/08/movieplex.png">
+<meta name="twitter:image:alt" content="MoviePlex">
+<link rel="canonical" href="https://www.tvinsider.com/network/movieplex/schedule/">
+
+ 
+
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<script defer src="https://cmp.osano.com/16BcscRpZUDCE2Y0Z/31c52822-b314-450c-9a60-45b2cd6ac22e/osano.js"></script>
+<script defer src="https://www.tvinsider.com/wp-content/themes/tv/js/lity.min.js"></script>
+
+
+<script type="text/javascript">
+if ( window.blogherads ) {
+  blogherads.adq.push( function() {
+     blogherads.setTargeting( "pub_meta_3", ["movieplex"] ); 
+  } );
+}
+</script>
+
+<!-- Pure Visibility -->
+<script>(function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"5524914", enableAutoSpaTracking: true};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");</script>
+
+</head>
+<body class="archive tax-network term-movieplex term-45245">
+<!-- Meta Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '2150724991788914');
+  fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=2150724991788914&ev=PageView&noscript=1"
+/></noscript>
+<!-- End Meta Pixel Code -->
+
+<!-- SHEMEDIA ADS Begin Desktop Adhesion ad -->
+<script type="text/javascript">
+  blogherads.adq.push('frame2');
+</script>
+
+
+
+<header id="header">
+  <nav class="top-nav"><a href="/search/">Search</a> <span>•</span> <a href="/shop/">Shop</a> <span>•</span> <a href="/tv-games-puzzles-quizzes/">Games</a> <span>•</span> <a href="/shows/calendar/">Calendar</a> <span>•</span> <a href="/newsletter-subscription/">Newsletters</a> <span>•</span> <a href="/lists/">Lists</a> <span>•</span> <a href="/trailers/">Trailers</a> <span>•</span> <a href="/login/">Login</a></nav>  <div class="logo">
+    <button href="" aria-label="Navigation" id="hamburger-button"></button>
+    <a href="https://www.tvinsider.com/"><img width="400" height="74" src="https://www.tvinsider.com/wp-content/themes/tv/images/tvinsider-logo-horizontal-white.svg" alt="TV Insider Logo" /></a>
+  </div>
+  <nav class="nav"><ul id="menu-new-menu" class="menu"><li id="menu-item-1105701" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1105701"><a href="https://www.tvinsider.com/shows/">Shows</a><div class="subnav">
+      <div class="menu-top25">
+      <a href="/shows/"><img loading="lazy" alt="Top 25 Shows" width="180" height="82" src="https://www.tvinsider.com/wp-content/themes/tv/images/top-25-shows1.png" /></a>
+      <ol><li><a href="/show/severance/">Severance</a></li><li><a href="/show/the-couple-next-door/">The Couple Next Door</a></li><li><a href="/show/hollywood-squares-2025/">Hollywood Squares</a></li><li><a href="/show/the-pitt/">The Pitt</a></li><li><a href="/show/back-in-action/">Back In Action</a></li><li><a href="/show/law-order-special-victims-unit/">Law &amp; Order: Special Victims Unit</a></li><li><a href="/show/xo-kitty/">XO, Kitty</a></li><li><a href="/show/the-rookie/">The Rookie</a></li><li><a href="/show/unstoppable-2025/">Unstoppable</a></li><li><a href="/show/diddy-the-making-of-a-bad-boy/">Diddy: The Making of a Bad Boy</a></li></ol>
+      <a class="basic-button" href="https://www.tvinsider.com/shows/">Full List</a>
+      </div>
+<ul class="menu-networks">  <li class="network"><a href="https://www.tvinsider.com/network/netflix/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/netflix.png" alt="Netflix" /></a>
+  <ul>    <li id="menu-item-1147714" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147714"><a href="https://www.tvinsider.com/show/emily-in-paris/">Emily in Paris</a></li>   <li id="menu-item-1147715" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147715"><a href="https://www.tvinsider.com/show/love-is-blind-uk/">Love Is Blind: UK</a></li>    <li id="menu-item-1147717" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147717"><a href="https://www.tvinsider.com/show/cobra-kai/">Cobra Kai</a></li>   <li id="menu-item-1147718" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147718"><a href="https://www.tvinsider.com/show/that-90s-show/">That &#8217;90s Show</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/hulu/" class="network-name" style="background-color:#38ce7f"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/hulu.png" alt="Hulu" /></a>
+  <ul>    <li id="menu-item-1147723" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147723"><a href="https://www.tvinsider.com/show/tell-me-lies/">Tell Me Lies</a></li>   <li id="menu-item-1147721" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147721"><a href="https://www.tvinsider.com/show/reasonable-doubt-2022/">Reasonable Doubt</a></li>    <li id="menu-item-1147722" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147722"><a href="https://www.tvinsider.com/show/only-murders-in-the-building/">Only Murders in the Building</a></li>   <li id="menu-item-1147724" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147724"><a href="https://www.tvinsider.com/show/the-handmaids-tale/">The Handmaid&#8217;s Tale</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/amazon-prime-video/" class="network-name" style="background-color:#212f3c"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/prime-video.png" alt="Prime Video" /></a>
+  <ul>    <li id="menu-item-1147725" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147725"><a href="https://www.tvinsider.com/show/the-lord-of-the-rings-the-rings-of-power/">The Lord of the Rings: The Rings of Power</a></li>    <li id="menu-item-1147726" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147726"><a href="https://www.tvinsider.com/show/the-boys/">The Boys</a></li>   <li id="menu-item-1147727" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147727"><a href="https://www.tvinsider.com/show/my-lady-jane/">My Lady Jane</a></li>   <li id="menu-item-1147728" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147728"><a href="https://www.tvinsider.com/show/the-legend-of-vox-machina/">The Legend of Vox Machina</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/max/" class="network-name" style="background-color:#003af0"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2023/05/max.png" alt="Max" /></a>
+  <ul>    <li id="menu-item-1147731" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147731"><a href="https://www.tvinsider.com/show/industry/">Industry</a></li>   <li id="menu-item-1147729" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147729"><a href="https://www.tvinsider.com/show/the-penguin/">The Penguin</a></li>   <li id="menu-item-1147732" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147732"><a href="https://www.tvinsider.com/show/house-of-the-dragon/">House of the Dragon</a></li>   <li id="menu-item-1124714" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124714"><a href="https://www.tvinsider.com/show/and-just-like-that/">And Just Like That&#8230;</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/apple-tv-plus/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/apple-tv-plus.png" alt="Apple TV+" /></a>
+  <ul>    <li id="menu-item-1147735" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147735"><a href="https://www.tvinsider.com/show/bad-monkey/">Bad Monkey</a></li>   <li id="menu-item-1147737" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147737"><a href="https://www.tvinsider.com/show/slow-horses/">Slow Horses</a></li>   <li id="menu-item-1147738" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147738"><a href="https://www.tvinsider.com/show/shrinking/">Shrinking</a></li>   <li id="menu-item-1147739" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147739"><a href="https://www.tvinsider.com/show/presumed-innocent/">Presumed Innocent</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/peacock/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/peacock.png" alt="Peacock" /></a>
+  <ul>    <li id="menu-item-1147745" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147745"><a href="https://www.tvinsider.com/show/love-island/">Love Island USA</a></li>   <li id="menu-item-1147746" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147746"><a href="https://www.tvinsider.com/show/mr-throwback/">Mr. Throwback</a></li>    <li id="menu-item-1147747" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147747"><a href="https://www.tvinsider.com/show/days-of-our-lives/">Days of our Lives</a></li>   <li id="menu-item-1147749" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147749"><a href="https://www.tvinsider.com/show/law-order-organized-crime/">Law &amp; Order: Organized Crime</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/nbc/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/nbc.png" alt="NBC" /></a>
+  <ul>    <li id="menu-item-1147751" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147751"><a href="https://www.tvinsider.com/show/americas-got-talent/">America&#8217;s Got Talent</a></li>    <li id="menu-item-1124724" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124724"><a href="https://www.tvinsider.com/show/one-chicago/">One Chicago</a></li>   <li id="menu-item-1147752" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147752"><a href="https://www.tvinsider.com/show/found-2023/">Found</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/cbs/" class="network-name" style="background-color:#1993ef"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/cbs.png" alt="CBS" /></a>
+  <ul>    <li id="menu-item-1147753" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147753"><a href="https://www.tvinsider.com/show/big-brother/">Big Brother</a></li>   <li id="menu-item-1124727" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124727"><a href="https://www.tvinsider.com/show/ncis/">NCIS</a></li>   <li id="menu-item-1124728" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124728"><a href="https://www.tvinsider.com/show/ghosts/">Ghosts</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/abc/" class="network-name" style="background-color:#5a3c00"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/abc.png" alt="ABC" /></a>
+  <ul>    <li id="menu-item-1147754" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147754"><a href="https://www.tvinsider.com/show/the-bachelorette/">The Bachelorette</a></li>   <li id="menu-item-1147756" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147756"><a href="https://www.tvinsider.com/show/general-hospital/">General Hospital</a></li>   <li id="menu-item-1147755" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147755"><a href="https://www.tvinsider.com/show/claim-to-fame/">Claim to Fame</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/fox/" class="network-name" style="background-color:#0182e7"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/fox.png" alt="FOX" /></a>
+  <ul>    <li id="menu-item-1147759" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147759"><a href="https://www.tvinsider.com/show/masterchef/">MasterChef</a></li>   <li id="menu-item-1147757" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147757"><a href="https://www.tvinsider.com/show/rescue-hi-surf/">Rescue: HI-Surf</a></li>    <li id="menu-item-1147758" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147758"><a href="https://www.tvinsider.com/show/9-1-1-lone-star/">9-1-1: Lone Star</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/showtime/" class="network-name" style="background-color:#ee1e24"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/showtime.png" alt="Showtime" /></a>
+  <ul>    <li id="menu-item-1147760" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147760"><a href="https://www.tvinsider.com/show/dexter-original-sin/">Dexter: Original Sin</a></li>    <li id="menu-item-1147761" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147761"><a href="https://www.tvinsider.com/show/a-gentleman-in-moscow/">A Gentleman in Moscow</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/pbs/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/pbs.png" alt="PBS" /></a>
+  <ul>    <li id="menu-item-1147764" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147764"><a href="https://www.tvinsider.com/show/di-ray/">DI Ray</a></li>   <li id="menu-item-1147763" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147763"><a href="https://www.tvinsider.com/show/van-der-valk/">Van der Valk</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/paramount-plus/" class="network-name" style="background-color:#007afc"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/paramount-plus.png" alt="Parmount+" /></a>
+  <ul>    <li id="menu-item-1147765" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147765"><a href="https://www.tvinsider.com/show/seal-team/">SEAL Team</a></li>   <li id="menu-item-1147766" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147766"><a href="https://www.tvinsider.com/show/evil/">Evil</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/the-cw/" class="network-name" style="background-color:#00942c"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/cw.png" alt="The CW" /></a>
+  <ul>    <li id="menu-item-1147769" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147769"><a href="https://www.tvinsider.com/show/all-american/">All American</a></li>   <li id="menu-item-1147768" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147768"><a href="https://www.tvinsider.com/show/the-chosen/">The Chosen</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/disney-plus/" class="network-name" style="background-color:#2b4754"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2024/03/disney-plus.png" alt="Disney+" /></a>
+  <ul>    <li id="menu-item-1147770" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147770"><a href="https://www.tvinsider.com/show/agatha-darkhold-diaries/">Agatha All Along</a></li>    <li id="menu-item-1147771" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147771"><a href="https://www.tvinsider.com/show/star-wars-the-acolyte/">Star Wars: The Acolyte</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/amc/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/amc.png" alt="AMC" /></a>
+  <ul>    <li id="menu-item-1147772" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147772"><a href="https://www.tvinsider.com/show/the-walking-dead-daryl-dixon/">The Walking Dead: Daryl Dixon</a></li>    <li id="menu-item-1108888" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1108888"><a href="https://www.tvinsider.com/show/interview-with-the-vampire/">Interview With the Vampire</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/hallmark-channel/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/hallmark.png" alt="Hallmark Channel" /></a>
+  <ul>    <li id="menu-item-1093255" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1093255"><a href="https://www.tvinsider.com/show/when-calls-the-heart/">When Calls the Heart</a></li>   <li id="menu-item-1147773" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147773"><a href="https://www.tvinsider.com/show/holidazed/">Holidazed</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/starz/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2020/05/starz.png" alt="Starz" /></a>
+  <ul>    <li id="menu-item-1036860" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1036860"><a href="https://www.tvinsider.com/show/outlander/">Outlander</a></li>   <li id="menu-item-1147774" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147774"><a href="https://www.tvinsider.com/show/power-book-ii-ghost/">Power Book II: Ghost</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/fx/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2020/05/fx.png" alt="FX" /></a>
+  <ul>    <li id="menu-item-1147776" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147776"><a href="https://www.tvinsider.com/show/the-old-man/">The Old Man</a></li>   <li id="menu-item-1147780" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147780"><a href="https://www.tvinsider.com/show/american-sports-story/">American Sports Story: Aaron Hernandez</a></li>  </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/britbox/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/britbox.png" alt="BritBox" /></a>
+  <ul>    <li id="menu-item-1147781" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147781"><a href="https://www.tvinsider.com/show/the-responder/">The Responder</a></li>   <li id="menu-item-1147782" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147782"><a href="https://www.tvinsider.com/show/after-the-flood/">After The Flood</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/acorn-tv/" class="network-name" style="background-color:#081635"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/acorn.png" alt="Acorn" /></a>
+  <ul>    <li id="menu-item-1147783" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147783"><a href="https://www.tvinsider.com/show/murdoch-mysteries/">Murdoch Mysteries</a></li>   <li id="menu-item-1147784" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147784"><a href="https://www.tvinsider.com/show/harry-wild/">Harry Wild</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/hgtv/" class="network-name" style="background-color:#00cbca"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/hgtv.png" alt="HGTV" /></a>
+  <ul>    <li id="menu-item-1147785" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147785"><a href="https://www.tvinsider.com/show/celebrity-iou/">Celebrity IOU</a></li>   <li id="menu-item-1147786" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147786"><a href="https://www.tvinsider.com/show/good-bones/">Good Bones</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/discovery-plus/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/discovery-plus.png" alt="Discovery+" /></a>
+  <ul>    <li id="menu-item-1124765" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124765"><a href="https://www.tvinsider.com/show/90-day-fiance/">90 Day Fiancé</a></li>   <li id="menu-item-1147787" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147787"><a href="https://www.tvinsider.com/show/deadliest-catch/">Deadliest Catch</a></li> </ul></li>  <li class="network"><a href="https://www.tvinsider.com/network/bbc-america/" class="network-name" style="background-color:#000000"><img loading="lazy" class="crisp" width="60" height="30" src="https://www.tvinsider.com/wp-content/uploads/2022/07/bbc-america.png" alt="BBC America" /></a>
+  <ul>    <li id="menu-item-1124766" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124766"><a href="https://www.tvinsider.com/show/doctor-who/">Doctor Who</a></li>   <li id="menu-item-1061411" class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1061411"><a href="https://www.tvinsider.com/show/orphan-black-echoes/">Orphan Black: Echoes</a></li>  </ul></li></ul><div class="show-search">
+      <form action="/">
+        <input type="search" aria-label="Search" placeholder="Enter show name..." name="search">
+        <input type="hidden" name="type" value="show">
+        <input type="submit" value="search">
+      </form>
+      </div></div></li><li id="menu-item-1073127" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1073127"><a href="/movies/">Movies</a></li><li id="menu-item-1036875" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1036875"><a href="https://www.tvinsider.com/what-to-watch/">What to Watch</a></li><li id="menu-item-1162260" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-1162260"><a href="https://www.tvinsider.com/category/game-shows/">Game Shows</a></li><li id="menu-item-1036877" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-1036877"><a href="https://www.tvinsider.com/category/reviews/">Reviews</a></li><li id="menu-item-1110680" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1110680"><a href="https://www.swooon.com/">Swooon</a></li><li id="searchlink"><a href="https://www.tvinsider.com/?search=">Search</a></li></ul></nav></header>
+
+<style>
+.menu li {
+  position: relative;
+}
+.menu li.menu-item-has-children {
+    position: static;
+}
+</style>
+
+<style>
+main {
+  text-align: center;
+}
+.advert-holder {
+  margin: 48px auto 0 auto;
+}
+
+
+h1 {
+  font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 72px;
+    font-weight: 700;
+    transition: .2s;
+    text-align: center;
+    padding: 0 8px;
+  line-height: 1;
+    margin: 48px auto 8px auto;
+    text-wrap: balance;
+    max-width: 1280px;
+    letter-spacing: -2px;
+  text-decoration-line: underline;
+  text-decoration-color: #60d0ff;
+}
+@media (max-width: 768px) {
+  h1 {
+    font-size: 42px;
+  }
+}
+
+h2.label {
+    margin: 12px auto 0 auto;
+    font-size: 30px;
+    font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  text-decoration-line: underline;
+  text-decoration-color: #60d0ff;
+    line-height: 24px;
+    display: inline-block;
+    text-transform: uppercase;
+    letter-spacing: -.5px;
+}
+h2.label.people {
+  text-transform: none;
+  text-decoration-line: underline;
+  text-decoration-color: #60d0ff;
+}
+h2 {
+  font-size: 20px;
+  margin-bottom: 8px;
+} 
+h2 span {
+  font-family: "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  text-transform: initial;
+  padding-left: 4px;
+}
+h2.header {
+  margin: 96px auto -96px auto;
+  font-size: 26px;
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  line-height: 26px;
+  display: table;
+  text-transform: uppercase;
+}
+h3.label {
+    margin: 16px 0 32px 0;
+    font-size: 32px;
+}
+h3.label span {
+    font-family: "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    font-size: 16px;
+    color: #838282;
+    display: block;
+    text-transform: uppercase;
+}
+
+.meta-box {
+  margin: 32px 0 0 0;
+}
+.meta-box-content {
+  display:inline-block; 
+  width: 100%;
+  max-width: 1080px;
+}
+.meta-box-content h3 {
+  text-transform: uppercase;
+}
+.meta-box-content h3 time {
+  margin-top: 4px;
+  margin-bottom: 0;
+}
+.meta-box-content h4 {
+  text-transform: uppercase;
+  color: #b1b1b1;
+    font-size: 12px;
+    font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    display: inline-block;
+}
+.meta-box-content h4 {
+  text-transform: uppercase;
+  color: #b1b1b1;
+    font-size: 12px;
+    font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    display: inline-block;
+}
+.meta-box-content h4.show-rating {
+  color: #838282;
+  font-weight: 400;
+  font-size: 11px;
+}
+.meta-box-content h4.show-rating span {
+  border: 1px solid #b1b1b1;
+  padding: 1px 6px;
+  font-family: serif;
+  font-weight: bold;
+}
+.meta-box-content h4.release-year {
+  color: #838282;
+  font-weight: 500;
+}
+.meta-box-content h4 a {
+  color: #838282 !important;
+  font-weight: 500 !important;
+}
+.meta-box-content h4 a:hover {
+  color: #00aeef !important;
+}
+.meta-box-content h4::after {
+  content: '\00a0\00a0•\00a0\00a0';
+  color: #dee1e3;
+}
+.meta-box-content h4.release-year::after {
+  color: #838282;
+}
+.meta-box-content h4.show-rating::after, .meta-box-content h4.duration::after {
+  content: '\00a0\00a0\00a0|\00a0\00a0\00a0';
+  color: #b1b1b1;
+  font-weight: 400 !important;
+}
+.meta-box-content h4.source-network {
+  font-weight: 500;
+  color: #838282;
+}
+.meta-box-content h4.source-network::after {
+  color: #838282;
+}
+.meta-box-content h4:last-child::after {
+  content: '';
+}
+.meta-box-content h4 a {
+  text-decoration: none;
+  color: #b1b1b1;
+    font-weight: 400;
+}
+.meta-box-content img.key-art {
+  float: left;
+  margin-right: 14px;
+    border-right: 1px solid #dee1e3;
+    padding-right: 14px;
+  aspect-ratio: 1014 / 570;
+}
+.meta-box-content .key-art-container {
+  position: relative;
+  display: block;
+    transition: .2s;
+}
+.meta-box-content .key-art-container .icon-expand {
+  position: absolute;
+    top: 308px;
+    left: 592px;
+    display: none;
+    transition: .2s;
+}
+@media (min-width: 1024px) {
+  .meta-box-content .key-art-container:hover .icon-expand {
+    display: block;
+  }
+}
+.meta-box-content time {
+  margin: 8px 0 16px 0;
+}
+.meta-box-content img.network-logo {
+  border-radius: 4px;
+  transition: .2s;
+}
+.meta-box-content a:hover img.network-logo {
+  transform: scale(1.06);
+}
+.meta-box-content .actor-photo {
+  width: 50%;
+  text-align: right;
+  display: inline-block;
+  padding-right: 14px;
+  border-right: 1px solid #dee1e3;
+}
+.meta-box-content .actor-photo img {
+  width: 320px;
+  height: 427px;
+}
+.meta-box-content .actor-data {
+  width: 50%;
+  float: right;
+  padding-left: 14px;
+}
+@media (max-width: 768px) {
+  .meta-box-content .actor-photo {
+    width: 100%;
+    text-align: center;
+    display: block;
+    padding-right: 0;
+    border-right: 0;
+  }
+  .meta-box-content .actor-data {
+    width: 100%;
+    float: none;
+    padding-left: 0;
+    margin-top: 16px;
+    padding: 0 4px;
+  }
+}
+.meta-box-content p {
+  font-size: 16px;
+  line-height: 26px;
+  text-align: center;
+  display: table;
+  width: 100%;
+}
+@media (max-width: 1024px) {
+  .meta-box-content img.key-art {
+    min-width: 100%;
+    margin-bottom: 16px;
+    border-right: 0;
+    padding-right: 0;
+  }
+}
+.show-data {
+  text-align: left;
+  display: flex;
+  position: relative;
+  flex-flow: column;
+} 
+.show-data p {
+  text-align: left;
+  font-size: 15px;
+  line-height: 22px;
+  padding-top: 6px;
+  padding-right: 4px;
+  border-top: 1px solid #dee1e3;
+  margin-top: 6px;
+  text-wrap: pretty;
+} 
+h2.returning-premiering  {
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif; 
+  font-size: 14px;
+  font-weight: 400;
+    background-color: #fbffb0;
+    padding: 12px;
+    display: flex;
+    margin: 32px auto 0 auto;
+    text-transform: uppercase;
+    width: fit-content;
+    align-items: center;
+    border-radius: 1px;
+    position: relative;
+}
+
+h2.returning-premiering img {
+  margin-right: 8px;
+}
+h2.returning-premiering time {
+  display: inline-block;
+  padding-left: 4px;
+  padding-top: 4px;
+  font-size: 14px;
+} 
+h2.returning-premiering time span {
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  text-transform: none;
+  padding-left: 0;
+} 
+.show-data .base-info {
+  margin-top: 12px;
+  left: 0;
+  display: flex;
+}
+.show-data .base-info h2 {
+  font-family: "IBMPlexSans", "Helvetica Neue", Helvetica, Arial, sans-serif; 
+  font-size: 15px;
+  font-weight: 400;
+    background-color: #fbffb0;
+    padding: 3px 0 2px 10px;
+  margin-bottom: 0;
+}
+.show-data .base-info a.trailer-link {
+    padding: 6px 4px 2px 4px;
+    background-color: #d60000;
+    transition: .2s;
+  margin-right: 16px;
+    border-radius: 6px;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 24px 1fr;
+    row-gap: 4px;
+    align-items: center;
+    text-align: center;
+    justify-items: center;
+    min-height: 74px;
+  min-width: 60px;
+  max-width: 70px;
+}
+.show-data .base-info a.trailer-link h2, .show-data .base-info a.trailer-link span {
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.1;
+    background-color: #d60000;
+    color: #fff;
+    text-transform: uppercase;
+    display: block;
+    padding: 0;
+}
+.show-data .base-info a.trailer-link span {
+    font-size: 12px;
+    line-height: 1;
+    word-break: break-word;
+}
+.show-data .base-info a.trailer-link:hover {
+  transform: scale(1.06);
+}
+.show-data .network-and-time {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-template-rows: 1fr;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.show-data .logonetwork img {
+  margin-right: 12px;
+}
+.show-data .top-info {
+  line-height: 18px;
+  text-wrap: pretty;
+  padding-top: 6px;
+  border-top: 1px solid #dee1e3;
+}
+.show-data .genres {
+  text-wrap: balance;
+}
+
+.show-data .base-info a.show-imdb-rating {
+  padding: 6px;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: space-between;
+  background-color: #fcc500;
+  margin-right: 16px;
+  border-radius: 6px;
+    transition: .2s;
+    text-align: center;
+    min-height: 74px;
+  min-width: 60px;
+}
+.show-data .base-info a.show-imdb-rating img {
+  margin-top: 3px;
+}
+.show-data .base-info a.show-imdb-rating h5 {
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  color: #000;
+  letter-spacing: -1px;
+}
+
+.show-data .base-info a.show-imdb-rating:hover {
+  transform: scale(1.06);
+}
+.show-data .base-info a.show-rotten-rating {
+  padding: 6px;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: space-between;
+  background-color: #89ff60;
+  margin-right: 16px;
+  border-radius: 6px;
+    transition: .2s;
+    text-align: center;
+    min-height: 74px;
+  min-width: 60px;
+}
+.show-data .base-info a.show-rotten-rating h5 {
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  color: #000;
+  letter-spacing: -1px;
+}
+.show-data .base-info a.show-rotten-rating h5 span {
+  font-size: 20px;
+  position: relative;
+  top: -3px;
+}
+
+.show-data .base-info a.show-rotten-rating:hover {
+  transform: scale(1.06);
+}
+.show-data time {
+  padding-left: 4px;
+  margin: 0 16px 0 0;
+  font-size: 14px;
+} 
+.show-data .network-logo {
+  float: left;
+} 
+.show-data h3.tune-in {
+    font-family: "IBMPlexSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    font-weight: 400;
+  color: #262727;
+  margin-top: -2px;
+}
+.show-data h3.tune-in time {
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+  color: #262727;
+}
+.show-data h3.tune-in time span {
+  text-transform: none;
+}
+.show-data h3.airing-next {
+  display: flex;
+  align-content: center;
+}
+.show-data h3.airing-next a {
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  border-radius: 4px; 
+  padding: 1px 4px;
+  font-size: 12px; 
+  border: 1px solid #f7d33b;
+  max-height: 18px;
+  transition: .2s;
+  color: #d0ad1a;
+  background-color: #feffea;
+}
+.show-data h3.airing-next a:hover {
+    background-color: #00aeef;
+    color: #fff;
+  border-color: #00aeef;
+}
+.show-data .base-info a.awards {
+  padding: 6px;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: space-around;
+    text-align: center;
+    row-gap: 4px;
+    border-radius: 6px;
+    transition: .2s;
+  border: 1px solid #00aeef;
+    background-color: #00aeef;
+    min-height: 74px;
+  min-width: 60px;
+}
+.meta-box a.awards-people h3 {
+    text-transform: uppercase;
+    border-radius: 3px;
+    white-space: nowrap;
+    padding: 4px 4px 0 17px;
+    font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    min-width: auto;
+    transition: .2s;
+  border: 1px solid #00aeef;
+    background-color: #00aeef;
+    color: #fff;
+  background-repeat: no-repeat;
+    background-image: url(/wp-content/themes/tv/images/symbol-award-white.png);
+    background-position: 3px center;
+    background-size: 12px 12px;
+    min-height: 24px;
+}
+
+.show-data .base-info a.awards h3 {
+    text-transform: uppercase;
+    font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    color: #fff;
+}
+.show-data .base-info a.awards:hover {
+  transform: scale(1.06);
+}
+@media (max-width: 1024px) {
+  .show-data {
+    display: block;
+    float: left;
+    padding: 0 4px;
+  }
+  .show-data .base-info {
+    position: relative;
+  }
+}
+
+.meta-box-content.people-page h3 {
+  text-transform: uppercase;
+  font-size: 16px;
+}
+.meta-box-content.people-page .known-for {
+  text-align: left;
+  margin-top: 12px;
+  position: relative;
+  left: -6px;
+}
+.meta-box-content.people-page .known-for a h3 {
+  text-transform: none;
+  border-radius: 3px;
+    border: 1px solid #00aeef;
+    padding: 1px 4px 0 4px;
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    position: relative;
+    color: #00aeef;
+    display: inline-block;
+    font-weight: 400;
+    margin: 0 2px 4px 6px;
+    line-height: 19px;
+    min-width: auto;
+    transition: .2s;
+    max-width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    z-index: 100;
+}
+.meta-box-content.people-page .known-for a.all-credits h3 {
+    border: 1px solid #b1b1b1;
+  color: #b1b1b1;
+}
+.meta-box-content.people-page .known-for a.all-credits:hover h3 {
+    border: 1px solid #00aeef;
+  background-color: #00aeef;
+  color: #fff;
+  transform: scale(1.06);
+}
+.meta-box-content.people-page .known-for a:hover h3 {
+  background-color: #00aeef;
+  color: #fff;
+  transform: scale(1.06);
+  max-width: 100%;
+}
+.meta-box-content.people-page span.role {
+  font-size: 13px;
+  color: #838282;
+    position: relative;
+    top: -11px;
+}
+.meta-box-content.people-page h2, .meta-box-content.people-page p {
+  text-align: left;
+  line-height: 20px;
+}
+.meta-box-content.people-page h2, .meta-box-content.people-page h2 {
+  font-size: 16px;
+  line-height: 18px;
+  text-wrap: balance;
+}
+.meta-box-content.people-page .external-links {
+  display: flex;
+  column-gap: 8px;
+    border-bottom: 1px solid #dee1e3;
+    margin-bottom: 6px;
+    padding-bottom: 6px;
+}
+.meta-box-content.people-page .external-links img {
+  /*
+  filter: grayscale(1);
+  transition: .2s;
+  */
+}
+.meta-box-content.people-page .external-links img:hover {
+  filter: grayscale(0);
+  transform: scale(1.06);
+}
+.meta-box-content a {
+  color: #00aeef;
+  transition: .2s;
+  cursor: pointer;
+  font-weight: 700;
+}
+.meta-box-content a:hover {
+  color: #262727;
+}
+.meta-box-content .social-icons {
+  text-align: center;
+  padding: 16px;
+}
+.meta-box-content .social-icons li {
+  margin: 0 6px;
+}
+.meta-box-content .more-content span {
+  display: none;
+}
+.meta-box-content .more-link {
+  color: #00aeef;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+
+.talk-show-sked {
+  margin: 0 auto;
+  max-width: 1366px;
+  display: inline-block;
+}
+.talk-show-sked h2 {
+  margin: 32px 0 16px 0;
+  font-size: 32px;
+}
+.talk-show-days {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-flow: row;
+  justify-content: center;
+}
+.talk-show-days p {
+  text-align: left;
+  margin: 0;
+  font-size: 14px;
+  line-height: 19px;
+}
+.talk-show-days p a {
+  color: #00aeef;
+}
+.talk-show-days time {
+  text-align: left;
+  margin: 0;
+  color: #d60000;
+}
+.talk-show-days .talk-show-guest {
+  border-radius: 4px 4px 0 0;
+  background-color: #fff;
+  padding: 8px;
+  margin: 0 8px 16px 8px;
+  width: 100%;
+  background-color: #f6f6f6;
+  max-width: 400px;
+}
+@media (max-width: 768px) {
+  .talk-show-days {
+    flex-wrap: wrap;
+  }
+}
+.records {
+  display: flex; 
+  flex-flow: row wrap;
+  justify-content: center;
+  max-width: 1366px;
+  width: 100%;
+  margin: 0 auto;
+}
+.records h2 {
+  color: #838282;
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 20px;
+  width: 100%;
+  font-weight: 400;
+  margin-bottom: 40px;
+  line-height: 28px;
+}
+.records h2 span {
+  color: #262727;
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 600;
+  font-size: 32px;
+  display: block;
+  font-style: italic;
+  text-decoration: underline;
+}
+.records-item {
+  margin: 0 12px 16px 12px;
+  max-width: 420px;
+  display: flex;
+  flex-flow: column nowrap;
+  transition: .2s;
+  text-align: left;
+  position: relative;
+}
+.records-item:hover h3 {
+  color: #00aeef;
+}
+.records-item img {
+  flex-grow: 0;
+  transition: .2s;
+}
+.records-item:hover img {
+  filter: brightness(70%);
+}
+.records-item time {
+  flex-grow: 0;
+  padding-top: 8px;
+}
+.records-item h3 {
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  flex-grow: 1;
+  padding-bottom: 16px;
+  font-weight: 600;
+  font-size: 22px;
+}
+.jw-offer {
+  position: relative;
+}
+.alt {
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  display: none;
+  position: absolute;
+  top: 75px;
+  font-size: 12px;
+  background-color: #00aeef;
+  color: #fff;
+  transition: .2s;
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 999;
+  width: 100%;
+  text-align: center;
+  overflow-wrap: break-word;
+}
+.jw-offer a:hover .alt {
+  display: block;
+}
+#where-to-watch h2 {
+    padding: 6px;
+    font-size: 28px;
+    line-height: 1;
+    text-transform: uppercase;
+    margin: 12px auto 4px auto;
+  font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    display: inline-block;
+    border-radius: 6px;
+    letter-spacing: -1px;
+    text-wrap: balance;
+}
+#where-to-watch .extra-show-data {
+  color: #838282;
+  font-size: 12px;
+  margin-top: -6px;
+  margin-bottom: 24px;
+  font-weight: 400;
+  text-transform: uppercase;
+  font-family: "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+#where-to-watch .extra-show-data a {
+  color: #838282;
+}
+#where-to-watch .extra-show-data a:hover {
+  color: #262727;
+}
+#where-to-watch .extra-show-data span::after {
+    content: '\00a0\00a0•\00a0';
+    color: #b1b1b1;
+}
+#where-to-watch .extra-show-data span:last-child::after {
+    content: '';
+}
+
+.matt-pick {
+  border: 1px solid #dee1e3;
+  background-color: #f6f6f6;
+  max-width: 860px;
+  width: 98%;
+  border-radius: 8px;
+  margin: 48px auto 32px auto;
+  text-align: left;
+  position: relative; 
+}
+.matt-pick.matt-review {
+  max-width: 620px;
+}
+.matt-pick.matt-review blockquote {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+.matt-pick .matt-header {
+  width: 100%;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: flex-end;
+  border-bottom: 1px solid #dee1e3;
+  justify-content: center;
+}
+.matt-pick .matt-header .matt-head {
+  margin-right: 6px;
+  margin-top: -16px;
+}
+.matt-pick .matt-header h4 {
+  font-size: 18px;
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-style: italic;
+}
+.matt-pick p {
+  padding: 16px 8px 8px 80px;
+  font-size: 15px;
+  background: url(/wp-content/themes/tv/images/quote-marks.png?x=4) 6px 12px no-repeat;
+  background-size: 60px 38px;
+  line-height: 150%;
+}
+.matt-pick p a {
+  color: #00aeef;
+  font-weight: bold;
+  transition: .2s;
+}
+.matt-pick p a:hover {
+  color: #fff;
+  background-color: #00aeef;
+  border-radius: 5px;
+}
+.matt-pick .matt-attribution {
+  padding: 0 8px 8px 8px;
+  text-align: right;
+  font-size: 14px;
+  font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial;
+  text-transform: uppercase;
+  color: #00aeef;
+}
+.matt-pick .matt-attribution a {
+  color: #00aeef;
+  transition: .2s;
+}
+.matt-pick .matt-attribution a:hover {
+  text-decoration: underline;
+}
+.show-newsletter-signup {
+  text-align: center;
+  margin: 32px 0 0 0;
+  padding: 16px 0;
+  background: linear-gradient(to bottom, #00aeef, #138ff8);
+}
+.show-newsletter-signup h4, .show-newsletter-signup h5, .show-newsletter-signup h6 {
+  color: #fff;
+}
+.show-newsletter-signup img {
+  filter: brightness(0) invert(1);
+}
+.show-newsletter-signup input[type="submit"] {
+  background-color: #000;
+}
+.recaps-holder {
+  background-color: #feffea;
+  margin-bottom: 32px;
+  padding-top: 32px;
+}
+.recaps-holder h2 {
+  text-transform: uppercase;
+  border-bottom: 3px solid #60d0ff;
+  font-size: 32px;
+  display: inline-block;
+  line-height: 28px;
+  margin-bottom: 24px;
+}
+.recaps {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0 auto;
+  justify-content: center;
+  max-width: 1366px;
+}
+.recaps-item {
+  margin: 0 8px 24px;
+  max-width: 280px;
+  display: inline-table;
+  transition: .2s;
+  position: relative;
+}
+.recaps-item img {
+  transition: .2s;
+  height: auto;
+}
+.recaps-item:hover img {
+  filter: brightness(70%);
+}
+.recaps-item .episode-metadata {
+  color: #838282;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.recaps-item .episode-rating img {
+  height: 16px;
+  width: auto !important;
+}
+.recaps-holder .ajax-load-more-wrap .alm-load-more-btn {
+  background-color: #00aeef !important;
+  color: #fff !important;
+  border: 1px solid #00aeef !important;
+}
+.lity-iframe-container {
+  border-radius: 6px;
+}
+
+.games {
+  margin: 16px auto;
+  display: flex;
+  flex-flow: row;
+  flex-wrap: wrap;
+  overflow-x: auto;
+  padding-bottom: 16px;
+  justify-content: flex-start;
+  max-width: 1366px;
+  gap: 12px;
+}
+@media (max-width: 768px) {
+  .games {
+    justify-content: center;
+  }
+}
+.game {
+    background-color: #feffea;
+    max-width: 260px;
+    min-width: 260px;
+    border: 1px solid #f7d33b;
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    padding: 8px 4px 8px 8px;
+    text-align: left;
+    transition: .2s;
+    display: flex;
+    border-radius: 2px;
+}
+.game time {
+    text-transform: uppercase;
+    color: #d60000;
+    font-size: 12px;
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    margin-bottom: 4px;
+}
+.game time span {
+    color: #262727;
+}
+.game h3 {
+    font-size: 16px;
+    margin: 0;
+    padding-right: 2px;
+}
+.game h4 {
+    font-size: 14px;
+    font-weight: normal;
+    margin: 0;
+    padding-right: 2px;
+    font-family: "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.game h5 {
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    text-transform: uppercase;
+    padding-top: 4px;
+}
+.game img {
+    margin-right: 8px;
+    width: 22px;
+    height: 22px;
+}
+
+.sports-nav {
+    display: flex;
+    flex-flow: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  margin: 16px auto 32px auto;
+  justify-content: center;
+}
+@media (max-width: 768px) {
+  .sports-nav {
+    justify-content: flex-start;
+  }
+}
+.sports-nav a {
+  background-color: #f5f9fd;
+  border: 1px solid #60d0ff;
+  color: #00aeef;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-weight: bold;
+  margin: 0 4px;
+  transition: .2s;
+}
+.sports-nav a:hover {
+  background-color: #60d0ff;
+  color: #fff;
+}
+.sports-nav a.selected {
+  background-color: #60d0ff;
+  color: #fff;
+}
+.inline-gallery {
+  margin: 8px auto 0 auto;
+  text-align: center;
+  padding-top: 8px;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  gap: 4px;
+}
+.inline-gallery a {
+  display: block;
+  transition: .2s;
+  position: relative;
+  border: 2px solid #f5f9fd;
+  transition: .2s;
+}
+.inline-gallery a img {
+  height: 100%;
+  transition: .2s;
+}
+.inline-gallery a.gracenote {
+  height: 180px;
+  overflow: hidden;
+}
+.inline-gallery a.gracenote img {
+  object-fit: cover;
+    object-position: 50% 0%;
+}
+.inline-gallery a:hover {
+  border: 2px solid #00aeef;
+  border-radius: 3px;
+}
+.inline-gallery a:hover img {
+    filter: brightness(70%);
+}
+.inline-gallery a.hidden {
+  display: none;
+}
+#inline-gallery-caption {
+  margin: 16px auto 0 auto;
+  text-align: center;
+  min-height: 48px;
+  font-size: 14px;
+  padding: 0 20px;
+}
+.lity-free-loader {
+    z-index: 999000;
+    color: #fff;
+    position: absolute;
+    top: 50%;
+    margin-top: -0.8em;
+    width: 100%;
+    text-align: center;
+    font-size: 15px;
+    font-family: "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    transition: opacity 0.2s ease;
+}
+.photo-caption {
+  color: #fff;
+  font-size: 12px;
+}
+.photo-credit {
+  color: #fff;
+  font-size: 12px;
+  text-align: right;
+}
+</style>
+
+<main>
+  <section>
+
+    <!-- CATEGORY PAGES -->
+        
+    <!-- AUTHOR PAGES -->
+    
+    <!-- SHOW PAGES -->
+    
+    <!-- PEOPLE PAGES -->
+    
+    <!-- NETWORK PAGES -->
+    <style>
+section {
+  margin: 0 auto;
+}
+section.inline {
+  max-width: 1366px;
+}
+.banner {
+    margin: 0 auto;
+    background-image: url(https://www.tvinsider.com/wp-content/uploads/2023/08/movieplex.png);
+    border-radius: 8px;
+    background-size: 548px 141px;
+    width: 220px;
+    height: 110px;
+    color: transparent;
+    background-repeat: no-repeat;
+    background-size: contain;
+    max-width: 100%;
+    border-bottom: none !important;
+    box-shadow: none;
+    font-size: 36px;
+    line-height: 100%;
+    display: inline-block;
+}
+h1 {
+  font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 72px;
+    font-weight: 700;
+    transition: .2s;
+    text-align: center;
+    padding: 0 8px;
+  line-height: 1;
+    margin: 48px auto 8px auto;
+    text-wrap: balance;
+    max-width: 1280px;
+    letter-spacing: -2px;
+  text-decoration-line: underline;
+  text-decoration-color: #60d0ff;
+}
+@media screen and (max-width: 768px) {
+  h1 {
+    font-size: 42px;
+  }
+}
+h2 {
+    margin: 48px auto 24px auto;
+    font-size: 30px;
+    font-family: "IBMPlexSansCondensed", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 26px;
+    display: table;
+    text-transform: uppercase;
+}
+h3.label {
+    margin-top: 48px;
+}
+h2.date {
+    margin: 48px auto 16px auto;
+    font-size: 26px;
+    text-align: center;
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    text-transform: uppercase;
+  text-decoration-line: underline;
+  text-decoration-color: #60d0ff;
+    display: table;
+    line-height: 24px;
+}
+.logo-area {
+    display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;   
+  background-color: #ffffff;
+  height: 180px;
+}
+.logo-area .banner:hover {
+  transform: scale(1.1);
+}
+
+
+.show-grid {
+  margin: 0 auto 64px auto;
+  display: grid;
+  grid-auto-flow: row; 
+  overflow: auto;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-rows: auto;
+  gap: 4px;
+  padding: 0 8px;
+}
+@media screen and (max-width: 768px) {
+  .show-grid {
+    grid-auto-columns: auto;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    grid-template-rows: 1fr;
+  }
+}
+.show-grid .show-upcoming {
+  border: 1px solid #dee1e3;
+  background-color: #f6f6f6;
+  padding: 8px;
+  min-width: 160px;
+  min-height: 148px;
+  text-align: left;
+}
+.show-grid a[href].show-upcoming.live:hover {
+  background-color: #f2f9ff;
+  border-color: #60d0ff;
+}
+.show-grid .show-upcoming h3 {
+  text-transform: none;
+    font-weight: 600;
+    font-size: 17px;
+    text-wrap: balance;
+    margin-top: 2px;
+    line-height: 1.1;
+}
+.show-grid .show-upcoming h3 span {
+  font-size: 12px;
+  color: #fff;
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  margin: 0 0 0 4px;
+  background-color: #d60000;
+  border-radius: 4px;
+  position: relative;
+  top: -1px;
+}
+.show-grid .show-upcoming h4 {
+  text-transform: none;
+    font-weight: 400;
+    font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 12px;
+    color: #838282;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+.show-grid .show-upcoming h5 {
+  text-transform: none;
+    font-weight: 500;
+    font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+}
+.show-grid .show-upcoming h6 {
+  text-transform: none;
+    font-weight: 400;
+    font-family: "IBMPlexSans", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: #838282;
+}
+.show-grid .show-upcoming .top-element {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+.show-grid .show-upcoming .top-element .streamit {
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    border-radius: 4px;
+    font-size: 10px;
+    border: 1px solid #60d0ff;
+    color: #00aeef;
+    padding: 3px 3px 2px 3px;
+    text-transform: uppercase;
+}
+.show-grid .show-upcoming time {
+  font-size: 13px;
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: #d60000;
+  padding-bottom: 4px;
+}
+.show-grid .show-upcoming p {
+    font-weight: 400;
+    font-size: 12px;
+}
+.full-sked-link {
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  padding: 8px 32px;
+  background-color: #00aeef;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  text-transform: uppercase;
+  transition: .2s;
+  border: 1px solid #00aeef;
+}
+.full-sked-link:hover {
+  border: 1px solid #60d0ff;
+  background-color: #f6f6f6;
+    color: #00aeef;
+}
+.channel-changer {
+  max-width: 200px;
+  text-transform: none;
+  margin: 16px auto 0 8px;
+}
+p.tooltip {
+    margin: 32px auto;
+    background-color: #fbffb0;
+    padding: 12px;
+    font-size: 14px;
+    line-height: 1.5;
+    border: 1px solid #f7d33b;
+    border-radius: 3px;
+    font-style: italic;
+    text-align: center;
+    max-width: 400px;
+    text-wrap: balance;
+}
+p.tooltip span {
+    margin: 6px 0;
+    display: block;
+    line-height: 19px;
+    text-wrap: balance;
+}
+.basic-button {
+  padding: 5px 6px 4px;
+  font-size: 12px;
+  border-radius: 4px;
+  transition: .2s;
+  background: #fff;
+    border: 1px solid #00aeef;
+    color: #838282 !important;
+}
+.basic-button:hover {
+  background: #00aeef;
+  color: #fff !important;
+}
+
+.find-show {
+  margin-top: 64px;
+  border: 1px solid #60d0ff;
+    padding: 8px;
+    background-color: #f2f9ff;
+}
+.find-show p {
+  margin: 32px 0;
+  background-color: #feffea; 
+  display: inline-block; 
+  padding: 16px;
+  text-align: left;
+  font-size: 15px;
+  line-height: 22px;
+  border: 1px solid #f7d33b;
+  border-radius: 3px;
+  max-width: 360px;
+}
+.find-show p span {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    color: #fff;
+    font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 30px;
+    line-height: 40px;
+    background-color: #f7d33b;
+    display: inline-block;
+    float: left;
+    text-align: center;
+    margin-right: 8px;
+}
+.find-show .show-search {
+  margin-bottom: 32px;
+}
+.find-show .show-search input[type=search]::placeholder {
+  color: #b1b1b1;
+}
+.find-show .show-search input[type=search] {
+  font-size: 26px;
+  border: 2px solid #00aeef;
+  border-radius: 8px;
+  display: inline-block;
+  margin: 16px auto;
+  padding: 12px;
+  min-width: 420px;
+}
+.find-show .show-search input[type=submit] {
+  padding: 12px;
+  font-size: 26px;
+  display: inline-block;
+  margin: 0 auto;
+}
+@media screen and (max-width: 420px) {
+  .find-show .show-search input[type=search] {
+    font-size: 22px;
+    min-width: 90%;
+    max-width: 90%;
+  }
+}
+
+
+.button-area {
+  margin-top: 12px;
+  margin-bottom: 16px;
+}
+.button-area input[type="button"] {
+  -webkit-appearance: none;
+    background-color: #fff;
+    color: #838282;
+  font-family: "Objet", "OpenSans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+    padding: 8px 12px;
+    border: 1px solid #838282;
+    border-radius: 4px;
+    text-transform: uppercase;
+    margin: 0 4px;
+    transition: .2s;
+    margin-bottom: 8px;
+}
+.button-area input[type="button"]:hover {
+    background-color: #f6f6f6;
+    color: #00aeef;
+    border: 1px solid #00aeef;
+}
+.button-area input[type="button"].selected,  .button-area input[type="button"].selected:hover {
+    color: #fff !important;
+    background-color: #00aeef;
+    border: 1px solid #00aeef;
+}
+
+</style>
+<div class="logo-area"><div class="banner">MoviePlex</div></div><a class="basic-button" href="https://www.tvinsider.com/network/movieplex/">< Back To MoviePlex</a><select class="channel-changer" onChange="window.location.href=this.value">
+<option value="">CHANGE CHANNEL</option><option value="/network/5-star-max/schedule/">5-Star MAX</option><option value="/network/ae/schedule/">A&amp;E</option><option value="/network/abc/schedule/">ABC</option><option value="/network/acc-network/schedule/">ACC Network</option><option value="/network/action-max/schedule/">Action MAX</option><option value="/network/adult-swim/schedule/">Adult Swim</option><option value="/network/altitude-sports/schedule/">Altitude Sports</option><option value="/network/amc/schedule/">AMC</option><option value="/network/american-heroes-channel/schedule/">American Heroes Channel</option><option value="/network/animal-planet/schedule/">Animal Planet</option><option value="/network/antenna-tv/schedule/">Antenna TV</option><option value="/network/aspire/schedule/">Aspire</option><option value="/network/awe/schedule/">AWE</option><option value="/network/axs/schedule/">AXS</option><option value="/network/babyfirst/schedule/">BabyFirst</option><option value="/network/bbc-america/schedule/">BBC America</option><option value="/network/bbc-news/schedule/">BBC News</option><option value="/network/bein-sports/schedule/">beIN Sports</option><option value="/network/bet/schedule/">BET</option><option value="/network/bet-gospel/schedule/">BET Gospel</option><option value="/network/bet-her/schedule/">BET Her</option><option value="/network/bet-jams/schedule/">BET Jams</option><option value="/network/bet-soul/schedule/">BET Soul</option><option value="/network/big-ten-network/schedule/">Big Ten Network</option><option value="/network/bloomberg/schedule/">Bloomberg</option><option value="/network/boomerang/schedule/">Boomerang</option><option value="/network/bounce-tv/schedule/">Bounce TV</option><option value="/network/bravo/schedule/">Bravo</option><option value="/network/buzzr/schedule/">Buzzr</option><option value="/network/byutv/schedule/">BYUtv</option><option value="/network/c-span/schedule/">C-SPAN</option><option value="/network/c-span-2/schedule/">C-SPAN 2</option><option value="/network/c-span-3/schedule/">C-SPAN 3</option><option value="/network/cars-tv/schedule/">Cars.TV</option><option value="/network/cartoon-network/schedule/">Cartoon Network</option><option value="/network/catchy-comedy/schedule/">Catchy Comedy</option><option value="/network/catholic-faith-network/schedule/">Catholic Faith Network</option><option value="/network/cbs/schedule/">CBS</option><option value="/network/cbs-sports-network/schedule/">CBS Sports Network</option><option value="/network/charge/schedule/">Charge!</option><option value="/network/cheddar/schedule/">Cheddar</option><option value="/network/cinemax/schedule/">Cinemax</option><option value="/network/circle/schedule/">Circle</option><option value="/network/cleo-tv/schedule/">Cleo TV</option><option value="/network/cmt/schedule/">CMT</option><option value="/network/cnbc/schedule/">CNBC</option><option value="/network/cnn/schedule/">CNN</option><option value="/network/cnn-international/schedule/">CNN International</option><option value="/network/comedy-central/schedule/">Comedy Central</option><option value="/network/comedy-tv/schedule/">Comedy TV</option><option value="/network/comet/schedule/">Comet</option><option value="/network/cooking-channel/schedule/">Cooking Channel</option><option value="/network/court-tv/schedule/">Court TV</option><option value="/network/cozi-tv/schedule/">Cozi TV</option><option value="/network/create/schedule/">Create</option><option value="/network/crime-and-investigation-network/schedule/">Crime and Investigation Network</option><option value="/network/dabl/schedule/">Dabl</option><option value="/network/daystar/schedule/">Daystar</option><option value="/network/dazn/schedule/">DAZN</option><option value="/network/destination-america/schedule/">Destination America</option><option value="/network/discovery/schedule/">Discovery Channel</option><option value="/network/discovery-family/schedule/">Discovery Family</option><option value="/network/discovery-life-channel/schedule/">Discovery Life Channel</option><option value="/network/disney-channel/schedule/">Disney Channel</option><option value="/network/disney-junior/schedule/">Disney Junior</option><option value="/network/disney-xd/schedule/">Disney XD</option><option value="/network/e/schedule/">E!</option><option value="/network/espn/schedule/">ESPN</option><option value="/network/espn-deportes/schedule/">ESPN Deportes</option><option value="/network/espn2/schedule/">ESPN2</option><option value="/network/espnu/schedule/">ESPNU</option><option value="/network/estrella-tv/schedule/">Estrella TV</option><option value="/network/family-movie-classics/schedule/">Family Movie Classics</option><option value="/network/fanduel-sports-detroit/schedule/">FanDuel Sports Detroit</option><option value="/network/fanduel-sports-florida/schedule/">FanDuel Sports Florida</option><option value="/network/fanduel-sports-great-lakes/schedule/">FanDuel Sports Great Lakes</option><option value="/network/fanduel-sports-indiana/schedule/">FanDuel Sports Indiana</option><option value="/network/fanduel-sports-kansas-city/schedule/">FanDuel Sports Kansas City</option><option value="/network/fanduel-sports-midwest/schedule/">FanDuel Sports Midwest</option><option value="/network/fanduel-sports-new-orleans/schedule/">FanDuel Sports New Orleans</option><option value="/network/fanduel-sports-north/schedule/">FanDuel Sports North</option><option value="/network/fanduel-sports-ohio/schedule/">FanDuel Sports Ohio</option><option value="/network/fanduel-sports-oklahoma/schedule/">FanDuel Sports Oklahoma</option><option value="/network/fanduel-sports-socal/schedule/">FanDuel Sports SoCal</option><option value="/network/fanduel-sports-south/schedule/">FanDuel Sports South</option><option value="/network/fanduel-sports-southeast/schedule/">FanDuel Sports Southeast</option><option value="/network/fanduel-sports-southwest/schedule/">FanDuel Sports Southwest</option><option value="/network/fanduel-sports-sun/schedule/">FanDuel Sports Sun</option><option value="/network/fanduel-sports-west/schedule/">FanDuel Sports West</option><option value="/network/fanduel-sports-wisconsin/schedule/">FanDuel Sports Wisconsin</option><option value="/network/fetv/schedule/">FETV</option><option value="/network/flix/schedule/">Flix</option><option value="/network/food-network/schedule/">Food Network</option><option value="/network/fox/schedule/">FOX</option><option value="/network/fox-business/schedule/">Fox Business</option><option value="/network/fox-deportes/schedule/">FOX Deportes</option><option value="/network/fox-news/schedule/">Fox News</option><option value="/network/fox-soccer-plus/schedule/">Fox Soccer Plus</option><option value="/network/fox-sports-1/schedule/">Fox Sports 1</option><option value="/network/fox-sports-2/schedule/">Fox Sports 2</option><option value="/network/freeform/schedule/">Freeform</option><option value="/network/fuse/schedule/">Fuse</option><option value="/network/fx/schedule/">FX</option><option value="/network/fx-movie-channel/schedule/">FX Movie Channel</option><option value="/network/fxx/schedule/">FXX</option><option value="/network/fyi/schedule/">FYI</option><option value="/network/game-show-network/schedule/">Game Show Network</option><option value="/network/gettv/schedule/">getTV</option><option value="/network/gol-tv/schedule/">GOL TV</option><option value="/network/golf-channel/schedule/">Golf Channel</option><option value="/network/great-american-faith-and-living/schedule/">Great American Faith &amp; Living</option><option value="/network/great-american-family/schedule/">Great American Family</option><option value="/network/grit/schedule/">Grit</option><option value="/network/hallmark-channel/schedule/">Hallmark Channel</option><option value="/network/hallmark-family/schedule/">Hallmark Family</option><option value="/network/hallmark-mystery/schedule/">Hallmark Mystery</option><option value="/network/hbo/schedule/">HBO</option><option value="/network/hbo-comedy/schedule/">HBO Comedy</option><option value="/network/hbo-family/schedule/">HBO Family</option><option value="/network/hbo-latino/schedule/">HBO Latino</option><option value="/network/hbo-signature/schedule/">HBO Signature</option><option value="/network/hbo-zone/schedule/">HBO Zone</option><option value="/network/hbo2/schedule/">HBO2</option><option value="/network/hdnet-movies/schedule/">HDNet Movies</option><option value="/network/here-tv/schedule/">Here TV</option><option value="/network/heroes-icons/schedule/">Heroes &amp; Icons</option><option value="/network/hgtv/schedule/">HGTV</option><option value="/network/history-channel/schedule/">History Channel</option><option value="/network/hln/schedule/">HLN</option><option value="/network/hsn/schedule/">HSN</option><option value="/network/ifc/schedule/">IFC</option><option value="/network/impact/schedule/">Impact</option><option value="/network/indieplex/schedule/">IndiePlex</option><option value="/network/insp/schedule/">INSP</option><option value="/network/investigation-discovery/schedule/">Investigation Discovery</option><option value="/network/ion-mystery/schedule/">ION Mystery</option><option value="/network/ion-plus/schedule/">Ion Plus</option><option value="/network/ion-television/schedule/">Ion Television</option><option value="/network/jewelry-television/schedule/">Jewelry Television</option><option value="/network/jewish-life-television/schedule/">Jewish Life Television</option><option value="/network/justice-central/schedule/">Justice Central</option><option value="/network/laff/schedule/">Laff</option><option value="/network/law-and-crime/schedule/">Law &amp; Crime</option><option value="/network/lifetime/schedule/">Lifetime</option><option value="/network/lmn/schedule/">Lifetime Movie Network</option><option value="/network/lifetime-real-women/schedule/">Lifetime Real Women</option><option value="/network/logo/schedule/">Logo</option><option value="/network/magnolia-network/schedule/">Magnolia Network</option><option value="/network/mavtv/schedule/">MAVTV</option><option value="/network/merit-street/schedule/">Merit Street</option><option value="/network/metv/schedule/">MeTV</option><option value="/network/metv-toons/schedule/">MeTV Toons</option><option value="/network/metv-plus/schedule/">MeTV+</option><option value="/network/mgm-plus/schedule/">MGM+</option><option value="/network/mgm-plus-drive-in/schedule/">MGM+ Drive-In</option><option value="/network/mgm-plus-hits/schedule/">MGM+ Hits</option><option value="/network/mgm-plus-marquee/schedule/">MGM+ Marquee</option><option value="/network/military-history/schedule/">Military History</option><option value="/network/mlb-network/schedule/">MLB Network</option><option value="/network/more-max/schedule/">More MAX</option><option value="/network/motortrend/schedule/">MotorTrend</option><option value="/network/moviemax/schedule/">Movie MAX</option><option value="/network/movieplex/schedule/">MoviePlex</option><option value="/network/movies/schedule/">Movies!</option><option value="/network/msg/schedule/">MSG</option><option value="/network/msnbc/schedule/">MSNBC</option><option value="/network/mtv/schedule/">MTV</option><option value="/network/mtv-classic/schedule/">MTV Classic</option><option value="/network/mtv-live/schedule/">MTV Live</option><option value="/network/mtv2/schedule/">MTV2</option><option value="/network/mynetworktv/schedule/">MyNetworkTV</option><option value="/network/nasa-tv/schedule/">NASA TV</option><option value="/network/nat-geo/schedule/">Nat Geo</option><option value="/network/nat-geo-wild/schedule/">Nat Geo Wild</option><option value="/network/nba-tv/schedule/">NBA TV</option><option value="/network/nbc/schedule/">NBC</option><option value="/network/nbc-sports-bay-area/schedule/">NBC Sports Bay Area</option><option value="/network/nbc-sports-chicago/schedule/">NBC Sports Chicago</option><option value="/network/nbc-sports-philadelphia/schedule/">NBC Sports Philadelphia</option><option value="/network/necn/schedule/">NECN</option><option value="/network/new-england-sports-network/schedule/">NESN</option><option value="/network/newsmax/schedule/">Newsmax</option><option value="/network/newsnation/schedule/">NewsNation</option><option value="/network/next-level-sports/schedule/">Next Level Sports</option><option value="/network/nfl-network/schedule/">NFL Network</option><option value="/network/nhk-world/schedule/">NHK World</option><option value="/network/nhl-network/schedule/">NHL Network</option><option value="/network/nick-jr/schedule/">Nick Jr.</option><option value="/network/nickelodeon/schedule/">Nickelodeon</option><option value="/network/nicktoons/schedule/">Nicktoons</option><option value="/network/oan/schedule/">OAN</option><option value="/network/outdoor-channel/schedule/">Outdoor Channel</option><option value="/network/outer-max/schedule/">Outer MAX</option><option value="/network/outlaw-the-western-channel/schedule/">Outlaw</option><option value="/network/ovation/schedule/">Ovation</option><option value="/network/own/schedule/">OWN</option><option value="/network/oxygen/schedule/">Oxygen</option><option value="/network/pac-12-network/schedule/">Pac-12 Network</option><option value="/network/paramount-network/schedule/">Paramount Network</option><option value="/network/pbs/schedule/">PBS</option><option value="/network/pbs-kids/schedule/">PBS Kids</option><option value="/network/pets/schedule/">Pets</option><option value="/network/pop/schedule/">Pop TV</option><option value="/network/primo-tv/schedule/">Primo TV</option><option value="/network/pursuit/schedule/">Pursuit</option><option value="/network/qvc/schedule/">QVC</option><option value="/network/real-americas-voice/schedule/">Real America's Voice</option><option value="/network/recipe-tv/schedule/">Recipe TV</option><option value="/network/reelz/schedule/">Reelz</option><option value="/network/retroplex/schedule/">RetroPlex</option><option value="/network/revolt/schedule/">Revolt</option><option value="/network/rewind-tv/schedule/">Rewind TV</option><option value="/network/rfd-tv/schedule/">RFD-TV</option><option value="/network/sbn/schedule/">SBN</option><option value="/network/sbs/schedule/">SBS</option><option value="/network/science-channel/schedule/">Science Channel</option><option value="/network/scripps-news/schedule/">Scripps News</option><option value="/network/sec-network/schedule/">SEC Network</option><option value="/network/showtime/schedule/">Showtime</option><option value="/network/showtime-2/schedule/">Showtime 2</option><option value="/network/showtime-extreme/schedule/">Showtime Extreme</option><option value="/network/showtime-familyzone/schedule/">Showtime FamilyZone</option><option value="/network/showtime-showcase/schedule/">Showtime Showcase</option><option value="/network/showtime-women/schedule/">Showtime Women</option><option value="/network/shoxbet/schedule/">SHOxBET</option><option value="/network/smile/schedule/">Smile</option><option value="/network/smithsonian-channel/schedule/">Smithsonian Channel</option><option value="/network/start-tv/schedule/">Start TV</option><option value="/network/starz/schedule/">Starz</option><option value="/network/starz-cinema/schedule/">Starz Cinema</option><option value="/network/starz-comedy/schedule/">Starz Comedy</option><option value="/network/starz-edge/schedule/">Starz Edge</option><option value="/network/starz-encore/schedule/">Starz Encore</option><option value="/network/starz-encore-action/schedule/">Starz Encore Action</option><option value="/network/starz-encore-black/schedule/">Starz Encore Black</option><option value="/network/starz-encore-classic/schedule/">Starz Encore Classic</option><option value="/network/starz-encore-family/schedule/">Starz Encore Family</option><option value="/network/starz-encore-suspense/schedule/">Starz Encore Suspense</option><option value="/network/starz-encore-westerns/schedule/">Starz Encore Westerns</option><option value="/network/starz-in-black/schedule/">Starz In Black</option><option value="/network/starz-kids-family/schedule/">Starz Kids &amp; Family</option><option value="/network/story-television/schedule/">Story Television</option><option value="/network/sundance/schedule/">Sundance</option><option value="/network/syfy/schedule/">Syfy</option><option value="/network/tastemade/schedule/">Tastemade</option><option value="/network/tbd/schedule/">TBD</option><option value="/network/tbs/schedule/">TBS</option><option value="/network/teennick/schedule/">TeenNick</option><option value="/network/telemundo/schedule/">Telemundo</option><option value="/network/telexitos/schedule/">TeleXitos</option><option value="/network/tennis-channel/schedule/">Tennis Channel</option><option value="/network/the-cowboy-channel/schedule/">The Cowboy Channel</option><option value="/network/the-cw/schedule/">The CW</option><option value="/network/the-design-network/schedule/">The Design Network</option><option value="/network/the-first/schedule/">The First</option><option value="/network/the-movie-channel/schedule/">The Movie Channel</option><option value="/network/the-movie-channel-extra/schedule/">The Movie Channel Extra</option><option value="/network/the-weather-channel/schedule/">The Weather Channel</option><option value="/network/the365/schedule/">The365</option><option value="/network/thegrio/schedule/">TheGrio</option><option value="/network/this-tv/schedule/">This TV</option><option value="/network/thrillermax/schedule/">Thriller MAX</option><option value="/network/tlc/schedule/">TLC</option><option value="/network/tnt/schedule/">TNT</option><option value="/network/travel-channel/schedule/">Travel Channel</option><option value="/network/trinity-broadcast-network/schedule/">Trinity Broadcast Network</option><option value="/network/true-crime-network/schedule/">True Crime Network</option><option value="/network/trutv/schedule/">truTV</option><option value="/network/tudn/schedule/">TUDN</option><option value="/network/turner-classic-movies/schedule/">Turner Classic Movies</option><option value="/network/tv-japan/schedule/">TV Japan</option><option value="/network/tv-land/schedule/">TV Land</option><option value="/network/tv-one/schedule/">TV One</option><option value="/network/twist/schedule/">Twist</option><option value="/network/unimas/schedule/">UniMás</option><option value="/network/universal-kids/schedule/">Universal Kids</option><option value="/network/universo/schedule/">Universo</option><option value="/network/univision/schedule/">Univision</option><option value="/network/uptv/schedule/">UPtv</option><option value="/network/usa-network/schedule/">USA Network</option><option value="/network/vh1/schedule/">VH1</option><option value="/network/vice-tv/schedule/">Vice TV</option><option value="/network/we-tv/schedule/">We TV</option><option value="/network/willow/schedule/">Willow</option><option value="/network/world-channel/schedule/">World Channel</option><option value="/network/yankee-entertainment-sports/schedule/">YES Network</option><option value="/network/z-living/schedule/">Z Living</option><option value="/network/zoomoo/schedule/">ZooMoo</option></select>
+
+
+
+
+<div class="shows"><section class="inline"><h1>MoviePlex TV Schedule</h1><p class="tooltip">A <b>complete schedule</b> of absolutely everything airing on <b>MoviePlex</b> over the next two weeks.</span> <span>Click a program to see all <b>upcoming airings</b> and <b>streaming options</b>.</p><div class="show-grid"></div><h2 id="01-15-2025" class="date">Wednesday, January 15</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/tarzan-2013/"><div class="top-element"><time>6:53 AM</time><div class="streamit">Stream</div></div><h3>Tarzan</h3><h4>Feature Film • 2013</h4><h6></h6><p>Tarzan and Jane face a mercenary army dispatched by the evil CEO of Greystoke Energies.</p></a><a class="show-upcoming"><div class="top-element"><time>8:29 AM</time></div><h3>Jungle Master</h3><h4>Feature Film • 2013</h4><h6></h6><p>Transported to a magical land, a girl meets an emerging leader who must save the rain forest.</p></a><a class="show-upcoming"><div class="top-element"><time>9:52 AM</time></div><h3>Ghoster</h3><h4>Feature Film • 2022</h4><h6></h6><p>A man and his young daughter discover a cute little ghost that is trapped in a mirrored prison.</p></a><a class="show-upcoming"><div class="top-element"><time>11:24 AM</time></div><h3>Let Us In</h3><h4>Feature Film • 2020</h4><h6></h6><p>A 12-year-old girl investigates a rash of disappearances occurring in her small town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/godsend/"><div class="top-element"><time>12:48 PM</time><div class="streamit">Stream</div></div><h3>Godsend</h3><h4>Feature Film • 2004</h4><h6></h6><p>A scientist (Robert De Niro) clones a couple's (Greg Kinnear, Rebecca Romijn-Stamos) dead son.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/out-of-liberty/"><div class="top-element"><time>2:31 PM</time><div class="streamit">Stream</div></div><h3>Out of Liberty</h3><h4>Feature Film • 2019</h4><h6></h6><p>A jailer is tasked with overseeing Missouri's most wanted men as they await trial.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/ground-control/"><div class="top-element"><time>4:24 PM</time><div class="streamit">Stream</div></div><h3>Ground Control</h3><h4>Feature Film • 1998</h4><h6></h6><p>An air-traffic controller (Kiefer Sutherland) helps an airport in trouble.</p></a><a class="show-upcoming"><div class="top-element"><time>6:03 PM</time></div><h3>Hope Springs Eternal</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen's cancer diagnosis makes her more popular at school, but then she goes into remission.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/undiscovered/"><div class="top-element"><time>7:23 PM</time><div class="streamit">Stream</div></div><h3>Undiscovered</h3><h4>Feature Film • 2005</h4><h6></h6><p>Aspiring entertainers (Pell James, Steven Strait) try to launch their careers.</p></a><a class="show-upcoming"><div class="top-element"><time>9:02 PM</time></div><h3>Words and Pictures</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two teachers have a competition and allow students to vote on words and pictures.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/rams/"><div class="top-element"><time>10:59 PM</time><div class="streamit">Stream</div></div><h3>Rams</h3><h4>Feature Film • 2020</h4><h6></h6><p>Australian brothers set aside their differences when an illness threatens their flocks of sheep.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-2"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-2').display(); });</script>
+        </div><h2 id="01-16-2025" class="date">Thursday, January 16</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>12:59 AM</time></div><h3>Hope Springs Eternal</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen's cancer diagnosis makes her more popular at school, but then she goes into remission.</p></a><a class="show-upcoming"><div class="top-element"><time>2:19 AM</time></div><h3>The Happy Elf</h3><h4>Special • 2005</h4><h6></h6><p>Eubie tries to bring Christmas joy to a dreary town called Bluesville.</p></a><a class="show-upcoming"><div class="top-element"><time>3:05 AM</time></div><h3>Jungle Master</h3><h4>Feature Film • 2013</h4><h6></h6><p>Transported to a magical land, a girl meets an emerging leader who must save the rain forest.</p></a><a class="show-upcoming"><div class="top-element"><time>4:28 AM</time></div><h3>Birds Like Us</h3><h4>Feature Film • 2017</h4><h6></h6><p>A bird and a king join a wise bat on an odyssey to find the tree they call home.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wings-2012/"><div class="top-element"><time>5:52 AM</time><div class="streamit">Stream</div></div><h3>Wings</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aircraft fighter pilot trains with a flying legend so that he can win a prestigious competition.</p></a><a class="show-upcoming"><div class="top-element"><time>7:20 AM</time></div><h3>Wings: Sky Force Heroes</h3><h4>Feature Film • 2014</h4><h6></h6><p>A firefighter (Josh Duhamel) resigns after his recklessness causes the death of a comrade.</p></a><a class="show-upcoming"><div class="top-element"><time>8:43 AM</time></div><h3>Hope Springs Eternal</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen's cancer diagnosis makes her more popular at school, but then she goes into remission.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/rams/"><div class="top-element"><time>10:03 AM</time><div class="streamit">Stream</div></div><h3>Rams</h3><h4>Feature Film • 2020</h4><h6></h6><p>Australian brothers set aside their differences when an illness threatens their flocks of sheep.</p></a><a class="show-upcoming"><div class="top-element"><time>12:03 PM</time></div><h3>Words and Pictures</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two teachers have a competition and allow students to vote on words and pictures.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/undiscovered/"><div class="top-element"><time>2:00 PM</time><div class="streamit">Stream</div></div><h3>Undiscovered</h3><h4>Feature Film • 2005</h4><h6></h6><p>Aspiring entertainers (Pell James, Steven Strait) try to launch their careers.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wings-2012/"><div class="top-element"><time>3:39 PM</time><div class="streamit">Stream</div></div><h3>Wings</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aircraft fighter pilot trains with a flying legend so that he can win a prestigious competition.</p></a><a class="show-upcoming"><div class="top-element"><time>5:07 PM</time></div><h3>Wings: Sky Force Heroes</h3><h4>Feature Film • 2014</h4><h6></h6><p>A firefighter (Josh Duhamel) resigns after his recklessness causes the death of a comrade.</p></a><a class="show-upcoming"><div class="top-element"><time>6:30 PM</time></div><h3>Birds Like Us</h3><h4>Feature Film • 2017</h4><h6></h6><p>A bird and a king join a wise bat on an odyssey to find the tree they call home.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/top-end-wedding/"><div class="top-element"><time>7:54 PM</time><div class="streamit">Stream</div></div><h3>Top End Wedding</h3><h4>Feature Film • 2019</h4><h6></h6><p>Lauren and Ned have 10 days to find Lauren's mother in time for their wedding.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-royal-night-out/"><div class="top-element"><time>9:37 PM</time><div class="streamit">Stream</div></div><h3>A Royal Night Out</h3><h4>Feature Film • 2015</h4><h6></h6><p>Teenage princesses Elizabeth II (Sarah Gadon) and Margaret (Bel Powley) spend an evening in London.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-presence/"><div class="top-element"><time>11:15 PM</time><div class="streamit">Stream</div></div><h3>The Presence</h3><h4>Feature Film • 2010</h4><h6></h6><p>A woman is stalked by a ghost and begins to exhibit irrational behavior.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-3"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-3').display(); });</script>
+        </div><h2 id="01-17-2025" class="date">Friday, January 17</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-song/"><div class="top-element"><time>12:43 AM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Song</h3><h4>Feature Film • 2022</h4><h6></h6><p>An aspiring country singer and her grandmother overcome adversity through their love of music.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-story/"><div class="top-element"><time>2:17 AM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Story</h3><h4>Feature Film • 2017</h4><h6></h6><p>Cowgirls in high school have to run their homes while their parents are deployed.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wings-2012/"><div class="top-element"><time>3:56 AM</time><div class="streamit">Stream</div></div><h3>Wings</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aircraft fighter pilot trains with a flying legend so that he can win a prestigious competition.</p></a><a class="show-upcoming"><div class="top-element"><time>5:24 AM</time></div><h3>Wings: Sky Force Heroes</h3><h4>Feature Film • 2014</h4><h6></h6><p>A firefighter (Josh Duhamel) resigns after his recklessness causes the death of a comrade.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-secret-of-roan-inish/"><div class="top-element"><time>6:47 AM</time><div class="streamit">Stream</div></div><h3>The Secret of Roan Inish</h3><h4>Feature Film • 1994</h4><h6></h6><p>An Irish girl convinces her grandparents to look into the mysterious fate of her infant brother.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-royal-night-out/"><div class="top-element"><time>8:32 AM</time><div class="streamit">Stream</div></div><h3>A Royal Night Out</h3><h4>Feature Film • 2015</h4><h6></h6><p>Teenage princesses Elizabeth II (Sarah Gadon) and Margaret (Bel Powley) spend an evening in London.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/top-end-wedding/"><div class="top-element"><time>10:10 AM</time><div class="streamit">Stream</div></div><h3>Top End Wedding</h3><h4>Feature Film • 2019</h4><h6></h6><p>Lauren and Ned have 10 days to find Lauren's mother in time for their wedding.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/peacock/"><div class="top-element"><time>11:53 AM</time><div class="streamit">Stream</div></div><h3>Peacock</h3><h4>Feature Film • 2010</h4><h6></h6><p>A man with a split personality fools townspeople into thinking his alter egos are husband and wife.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-presence/"><div class="top-element"><time>1:25 PM</time><div class="streamit">Stream</div></div><h3>The Presence</h3><h4>Feature Film • 2010</h4><h6></h6><p>A woman is stalked by a ghost and begins to exhibit irrational behavior.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>2:53 PM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-royal-night-out/"><div class="top-element"><time>4:20 PM</time><div class="streamit">Stream</div></div><h3>A Royal Night Out</h3><h4>Feature Film • 2015</h4><h6></h6><p>Teenage princesses Elizabeth II (Sarah Gadon) and Margaret (Bel Powley) spend an evening in London.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-secret-of-roan-inish/"><div class="top-element"><time>5:58 PM</time><div class="streamit">Stream</div></div><h3>The Secret of Roan Inish</h3><h4>Feature Film • 1994</h4><h6></h6><p>An Irish girl convinces her grandparents to look into the mysterious fate of her infant brother.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/nine/"><div class="top-element"><time>7:43 PM</time><div class="streamit">Stream</div></div><h3>Nine</h3><h4>Feature Film • 2009</h4><h6></h6><p>An Italian filmmaker (Daniel Day-Lewis) juggles relationships with the numerous women in his life.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/peacock/"><div class="top-element"><time>9:43 PM</time><div class="streamit">Stream</div></div><h3>Peacock</h3><h4>Feature Film • 2010</h4><h6></h6><p>A man with a split personality fools townspeople into thinking his alter egos are husband and wife.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/18-1-2/"><div class="top-element"><time>11:15 PM</time><div class="streamit">Stream</div></div><h3>18 1/2</h3><h4>Feature Film • 2021</h4><h6></h6><p>In 1974, a White House transcriber is thrust into the Watergate scandal.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-4"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-4').display(); });</script>
+        </div><h2 id="01-18-2025" class="date">Saturday, January 18</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>12:45 AM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-secret-of-roan-inish/"><div class="top-element"><time>2:12 AM</time><div class="streamit">Stream</div></div><h3>The Secret of Roan Inish</h3><h4>Feature Film • 1994</h4><h6></h6><p>An Irish girl convinces her grandparents to look into the mysterious fate of her infant brother.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/peacock/"><div class="top-element"><time>3:57 AM</time><div class="streamit">Stream</div></div><h3>Peacock</h3><h4>Feature Film • 2010</h4><h6></h6><p>A man with a split personality fools townspeople into thinking his alter egos are husband and wife.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/nine/"><div class="top-element"><time>5:29 AM</time><div class="streamit">Stream</div></div><h3>Nine</h3><h4>Feature Film • 2009</h4><h6></h6><p>An Italian filmmaker (Daniel Day-Lewis) juggles relationships with the numerous women in his life.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/18-1-2/"><div class="top-element"><time>7:29 AM</time><div class="streamit">Stream</div></div><h3>18 1/2</h3><h4>Feature Film • 2021</h4><h6></h6><p>In 1974, a White House transcriber is thrust into the Watergate scandal.</p></a><a class="show-upcoming"><div class="top-element"><time>8:59 AM</time></div><h3>Battle for Terra</h3><h4>Feature Film • 2007</h4><h6></h6><p>Human invaders plan to colonize an alien world and destroy its native inhabitants in the process.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/trading-mom/"><div class="top-element"><time>10:19 AM</time><div class="streamit">Stream</div></div><h3>Trading Mom</h3><h4>Feature Film • 1994</h4><h6></h6><p>Kids (Anna Chlumsky, Aaron Michael Metchik) under magic spell shop for another mother.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>11:43 AM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/nine/"><div class="top-element"><time>1:10 PM</time><div class="streamit">Stream</div></div><h3>Nine</h3><h4>Feature Film • 2009</h4><h6></h6><p>An Italian filmmaker (Daniel Day-Lewis) juggles relationships with the numerous women in his life.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/still-mine/"><div class="top-element"><time>3:10 PM</time><div class="streamit">Stream</div></div><h3>Still Mine</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aging farmer fights back when authorities hamper his plan to build a cottage for his sick wife.</p></a><a class="show-upcoming"><div class="top-element"><time>4:54 PM</time></div><h3>Show Me the Father</h3><h4>Feature Film • 2021</h4><h6></h6><p>Captivating stories interwoven with inspirational truths about the fatherhood of God.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-best-of-me/"><div class="top-element"><time>6:26 PM</time><div class="streamit">Stream</div></div><h3>The Best of Me</h3><h4>Feature Film • 2014</h4><h6></h6><p>A friend's funeral reunites former high-school sweethearts, who find that they are still in love.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/fair-game/"><div class="top-element"><time>8:25 PM</time><div class="streamit">Stream</div></div><h3>Fair Game</h3><h4>Feature Film • 2010</h4><h6></h6><p>Valerie Plame and her husband face the fallout when her cover is blown as a covert CIA agent.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/modern-persuasion/"><div class="top-element"><time>10:14 PM</time><div class="streamit">Stream</div></div><h3>Modern Persuasion</h3><h4>Feature Film • 2020</h4><h6></h6><p>A career woman deals with the aftermath of a failed relationship when an ex hires her company.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/trading-mom/"><div class="top-element"><time>11:42 PM</time><div class="streamit">Stream</div></div><h3>Trading Mom</h3><h4>Feature Film • 1994</h4><h6></h6><p>Kids (Anna Chlumsky, Aaron Michael Metchik) under magic spell shop for another mother.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-5"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-5').display(); });</script>
+        </div><h2 id="01-19-2025" class="date">Sunday, January 19</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>1:06 AM</time></div><h3>Show Me the Father</h3><h4>Feature Film • 2021</h4><h6></h6><p>Captivating stories interwoven with inspirational truths about the fatherhood of God.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/fair-game/"><div class="top-element"><time>2:38 AM</time><div class="streamit">Stream</div></div><h3>Fair Game</h3><h4>Feature Film • 2010</h4><h6></h6><p>Valerie Plame and her husband face the fallout when her cover is blown as a covert CIA agent.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/showdown-1963/"><div class="top-element"><time>4:27 AM</time><div class="streamit">Stream</div></div><h3>Showdown</h3><h4>Feature Film • 1963</h4><h6></h6><p>Cowboys (Audie Murphy, Charles Drake) and dancer (Kathleen Crowley) have trouble with outlaws.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-wild-and-the-innocent/"><div class="top-element"><time>5:47 AM</time><div class="streamit">Stream</div></div><h3>The Wild and the Innocent</h3><h4>Feature Film • 1959</h4><h6></h6><p>Two innocents (Audie Murphy, Sandra Dee) meet trouble in a wild town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/jericho-2000/"><div class="top-element"><time>7:13 AM</time><div class="streamit">Stream</div></div><h3>Jericho</h3><h4>Feature Film • 2000</h4><h6></h6><p>A charismatic preacher rescues a mysterious gunman who tries to find answers about his identity.</p></a><a class="show-upcoming"><div class="top-element"><time>8:55 AM</time></div><h3>Moondance Alexander</h3><h4>Feature Film • 2007</h4><h6></h6><p>A girl convinces a gruff horseman to coach her for a prestigious jumping competition.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/still-mine/"><div class="top-element"><time>10:30 AM</time><div class="streamit">Stream</div></div><h3>Still Mine</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aging farmer fights back when authorities hamper his plan to build a cottage for his sick wife.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/modern-persuasion/"><div class="top-element"><time>12:14 PM</time><div class="streamit">Stream</div></div><h3>Modern Persuasion</h3><h4>Feature Film • 2020</h4><h6></h6><p>A career woman deals with the aftermath of a failed relationship when an ex hires her company.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-best-of-me/"><div class="top-element"><time>1:42 PM</time><div class="streamit">Stream</div></div><h3>The Best of Me</h3><h4>Feature Film • 2014</h4><h6></h6><p>A friend's funeral reunites former high-school sweethearts, who find that they are still in love.</p></a><a class="show-upcoming"><div class="top-element"><time>3:41 PM</time></div><h3>Moondance Alexander</h3><h4>Feature Film • 2007</h4><h6></h6><p>A girl convinces a gruff horseman to coach her for a prestigious jumping competition.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-wild-and-the-innocent/"><div class="top-element"><time>5:16 PM</time><div class="streamit">Stream</div></div><h3>The Wild and the Innocent</h3><h4>Feature Film • 1959</h4><h6></h6><p>Two innocents (Audie Murphy, Sandra Dee) meet trouble in a wild town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/showdown-1963/"><div class="top-element"><time>6:42 PM</time><div class="streamit">Stream</div></div><h3>Showdown</h3><h4>Feature Film • 1963</h4><h6></h6><p>Cowboys (Audie Murphy, Charles Drake) and dancer (Kathleen Crowley) have trouble with outlaws.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/jericho-2000/"><div class="top-element"><time>8:02 PM</time><div class="streamit">Stream</div></div><h3>Jericho</h3><h4>Feature Film • 2000</h4><h6></h6><p>A charismatic preacher rescues a mysterious gunman who tries to find answers about his identity.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/love-wrecked/"><div class="top-element"><time>9:44 PM</time><div class="streamit">Stream</div></div><h3>Love Wrecked</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenager takes her favorite rock star to a nearby island and tells him that they are castaways.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/man-of-the-year/"><div class="top-element"><time>11:12 PM</time><div class="streamit">Stream</div></div><h3>Man of the Year</h3><h4>Feature Film • 2006</h4><h6></h6><p>A talk-show host (Robin Williams) becomes president of the United States.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-6"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-6').display(); });</script>
+        </div><h2 id="01-20-2025" class="date">Monday, January 20</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>1:08 AM</time></div><h3>Frog Kingdom</h3><h4>Feature Film • 2013</h4><h6></h6><p>A frog princess secretly competes in the Frog Olympics to win her own hand in marriage.</p></a><a class="show-upcoming"><div class="top-element"><time>2:37 AM</time></div><h3>Sea Level</h3><h4>Feature Film • 2011</h4><h6></h6><p>Pup sees human poachers stealing eggs from his reef, and he follows them into the human world.</p></a><a class="show-upcoming"><div class="top-element"><time>4:10 AM</time></div><h3>Sea Level 2: Magic Arch</h3><h4>Feature Film • 2020</h4><h6></h6><p>A young dolphin with an active imagination discovers a magic arch that makes wishes come true.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-mouse-tale/"><div class="top-element"><time>5:33 AM</time><div class="streamit">Stream</div></div><h3>A Mouse Tale</h3><h4>Feature Film • 2015</h4><h6></h6><p>The king sends Sebastian and Samantha on a quest to find a legendary crystal.</p></a><a class="show-upcoming"><div class="top-element"><time>7:06 AM</time></div><h3>Against the Wild</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two siblings and their dogs become lost in the wilderness and combine their skills to survive.</p></a><a class="show-upcoming"><div class="top-element"><time>8:39 AM</time></div><h3>Against the Wild: Survive the Serengeti</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two kids and their dog have to survive in the African bush after their plane crashes.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/man-of-the-year/"><div class="top-element"><time>10:12 AM</time><div class="streamit">Stream</div></div><h3>Man of the Year</h3><h4>Feature Film • 2006</h4><h6></h6><p>A talk-show host (Robin Williams) becomes president of the United States.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/love-wrecked/"><div class="top-element"><time>12:08 PM</time><div class="streamit">Stream</div></div><h3>Love Wrecked</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenager takes her favorite rock star to a nearby island and tells him that they are castaways.</p></a><a class="show-upcoming"><div class="top-element"><time>1:36 PM</time></div><h3>Sea Level</h3><h4>Feature Film • 2011</h4><h6></h6><p>Pup sees human poachers stealing eggs from his reef, and he follows them into the human world.</p></a><a class="show-upcoming"><div class="top-element"><time>3:09 PM</time></div><h3>Sea Level 2: Magic Arch</h3><h4>Feature Film • 2020</h4><h6></h6><p>A young dolphin with an active imagination discovers a magic arch that makes wishes come true.</p></a><a class="show-upcoming"><div class="top-element"><time>4:32 PM</time></div><h3>Against the Wild</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two siblings and their dogs become lost in the wilderness and combine their skills to survive.</p></a><a class="show-upcoming"><div class="top-element"><time>6:05 PM</time></div><h3>Against the Wild: Survive the Serengeti</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two kids and their dog have to survive in the African bush after their plane crashes.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-plus-one/"><div class="top-element"><time>7:38 PM</time><div class="streamit">Stream</div></div><h3>The Plus One</h3><h4>Feature Film • 2023</h4><h6></h6><p>A woman plans the perfect destination wedding -- until her man of honor brings his obnoxious ex.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>9:13 PM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a><a class="show-upcoming"><div class="top-element"><time>10:46 PM</time></div><h3>I Still See You</h3><h4>Feature Film • 2018</h4><h6></h6><p>Ghosts inhabit what's left of the world after an apocalyptic event.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-7"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-7').display(); });</script>
+        </div><h2 id="01-21-2025" class="date">Tuesday, January 21</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>12:25 AM</time></div><h3>Against the Wild</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two siblings and their dogs become lost in the wilderness and combine their skills to survive.</p></a><a class="show-upcoming"><div class="top-element"><time>1:58 AM</time></div><h3>Against the Wild: Survive the Serengeti</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two kids and their dog have to survive in the African bush after their plane crashes.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>3:31 AM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-plus-one/"><div class="top-element"><time>5:04 AM</time><div class="streamit">Stream</div></div><h3>The Plus One</h3><h4>Feature Film • 2023</h4><h6></h6><p>A woman plans the perfect destination wedding -- until her man of honor brings his obnoxious ex.</p></a><a class="show-upcoming"><div class="top-element"><time>6:39 AM</time></div><h3>I Still See You</h3><h4>Feature Film • 2018</h4><h6></h6><p>Ghosts inhabit what's left of the world after an apocalyptic event.</p></a><a class="show-upcoming"><div class="top-element"><time>8:18 AM</time></div><h3>Thomas and the Magic Railroad</h3><h4>Feature Film • 2000</h4><h6></h6><p>A girl (Mara Wilson) and her grandfather (Peter Fonda) help the talking train.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-blue-elephant/"><div class="top-element"><time>9:45 AM</time></div><h3>The Blue Elephant</h3><h4>Feature Film • 2008</h4><h6></h6><p>A young elephant becomes separated from his herd and seeks help from new friends.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/yellowbird/"><div class="top-element"><time>11:03 AM</time><div class="streamit">Stream</div></div><h3>Yellowbird</h3><h4>Feature Film • 2014</h4><h6></h6><p>Yellowbird suddenly finds himself leading a flock on its migration to Africa.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-storks-journey/"><div class="top-element"><time>12:34 PM</time><div class="streamit">Stream</div></div><h3>A Stork&#8217;s Journey</h3><h4>Feature Film • 2017</h4><h6></h6><p>An orphaned sparrow, adopted and raised by storks, struggles to make the annual migration.</p></a><a class="show-upcoming"><div class="top-element"><time>2:00 PM</time></div><h3>Cattle Hill</h3><h4>Feature Film • 2018</h4><h6></h6><p>A young cow who lives in the city dreams of becoming a pop star.</p></a><a class="show-upcoming"><div class="top-element"><time>3:07 PM</time></div><h3>Thomas and the Magic Railroad</h3><h4>Feature Film • 2000</h4><h6></h6><p>A girl (Mara Wilson) and her grandfather (Peter Fonda) help the talking train.</p></a><a class="show-upcoming"><div class="top-element"><time>4:34 PM</time></div><h3>Pit Pony</h3><h4>TV Movie • 1997</h4><h6></h6><p>A horse's companionship helps a boy overcome his fears and work in a Nova Scotia coal mine.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>6:07 PM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>7:40 PM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/brave-new-girl/"><div class="top-element"><time>9:07 PM</time><div class="streamit">Stream</div></div><h3>Brave New Girl</h3><h4>TV Movie • 2004</h4><h6></h6><p>A woman (Virginia Madsen) helps her daughter (Lindsey Haun) attend music school.</p></a><a class="show-upcoming"><div class="top-element"><time>10:37 PM</time></div><h3>Stars Fell on Alabama</h3><h4>Feature Film • 2021</h4><h6></h6><p>An actress pretends to be a Hollywood agent's girlfriend at his high school reunion.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-8"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-8').display(); });</script>
+        </div><h2 id="01-22-2025" class="date">Wednesday, January 22</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>12:21 AM</time></div><h3>Pit Pony</h3><h4>TV Movie • 1997</h4><h6></h6><p>A horse's companionship helps a boy overcome his fears and work in a Nova Scotia coal mine.</p></a><a class="show-upcoming"><div class="top-element"><time>1:54 AM</time></div><h3>Thomas and the Magic Railroad</h3><h4>Feature Film • 2000</h4><h6></h6><p>A girl (Mara Wilson) and her grandfather (Peter Fonda) help the talking train.</p></a><a class="show-upcoming"><div class="top-element"><time>3:21 AM</time></div><h3>Cattle Hill</h3><h4>Feature Film • 2018</h4><h6></h6><p>A young cow who lives in the city dreams of becoming a pop star.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-storks-journey/"><div class="top-element"><time>4:28 AM</time><div class="streamit">Stream</div></div><h3>A Stork&#8217;s Journey</h3><h4>Feature Film • 2017</h4><h6></h6><p>An orphaned sparrow, adopted and raised by storks, struggles to make the annual migration.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/yellowbird/"><div class="top-element"><time>5:54 AM</time><div class="streamit">Stream</div></div><h3>Yellowbird</h3><h4>Feature Film • 2014</h4><h6></h6><p>Yellowbird suddenly finds himself leading a flock on its migration to Africa.</p></a><a class="show-upcoming"><div class="top-element"><time>7:25 AM</time></div><h3>Birds Like Us</h3><h4>Feature Film • 2017</h4><h6></h6><p>A bird and a king join a wise bat on an odyssey to find the tree they call home.</p></a><a class="show-upcoming"><div class="top-element"><time>8:49 AM</time></div><h3>Pit Pony</h3><h4>TV Movie • 1997</h4><h6></h6><p>A horse's companionship helps a boy overcome his fears and work in a Nova Scotia coal mine.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bernie-the-dolphin/"><div class="top-element"><time>10:22 AM</time><div class="streamit">Stream</div></div><h3>Bernie the Dolphin</h3><h4>Feature Film • 2018</h4><h6></h6><p>A brother and sister befriend a badly sunburned dolphin and uncover a secret plan.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bernie-the-dolphin-2/"><div class="top-element"><time>11:51 AM</time><div class="streamit">Stream</div></div><h3>Bernie the Dolphin 2</h3><h4>Feature Film • 2019</h4><h6></h6><p>Kevin and Holly must foil a plan to kidnap Bernie the world-famous dolphin.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/go-fish/"><div class="top-element"><time>1:31 PM</time><div class="streamit">Stream</div></div><h3>Go Fish</h3><h4>Feature Film • 2019</h4><h6></h6><p>A parrotfish and its friends bravely confront a menace that threatens their reef home.</p></a><a class="show-upcoming"><div class="top-element"><time>2:47 PM</time></div><h3>Let Us In</h3><h4>Feature Film • 2020</h4><h6></h6><p>A 12-year-old girl investigates a rash of disappearances occurring in her small town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/brave-new-girl/"><div class="top-element"><time>4:11 PM</time><div class="streamit">Stream</div></div><h3>Brave New Girl</h3><h4>TV Movie • 2004</h4><h6></h6><p>A woman (Virginia Madsen) helps her daughter (Lindsey Haun) attend music school.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>5:41 PM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming"><div class="top-element"><time>7:08 PM</time></div><h3>Stars Fell on Alabama</h3><h4>Feature Film • 2021</h4><h6></h6><p>An actress pretends to be a Hollywood agent's girlfriend at his high school reunion.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>8:54 PM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/ground-control/"><div class="top-element"><time>10:21 PM</time><div class="streamit">Stream</div></div><h3>Ground Control</h3><h4>Feature Film • 1998</h4><h6></h6><p>An air-traffic controller (Kiefer Sutherland) helps an airport in trouble.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-9"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-9').display(); });</script>
+        </div><h2 id="01-23-2025" class="date">Thursday, January 23</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>12:00 AM</time></div><h3>Let Us In</h3><h4>Feature Film • 2020</h4><h6></h6><p>A 12-year-old girl investigates a rash of disappearances occurring in her small town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/go-fish/"><div class="top-element"><time>1:24 AM</time><div class="streamit">Stream</div></div><h3>Go Fish</h3><h4>Feature Film • 2019</h4><h6></h6><p>A parrotfish and its friends bravely confront a menace that threatens their reef home.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bernie-the-dolphin/"><div class="top-element"><time>2:40 AM</time><div class="streamit">Stream</div></div><h3>Bernie the Dolphin</h3><h4>Feature Film • 2018</h4><h6></h6><p>A brother and sister befriend a badly sunburned dolphin and uncover a secret plan.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bernie-the-dolphin-2/"><div class="top-element"><time>4:09 AM</time><div class="streamit">Stream</div></div><h3>Bernie the Dolphin 2</h3><h4>Feature Film • 2019</h4><h6></h6><p>Kevin and Holly must foil a plan to kidnap Bernie the world-famous dolphin.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-nutcracker-and-the-magic-flute/"><div class="top-element"><time>5:49 AM</time><div class="streamit">Stream</div></div><h3>The Nutcracker and the Magic Flute</h3><h4>Feature Film • 2022</h4><h6></h6><p>Before she's forced to marry, a young girl is magically shrunk to the size of her childhood toys.</p></a><a class="show-upcoming"><div class="top-element"><time>7:18 AM</time></div><h3>Pinocchio</h3><h4>Feature Film • 2012</h4><h6></h6><p>Playful puppet Pinocchio is eager to do good and become a real human.</p></a><a class="show-upcoming"><div class="top-element"><time>8:43 AM</time></div><h3>Pinocchio: A True Story</h3><h4>Feature Film • 2021</h4><h6></h6><p>The wooden hero is a skilled circus acrobat who longs to become human.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/jurassic-tale/"><div class="top-element"><time>10:18 AM</time><div class="streamit">Stream</div></div><h3>Jurassic Tale</h3><h4>Feature Film • 2022</h4><h6></h6><p>Siblings Emma and Brian discover a baby T. rex and must protect it from an evil scientist.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/lena-and-snowball/"><div class="top-element"><time>11:43 AM</time><div class="streamit">Stream</div></div><h3>Lena and Snowball</h3><h4>Feature Film • 2021</h4><h6></h6><p>A lonely girl tries to protect a valuable white lion cub from the poachers who kidnapped it.</p></a><a class="show-upcoming"><div class="top-element"><time>1:14 PM</time></div><h3>Joey &#038; Ella</h3><h4>Feature Film • 2021</h4><h6></h6><p>Two bumbling thieves pursue a teen and a talking kangaroo to retrieve a magical diamond.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>2:44 PM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/jurassic-tale/"><div class="top-element"><time>4:11 PM</time><div class="streamit">Stream</div></div><h3>Jurassic Tale</h3><h4>Feature Film • 2022</h4><h6></h6><p>Siblings Emma and Brian discover a baby T. rex and must protect it from an evil scientist.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-nutcracker-and-the-magic-flute/"><div class="top-element"><time>5:36 PM</time><div class="streamit">Stream</div></div><h3>The Nutcracker and the Magic Flute</h3><h4>Feature Film • 2022</h4><h6></h6><p>Before she's forced to marry, a young girl is magically shrunk to the size of her childhood toys.</p></a><a class="show-upcoming"><div class="top-element"><time>7:05 PM</time></div><h3>Pinocchio</h3><h4>Feature Film • 2012</h4><h6></h6><p>Playful puppet Pinocchio is eager to do good and become a real human.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/ground-control/"><div class="top-element"><time>8:30 PM</time><div class="streamit">Stream</div></div><h3>Ground Control</h3><h4>Feature Film • 1998</h4><h6></h6><p>An air-traffic controller (Kiefer Sutherland) helps an airport in trouble.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/ricochet-2011/"><div class="top-element"><time>10:09 PM</time><div class="streamit">Stream</div></div><h3>Ricochet</h3><h4>TV Movie • 2011</h4><h6></h6><p>A detective (John Corbett) finds romance with the wife (Julie Benz) of a corrupt judge (Gary Cole).</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/undiscovered/"><div class="top-element"><time>11:40 PM</time><div class="streamit">Stream</div></div><h3>Undiscovered</h3><h4>Feature Film • 2005</h4><h6></h6><p>Aspiring entertainers (Pell James, Steven Strait) try to launch their careers.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-10"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-10').display(); });</script>
+        </div><h2 id="01-24-2025" class="date">Friday, January 24</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>1:19 AM</time></div><h3>Joey &#038; Ella</h3><h4>Feature Film • 2021</h4><h6></h6><p>Two bumbling thieves pursue a teen and a talking kangaroo to retrieve a magical diamond.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-nutty-professor-2008/"><div class="top-element"><time>2:49 AM</time><div class="streamit">Stream</div></div><h3>The Nutty Professor</h3><h4>Feature Film • 2008</h4><h6></h6><p>A boy (Drake Bell) finds an elixir that releases an obnoxious alter ego.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-blood-and-iron/"><div class="top-element"><time>4:06 AM</time><div class="streamit">Stream</div></div><h3>Hellboy: Blood and Iron</h3><h4>TV Movie • 2007</h4><h6></h6><p>Hellboy (Ron Perlman) encounters monsters and a resurrected vampire.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-sword-of-storms/"><div class="top-element"><time>5:23 AM</time><div class="streamit">Stream</div></div><h3>Hellboy: Sword of Storms</h3><h4>TV Movie • 2006</h4><h6></h6><p>Hellboy (Ron Perlman) battles creatures searching for a powerful sword.</p></a><a class="show-upcoming"><div class="top-element"><time>6:42 AM</time></div><h3>My Sweet Monster</h3><h4>Feature Film • 2021</h4><h6></h6><p>Sweet monster Boogey does everything in his might to help Princess Barbara save the kingdom.</p></a><a class="show-upcoming"><div class="top-element"><time>8:21 AM</time></div><h3>Monsters at Large</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen task force that fights imaginary monsters finds itself face to face with the real thing.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wings-2012/"><div class="top-element"><time>9:53 AM</time><div class="streamit">Stream</div></div><h3>Wings</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aircraft fighter pilot trains with a flying legend so that he can win a prestigious competition.</p></a><a class="show-upcoming"><div class="top-element"><time>11:21 AM</time></div><h3>Wings: Sky Force Heroes</h3><h4>Feature Film • 2014</h4><h6></h6><p>A firefighter (Josh Duhamel) resigns after his recklessness causes the death of a comrade.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-sword-of-storms/"><div class="top-element"><time>12:44 PM</time><div class="streamit">Stream</div></div><h3>Hellboy: Sword of Storms</h3><h4>TV Movie • 2006</h4><h6></h6><p>Hellboy (Ron Perlman) battles creatures searching for a powerful sword.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-blood-and-iron/"><div class="top-element"><time>2:03 PM</time><div class="streamit">Stream</div></div><h3>Hellboy: Blood and Iron</h3><h4>TV Movie • 2007</h4><h6></h6><p>Hellboy (Ron Perlman) encounters monsters and a resurrected vampire.</p></a><a class="show-upcoming"><div class="top-element"><time>3:20 PM</time></div><h3>Monsters at Large</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen task force that fights imaginary monsters finds itself face to face with the real thing.</p></a><a class="show-upcoming"><div class="top-element"><time>4:52 PM</time></div><h3>My Sweet Monster</h3><h4>Feature Film • 2021</h4><h6></h6><p>Sweet monster Boogey does everything in his might to help Princess Barbara save the kingdom.</p></a><a class="show-upcoming"><div class="top-element"><time>6:31 PM</time></div><h3>Hope Springs Eternal</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen's cancer diagnosis makes her more popular at school, but then she goes into remission.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/12-mighty-orphans/"><div class="top-element"><time>7:51 PM</time><div class="streamit">Stream</div></div><h3>12 Mighty Orphans</h3><h4>Feature Film • 2021</h4><h6></h6><p>Rusty Russell coaches football at an orphanage in Fort Worth, Texas, during the Great Depression.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/out-of-liberty/"><div class="top-element"><time>9:50 PM</time><div class="streamit">Stream</div></div><h3>Out of Liberty</h3><h4>Feature Film • 2019</h4><h6></h6><p>A jailer is tasked with overseeing Missouri's most wanted men as they await trial.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wings-2012/"><div class="top-element"><time>11:43 PM</time><div class="streamit">Stream</div></div><h3>Wings</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aircraft fighter pilot trains with a flying legend so that he can win a prestigious competition.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-11"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-11').display(); });</script>
+        </div><h2 id="01-25-2025" class="date">Saturday, January 25</h2><div class="show-grid"><a class="show-upcoming"><div class="top-element"><time>1:11 AM</time></div><h3>Wings: Sky Force Heroes</h3><h4>Feature Film • 2014</h4><h6></h6><p>A firefighter (Josh Duhamel) resigns after his recklessness causes the death of a comrade.</p></a><a class="show-upcoming"><div class="top-element"><time>2:34 AM</time></div><h3>The Happy Elf</h3><h4>Special • 2005</h4><h6></h6><p>Eubie tries to bring Christmas joy to a dreary town called Bluesville.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/guardians-of-oz/"><div class="top-element"><time>3:20 AM</time><div class="streamit">Stream</div></div><h3>Guardians of Oz</h3><h4>Feature Film • 2015</h4><h6></h6><p>Ozzy, a winged monkey, seeks help from the "Champions of Oz" to stop the wicked Evilene.</p></a><a class="show-upcoming"><div class="top-element"><time>4:49 AM</time></div><h3>Pororo: Treasure Island Adventure</h3><h4>Feature Film • 2019</h4><h6></h6><p>Animal friends encounter Capt. Dark and a sea monster while searching for gold on a tropical island.</p></a><a class="show-upcoming"><div class="top-element"><time>6:10 AM</time></div><h3>The Little Penguin: Pororo&#8217;s Dinosaur Island Adventure</h3><h4>Feature Film • 2020</h4><h6></h6><p>Pororo and friends encounter aliens, robots and kidnapped dinosaurs.</p></a><a class="show-upcoming"><div class="top-element"><time>7:30 AM</time></div><h3>The Little Penguin: Pororo&#8217;s Racing Adventure</h3><h4>Feature Film • 2013</h4><h6></h6><p>Pororo, a curious little penguin, learns how to race ice sleds and makes it to the finals.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/shaun-the-sheep-movie/"><div class="top-element"><time>8:48 AM</time><div class="streamit">Stream</div></div><h3>Shaun the Sheep Movie</h3><h4>Feature Film • 2015</h4><h6></h6><p>Shaun the sheep and his farm-animal friends travel to the big city to save their amnesiac master.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/rams/"><div class="top-element"><time>10:14 AM</time><div class="streamit">Stream</div></div><h3>Rams</h3><h4>Feature Film • 2020</h4><h6></h6><p>Australian brothers set aside their differences when an illness threatens their flocks of sheep.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/12-mighty-orphans/"><div class="top-element"><time>12:14 PM</time><div class="streamit">Stream</div></div><h3>12 Mighty Orphans</h3><h4>Feature Film • 2021</h4><h6></h6><p>Rusty Russell coaches football at an orphanage in Fort Worth, Texas, during the Great Depression.</p></a><a class="show-upcoming"><div class="top-element"><time>2:13 PM</time></div><h3>Hope Springs Eternal</h3><h4>Feature Film • 2018</h4><h6></h6><p>A teen's cancer diagnosis makes her more popular at school, but then she goes into remission.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/shaun-the-sheep-movie/"><div class="top-element"><time>3:33 PM</time><div class="streamit">Stream</div></div><h3>Shaun the Sheep Movie</h3><h4>Feature Film • 2015</h4><h6></h6><p>Shaun the sheep and his farm-animal friends travel to the big city to save their amnesiac master.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/man-of-the-year/"><div class="top-element"><time>5:00 PM</time><div class="streamit">Stream</div></div><h3>Man of the Year</h3><h4>Feature Film • 2006</h4><h6></h6><p>A talk-show host (Robin Williams) becomes president of the United States.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/rams/"><div class="top-element"><time>6:56 PM</time><div class="streamit">Stream</div></div><h3>Rams</h3><h4>Feature Film • 2020</h4><h6></h6><p>Australian brothers set aside their differences when an illness threatens their flocks of sheep.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/parkland/"><div class="top-element"><time>8:56 PM</time><div class="streamit">Stream</div></div><h3>Parkland</h3><h4>Feature Film • 2013</h4><h6></h6><p>Parkland Hospital in Dallas saw chaotic events with the assassination of President John F. Kennedy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/nine/"><div class="top-element"><time>10:30 PM</time><div class="streamit">Stream</div></div><h3>Nine</h3><h4>Feature Film • 2009</h4><h6></h6><p>An Italian filmmaker (Daniel Day-Lewis) juggles relationships with the numerous women in his life.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-12"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-12').display(); });</script>
+        </div><h2 id="01-26-2025" class="date">Sunday, January 26</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/man-of-the-year/"><div class="top-element"><time>12:30 AM</time><div class="streamit">Stream</div></div><h3>Man of the Year</h3><h4>Feature Film • 2006</h4><h6></h6><p>A talk-show host (Robin Williams) becomes president of the United States.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/shaun-the-sheep-movie/"><div class="top-element"><time>2:26 AM</time><div class="streamit">Stream</div></div><h3>Shaun the Sheep Movie</h3><h4>Feature Film • 2015</h4><h6></h6><p>Shaun the sheep and his farm-animal friends travel to the big city to save their amnesiac master.</p></a><a class="show-upcoming"><div class="top-element"><time>3:52 AM</time></div><h3>Moondance Alexander</h3><h4>Feature Film • 2007</h4><h6></h6><p>A girl convinces a gruff horseman to coach her for a prestigious jumping competition.</p></a><a class="show-upcoming"><div class="top-element"><time>5:27 AM</time></div><h3>Pegasus: Pony With a Broken Wing</h3><h4>Feature Film • 2019</h4><h6></h6><p>Sydney and a neighbor find a mysterious pony that has an injured wing.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-dog-and-pony-show/"><div class="top-element"><time>6:54 AM</time><div class="streamit">Stream</div></div><h3>A Dog and Pony Show</h3><h4>Feature Film • 2018</h4><h6></h6><p>Dede, a famous performing circus dog, gets left behind when her show leaves town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/saving-sloane/"><div class="top-element"><time>8:33 AM</time><div class="streamit">Stream</div></div><h3>Saving Sloane</h3><h4>Feature Film • 2021</h4><h6></h6><p>A rebellious, spoiled city girl forms a deep bond with a horse when she's sent to the countryside.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/my-best-friend/"><div class="top-element"><time>10:03 AM</time><div class="streamit">Stream</div></div><h3>My Best Friend</h3><h4>TV Movie • 2016</h4><h6></h6><p>A city girl moves to the country with her family and befriends a telepathic horse.</p></a><a class="show-upcoming"><div class="top-element"><time>11:43 AM</time></div><h3>Moondance Alexander</h3><h4>Feature Film • 2007</h4><h6></h6><p>A girl convinces a gruff horseman to coach her for a prestigious jumping competition.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-story/"><div class="top-element"><time>1:18 PM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Story</h3><h4>Feature Film • 2017</h4><h6></h6><p>Cowgirls in high school have to run their homes while their parents are deployed.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-song/"><div class="top-element"><time>2:57 PM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Song</h3><h4>Feature Film • 2022</h4><h6></h6><p>An aspiring country singer and her grandmother overcome adversity through their love of music.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/nine/"><div class="top-element"><time>4:31 PM</time><div class="streamit">Stream</div></div><h3>Nine</h3><h4>Feature Film • 2009</h4><h6></h6><p>An Italian filmmaker (Daniel Day-Lewis) juggles relationships with the numerous women in his life.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/parkland/"><div class="top-element"><time>6:31 PM</time><div class="streamit">Stream</div></div><h3>Parkland</h3><h4>Feature Film • 2013</h4><h6></h6><p>Parkland Hospital in Dallas saw chaotic events with the assassination of President John F. Kennedy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/public-disturbance/"><div class="top-element"><time>8:05 PM</time><div class="streamit">Stream</div></div><h3>Public Disturbance</h3><h4>Feature Film • 2017</h4><h6></h6><p>The Janoskians decide to throw an epic party in Los Angeles as they pull off stunts.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/make-it-happen/"><div class="top-element"><time>9:30 PM</time><div class="streamit">Stream</div></div><h3>Make It Happen</h3><h4>Feature Film • 2008</h4><h6></h6><p>A young woman discovers a dance form which brings conflict and self-discovery.</p></a><a class="show-upcoming"><div class="top-element"><time>11:01 PM</time></div><h3>Stomp the Yard: Homecoming</h3><h4>Feature Film • 2010</h4><h6></h6><p>A troubled youth (Collins Pennie) leads a dance troupe in a national competition.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-13"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-13').display(); });</script>
+        </div><h2 id="01-27-2025" class="date">Monday, January 27</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-song/"><div class="top-element"><time>12:30 AM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Song</h3><h4>Feature Film • 2022</h4><h6></h6><p>An aspiring country singer and her grandmother overcome adversity through their love of music.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-cowgirls-story/"><div class="top-element"><time>2:04 AM</time><div class="streamit">Stream</div></div><h3>A Cowgirl&#8217;s Story</h3><h4>Feature Film • 2017</h4><h6></h6><p>Cowgirls in high school have to run their homes while their parents are deployed.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/my-best-friend/"><div class="top-element"><time>3:43 AM</time><div class="streamit">Stream</div></div><h3>My Best Friend</h3><h4>TV Movie • 2016</h4><h6></h6><p>A city girl moves to the country with her family and befriends a telepathic horse.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/saving-sloane/"><div class="top-element"><time>5:23 AM</time><div class="streamit">Stream</div></div><h3>Saving Sloane</h3><h4>Feature Film • 2021</h4><h6></h6><p>A rebellious, spoiled city girl forms a deep bond with a horse when she's sent to the countryside.</p></a><a class="show-upcoming"><div class="top-element"><time>6:53 AM</time></div><h3>Pups United</h3><h4>Feature Film • 2015</h4><h6></h6><p>A group of talking dogs team up to save the Youth World Cup soccer finals.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/pawparazzi/"><div class="top-element"><time>8:23 AM</time><div class="streamit">Stream</div></div><h3>PawParazzi</h3><h4>Feature Film • 2018</h4><h6></h6><p>A rising Hollywood starlet learns to rough it when she shoots a movie on a farm.</p></a><a class="show-upcoming"><div class="top-element"><time>10:02 AM</time></div><h3>Paws P.I.</h3><h4>Feature Film • 2018</h4><h6></h6><p>A boy recruits his talking dog and parrot to help him take down a tyrannical tycoon.</p></a><a class="show-upcoming"><div class="top-element"><time>11:30 AM</time></div><h3>Hero Dog: The Journey Home</h3><h4>Feature Film • 2021</h4><h6></h6><p>Chinook, the Alaskan malamute, must lead a shipwrecked blind man out of the wilderness.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/red-dog-true-blue/"><div class="top-element"><time>1:01 PM</time><div class="streamit">Stream</div></div><h3>Red Dog: True Blue</h3><h4>Feature Film • 2016</h4><h6></h6><p>An 11-year-old boy strikes up a friendship with a scrappy, red Australian kelpie.</p></a><a class="show-upcoming"><div class="top-element"><time>2:31 PM</time></div><h3>Pups United</h3><h4>Feature Film • 2015</h4><h6></h6><p>A group of talking dogs team up to save the Youth World Cup soccer finals.</p></a><a class="show-upcoming"><div class="top-element"><time>4:01 PM</time></div><h3>Paws P.I.</h3><h4>Feature Film • 2018</h4><h6></h6><p>A boy recruits his talking dog and parrot to help him take down a tyrannical tycoon.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/pawparazzi/"><div class="top-element"><time>5:29 PM</time><div class="streamit">Stream</div></div><h3>PawParazzi</h3><h4>Feature Film • 2018</h4><h6></h6><p>A rising Hollywood starlet learns to rough it when she shoots a movie on a farm.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/red-dog-true-blue/"><div class="top-element"><time>7:08 PM</time><div class="streamit">Stream</div></div><h3>Red Dog: True Blue</h3><h4>Feature Film • 2016</h4><h6></h6><p>An 11-year-old boy strikes up a friendship with a scrappy, red Australian kelpie.</p></a><a class="show-upcoming"><div class="top-element"><time>8:38 PM</time></div><h3>Hero Dog: The Journey Home</h3><h4>Feature Film • 2021</h4><h6></h6><p>Chinook, the Alaskan malamute, must lead a shipwrecked blind man out of the wilderness.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>10:09 PM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-royal-night-out/"><div class="top-element"><time>11:36 PM</time><div class="streamit">Stream</div></div><h3>A Royal Night Out</h3><h4>Feature Film • 2015</h4><h6></h6><p>Teenage princesses Elizabeth II (Sarah Gadon) and Margaret (Bel Powley) spend an evening in London.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-14"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-14').display(); });</script>
+        </div><h2 id="01-28-2025" class="date">Tuesday, January 28</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>1:14 AM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/red-dog-true-blue/"><div class="top-element"><time>2:39 AM</time><div class="streamit">Stream</div></div><h3>Red Dog: True Blue</h3><h4>Feature Film • 2016</h4><h6></h6><p>An 11-year-old boy strikes up a friendship with a scrappy, red Australian kelpie.</p></a><a class="show-upcoming"><div class="top-element"><time>4:09 AM</time></div><h3>Paws P.I.</h3><h4>Feature Film • 2018</h4><h6></h6><p>A boy recruits his talking dog and parrot to help him take down a tyrannical tycoon.</p></a><a class="show-upcoming"><div class="top-element"><time>5:37 AM</time></div><h3>Hero Dog: The Journey Home</h3><h4>Feature Film • 2021</h4><h6></h6><p>Chinook, the Alaskan malamute, must lead a shipwrecked blind man out of the wilderness.</p></a><a class="show-upcoming"><div class="top-element"><time>7:08 AM</time></div><h3>Hoodwinked Too! Hood vs. Evil</h3><h4>Feature Film • 2011</h4><h6></h6><p>Red Riding Hood looks into the sudden disappearance of Hansel and Gretel.</p></a><a class="show-upcoming"><div class="top-element"><time>8:36 AM</time></div><h3>Big Trip</h3><h4>Feature Film • 2019</h4><h6></h6><p>A gang of misfit animals on an exciting quest to return a panda cub to its family.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/big-trip-2-special-delivery/"><div class="top-element"><time>10:01 AM</time><div class="streamit">Stream</div></div><h3>Big Trip 2: Special Delivery</h3><h4>Feature Film • 2022</h4><h6></h6><p>A bear must bring a cub to America by flying on an airship, avoiding an evil vulture on the way.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>11:32 AM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-royal-night-out/"><div class="top-element"><time>12:57 PM</time><div class="streamit">Stream</div></div><h3>A Royal Night Out</h3><h4>Feature Film • 2015</h4><h6></h6><p>Teenage princesses Elizabeth II (Sarah Gadon) and Margaret (Bel Powley) spend an evening in London.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/wild-oats/"><div class="top-element"><time>2:35 PM</time><div class="streamit">Stream</div></div><h3>Wild Oats</h3><h4>Feature Film • 2016</h4><h6></h6><p>Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.</p></a><a class="show-upcoming"><div class="top-element"><time>4:02 PM</time></div><h3>Big Trip</h3><h4>Feature Film • 2019</h4><h6></h6><p>A gang of misfit animals on an exciting quest to return a panda cub to its family.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/big-trip-2-special-delivery/"><div class="top-element"><time>5:27 PM</time><div class="streamit">Stream</div></div><h3>Big Trip 2: Special Delivery</h3><h4>Feature Film • 2022</h4><h6></h6><p>A bear must bring a cub to America by flying on an airship, avoiding an evil vulture on the way.</p></a><a class="show-upcoming"><div class="top-element"><time>6:58 PM</time></div><h3>Show Me the Father</h3><h4>Feature Film • 2021</h4><h6></h6><p>Captivating stories interwoven with inspirational truths about the fatherhood of God.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>8:30 PM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming"><div class="top-element"><time>9:55 PM</time></div><h3>I Still See You</h3><h4>Feature Film • 2018</h4><h6></h6><p>Ghosts inhabit what's left of the world after an apocalyptic event.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>11:34 PM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-15"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-15').display(); });</script>
+        </div><h2 id="01-29-2025" class="date">Wednesday, January 29</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-presence/"><div class="top-element"><time>1:07 AM</time><div class="streamit">Stream</div></div><h3>The Presence</h3><h4>Feature Film • 2010</h4><h6></h6><p>A woman is stalked by a ghost and begins to exhibit irrational behavior.</p></a><a class="show-upcoming"><div class="top-element"><time>2:35 AM</time></div><h3>Show Me the Father</h3><h4>Feature Film • 2021</h4><h6></h6><p>Captivating stories interwoven with inspirational truths about the fatherhood of God.</p></a><a class="show-upcoming"><div class="top-element"><time>4:07 AM</time></div><h3>Big Trip</h3><h4>Feature Film • 2019</h4><h6></h6><p>A gang of misfit animals on an exciting quest to return a panda cub to its family.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/big-trip-2-special-delivery/"><div class="top-element"><time>5:32 AM</time><div class="streamit">Stream</div></div><h3>Big Trip 2: Special Delivery</h3><h4>Feature Film • 2022</h4><h6></h6><p>A bear must bring a cub to America by flying on an airship, avoiding an evil vulture on the way.</p></a><a class="show-upcoming"><div class="top-element"><time>7:03 AM</time></div><h3>I Still See You</h3><h4>Feature Film • 2018</h4><h6></h6><p>Ghosts inhabit what's left of the world after an apocalyptic event.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-presence/"><div class="top-element"><time>8:42 AM</time><div class="streamit">Stream</div></div><h3>The Presence</h3><h4>Feature Film • 2010</h4><h6></h6><p>A woman is stalked by a ghost and begins to exhibit irrational behavior.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>10:10 AM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/golden-shoes/"><div class="top-element"><time>11:43 AM</time><div class="streamit">Stream</div></div><h3>Golden Shoes</h3><h4>Feature Film • 2015</h4><h6></h6><p>A young boy overcomes bullying and solitude to fulfil his dream of playing in a soccer league.</p></a><a class="show-upcoming"><div class="top-element"><time>1:13 PM</time></div><h3>Opposite Day</h3><h4>Feature Film • 2009</h4><h6></h6><p>A little boy's (Billy Unger) wish turns children into adults and adults into children.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/alex-rider-operation-stormbreaker/"><div class="top-element"><time>2:35 PM</time><div class="streamit">Stream</div></div><h3>Alex Rider: Operation Stormbreaker</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenage spy for MI6 investigates a billionaire who donated computers to every school in England.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-snowy-day-in-oakland/"><div class="top-element"><time>4:10 PM</time><div class="streamit">Stream</div></div><h3>A Snowy Day in Oakland</h3><h4>Feature Film • 2023</h4><h6></h6><p>A psychologist splits with her boyfriend and business partner, opening her own practice in Oakland.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/star-kid/"><div class="top-element"><time>5:43 PM</time><div class="streamit">Stream</div></div><h3>Star Kid</h3><h4>Feature Film • 1997</h4><h6></h6><p>A space robot (Alex Daniels) helps a boy (Joseph Mazzello) get superpowers.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-presence/"><div class="top-element"><time>7:25 PM</time><div class="streamit">Stream</div></div><h3>The Presence</h3><h4>Feature Film • 2010</h4><h6></h6><p>A woman is stalked by a ghost and begins to exhibit irrational behavior.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-plus-one/"><div class="top-element"><time>8:53 PM</time><div class="streamit">Stream</div></div><h3>The Plus One</h3><h4>Feature Film • 2023</h4><h6></h6><p>A woman plans the perfect destination wedding -- until her man of honor brings his obnoxious ex.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bandslam/"><div class="top-element"><time>10:28 PM</time><div class="streamit">Stream</div></div><h3>Bandslam</h3><h4>Feature Film • 2009</h4><h6></h6><p>A gifted singer-songwriter hires a new guy in town to help her fledgling rock band.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-16"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-16').display(); });</script>
+        </div><h2 id="01-30-2025" class="date">Thursday, January 30</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/love-wrecked/"><div class="top-element"><time>12:20 AM</time><div class="streamit">Stream</div></div><h3>Love Wrecked</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenager takes her favorite rock star to a nearby island and tells him that they are castaways.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/star-kid/"><div class="top-element"><time>1:50 AM</time><div class="streamit">Stream</div></div><h3>Star Kid</h3><h4>Feature Film • 1997</h4><h6></h6><p>A space robot (Alex Daniels) helps a boy (Joseph Mazzello) get superpowers.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/alex-rider-operation-stormbreaker/"><div class="top-element"><time>3:34 AM</time><div class="streamit">Stream</div></div><h3>Alex Rider: Operation Stormbreaker</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenage spy for MI6 investigates a billionaire who donated computers to every school in England.</p></a><a class="show-upcoming"><div class="top-element"><time>5:11 AM</time></div><h3>Opposite Day</h3><h4>Feature Film • 2009</h4><h6></h6><p>A little boy's (Billy Unger) wish turns children into adults and adults into children.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/golden-shoes/"><div class="top-element"><time>6:34 AM</time><div class="streamit">Stream</div></div><h3>Golden Shoes</h3><h4>Feature Film • 2015</h4><h6></h6><p>A young boy overcomes bullying and solitude to fulfil his dream of playing in a soccer league.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/bandslam/"><div class="top-element"><time>8:05 AM</time><div class="streamit">Stream</div></div><h3>Bandslam</h3><h4>Feature Film • 2009</h4><h6></h6><p>A gifted singer-songwriter hires a new guy in town to help her fledgling rock band.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/yellowbird/"><div class="top-element"><time>9:57 AM</time><div class="streamit">Stream</div></div><h3>Yellowbird</h3><h4>Feature Film • 2014</h4><h6></h6><p>Yellowbird suddenly finds himself leading a flock on its migration to Africa.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-blue-elephant/"><div class="top-element"><time>11:28 AM</time></div><h3>The Blue Elephant</h3><h4>Feature Film • 2008</h4><h6></h6><p>A young elephant becomes separated from his herd and seeks help from new friends.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/a-storks-journey/"><div class="top-element"><time>12:46 PM</time><div class="streamit">Stream</div></div><h3>A Stork&#8217;s Journey</h3><h4>Feature Film • 2017</h4><h6></h6><p>An orphaned sparrow, adopted and raised by storks, struggles to make the annual migration.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-sword-of-storms/"><div class="top-element"><time>2:11 PM</time><div class="streamit">Stream</div></div><h3>Hellboy: Sword of Storms</h3><h4>TV Movie • 2006</h4><h6></h6><p>Hellboy (Ron Perlman) battles creatures searching for a powerful sword.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-blood-and-iron/"><div class="top-element"><time>3:30 PM</time><div class="streamit">Stream</div></div><h3>Hellboy: Blood and Iron</h3><h4>TV Movie • 2007</h4><h6></h6><p>Hellboy (Ron Perlman) encounters monsters and a resurrected vampire.</p></a><a class="show-upcoming"><div class="top-element"><time>4:47 PM</time></div><h3>Thomas and the Magic Railroad</h3><h4>Feature Film • 2000</h4><h6></h6><p>A girl (Mara Wilson) and her grandfather (Peter Fonda) help the talking train.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/love-wrecked/"><div class="top-element"><time>6:14 PM</time><div class="streamit">Stream</div></div><h3>Love Wrecked</h3><h4>Feature Film • 2006</h4><h6></h6><p>A teenager takes her favorite rock star to a nearby island and tells him that they are castaways.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/still-mine/"><div class="top-element"><time>7:44 PM</time><div class="streamit">Stream</div></div><h3>Still Mine</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aging farmer fights back when authorities hamper his plan to build a cottage for his sick wife.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/godsend/"><div class="top-element"><time>9:30 PM</time><div class="streamit">Stream</div></div><h3>Godsend</h3><h4>Feature Film • 2004</h4><h6></h6><p>A scientist (Robert De Niro) clones a couple's (Greg Kinnear, Rebecca Romijn-Stamos) dead son.</p></a><a class="show-upcoming"><div class="top-element"><time>11:15 PM</time></div><h3>Let Us In</h3><h4>Feature Film • 2020</h4><h6></h6><p>A 12-year-old girl investigates a rash of disappearances occurring in her small town.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-17"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-17').display(); });</script>
+        </div><h2 id="01-31-2025" class="date">Friday, January 31</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-blood-and-iron/"><div class="top-element"><time>12:41 AM</time><div class="streamit">Stream</div></div><h3>Hellboy: Blood and Iron</h3><h4>TV Movie • 2007</h4><h6></h6><p>Hellboy (Ron Perlman) encounters monsters and a resurrected vampire.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/hellboy-sword-of-storms/"><div class="top-element"><time>1:58 AM</time><div class="streamit">Stream</div></div><h3>Hellboy: Sword of Storms</h3><h4>TV Movie • 2006</h4><h6></h6><p>Hellboy (Ron Perlman) battles creatures searching for a powerful sword.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-wild-and-the-innocent/"><div class="top-element"><time>3:17 AM</time><div class="streamit">Stream</div></div><h3>The Wild and the Innocent</h3><h4>Feature Film • 1959</h4><h6></h6><p>Two innocents (Audie Murphy, Sandra Dee) meet trouble in a wild town.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/showdown-1963/"><div class="top-element"><time>4:43 AM</time><div class="streamit">Stream</div></div><h3>Showdown</h3><h4>Feature Film • 1963</h4><h6></h6><p>Cowboys (Audie Murphy, Charles Drake) and dancer (Kathleen Crowley) have trouble with outlaws.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/jericho-2000/"><div class="top-element"><time>6:03 AM</time><div class="streamit">Stream</div></div><h3>Jericho</h3><h4>Feature Film • 2000</h4><h6></h6><p>A charismatic preacher rescues a mysterious gunman who tries to find answers about his identity.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/godsend/"><div class="top-element"><time>7:45 AM</time><div class="streamit">Stream</div></div><h3>Godsend</h3><h4>Feature Film • 2004</h4><h6></h6><p>A scientist (Robert De Niro) clones a couple's (Greg Kinnear, Rebecca Romijn-Stamos) dead son.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/still-mine/"><div class="top-element"><time>9:28 AM</time><div class="streamit">Stream</div></div><h3>Still Mine</h3><h4>Feature Film • 2012</h4><h6></h6><p>An aging farmer fights back when authorities hamper his plan to build a cottage for his sick wife.</p></a><a class="show-upcoming"><div class="top-element"><time>11:12 AM</time></div><h3>Stars Fell on Alabama</h3><h4>Feature Film • 2021</h4><h6></h6><p>An actress pretends to be a Hollywood agent's girlfriend at his high school reunion.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/fair-game/"><div class="top-element"><time>12:56 PM</time><div class="streamit">Stream</div></div><h3>Fair Game</h3><h4>Feature Film • 2010</h4><h6></h6><p>Valerie Plame and her husband face the fallout when her cover is blown as a covert CIA agent.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-best-of-me/"><div class="top-element"><time>2:45 PM</time><div class="streamit">Stream</div></div><h3>The Best of Me</h3><h4>Feature Film • 2014</h4><h6></h6><p>A friend's funeral reunites former high-school sweethearts, who find that they are still in love.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/brave-new-girl/"><div class="top-element"><time>4:44 PM</time><div class="streamit">Stream</div></div><h3>Brave New Girl</h3><h4>TV Movie • 2004</h4><h6></h6><p>A woman (Virginia Madsen) helps her daughter (Lindsey Haun) attend music school.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/top-end-wedding/"><div class="top-element"><time>6:14 PM</time><div class="streamit">Stream</div></div><h3>Top End Wedding</h3><h4>Feature Film • 2019</h4><h6></h6><p>Lauren and Ned have 10 days to find Lauren's mother in time for their wedding.</p></a><a class="show-upcoming"><div class="top-element"><time>7:57 PM</time></div><h3>Words and Pictures</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two teachers have a competition and allow students to vote on words and pictures.</p></a><a class="show-upcoming"><div class="top-element"><time>9:54 PM</time></div><h3>Stars Fell on Alabama</h3><h4>Feature Film • 2021</h4><h6></h6><p>An actress pretends to be a Hollywood agent's girlfriend at his high school reunion.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-best-of-me/"><div class="top-element"><time>11:38 PM</time><div class="streamit">Stream</div></div><h3>The Best of Me</h3><h4>Feature Film • 2014</h4><h6></h6><p>A friend's funeral reunites former high-school sweethearts, who find that they are still in love.</p></a></div><div class="advert-holder banner-ad">
+          <div id="responsive-banner-18"></div>
+          <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner-18').display(); });</script>
+        </div><h2 id="02-01-2025" class="date">Saturday, February 1</h2><div class="show-grid"><a class="show-upcoming live" href="https://www.tvinsider.com/show/fair-game/"><div class="top-element"><time>1:37 AM</time><div class="streamit">Stream</div></div><h3>Fair Game</h3><h4>Feature Film • 2010</h4><h6></h6><p>Valerie Plame and her husband face the fallout when her cover is blown as a covert CIA agent.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/brave-new-girl/"><div class="top-element"><time>3:26 AM</time><div class="streamit">Stream</div></div><h3>Brave New Girl</h3><h4>TV Movie • 2004</h4><h6></h6><p>A woman (Virginia Madsen) helps her daughter (Lindsey Haun) attend music school.</p></a><a class="show-upcoming"><div class="top-element"><time>4:56 AM</time></div><h3>Words and Pictures</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two teachers have a competition and allow students to vote on words and pictures.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-best-of-me/"><div class="top-element"><time>6:53 AM</time><div class="streamit">Stream</div></div><h3>The Best of Me</h3><h4>Feature Film • 2014</h4><h6></h6><p>A friend's funeral reunites former high-school sweethearts, who find that they are still in love.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/beyond-the-lights/"><div class="top-element"><time>8:52 AM</time><div class="streamit">Stream</div></div><h3>Beyond the Lights</h3><h4>Feature Film • 2014</h4><h6></h6><p>A rising singer struggles with success and finds comfort in the arms of an aspiring politician.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/undiscovered/"><div class="top-element"><time>10:49 AM</time><div class="streamit">Stream</div></div><h3>Undiscovered</h3><h4>Feature Film • 2005</h4><h6></h6><p>Aspiring entertainers (Pell James, Steven Strait) try to launch their careers.</p></a><a class="show-upcoming"><div class="top-element"><time>12:28 PM</time></div><h3>Words and Pictures</h3><h4>Feature Film • 2013</h4><h6></h6><p>Two teachers have a competition and allow students to vote on words and pictures.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/make-it-happen/"><div class="top-element"><time>2:25 PM</time><div class="streamit">Stream</div></div><h3>Make It Happen</h3><h4>Feature Film • 2008</h4><h6></h6><p>A young woman discovers a dance form which brings conflict and self-discovery.</p></a><a class="show-upcoming"><div class="top-element"><time>3:56 PM</time></div><h3>In the Mix</h3><h4>Feature Film • 2005</h4><h6></h6><p>A disc jockey (Usher) becomes a bodyguard for a mobster's (Chazz Palminteri) daughter.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/the-truffle-hunters/"><div class="top-element"><time>5:33 PM</time><div class="streamit">Stream</div></div><h3>The Truffle Hunters</h3><h4>Feature Film • 2020</h4><h6></h6><p>A handful of men search for rare, expensive and delicious white Alba truffles in Piedmont, Italy.</p></a><a class="show-upcoming live" href="https://www.tvinsider.com/show/mirror-mirror/"><div class="top-element"><time>6:58 PM</time><div class="streamit">Stream</div></div><h3>Mirror Mirror</h3><h4>Feature Film • 2012</h4><h6></h6><p>Seven dwarves help an exiled princess (Lily Collins) win back her kingdom from an evil queen.</p></a></section></div>
+<a class="basic-button" href="https://www.tvinsider.com/network/movieplex/">< Back To MoviePlex</a><select class="channel-changer" onChange="window.location.href=this.value">
+<option value="">CHANGE CHANNEL</option><option value="/network/5-star-max/schedule/">5-Star MAX</option><option value="/network/ae/schedule/">A&amp;E</option><option value="/network/abc/schedule/">ABC</option><option value="/network/acc-network/schedule/">ACC Network</option><option value="/network/action-max/schedule/">Action MAX</option><option value="/network/adult-swim/schedule/">Adult Swim</option><option value="/network/altitude-sports/schedule/">Altitude Sports</option><option value="/network/amc/schedule/">AMC</option><option value="/network/american-heroes-channel/schedule/">American Heroes Channel</option><option value="/network/animal-planet/schedule/">Animal Planet</option><option value="/network/antenna-tv/schedule/">Antenna TV</option><option value="/network/aspire/schedule/">Aspire</option><option value="/network/awe/schedule/">AWE</option><option value="/network/axs/schedule/">AXS</option><option value="/network/babyfirst/schedule/">BabyFirst</option><option value="/network/bbc-america/schedule/">BBC America</option><option value="/network/bbc-news/schedule/">BBC News</option><option value="/network/bein-sports/schedule/">beIN Sports</option><option value="/network/bet/schedule/">BET</option><option value="/network/bet-gospel/schedule/">BET Gospel</option><option value="/network/bet-her/schedule/">BET Her</option><option value="/network/bet-jams/schedule/">BET Jams</option><option value="/network/bet-soul/schedule/">BET Soul</option><option value="/network/big-ten-network/schedule/">Big Ten Network</option><option value="/network/bloomberg/schedule/">Bloomberg</option><option value="/network/boomerang/schedule/">Boomerang</option><option value="/network/bounce-tv/schedule/">Bounce TV</option><option value="/network/bravo/schedule/">Bravo</option><option value="/network/buzzr/schedule/">Buzzr</option><option value="/network/byutv/schedule/">BYUtv</option><option value="/network/c-span/schedule/">C-SPAN</option><option value="/network/c-span-2/schedule/">C-SPAN 2</option><option value="/network/c-span-3/schedule/">C-SPAN 3</option><option value="/network/cars-tv/schedule/">Cars.TV</option><option value="/network/cartoon-network/schedule/">Cartoon Network</option><option value="/network/catchy-comedy/schedule/">Catchy Comedy</option><option value="/network/catholic-faith-network/schedule/">Catholic Faith Network</option><option value="/network/cbs/schedule/">CBS</option><option value="/network/cbs-sports-network/schedule/">CBS Sports Network</option><option value="/network/charge/schedule/">Charge!</option><option value="/network/cheddar/schedule/">Cheddar</option><option value="/network/cinemax/schedule/">Cinemax</option><option value="/network/circle/schedule/">Circle</option><option value="/network/cleo-tv/schedule/">Cleo TV</option><option value="/network/cmt/schedule/">CMT</option><option value="/network/cnbc/schedule/">CNBC</option><option value="/network/cnn/schedule/">CNN</option><option value="/network/cnn-international/schedule/">CNN International</option><option value="/network/comedy-central/schedule/">Comedy Central</option><option value="/network/comedy-tv/schedule/">Comedy TV</option><option value="/network/comet/schedule/">Comet</option><option value="/network/cooking-channel/schedule/">Cooking Channel</option><option value="/network/court-tv/schedule/">Court TV</option><option value="/network/cozi-tv/schedule/">Cozi TV</option><option value="/network/create/schedule/">Create</option><option value="/network/crime-and-investigation-network/schedule/">Crime and Investigation Network</option><option value="/network/dabl/schedule/">Dabl</option><option value="/network/daystar/schedule/">Daystar</option><option value="/network/dazn/schedule/">DAZN</option><option value="/network/destination-america/schedule/">Destination America</option><option value="/network/discovery/schedule/">Discovery Channel</option><option value="/network/discovery-family/schedule/">Discovery Family</option><option value="/network/discovery-life-channel/schedule/">Discovery Life Channel</option><option value="/network/disney-channel/schedule/">Disney Channel</option><option value="/network/disney-junior/schedule/">Disney Junior</option><option value="/network/disney-xd/schedule/">Disney XD</option><option value="/network/e/schedule/">E!</option><option value="/network/espn/schedule/">ESPN</option><option value="/network/espn-deportes/schedule/">ESPN Deportes</option><option value="/network/espn2/schedule/">ESPN2</option><option value="/network/espnu/schedule/">ESPNU</option><option value="/network/estrella-tv/schedule/">Estrella TV</option><option value="/network/family-movie-classics/schedule/">Family Movie Classics</option><option value="/network/fanduel-sports-detroit/schedule/">FanDuel Sports Detroit</option><option value="/network/fanduel-sports-florida/schedule/">FanDuel Sports Florida</option><option value="/network/fanduel-sports-great-lakes/schedule/">FanDuel Sports Great Lakes</option><option value="/network/fanduel-sports-indiana/schedule/">FanDuel Sports Indiana</option><option value="/network/fanduel-sports-kansas-city/schedule/">FanDuel Sports Kansas City</option><option value="/network/fanduel-sports-midwest/schedule/">FanDuel Sports Midwest</option><option value="/network/fanduel-sports-new-orleans/schedule/">FanDuel Sports New Orleans</option><option value="/network/fanduel-sports-north/schedule/">FanDuel Sports North</option><option value="/network/fanduel-sports-ohio/schedule/">FanDuel Sports Ohio</option><option value="/network/fanduel-sports-oklahoma/schedule/">FanDuel Sports Oklahoma</option><option value="/network/fanduel-sports-socal/schedule/">FanDuel Sports SoCal</option><option value="/network/fanduel-sports-south/schedule/">FanDuel Sports South</option><option value="/network/fanduel-sports-southeast/schedule/">FanDuel Sports Southeast</option><option value="/network/fanduel-sports-southwest/schedule/">FanDuel Sports Southwest</option><option value="/network/fanduel-sports-sun/schedule/">FanDuel Sports Sun</option><option value="/network/fanduel-sports-west/schedule/">FanDuel Sports West</option><option value="/network/fanduel-sports-wisconsin/schedule/">FanDuel Sports Wisconsin</option><option value="/network/fetv/schedule/">FETV</option><option value="/network/flix/schedule/">Flix</option><option value="/network/food-network/schedule/">Food Network</option><option value="/network/fox/schedule/">FOX</option><option value="/network/fox-business/schedule/">Fox Business</option><option value="/network/fox-deportes/schedule/">FOX Deportes</option><option value="/network/fox-news/schedule/">Fox News</option><option value="/network/fox-soccer-plus/schedule/">Fox Soccer Plus</option><option value="/network/fox-sports-1/schedule/">Fox Sports 1</option><option value="/network/fox-sports-2/schedule/">Fox Sports 2</option><option value="/network/freeform/schedule/">Freeform</option><option value="/network/fuse/schedule/">Fuse</option><option value="/network/fx/schedule/">FX</option><option value="/network/fx-movie-channel/schedule/">FX Movie Channel</option><option value="/network/fxx/schedule/">FXX</option><option value="/network/fyi/schedule/">FYI</option><option value="/network/game-show-network/schedule/">Game Show Network</option><option value="/network/gettv/schedule/">getTV</option><option value="/network/gol-tv/schedule/">GOL TV</option><option value="/network/golf-channel/schedule/">Golf Channel</option><option value="/network/great-american-faith-and-living/schedule/">Great American Faith &amp; Living</option><option value="/network/great-american-family/schedule/">Great American Family</option><option value="/network/grit/schedule/">Grit</option><option value="/network/hallmark-channel/schedule/">Hallmark Channel</option><option value="/network/hallmark-family/schedule/">Hallmark Family</option><option value="/network/hallmark-mystery/schedule/">Hallmark Mystery</option><option value="/network/hbo/schedule/">HBO</option><option value="/network/hbo-comedy/schedule/">HBO Comedy</option><option value="/network/hbo-family/schedule/">HBO Family</option><option value="/network/hbo-latino/schedule/">HBO Latino</option><option value="/network/hbo-signature/schedule/">HBO Signature</option><option value="/network/hbo-zone/schedule/">HBO Zone</option><option value="/network/hbo2/schedule/">HBO2</option><option value="/network/hdnet-movies/schedule/">HDNet Movies</option><option value="/network/here-tv/schedule/">Here TV</option><option value="/network/heroes-icons/schedule/">Heroes &amp; Icons</option><option value="/network/hgtv/schedule/">HGTV</option><option value="/network/history-channel/schedule/">History Channel</option><option value="/network/hln/schedule/">HLN</option><option value="/network/hsn/schedule/">HSN</option><option value="/network/ifc/schedule/">IFC</option><option value="/network/impact/schedule/">Impact</option><option value="/network/indieplex/schedule/">IndiePlex</option><option value="/network/insp/schedule/">INSP</option><option value="/network/investigation-discovery/schedule/">Investigation Discovery</option><option value="/network/ion-mystery/schedule/">ION Mystery</option><option value="/network/ion-plus/schedule/">Ion Plus</option><option value="/network/ion-television/schedule/">Ion Television</option><option value="/network/jewelry-television/schedule/">Jewelry Television</option><option value="/network/jewish-life-television/schedule/">Jewish Life Television</option><option value="/network/justice-central/schedule/">Justice Central</option><option value="/network/laff/schedule/">Laff</option><option value="/network/law-and-crime/schedule/">Law &amp; Crime</option><option value="/network/lifetime/schedule/">Lifetime</option><option value="/network/lmn/schedule/">Lifetime Movie Network</option><option value="/network/lifetime-real-women/schedule/">Lifetime Real Women</option><option value="/network/logo/schedule/">Logo</option><option value="/network/magnolia-network/schedule/">Magnolia Network</option><option value="/network/mavtv/schedule/">MAVTV</option><option value="/network/merit-street/schedule/">Merit Street</option><option value="/network/metv/schedule/">MeTV</option><option value="/network/metv-toons/schedule/">MeTV Toons</option><option value="/network/metv-plus/schedule/">MeTV+</option><option value="/network/mgm-plus/schedule/">MGM+</option><option value="/network/mgm-plus-drive-in/schedule/">MGM+ Drive-In</option><option value="/network/mgm-plus-hits/schedule/">MGM+ Hits</option><option value="/network/mgm-plus-marquee/schedule/">MGM+ Marquee</option><option value="/network/military-history/schedule/">Military History</option><option value="/network/mlb-network/schedule/">MLB Network</option><option value="/network/more-max/schedule/">More MAX</option><option value="/network/motortrend/schedule/">MotorTrend</option><option value="/network/moviemax/schedule/">Movie MAX</option><option value="/network/movieplex/schedule/">MoviePlex</option><option value="/network/movies/schedule/">Movies!</option><option value="/network/msg/schedule/">MSG</option><option value="/network/msnbc/schedule/">MSNBC</option><option value="/network/mtv/schedule/">MTV</option><option value="/network/mtv-classic/schedule/">MTV Classic</option><option value="/network/mtv-live/schedule/">MTV Live</option><option value="/network/mtv2/schedule/">MTV2</option><option value="/network/mynetworktv/schedule/">MyNetworkTV</option><option value="/network/nasa-tv/schedule/">NASA TV</option><option value="/network/nat-geo/schedule/">Nat Geo</option><option value="/network/nat-geo-wild/schedule/">Nat Geo Wild</option><option value="/network/nba-tv/schedule/">NBA TV</option><option value="/network/nbc/schedule/">NBC</option><option value="/network/nbc-sports-bay-area/schedule/">NBC Sports Bay Area</option><option value="/network/nbc-sports-chicago/schedule/">NBC Sports Chicago</option><option value="/network/nbc-sports-philadelphia/schedule/">NBC Sports Philadelphia</option><option value="/network/necn/schedule/">NECN</option><option value="/network/new-england-sports-network/schedule/">NESN</option><option value="/network/newsmax/schedule/">Newsmax</option><option value="/network/newsnation/schedule/">NewsNation</option><option value="/network/next-level-sports/schedule/">Next Level Sports</option><option value="/network/nfl-network/schedule/">NFL Network</option><option value="/network/nhk-world/schedule/">NHK World</option><option value="/network/nhl-network/schedule/">NHL Network</option><option value="/network/nick-jr/schedule/">Nick Jr.</option><option value="/network/nickelodeon/schedule/">Nickelodeon</option><option value="/network/nicktoons/schedule/">Nicktoons</option><option value="/network/oan/schedule/">OAN</option><option value="/network/outdoor-channel/schedule/">Outdoor Channel</option><option value="/network/outer-max/schedule/">Outer MAX</option><option value="/network/outlaw-the-western-channel/schedule/">Outlaw</option><option value="/network/ovation/schedule/">Ovation</option><option value="/network/own/schedule/">OWN</option><option value="/network/oxygen/schedule/">Oxygen</option><option value="/network/pac-12-network/schedule/">Pac-12 Network</option><option value="/network/paramount-network/schedule/">Paramount Network</option><option value="/network/pbs/schedule/">PBS</option><option value="/network/pbs-kids/schedule/">PBS Kids</option><option value="/network/pets/schedule/">Pets</option><option value="/network/pop/schedule/">Pop TV</option><option value="/network/primo-tv/schedule/">Primo TV</option><option value="/network/pursuit/schedule/">Pursuit</option><option value="/network/qvc/schedule/">QVC</option><option value="/network/real-americas-voice/schedule/">Real America's Voice</option><option value="/network/recipe-tv/schedule/">Recipe TV</option><option value="/network/reelz/schedule/">Reelz</option><option value="/network/retroplex/schedule/">RetroPlex</option><option value="/network/revolt/schedule/">Revolt</option><option value="/network/rewind-tv/schedule/">Rewind TV</option><option value="/network/rfd-tv/schedule/">RFD-TV</option><option value="/network/sbn/schedule/">SBN</option><option value="/network/sbs/schedule/">SBS</option><option value="/network/science-channel/schedule/">Science Channel</option><option value="/network/scripps-news/schedule/">Scripps News</option><option value="/network/sec-network/schedule/">SEC Network</option><option value="/network/showtime/schedule/">Showtime</option><option value="/network/showtime-2/schedule/">Showtime 2</option><option value="/network/showtime-extreme/schedule/">Showtime Extreme</option><option value="/network/showtime-familyzone/schedule/">Showtime FamilyZone</option><option value="/network/showtime-showcase/schedule/">Showtime Showcase</option><option value="/network/showtime-women/schedule/">Showtime Women</option><option value="/network/shoxbet/schedule/">SHOxBET</option><option value="/network/smile/schedule/">Smile</option><option value="/network/smithsonian-channel/schedule/">Smithsonian Channel</option><option value="/network/start-tv/schedule/">Start TV</option><option value="/network/starz/schedule/">Starz</option><option value="/network/starz-cinema/schedule/">Starz Cinema</option><option value="/network/starz-comedy/schedule/">Starz Comedy</option><option value="/network/starz-edge/schedule/">Starz Edge</option><option value="/network/starz-encore/schedule/">Starz Encore</option><option value="/network/starz-encore-action/schedule/">Starz Encore Action</option><option value="/network/starz-encore-black/schedule/">Starz Encore Black</option><option value="/network/starz-encore-classic/schedule/">Starz Encore Classic</option><option value="/network/starz-encore-family/schedule/">Starz Encore Family</option><option value="/network/starz-encore-suspense/schedule/">Starz Encore Suspense</option><option value="/network/starz-encore-westerns/schedule/">Starz Encore Westerns</option><option value="/network/starz-in-black/schedule/">Starz In Black</option><option value="/network/starz-kids-family/schedule/">Starz Kids &amp; Family</option><option value="/network/story-television/schedule/">Story Television</option><option value="/network/sundance/schedule/">Sundance</option><option value="/network/syfy/schedule/">Syfy</option><option value="/network/tastemade/schedule/">Tastemade</option><option value="/network/tbd/schedule/">TBD</option><option value="/network/tbs/schedule/">TBS</option><option value="/network/teennick/schedule/">TeenNick</option><option value="/network/telemundo/schedule/">Telemundo</option><option value="/network/telexitos/schedule/">TeleXitos</option><option value="/network/tennis-channel/schedule/">Tennis Channel</option><option value="/network/the-cowboy-channel/schedule/">The Cowboy Channel</option><option value="/network/the-cw/schedule/">The CW</option><option value="/network/the-design-network/schedule/">The Design Network</option><option value="/network/the-first/schedule/">The First</option><option value="/network/the-movie-channel/schedule/">The Movie Channel</option><option value="/network/the-movie-channel-extra/schedule/">The Movie Channel Extra</option><option value="/network/the-weather-channel/schedule/">The Weather Channel</option><option value="/network/the365/schedule/">The365</option><option value="/network/thegrio/schedule/">TheGrio</option><option value="/network/this-tv/schedule/">This TV</option><option value="/network/thrillermax/schedule/">Thriller MAX</option><option value="/network/tlc/schedule/">TLC</option><option value="/network/tnt/schedule/">TNT</option><option value="/network/travel-channel/schedule/">Travel Channel</option><option value="/network/trinity-broadcast-network/schedule/">Trinity Broadcast Network</option><option value="/network/true-crime-network/schedule/">True Crime Network</option><option value="/network/trutv/schedule/">truTV</option><option value="/network/tudn/schedule/">TUDN</option><option value="/network/turner-classic-movies/schedule/">Turner Classic Movies</option><option value="/network/tv-japan/schedule/">TV Japan</option><option value="/network/tv-land/schedule/">TV Land</option><option value="/network/tv-one/schedule/">TV One</option><option value="/network/twist/schedule/">Twist</option><option value="/network/unimas/schedule/">UniMás</option><option value="/network/universal-kids/schedule/">Universal Kids</option><option value="/network/universo/schedule/">Universo</option><option value="/network/univision/schedule/">Univision</option><option value="/network/uptv/schedule/">UPtv</option><option value="/network/usa-network/schedule/">USA Network</option><option value="/network/vh1/schedule/">VH1</option><option value="/network/vice-tv/schedule/">Vice TV</option><option value="/network/we-tv/schedule/">We TV</option><option value="/network/willow/schedule/">Willow</option><option value="/network/world-channel/schedule/">World Channel</option><option value="/network/yankee-entertainment-sports/schedule/">YES Network</option><option value="/network/z-living/schedule/">Z Living</option><option value="/network/zoomoo/schedule/">ZooMoo</option></select>
+
+<section class="find-show">
+  <p><span>?</span><i><b>Can't find what you're looking for?</b> Search for any show or movie below.</i></p>
+  <div class="show-search">
+    <form action="/">
+      <input type="search" aria-label="Search" placeholder="Enter show or movie title..." name="search">
+      <input type="hidden" name="type" value="show">
+      <input type="submit" value="search">
+    </form>
+  </div>
+</section>
+
+<script>
+
+
+  $(document).ready(function() {
+
+      function getQueryStringValue(key) {
+          return new URLSearchParams(window.location.search).get(key);
+      }
+  
+      var region = getQueryStringValue('region');
+  
+      if(region === 'west') {
+          $('input[data-sort="west"]').addClass('selected');
+          $('input[data-sort="east"]').removeClass('selected');
+      } 
+  });
+
+  $('.button-area input').click(function() {
+  
+    $('.button-area input').removeClass('selected');
+    $(this).addClass('selected');
+    
+    var selectedtype = $(this).attr('data-sort');
+    if (selectedtype == 'west') {
+        window.location.href = '/network/movieplex/schedule/?region=west';
+    } else {
+        window.location.href = '/network/movieplex/schedule/';
+    }
+    return false;
+  });
+</script>
+    <!-- QUERIES -->
+                  </section>
+  <div class="advert-holder banner-ad">
+    <div class="advert-label">ADVERTISEMENT</div>
+    <div id="responsive-banner1"></div>
+    <script type="text/javascript">blogherads.adq.push(function () { blogherads.defineResponsiveSlot([ [[970, 0], 'flexbanner'], [[728,0], 'banner'], [[0, 0], 'tinybanner'] ], 'responsive-banner1').display(); });</script>
+  </div>
+</main>
+
+
+
+
+
+
+
+
+<script>
+$(document).on('lity:ready', function(event, instance) {
+  if ( $('.lity-iframe-container').length ) { 
+      $('.lity-wrap').append( '<div class="lity-free-loader" aria-hidden="true">Loading...</div>' );
+  }
+    $('.lity-iframe-container iframe').on('load', function() {
+    $('.lity-free-loader').empty();
+    });
+});
+$(document).on('lity:close', function(event, instance) {
+  window.history.pushState('', document.title, window.location.pathname + window.location.search)
+});
+$('.button-area').on('click', 'input', function(event){
+  $('.search-area').empty();
+  $('.results-area').empty();
+  $('.button-area input').removeClass('selected');
+  $(this).addClass('selected');
+  $('.net-shows .show').css('opacity','.2');
+  var sort = $(this).data('sort'); 
+
+  var loadingText = '<span id="loading">Loading...</span>';
+  $('.results-area').html(loadingText);
+
+  $.ajax({
+    url: '/wp-admin/admin-ajax.php?action=fetch_top_shows',
+    data: {
+      'term_id':45245,
+            'sort':sort
+    },
+    success: function(data) {
+      $('.results-area').empty();
+      $('.net-shows').html(data);
+      if (inputval == 'Newest') {
+        $('.results-area').html('<spam class="message">Ordered by Release Year</span>');
+      };
+      if (inputval == 'Top Rated') {
+        $('.results-area').html('<spam class="message">Ordered by IMDB Rating</span>');
+      };
+      if (inputval == 'Search') {
+        $('.search-area').append('<input placeholder="Enter show name" id="show-search" type="search" />');
+        $('#show-search').focus();
+        $('#show-search').on('input', function () {
+            $('.results-area').empty();
+          var valThis = $(this).val().toLowerCase();
+            if(valThis == ''){
+                $('.net-shows .show').show();
+            } else {
+                $('.net-shows .show').each(function(){
+                    var text = $(this).find('h3').text().toLowerCase();
+                    if (text.indexOf(valThis) >= 0) { 
+                      $(this).show(); 
+                  }
+                    else { 
+                      $(this).hide();
+                  }
+                });
+           };
+           var visshows = $('.net-shows .show:visible').length;
+           
+           //if they're all hidden
+           if (visshows == 0) {
+              $('.results-area').append('<h4>No Results</h4><p><i>Can\'t find the show you\'re looking for?<br>Try our <a href="https://www.tvinsider.com/?search=&type=show">full show search</a> spanning all sources.</i></p>');
+           } else {
+              $('.results-area').append('<p><i>'+visshows+' shows found<i></p>');
+           }
+           
+        });
+      };
+    },
+  });
+  var inputval = $(this).val();
+  if (inputval == 'Top Rated') {
+    // the trick here is to make attache the click events back onto these
+    //$('.search-area').append('<div class="button-area"><input type="button" value="IMDB" data-sort="rating-imdb" /><input type="button" value="Rotten" data-sort="rating-rotten" /></div>');
+  }
+  return false;
+});
+
+// calendar layout
+function adjustCalLayout() {
+  var items = $('.show-returning').length;
+  if (items > 4) {
+    $('.net-returns').css('justify-content','flex-start');
+  }
+}
+adjustCalLayout();
+</script>
+
+
+
+
+
+<footer id="footer">
+  <div class="footer-top">
+    <div class="footer-left">
+      <h4>Newsletter</h4>
+      <p>Keep up with your favorite shows... delivered to your inbox!</p>
+      <form class="subscribe-block validate mc4wp-form mc4wp-form-87" action="//tvinsider.us10.list-manage.com/subscribe/post?u=a35d27604ff7f9b1358c4e8d7&amp;id=3576f8ead4" method="post" id="mc4wp-form-1" name="mc-embedded-subscribe-form" target="_blank" novalidate>
+        <div class="mc4wp-form-fields">
+          <div>
+            <input type="email" value="" name="EMAIL" placeholder="Enter your email" id="mce-EMAIL" />
+            <input id="email-submit-button" type="submit" value="SIGN UP" />
+          </div>
+          <div class="newsletter-options">
+            <div>
+              <input type="checkbox" value="2" name="group[29][2]" id="mce-group1" checked="checked" />
+              <label for="mce-group1">The Daily</label>
+            </div>
+            <div>
+              <input type="checkbox" value="1" name="group[29][1]" id="mce-group0" checked="checked" />
+              <label for="mce-group0">What's Worth Watching</label>
+            </div>
+            <div>
+              <input type="checkbox" value="4" name="group[29][4]" id="mce-group2" checked="checked" />
+              <label for="mce-group2">Breaking News Alerts</label>
+            </div>
+          </div>
+          <input type="hidden" name="SLOC" value="footer" />
+        </div>
+        <div style="position: absolute; left: -5000px;">
+          <input aria-hidden="true" id="hidden-input" type="text" name="b_a35d27604ff7f9b1358c4e8d7_3576f8ead4" tabindex="-1" value="">
+        </div>
+        <a class="more-button" href="https://www.tvinsider.com/newsletter-subscription/">More Newsletters</a>
+      </form>
+      <!-- better form
+      <form id="subscribe-form">
+        <div>
+          <input type="email" value="" name="email" placeholder="Enter your email" />
+          <input type="submit" value="Subscribe" id="email-submit-button" />
+          <input type="hidden" name="SLOC" value="footer" />
+        </div>
+        <div class="newsletter-options">
+          <div>
+            <input class="newslettercheck" type="checkbox" value="8fac24a06a" name="groupid" id="mce-group0" checked="checked" />
+            <label for="mce-group0">The Daily</label>
+          </div>
+          <div>
+            <input class="newslettercheck" type="checkbox" value="07ddc60d5d" name="groupid" id="mce-group1" checked="checked" />
+            <label for="mce-group1">What's Worth Watching</label>
+          </div>
+          <div>
+            <input class="newslettercheck" type="checkbox" value="3952b7cf05" name="groupid" id="mce-group2" checked="checked" />
+            <label for="mce-group2">Breaking News Alerts</label>
+          </div>
+        </div>
+        <div id="result-text"></div>
+      </form>
+       -->
+    </div>
+    <div class="footer-right">
+      <div>
+        <h4>Follow us</h4>
+        <ul class="social-footer social-icons">
+          <li><a target="_blank" href="https://www.youtube.com/tvinsider/"><img loading="lazy" class="icon-youtube" alt="icon - youtube" height="32" width="32" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-youtube.svg" /></a></li>
+          <li><a target="_blank" href="https://www.facebook.com/tvinsider/"><img loading="lazy" class="icon-facebook" alt="icon - facebook" height="32" width="32" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-facebook.svg" /></a></li>
+          <li><a target="_blank" href="https://twitter.com/tvinsider/"><img loading="lazy" class="icon-twitter" alt="icon - twitter" height="32" width="32" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-twitter.svg" /></a></li>
+          <li><a target="_blank" href="https://www.instagram.com/tvinsider/"><img loading="lazy" class="icon-instagram" alt="icon - instagram" height="32" width="32" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-instagram.svg" /></a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Quick Links</h4>
+        <ul class="list-links">
+          <li><a href="https://www.tvinsider.com/about-us/">About</a></li>
+          <li><a href="https://www.tvinsider.com/advertise-with-us/">Advertise</a></li>
+          <li><a href="https://www.tvinsider.com/privacy-policy/">Privacy</a></li>
+          <li><a href="https://www.tvinsider.com/terms-of-use/">Terms of Service</a></li>
+          <li><a href="https://www.tvinsider.com/dsar/">Do Not Sell</a></li>
+          <li><a href="https://www.tvinsider.com/contact-us/">Contact Us</a></li>
+          <li><a id="osano-link" href="#" onclick="Osano.cm.showDrawer('osano-cm-dom-info-dialog-open'); return false;">Cookie Prefs</a></li>
+        </ul>             
+      </div>
+      <div>
+        <h4><a href="/magazines/">Our Publications</a></h4>
+        <ul class="list-partners">
+          <li><a target="_blank" href="https://www.tvguidemagazine.com/"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-tv-guide.png" height="27" width="35" alt="TV Guide Magazine Logo"></a></li>
+          <li><a target="_blank" href="https://tvpuzzler.com/tvipz"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-puzzler.png" height="25" width="110" alt="Puzzler"></a></li>
+          <li><a target="_blank" href="https://www.iwantmytvmagazine.com/"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-tv-weekly.png" height="25" width="32" alt="TV Weekly Logo"></a></li>
+          <li><a target="_blank" href="https://www.channelguidemag.com/"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-channel-guide.png" height="25" width="106" alt="Channel Guide Logo"></a></li>
+          <li><a target="_blank" href="https://www.ondishmag.com/"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-on-dish.png" height="25" width="113" alt="OnDISH Logo"></a></li>
+          <li><a target="_blank" href="https://www.remindmagazine.com/tvirm"><img loading="lazy" src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-remind.png" height="25" width="97" alt="Remind Logo"></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <div class="">
+      <span class="copyright">Copyright &copy; 2025 NTVB Media, Inc., All Rights Reserved</span>
+    </div>
+  </div>
+</footer>
+
+<!-- Navigation & Search -->
+
+
+<script>
+$('.search-area #search-form').hover(function() {
+  $('#search-form-input').focus();
+});
+$('#hamburger-button').click(function() {
+  $('.menu').toggleClass('responsive');
+  $('#hamburger-button').toggleClass('responsive');
+  return false;
+});
+$(window).on('resize', function() {
+  if ($(window).width() > 1024) {
+  $('.menu').removeClass('responsive');
+  $('#hamburger-button').removeClass('responsive');
+  }
+});
+</script>
+
+<!-- Comscore -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "19587797" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; 
+    s.async = true;
+    s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+
+<!-- Chartbeat -->
+
+<script type='text/javascript'>
+    (function() {
+        /** CONFIGURATION START **/
+        var _sf_async_config = window._sf_async_config = (window._sf_async_config || {});
+        _sf_async_config.uid = 62629; 
+        _sf_async_config.domain = 'tvinsider.com';
+        _sf_async_config.useCanonical = true;
+        _sf_async_config.useCanonicalDomain = true;
+                /** CONFIGURATION END **/
+        function loadChartbeat() {
+            var e = document.createElement('script');
+            var n = document.getElementsByTagName('script')[0];
+            e.type = 'text/javascript';
+            e.async = true;
+            e.src = '//static.chartbeat.com/js/chartbeat.js';
+            n.parentNode.insertBefore(e, n);
+        }
+        loadChartbeat();
+     })();
+</script>
+
+<!-- Google Analytics - G4 -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-DB9HERH5PW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  
+  
+      var userType = 'unregistered';
+      gtag('config', 'G-DB9HERH5PW', {
+        'user_properties': {
+            'user_type': userType
+        }
+    });
+
+  
+</script>
+
+
+<!-- Registration Promo -->
+
+<div id="reg-promo" class="personalize-modal" style="display:none;">
+  <div class="personalize-modal-content">
+    <button class="close-modal">X</button>
+    <h3>Benefits to Registering & Following</h3>
+  <ul class="benefits">
+      <li class="icon-watchlist"><img height="100" width="100" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-watchlist-alert.png?x=10"><b>Watchlist</b> Easy access to only the shows you care about — all in one simple place</li>
+      <li class="icon-tv-alerts"><img height="100" width="100" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-notification.png?x=10"><b>Alerts</b> Only important notifications — when a show is returning, when it becomes available to stream, and more.</li>
+      <li class="icon-special-offers"><img height="100" width="100" src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-offer.png?x=10"><b>Special Offers</b> Exclusive products we release related to your favorite shows and streaming services</li>
+  </ul>
+    <p><a class="basic-button" href="https://www.tvinsider.com/register/?showid=45245">Sign Up</a></p>
+    <p>(It's free!)</p>
+  </div>
+</div>
+
+
+
+<script>
+
+$(document).ready(function() {
+
+  // REGISTRATION MODAL
+
+  // Open Modal
+  $('.why-watchlist a').click(function(){
+    $('#reg-promo').css('display', 'block');
+    return false;
+  });
+  
+  // Close Modal
+  $('.close-modal').click(function(){
+    $('#reg-promo').css('display', 'none');
+  });
+  
+  // Close Modal When Clicking Outside
+  $(window).click(function(e) {
+    if ($(e.target).is('#reg-promo')) {
+      $('#reg-promo').css('display', 'none');
+    }
+  });
+  
+  // WATCHLIST
+
+  var isPanelOpen = false;
+  
+    $('.add-to-watchlist-wrapper .add-to-watchlist').click(function() {
+    // if user logged in
+    if ($('body').hasClass('logged-in')) {
+        if ($(this).hasClass('selected')) {
+          removeShowFromWatchlist();
+        } else {
+          togglePanel();
+          addShowToWatchlist();
+        }
+    // otherwise launch registration
+    } else {
+      $('.why-watchlist a').click();
+    }
+    });
+  
+    $('.close-panel').click(function() {
+      togglePanel();
+    });
+
+    $('.open-watchlist-btn').click(function() {
+        if (isPanelOpen) {
+        togglePanel();
+        } else {
+        togglePanel();
+            getShowWatchlist();
+        }
+    });
+
+    function togglePanel() {
+        if (isPanelOpen) {
+            $('.watchlist-panel').css('transform', 'translateX(100%)');
+            $('body > *:not(.watchlist-panel)').css('filter', 'none');
+            isPanelOpen = false;
+        } else {
+            $('.watchlist-panel').css('transform', 'translateX(0%)');
+            $('body > *:not(.watchlist-panel)').css('filter', 'blur(5px)');
+            isPanelOpen = true;
+        }
+    }
+    
+  
+  
+});
+
+</script>
+
+
+
+
+
+</body>
+</html>

--- a/sites/tvinsider.com/__data__/no_content.html
+++ b/sites/tvinsider.com/__data__/no_content.html
@@ -1,0 +1,1772 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="//ads.blogherads.com" crossorigin />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+      href="https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2"
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+      href="https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2"
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+      href="https://fonts.gstatic.com/s/ibmplexsanscondensed/v7/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7bvspYYnFBq4.woff2"
+    />
+    <style>
+      @font-face {
+        font-family: 'IBMPlexSans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src:
+          local('IBM Plex Sans'),
+          local('IBMPlexSans'),
+          url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYXgKVElMYYaJe8bpLHnCwDKhdHeFaxOedc.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'IBMPlexSans';
+        font-style: normal;
+        font-weight: 500;
+        font-display: swap;
+        src:
+          local('IBM Plex Sans Medium'),
+          local('IBMPlexSans-Medium'),
+          url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjSL9AIFsdP3pBms.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'IBMPlexSans';
+        font-style: normal;
+        font-weight: 600;
+        font-display: swap;
+        src:
+          local('IBM Plex Sans SemiBold'),
+          local('IBMPlexSans-SemiBold'),
+          url(https://fonts.gstatic.com/s/ibmplexsans/v8/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFsdP3pBms.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'IBMPlexSansCondensed';
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        src:
+          local('IBM Plex Sans Condensed Bold'),
+          local('IBMPlexSansCond-Bold'),
+          url(https://fonts.gstatic.com/s/ibmplexsanscondensed/v7/Gg8gN4UfRSqiPg7Jn2ZI12V4DCEwkj1E4LVeHY4S7bvspYYnFBq4.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'Objet';
+        font-display: swap;
+        src: url('https://www.tvinsider.com/wp-content/themes/tv/fonts/Objet-Regular.woff2')
+          format('woff2');
+        font-weight: 400;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: 'OpenSans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src:
+          local('Open Sans Regular'),
+          local('Open-Sans-Regular'),
+          url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'OpenSans';
+        font-style: italic;
+        font-weight: 400;
+        font-display: swap;
+        src:
+          local('Open Sans Italic'),
+          local('Open-Sans-Italic'),
+          url(https://fonts.gstatic.com/s/opensans/v17/mem6YaGs126MiZpBA-UFUK0Zdc1GAK6b.woff2)
+            format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      /* actually using the semi-bold typeface in the url here */
+      @font-face {
+        font-family: 'OpenSans';
+        font-style: normal;
+        font-weight: bold;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem5YaGs126MiZpBA-UNirkOUuhpKKSTjw.woff2)
+          format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+      @font-face {
+        font-family: 'OpenSans';
+        font-style: italic;
+        font-weight: bold;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/memnYaGs126MiZpBA-UFUKXGUdhrIqOxjaPX.woff2)
+          format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+    </style>
+    <link
+      rel="shortcut icon"
+      href="https://www.tvinsider.com/wp-content/themes/tv/images/favicon.ico"
+      type="image/x-icon"
+    />
+    <link
+      rel="icon"
+      href="https://www.tvinsider.com/wp-content/themes/tv/images/favicon.ico"
+      type="image/x-icon"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google-site-verification" content="u5Ue-P2oV1f9Pq2AURnZ4gpuZ1Nrgcgwn09AmMPLgCE" />
+    <meta name="google-site-verification" content="it2r-MRipevefeCYWkPlW540pNwHDj9JpbST3-LAA-o" />
+    <meta name="pocket-site-verification" content="c2d9d3d73032bf0b0959f31688efb2" />
+    <meta name="google-site-verification" content="FsdlLOvbsiYf4t8sZFZgs9am050TrtgyydB9KbUhYvU" />
+    <meta property="fb:pages" content="112199118797264" />
+    <meta property="fb:app_id" content="2128917200700396" />
+    <meta property="og:site_name" content="TV Insider" />
+    <meta name="theme-color" content="#00aeef" />
+    <meta name="robots" content="max-image-preview:large" />
+    <style>
+      img:is([sizes='auto' i], [sizes^='auto,' i]) {
+        contain-intrinsic-size: 3000px 1500px;
+      }
+    </style>
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="TV Insider &raquo; Feed"
+      href="https://www.tvinsider.com/feed/"
+    />
+    <script
+      type="text/javascript"
+      id="wpp-js"
+      src="https://www.tvinsider.com/wp-content/plugins/wordpress-popular-posts/assets/js/wpp.min.js?ver=7.2.0"
+      data-sampling="1"
+      data-sampling-rate="100"
+      data-api-url="https://www.tvinsider.com/wp-json/wordpress-popular-posts"
+      data-post-id="0"
+      data-token="5a661f22f8"
+      data-lang="0"
+      data-debug="0"
+    ></script>
+    <style id="classic-theme-styles-inline-css" type="text/css">
+      /*! This file is auto-generated */
+      .wp-block-button__link {
+        color: #fff;
+        background-color: #32373c;
+        border-radius: 9999px;
+        box-shadow: none;
+        text-decoration: none;
+        padding: calc(0.667em + 2px) calc(1.333em + 2px);
+        font-size: 1.125em;
+      }
+      .wp-block-file__button {
+        background: #32373c;
+        color: #fff;
+        text-decoration: none;
+      }
+    </style>
+    <link
+      rel="stylesheet"
+      id="sheknows-infuse-css"
+      href="https://www.tvinsider.com/wp-content/plugins/sheknows-infuse/public/css/style.css?ver=1.0.42"
+      type="text/css"
+      media="all"
+    />
+    <link
+      rel="stylesheet"
+      id="base-style-css"
+      href="https://www.tvinsider.com/wp-content/themes/tv/style.css?ver=1329"
+      type="text/css"
+      media="all"
+    />
+    <script>
+      !(function (o, _name) {
+        ;(o[_name] =
+          o[_name] ||
+          function $() {
+            ;($.q = $.q || []).push(arguments)
+          }),
+          (o[_name].v = o[_name].v || 2)
+        !(function (o, t, e, n, c, a) {
+          function f(n, c) {
+            ;(n = (function (t, e) {
+              try {
+                if (
+                  (e = (t = o.localStorage).getItem('_aQS01ODhGOEZCQjAxRjgyQjdBMzk0MjhGMjItOTAx'))
+                )
+                  return JSON.parse(e).lgk || []
+                if (
+                  (
+                    t.getItem(
+                      decodeURI(
+                        decodeURI('%25%37%36%34%61%256%33%31%2565%25%36%39%255%61%25%37%32%2530')
+                      )
+                    ) || ''
+                  ).split(',')[4] > 0
+                )
+                  return [[_name + '-engaged', 'true']]
+              } catch (n) {}
+            })()) &&
+              typeof n.forEach === e &&
+              (c = o[t].pubads()) &&
+              n.forEach(function (o) {
+                o && o[0] && c.setTargeting(o[0], o[1] || '')
+              })
+          }
+          try {
+            ;((a = o[t] = o[t] || {}).cmd = a.cmd || []),
+              typeof a.pubads === e
+                ? f()
+                : typeof a.cmd.unshift === e
+                ? a.cmd.unshift(f)
+                : a.cmd.push(f)
+          } catch (i) {}
+        })(window, 'googletag', 'function')
+      })(window, decodeURI(decodeURI('a%25%36%34%256d%2569%2572a%25%36%63')))
+      !(function (t, c, i) {
+        ;(i = t.createElement(c)),
+          (t = t.getElementsByTagName(c)[0]),
+          (i.async = 1),
+          (i.src =
+            'https://absentairport.com/chunks/39e8d6d4b4/a216c1cf9d948c6d545180ca42bee3d3b6a0a1.js'),
+          t.parentNode.insertBefore(i, t)
+      })(document, 'script')
+    </script>
+    <script
+      type="text/javascript"
+      src="https://www.tvinsider.com/wp-content/plugins/she-media-cli-script/inc/connatix-player.js?ver=1736973322"
+      id="connatix-js"
+    ></script>
+    <!-- Begin Boomerang header tag -->
+    <script type="text/javascript">
+      var blogherads = blogherads || {}
+      blogherads.adq = blogherads.adq || []
+
+      blogherads.adq.push(function () {
+        if (blogherads.setADmantXData) {
+          blogherads.setADmantXData(null, 'not_ready')
+        }
+      })
+    </script>
+    <script
+      type="text/javascript"
+      async="async"
+      data-cfasync="false"
+      src="https://ads.blogherads.com/static/blogherads.js"
+    ></script>
+    <script
+      type="text/javascript"
+      async="async"
+      data-cfasync="false"
+      src="https://ads.blogherads.com/sk/12/122/1228136/26554/header.js"
+    ></script>
+    <!-- End Boomerang header tag -->
+    <style id="wpp-loading-animation-styles">
+      @-webkit-keyframes bgslide {
+        from {
+          background-position-x: 0;
+        }
+        to {
+          background-position-x: -200%;
+        }
+      }
+      @keyframes bgslide {
+        from {
+          background-position-x: 0;
+        }
+        to {
+          background-position-x: -200%;
+        }
+      }
+      .wpp-widget-block-placeholder,
+      .wpp-shortcode-placeholder {
+        margin: 0 auto;
+        width: 60px;
+        height: 3px;
+        background: #dd3737;
+        background: linear-gradient(90deg, #dd3737 0%, #571313 10%, #dd3737 100%);
+        background-size: 200% auto;
+        border-radius: 3px;
+        -webkit-animation: bgslide 1s infinite linear;
+        animation: bgslide 1s infinite linear;
+      }
+    </style>
+
+    <title>404 - TV Insider</title>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script
+      defer
+      src="https://cmp.osano.com/16BcscRpZUDCE2Y0Z/31c52822-b314-450c-9a60-45b2cd6ac22e/osano.js"
+    ></script>
+    <script defer src="https://www.tvinsider.com/wp-content/themes/tv/js/lity.min.js"></script>
+
+    <!-- Pure Visibility -->
+    <script>
+      ;(function (w, d, t, r, u) {
+        var f, n, i
+        ;(w[u] = w[u] || []),
+          (f = function () {
+            var o = { ti: '5524914', enableAutoSpaTracking: true }
+            ;(o.q = w[u]), (w[u] = new UET(o)), w[u].push('pageLoad')
+          }),
+          (n = d.createElement(t)),
+          (n.src = r),
+          (n.async = 1),
+          (n.onload = n.onreadystatechange =
+            function () {
+              var s = this.readyState
+              ;(s && s !== 'loaded' && s !== 'complete') ||
+                (f(), (n.onload = n.onreadystatechange = null))
+            }),
+          (i = d.getElementsByTagName(t)[0]),
+          i.parentNode.insertBefore(n, i)
+      })(window, document, 'script', '//bat.bing.com/bat.js', 'uetq')
+    </script>
+  </head>
+  <body class="error404">
+    <!-- Meta Pixel Code -->
+    <script>
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return
+        n = f.fbq = function () {
+          n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments)
+        }
+        if (!f._fbq) f._fbq = n
+        n.push = n
+        n.loaded = !0
+        n.version = '2.0'
+        n.queue = []
+        t = b.createElement(e)
+        t.async = !0
+        t.src = v
+        s = b.getElementsByTagName(e)[0]
+        s.parentNode.insertBefore(t, s)
+      })(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js')
+      fbq('init', '2150724991788914')
+      fbq('track', 'PageView')
+    </script>
+    <noscript
+      ><img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=2150724991788914&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+
+    <!-- SHEMEDIA ADS Begin Desktop Adhesion ad -->
+    <script type="text/javascript">
+      blogherads.adq.push('frame2')
+    </script>
+
+    <header id="header">
+      <nav class="top-nav">
+        <a href="/search/">Search</a> <span>•</span> <a href="/shop/">Shop</a> <span>•</span>
+        <a href="/tv-games-puzzles-quizzes/">Games</a> <span>•</span>
+        <a href="/shows/calendar/">Calendar</a> <span>•</span>
+        <a href="/newsletter-subscription/">Newsletters</a> <span>•</span>
+        <a href="/lists/">Lists</a> <span>•</span> <a href="/trailers/">Trailers</a> <span>•</span>
+        <a href="/login/">Login</a>
+      </nav>
+      <div class="logo">
+        <button href="" aria-label="Navigation" id="hamburger-button"></button>
+        <a href="https://www.tvinsider.com/"
+          ><img
+            width="400"
+            height="74"
+            src="https://www.tvinsider.com/wp-content/themes/tv/images/tvinsider-logo-horizontal-white.svg"
+            alt="TV Insider Logo"
+        /></a>
+      </div>
+      <nav class="nav">
+        <ul id="menu-new-menu" class="menu">
+          <li
+            id="menu-item-1105701"
+            class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1105701"
+          >
+            <a href="https://www.tvinsider.com/shows/">Shows</a>
+            <div class="subnav">
+              <div class="menu-top25">
+                <a href="/shows/"
+                  ><img
+                    loading="lazy"
+                    alt="Top 25 Shows"
+                    width="180"
+                    height="82"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/top-25-shows1.png"
+                /></a>
+                <ol>
+                  <li><a href="/show/severance/">Severance</a></li>
+                  <li><a href="/show/the-couple-next-door/">The Couple Next Door</a></li>
+                  <li><a href="/show/hollywood-squares-2025/">Hollywood Squares</a></li>
+                  <li><a href="/show/the-pitt/">The Pitt</a></li>
+                  <li><a href="/show/back-in-action/">Back In Action</a></li>
+                  <li>
+                    <a href="/show/law-order-special-victims-unit/"
+                      >Law &amp; Order: Special Victims Unit</a
+                    >
+                  </li>
+                  <li><a href="/show/xo-kitty/">XO, Kitty</a></li>
+                  <li><a href="/show/the-rookie/">The Rookie</a></li>
+                  <li><a href="/show/unstoppable-2025/">Unstoppable</a></li>
+                  <li>
+                    <a href="/show/diddy-the-making-of-a-bad-boy/"
+                      >Diddy: The Making of a Bad Boy</a
+                    >
+                  </li>
+                </ol>
+                <a class="basic-button" href="https://www.tvinsider.com/shows/">Full List</a>
+              </div>
+              <ul class="menu-networks">
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/netflix/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/netflix.png"
+                      alt="Netflix"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147714"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147714"
+                    >
+                      <a href="https://www.tvinsider.com/show/emily-in-paris/">Emily in Paris</a>
+                    </li>
+                    <li
+                      id="menu-item-1147715"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147715"
+                    >
+                      <a href="https://www.tvinsider.com/show/love-is-blind-uk/"
+                        >Love Is Blind: UK</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147717"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147717"
+                    >
+                      <a href="https://www.tvinsider.com/show/cobra-kai/">Cobra Kai</a>
+                    </li>
+                    <li
+                      id="menu-item-1147718"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147718"
+                    >
+                      <a href="https://www.tvinsider.com/show/that-90s-show/"
+                        >That &#8217;90s Show</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/hulu/"
+                    class="network-name"
+                    style="background-color: #38ce7f"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/hulu.png"
+                      alt="Hulu"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147723"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147723"
+                    >
+                      <a href="https://www.tvinsider.com/show/tell-me-lies/">Tell Me Lies</a>
+                    </li>
+                    <li
+                      id="menu-item-1147721"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147721"
+                    >
+                      <a href="https://www.tvinsider.com/show/reasonable-doubt-2022/"
+                        >Reasonable Doubt</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147722"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147722"
+                    >
+                      <a href="https://www.tvinsider.com/show/only-murders-in-the-building/"
+                        >Only Murders in the Building</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147724"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147724"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-handmaids-tale/"
+                        >The Handmaid&#8217;s Tale</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/amazon-prime-video/"
+                    class="network-name"
+                    style="background-color: #212f3c"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/prime-video.png"
+                      alt="Prime Video"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147725"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147725"
+                    >
+                      <a
+                        href="https://www.tvinsider.com/show/the-lord-of-the-rings-the-rings-of-power/"
+                        >The Lord of the Rings: The Rings of Power</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147726"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147726"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-boys/">The Boys</a>
+                    </li>
+                    <li
+                      id="menu-item-1147727"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147727"
+                    >
+                      <a href="https://www.tvinsider.com/show/my-lady-jane/">My Lady Jane</a>
+                    </li>
+                    <li
+                      id="menu-item-1147728"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147728"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-legend-of-vox-machina/"
+                        >The Legend of Vox Machina</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/max/"
+                    class="network-name"
+                    style="background-color: #003af0"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2023/05/max.png"
+                      alt="Max"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147731"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147731"
+                    >
+                      <a href="https://www.tvinsider.com/show/industry/">Industry</a>
+                    </li>
+                    <li
+                      id="menu-item-1147729"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147729"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-penguin/">The Penguin</a>
+                    </li>
+                    <li
+                      id="menu-item-1147732"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147732"
+                    >
+                      <a href="https://www.tvinsider.com/show/house-of-the-dragon/"
+                        >House of the Dragon</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1124714"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124714"
+                    >
+                      <a href="https://www.tvinsider.com/show/and-just-like-that/"
+                        >And Just Like That&#8230;</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/apple-tv-plus/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/apple-tv-plus.png"
+                      alt="Apple TV+"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147735"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147735"
+                    >
+                      <a href="https://www.tvinsider.com/show/bad-monkey/">Bad Monkey</a>
+                    </li>
+                    <li
+                      id="menu-item-1147737"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147737"
+                    >
+                      <a href="https://www.tvinsider.com/show/slow-horses/">Slow Horses</a>
+                    </li>
+                    <li
+                      id="menu-item-1147738"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147738"
+                    >
+                      <a href="https://www.tvinsider.com/show/shrinking/">Shrinking</a>
+                    </li>
+                    <li
+                      id="menu-item-1147739"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147739"
+                    >
+                      <a href="https://www.tvinsider.com/show/presumed-innocent/"
+                        >Presumed Innocent</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/peacock/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/peacock.png"
+                      alt="Peacock"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147745"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147745"
+                    >
+                      <a href="https://www.tvinsider.com/show/love-island/">Love Island USA</a>
+                    </li>
+                    <li
+                      id="menu-item-1147746"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147746"
+                    >
+                      <a href="https://www.tvinsider.com/show/mr-throwback/">Mr. Throwback</a>
+                    </li>
+                    <li
+                      id="menu-item-1147747"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147747"
+                    >
+                      <a href="https://www.tvinsider.com/show/days-of-our-lives/"
+                        >Days of our Lives</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147749"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147749"
+                    >
+                      <a href="https://www.tvinsider.com/show/law-order-organized-crime/"
+                        >Law &amp; Order: Organized Crime</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/nbc/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/nbc.png"
+                      alt="NBC"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147751"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147751"
+                    >
+                      <a href="https://www.tvinsider.com/show/americas-got-talent/"
+                        >America&#8217;s Got Talent</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1124724"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124724"
+                    >
+                      <a href="https://www.tvinsider.com/show/one-chicago/">One Chicago</a>
+                    </li>
+                    <li
+                      id="menu-item-1147752"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147752"
+                    >
+                      <a href="https://www.tvinsider.com/show/found-2023/">Found</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/cbs/"
+                    class="network-name"
+                    style="background-color: #1993ef"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/cbs.png"
+                      alt="CBS"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147753"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147753"
+                    >
+                      <a href="https://www.tvinsider.com/show/big-brother/">Big Brother</a>
+                    </li>
+                    <li
+                      id="menu-item-1124727"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124727"
+                    >
+                      <a href="https://www.tvinsider.com/show/ncis/">NCIS</a>
+                    </li>
+                    <li
+                      id="menu-item-1124728"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124728"
+                    >
+                      <a href="https://www.tvinsider.com/show/ghosts/">Ghosts</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/abc/"
+                    class="network-name"
+                    style="background-color: #5a3c00"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/abc.png"
+                      alt="ABC"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147754"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147754"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-bachelorette/"
+                        >The Bachelorette</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147756"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147756"
+                    >
+                      <a href="https://www.tvinsider.com/show/general-hospital/"
+                        >General Hospital</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147755"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147755"
+                    >
+                      <a href="https://www.tvinsider.com/show/claim-to-fame/">Claim to Fame</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/fox/"
+                    class="network-name"
+                    style="background-color: #0182e7"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/fox.png"
+                      alt="FOX"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147759"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147759"
+                    >
+                      <a href="https://www.tvinsider.com/show/masterchef/">MasterChef</a>
+                    </li>
+                    <li
+                      id="menu-item-1147757"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147757"
+                    >
+                      <a href="https://www.tvinsider.com/show/rescue-hi-surf/">Rescue: HI-Surf</a>
+                    </li>
+                    <li
+                      id="menu-item-1147758"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147758"
+                    >
+                      <a href="https://www.tvinsider.com/show/9-1-1-lone-star/">9-1-1: Lone Star</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/showtime/"
+                    class="network-name"
+                    style="background-color: #ee1e24"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/showtime.png"
+                      alt="Showtime"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147760"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147760"
+                    >
+                      <a href="https://www.tvinsider.com/show/dexter-original-sin/"
+                        >Dexter: Original Sin</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147761"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147761"
+                    >
+                      <a href="https://www.tvinsider.com/show/a-gentleman-in-moscow/"
+                        >A Gentleman in Moscow</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/pbs/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/pbs.png"
+                      alt="PBS"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147764"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147764"
+                    >
+                      <a href="https://www.tvinsider.com/show/di-ray/">DI Ray</a>
+                    </li>
+                    <li
+                      id="menu-item-1147763"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147763"
+                    >
+                      <a href="https://www.tvinsider.com/show/van-der-valk/">Van der Valk</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/paramount-plus/"
+                    class="network-name"
+                    style="background-color: #007afc"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/paramount-plus.png"
+                      alt="Parmount+"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147765"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147765"
+                    >
+                      <a href="https://www.tvinsider.com/show/seal-team/">SEAL Team</a>
+                    </li>
+                    <li
+                      id="menu-item-1147766"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147766"
+                    >
+                      <a href="https://www.tvinsider.com/show/evil/">Evil</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/the-cw/"
+                    class="network-name"
+                    style="background-color: #00942c"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/cw.png"
+                      alt="The CW"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147769"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147769"
+                    >
+                      <a href="https://www.tvinsider.com/show/all-american/">All American</a>
+                    </li>
+                    <li
+                      id="menu-item-1147768"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147768"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-chosen/">The Chosen</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/disney-plus/"
+                    class="network-name"
+                    style="background-color: #2b4754"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2024/03/disney-plus.png"
+                      alt="Disney+"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147770"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147770"
+                    >
+                      <a href="https://www.tvinsider.com/show/agatha-darkhold-diaries/"
+                        >Agatha All Along</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147771"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147771"
+                    >
+                      <a href="https://www.tvinsider.com/show/star-wars-the-acolyte/"
+                        >Star Wars: The Acolyte</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/amc/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/amc.png"
+                      alt="AMC"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147772"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147772"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-walking-dead-daryl-dixon/"
+                        >The Walking Dead: Daryl Dixon</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1108888"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1108888"
+                    >
+                      <a href="https://www.tvinsider.com/show/interview-with-the-vampire/"
+                        >Interview With the Vampire</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/hallmark-channel/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/hallmark.png"
+                      alt="Hallmark Channel"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1093255"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1093255"
+                    >
+                      <a href="https://www.tvinsider.com/show/when-calls-the-heart/"
+                        >When Calls the Heart</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147773"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147773"
+                    >
+                      <a href="https://www.tvinsider.com/show/holidazed/">Holidazed</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/starz/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2020/05/starz.png"
+                      alt="Starz"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1036860"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1036860"
+                    >
+                      <a href="https://www.tvinsider.com/show/outlander/">Outlander</a>
+                    </li>
+                    <li
+                      id="menu-item-1147774"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147774"
+                    >
+                      <a href="https://www.tvinsider.com/show/power-book-ii-ghost/"
+                        >Power Book II: Ghost</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/fx/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2020/05/fx.png"
+                      alt="FX"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147776"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147776"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-old-man/">The Old Man</a>
+                    </li>
+                    <li
+                      id="menu-item-1147780"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147780"
+                    >
+                      <a href="https://www.tvinsider.com/show/american-sports-story/"
+                        >American Sports Story: Aaron Hernandez</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/britbox/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/britbox.png"
+                      alt="BritBox"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147781"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147781"
+                    >
+                      <a href="https://www.tvinsider.com/show/the-responder/">The Responder</a>
+                    </li>
+                    <li
+                      id="menu-item-1147782"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147782"
+                    >
+                      <a href="https://www.tvinsider.com/show/after-the-flood/">After The Flood</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/acorn-tv/"
+                    class="network-name"
+                    style="background-color: #081635"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/acorn.png"
+                      alt="Acorn"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147783"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147783"
+                    >
+                      <a href="https://www.tvinsider.com/show/murdoch-mysteries/"
+                        >Murdoch Mysteries</a
+                      >
+                    </li>
+                    <li
+                      id="menu-item-1147784"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147784"
+                    >
+                      <a href="https://www.tvinsider.com/show/harry-wild/">Harry Wild</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/hgtv/"
+                    class="network-name"
+                    style="background-color: #00cbca"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/hgtv.png"
+                      alt="HGTV"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1147785"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147785"
+                    >
+                      <a href="https://www.tvinsider.com/show/celebrity-iou/">Celebrity IOU</a>
+                    </li>
+                    <li
+                      id="menu-item-1147786"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147786"
+                    >
+                      <a href="https://www.tvinsider.com/show/good-bones/">Good Bones</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/discovery-plus/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/discovery-plus.png"
+                      alt="Discovery+"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1124765"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124765"
+                    >
+                      <a href="https://www.tvinsider.com/show/90-day-fiance/">90 Day Fiancé</a>
+                    </li>
+                    <li
+                      id="menu-item-1147787"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1147787"
+                    >
+                      <a href="https://www.tvinsider.com/show/deadliest-catch/">Deadliest Catch</a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="network">
+                  <a
+                    href="https://www.tvinsider.com/network/bbc-america/"
+                    class="network-name"
+                    style="background-color: #000000"
+                    ><img
+                      loading="lazy"
+                      class="crisp"
+                      width="60"
+                      height="30"
+                      src="https://www.tvinsider.com/wp-content/uploads/2022/07/bbc-america.png"
+                      alt="BBC America"
+                  /></a>
+                  <ul>
+                    <li
+                      id="menu-item-1124766"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1124766"
+                    >
+                      <a href="https://www.tvinsider.com/show/doctor-who/">Doctor Who</a>
+                    </li>
+                    <li
+                      id="menu-item-1061411"
+                      class="menu-item menu-item-type-taxonomy menu-item-object-show menu-item-1061411"
+                    >
+                      <a href="https://www.tvinsider.com/show/orphan-black-echoes/"
+                        >Orphan Black: Echoes</a
+                      >
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+              <div class="show-search">
+                <form action="/">
+                  <input
+                    type="search"
+                    aria-label="Search"
+                    placeholder="Enter show name..."
+                    name="search"
+                  />
+                  <input type="hidden" name="type" value="show" />
+                  <input type="submit" value="search" />
+                </form>
+              </div>
+            </div>
+          </li>
+          <li
+            id="menu-item-1073127"
+            class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1073127"
+          >
+            <a href="/movies/">Movies</a>
+          </li>
+          <li
+            id="menu-item-1036875"
+            class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1036875"
+          >
+            <a href="https://www.tvinsider.com/what-to-watch/">What to Watch</a>
+          </li>
+          <li
+            id="menu-item-1162260"
+            class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-1162260"
+          >
+            <a href="https://www.tvinsider.com/category/game-shows/">Game Shows</a>
+          </li>
+          <li
+            id="menu-item-1036877"
+            class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-1036877"
+          >
+            <a href="https://www.tvinsider.com/category/reviews/">Reviews</a>
+          </li>
+          <li
+            id="menu-item-1110680"
+            class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1110680"
+          >
+            <a href="https://www.swooon.com/">Swooon</a>
+          </li>
+          <li id="searchlink"><a href="https://www.tvinsider.com/?search=">Search</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <style>
+      .menu li {
+        position: relative;
+      }
+      .menu li.menu-item-has-children {
+        position: static;
+      }
+    </style>
+    <style>
+      p a {
+        color: #00aeef;
+        font-weight: bold;
+      }
+    </style>
+    <main>
+      <section>
+        <div style="margin-top: 134px; text-align: center">
+          <img
+            alt="Ron Swanson 404 Error"
+            src="https://www.tvinsider.com/wp-content/uploads/2020/08/ron-swanson-404.jpg"
+          />
+          <p style="margin-top: 32px">
+            Why the frumpy face?<br /><a href="/">Try the homepage</a> or
+            <a href="/shows/">find a show to watch</a>.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer id="footer">
+      <div class="footer-top">
+        <div class="footer-left">
+          <h4>Newsletter</h4>
+          <p>Keep up with your favorite shows... delivered to your inbox!</p>
+          <form
+            class="subscribe-block validate mc4wp-form mc4wp-form-87"
+            action="//tvinsider.us10.list-manage.com/subscribe/post?u=a35d27604ff7f9b1358c4e8d7&amp;id=3576f8ead4"
+            method="post"
+            id="mc4wp-form-1"
+            name="mc-embedded-subscribe-form"
+            target="_blank"
+            novalidate
+          >
+            <div class="mc4wp-form-fields">
+              <div>
+                <input
+                  type="email"
+                  value=""
+                  name="EMAIL"
+                  placeholder="Enter your email"
+                  id="mce-EMAIL"
+                />
+                <input id="email-submit-button" type="submit" value="SIGN UP" />
+              </div>
+              <div class="newsletter-options">
+                <div>
+                  <input
+                    type="checkbox"
+                    value="2"
+                    name="group[29][2]"
+                    id="mce-group1"
+                    checked="checked"
+                  />
+                  <label for="mce-group1">The Daily</label>
+                </div>
+                <div>
+                  <input
+                    type="checkbox"
+                    value="1"
+                    name="group[29][1]"
+                    id="mce-group0"
+                    checked="checked"
+                  />
+                  <label for="mce-group0">What's Worth Watching</label>
+                </div>
+                <div>
+                  <input
+                    type="checkbox"
+                    value="4"
+                    name="group[29][4]"
+                    id="mce-group2"
+                    checked="checked"
+                  />
+                  <label for="mce-group2">Breaking News Alerts</label>
+                </div>
+              </div>
+              <input type="hidden" name="SLOC" value="footer" />
+            </div>
+            <div style="position: absolute; left: -5000px">
+              <input
+                aria-hidden="true"
+                id="hidden-input"
+                type="text"
+                name="b_a35d27604ff7f9b1358c4e8d7_3576f8ead4"
+                tabindex="-1"
+                value=""
+              />
+            </div>
+            <a class="more-button" href="https://www.tvinsider.com/newsletter-subscription/"
+              >More Newsletters</a
+            >
+          </form>
+          <!-- better form
+      <form id="subscribe-form">
+        <div>
+          <input type="email" value="" name="email" placeholder="Enter your email" />
+          <input type="submit" value="Subscribe" id="email-submit-button" />
+          <input type="hidden" name="SLOC" value="footer" />
+        </div>
+        <div class="newsletter-options">
+          <div>
+            <input class="newslettercheck" type="checkbox" value="8fac24a06a" name="groupid" id="mce-group0" checked="checked" />
+            <label for="mce-group0">The Daily</label>
+          </div>
+          <div>
+            <input class="newslettercheck" type="checkbox" value="07ddc60d5d" name="groupid" id="mce-group1" checked="checked" />
+            <label for="mce-group1">What's Worth Watching</label>
+          </div>
+          <div>
+            <input class="newslettercheck" type="checkbox" value="3952b7cf05" name="groupid" id="mce-group2" checked="checked" />
+            <label for="mce-group2">Breaking News Alerts</label>
+          </div>
+        </div>
+        <div id="result-text"></div>
+      </form>
+       -->
+        </div>
+        <div class="footer-right">
+          <div>
+            <h4>Follow us</h4>
+            <ul class="social-footer social-icons">
+              <li>
+                <a target="_blank" href="https://www.youtube.com/tvinsider/"
+                  ><img
+                    loading="lazy"
+                    class="icon-youtube"
+                    alt="icon - youtube"
+                    height="32"
+                    width="32"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-youtube.svg"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.facebook.com/tvinsider/"
+                  ><img
+                    loading="lazy"
+                    class="icon-facebook"
+                    alt="icon - facebook"
+                    height="32"
+                    width="32"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-facebook.svg"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://twitter.com/tvinsider/"
+                  ><img
+                    loading="lazy"
+                    class="icon-twitter"
+                    alt="icon - twitter"
+                    height="32"
+                    width="32"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-twitter.svg"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.instagram.com/tvinsider/"
+                  ><img
+                    loading="lazy"
+                    class="icon-instagram"
+                    alt="icon - instagram"
+                    height="32"
+                    width="32"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-instagram.svg"
+                /></a>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4>Quick Links</h4>
+            <ul class="list-links">
+              <li><a href="https://www.tvinsider.com/about-us/">About</a></li>
+              <li><a href="https://www.tvinsider.com/advertise-with-us/">Advertise</a></li>
+              <li><a href="https://www.tvinsider.com/privacy-policy/">Privacy</a></li>
+              <li><a href="https://www.tvinsider.com/terms-of-use/">Terms of Service</a></li>
+              <li><a href="https://www.tvinsider.com/dsar/">Do Not Sell</a></li>
+              <li><a href="https://www.tvinsider.com/contact-us/">Contact Us</a></li>
+              <li>
+                <a
+                  id="osano-link"
+                  href="#"
+                  onclick="Osano.cm.showDrawer('osano-cm-dom-info-dialog-open'); return false;"
+                  >Cookie Prefs</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4><a href="/magazines/">Our Publications</a></h4>
+            <ul class="list-partners">
+              <li>
+                <a target="_blank" href="https://www.tvguidemagazine.com/"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-tv-guide.png"
+                    height="27"
+                    width="35"
+                    alt="TV Guide Magazine Logo"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://tvpuzzler.com/tvipz"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-puzzler.png"
+                    height="25"
+                    width="110"
+                    alt="Puzzler"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.iwantmytvmagazine.com/"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-tv-weekly.png"
+                    height="25"
+                    width="32"
+                    alt="TV Weekly Logo"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.channelguidemag.com/"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-channel-guide.png"
+                    height="25"
+                    width="106"
+                    alt="Channel Guide Logo"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.ondishmag.com/"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-on-dish.png"
+                    height="25"
+                    width="113"
+                    alt="OnDISH Logo"
+                /></a>
+              </li>
+              <li>
+                <a target="_blank" href="https://www.remindmagazine.com/tvirm"
+                  ><img
+                    loading="lazy"
+                    src="https://www.tvinsider.com/wp-content/themes/tv/images/logo-remind.png"
+                    height="25"
+                    width="97"
+                    alt="Remind Logo"
+                /></a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <div class="">
+          <span class="copyright">Copyright &copy; 2025 NTVB Media, Inc., All Rights Reserved</span>
+        </div>
+      </div>
+    </footer>
+
+    <!-- Navigation & Search -->
+
+    <script>
+      $('.search-area #search-form').hover(function () {
+        $('#search-form-input').focus()
+      })
+      $('#hamburger-button').click(function () {
+        $('.menu').toggleClass('responsive')
+        $('#hamburger-button').toggleClass('responsive')
+        return false
+      })
+      $(window).on('resize', function () {
+        if ($(window).width() > 1024) {
+          $('.menu').removeClass('responsive')
+          $('#hamburger-button').removeClass('responsive')
+        }
+      })
+    </script>
+
+    <!-- Comscore -->
+    <script>
+      var _comscore = _comscore || []
+      _comscore.push({ c1: '2', c2: '19587797' })
+      ;(function () {
+        var s = document.createElement('script'),
+          el = document.getElementsByTagName('script')[0]
+        s.async = true
+        s.src =
+          (document.location.protocol == 'https:' ? 'https://sb' : 'http://b') +
+          '.scorecardresearch.com/beacon.js'
+        el.parentNode.insertBefore(s, el)
+      })()
+    </script>
+
+    <!-- Chartbeat -->
+
+    <script type="text/javascript">
+      ;(function () {
+        /** CONFIGURATION START **/
+        var _sf_async_config = (window._sf_async_config = window._sf_async_config || {})
+        _sf_async_config.uid = 62629
+        _sf_async_config.domain = 'tvinsider.com'
+        _sf_async_config.useCanonical = true
+        _sf_async_config.useCanonicalDomain = true
+        /** CONFIGURATION END **/
+        function loadChartbeat() {
+          var e = document.createElement('script')
+          var n = document.getElementsByTagName('script')[0]
+          e.type = 'text/javascript'
+          e.async = true
+          e.src = '//static.chartbeat.com/js/chartbeat.js'
+          n.parentNode.insertBefore(e, n)
+        }
+        loadChartbeat()
+      })()
+    </script>
+
+    <!-- Google Analytics - G4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-DB9HERH5PW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+
+      var userType = 'unregistered'
+      gtag('config', 'G-DB9HERH5PW', {
+        user_properties: {
+          user_type: userType
+        }
+      })
+    </script>
+
+    <!-- Registration Promo -->
+
+    <div id="reg-promo" class="personalize-modal" style="display: none">
+      <div class="personalize-modal-content">
+        <button class="close-modal">X</button>
+        <h3>Benefits to Registering & Following</h3>
+        <ul class="benefits">
+          <li class="icon-watchlist">
+            <img
+              height="100"
+              width="100"
+              src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-watchlist-alert.png?x=10"
+            /><b>Watchlist</b> Easy access to only the shows you care about — all in one simple
+            place
+          </li>
+          <li class="icon-tv-alerts">
+            <img
+              height="100"
+              width="100"
+              src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-notification.png?x=10"
+            /><b>Alerts</b> Only important notifications — when a show is returning, when it becomes
+            available to stream, and more.
+          </li>
+          <li class="icon-special-offers">
+            <img
+              height="100"
+              width="100"
+              src="https://www.tvinsider.com/wp-content/themes/tv/images/icon-offer.png?x=10"
+            /><b>Special Offers</b> Exclusive products we release related to your favorite shows and
+            streaming services
+          </li>
+        </ul>
+        <p>
+          <a class="basic-button" href="https://www.tvinsider.com/register/?showid=0">Sign Up</a>
+        </p>
+        <p>(It's free!)</p>
+      </div>
+    </div>
+
+    <script>
+      $(document).ready(function () {
+        // REGISTRATION MODAL
+
+        // Open Modal
+        $('.why-watchlist a').click(function () {
+          $('#reg-promo').css('display', 'block')
+          return false
+        })
+
+        // Close Modal
+        $('.close-modal').click(function () {
+          $('#reg-promo').css('display', 'none')
+        })
+
+        // Close Modal When Clicking Outside
+        $(window).click(function (e) {
+          if ($(e.target).is('#reg-promo')) {
+            $('#reg-promo').css('display', 'none')
+          }
+        })
+
+        // WATCHLIST
+
+        var isPanelOpen = false
+
+        $('.add-to-watchlist-wrapper .add-to-watchlist').click(function () {
+          // if user logged in
+          if ($('body').hasClass('logged-in')) {
+            if ($(this).hasClass('selected')) {
+              removeShowFromWatchlist()
+            } else {
+              togglePanel()
+              addShowToWatchlist()
+            }
+            // otherwise launch registration
+          } else {
+            $('.why-watchlist a').click()
+          }
+        })
+
+        $('.close-panel').click(function () {
+          togglePanel()
+        })
+
+        $('.open-watchlist-btn').click(function () {
+          if (isPanelOpen) {
+            togglePanel()
+          } else {
+            togglePanel()
+            getShowWatchlist()
+          }
+        })
+
+        function togglePanel() {
+          if (isPanelOpen) {
+            $('.watchlist-panel').css('transform', 'translateX(100%)')
+            $('body > *:not(.watchlist-panel)').css('filter', 'none')
+            isPanelOpen = false
+          } else {
+            $('.watchlist-panel').css('transform', 'translateX(0%)')
+            $('body > *:not(.watchlist-panel)').css('filter', 'blur(5px)')
+            isPanelOpen = true
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/sites/tvinsider.com/readme.md
+++ b/sites/tvinsider.com/readme.md
@@ -1,0 +1,21 @@
+# tvinsider.com
+
+https://www.tvinsider.com/
+
+### Download the guide
+
+```sh
+npm run grab --- --site=tvinsider.com
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/tvinsider.com/tvinsider.com.config.js --output=./sites/tvinsider.com/tvinsider.com.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- tvinsider.com
+```

--- a/sites/tvinsider.com/tvinsider.com.channels.xml
+++ b/sites/tvinsider.com/tvinsider.com.channels.xml
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="5-star-max">5-Star MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="abc">ABC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="acc-network">ACC Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="acorn-tv">Acorn TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="action-max">Action MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="adult-swim">Adult Swim</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ae">A&amp;E</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="allblk">ALLBLK</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="altitude-sports">Altitude Sports</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="amazon-prime-video">Amazon Prime Video</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="amc">AMC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="amc-plus">AMC+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="american-heroes-channel">American Heroes Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="animal-planet">Animal Planet</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="antenna-tv">Antenna TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="aol">AOL</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="apple-tv-plus">Apple TV+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="aspire">Aspire</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="audience-network">Audience Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="awe">AWE</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="axn">AXN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="axs">AXS</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="babyfirst">BabyFirst</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bbc-america">BBC America</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bbc-news">BBC News</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bein-sports">beIN Sports</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet">BET</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet-gospel">BET Gospel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet-her">BET Her</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet-jams">BET Jams</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet-plus">BET+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bet-soul">BET Soul</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="big-ten-network">Big Ten Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bloomberg">Bloomberg</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="boomerang">Boomerang</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bounce-tv">Bounce TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="bravo">Bravo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="britbox">BritBox</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="buzzr">Buzzr</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="byutv">BYUtv</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="c-span">C-SPAN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="c-span-2">C-SPAN 2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="c-span-3">C-SPAN 3</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cars-tv">Cars.TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cartoon-network">Cartoon Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="catchy-comedy">Catchy Comedy</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="catholic-faith-network">Catholic Faith Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cbs">CBS</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cbs-sports-network">CBS Sports Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="charge">Charge!</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cheddar">Cheddar</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cinemax">Cinemax</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="circle">Circle</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cleo-tv">Cleo TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cmt">CMT</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cnbc">CNBC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cnn">CNN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cnn-international">CNN International</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cnn-plus">CNN+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="comedy-central">Comedy Central</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="comedy-tv">Comedy TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="comet">Comet</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cooking-channel">Cooking Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="court-tv">Court TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="cozi-tv">Cozi TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="crackle">Crackle</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="create">Create</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="crime-and-investigation-network">Crime and Investigation Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="crunchyroll">Crunchyroll</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="curiosity-stream">Curiosity Stream</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="dabl">Dabl</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="dailywire-plus">Dailywire+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="daystar">Daystar</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="dazn">DAZN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="dc-universe">DC Universe</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="destination-america">Destination America</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="directtv">DirectTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="discovery">Discovery Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="discovery-family">Discovery Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="discovery-life-channel">Discovery Life Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="discovery-plus">Discovery+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="disney-channel">Disney Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="disney-junior">Disney Junior</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="disney-plus">Disney+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="disney-xd">Disney XD</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="diy-network">DIY Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="e">E!</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="el-rey">El Rey</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="espn">ESPN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="espn2">ESPN2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="espn-deportes">ESPN Deportes</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="espn-plus">ESPN+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="espnu">ESPNU</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="esquire-network">Esquire Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="estrella-tv">Estrella TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="facebook-watch">Facebook Watch</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="family-movie-classics">Family Movie Classics</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-detroit">FanDuel Sports Detroit</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-florida">FanDuel Sports Florida</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-great-lakes">FanDuel Sports Great Lakes</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-indiana">FanDuel Sports Indiana</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-kansas-city">FanDuel Sports Kansas City</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-midwest">FanDuel Sports Midwest</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-new-orleans">FanDuel Sports New Orleans</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-north">FanDuel Sports North</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-ohio">FanDuel Sports Ohio</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-oklahoma">FanDuel Sports Oklahoma</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-socal">FanDuel Sports SoCal</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-south">FanDuel Sports South</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-southeast">FanDuel Sports Southeast</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-southwest">FanDuel Sports Southwest</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-sun">FanDuel Sports Sun</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-west">FanDuel Sports West</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fanduel-sports-wisconsin">FanDuel Sports Wisconsin</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fetv">FETV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="flix">Flix</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="food-network">Food Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox">FOX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-business">Fox Business</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-deportes">FOX Deportes</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-nation">FOX Nation</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-news">Fox News</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-soccer-plus">Fox Soccer Plus</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-sports-1">Fox Sports 1</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fox-sports-2">Fox Sports 2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="freeform">Freeform</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="freevee">Freevee</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fsn">FSN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fuse">Fuse</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fusion">Fusion</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fx">FX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fx-movie-channel">FX Movie Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fxx">FXX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="fyi">FYI</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="g4">G4</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="game-show-network">Game Show Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="gettv">getTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="go90">go90</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="gol-tv">GOL TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="golf-channel">Golf Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="golfpass">GolfPass</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="great-american-faith-and-living">Great American Faith &amp; Living</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="great-american-family">Great American Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="grit">Grit</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hallmark-channel">Hallmark Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hallmark-family">Hallmark Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hallmark-mystery">Hallmark Mystery</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hallmark-plus">Hallmark+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo">HBO</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo2">HBO2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo-comedy">HBO Comedy</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo-family">HBO Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo-latino">HBO Latino</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo-signature">HBO Signature</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hbo-zone">HBO Zone</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hdnet-movies">HDNet Movies</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="here-tv">Here TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="heroes-icons">Heroes &amp; Icons</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hgtv">HGTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hidive">HIDIVE</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="history-channel">History Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hln">HLN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hoichoi">Hoichoi</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hsn">HSN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="hulu">Hulu</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ifc">IFC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="impact">Impact</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="indieplex">IndiePlex</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="insp">INSP</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="investigation-discovery">Investigation Discovery</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ion-mystery">ION Mystery</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ion-plus">Ion Plus</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ion-television">Ion Television</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="jewelry-television">Jewelry Television</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="jewish-life-television">Jewish Life Television</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="justice-central">Justice Central</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="laff">Laff</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="law-and-crime">Law &amp; Crime</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="lifetime">Lifetime</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="lifetime-real-women">Lifetime Real Women</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="lmn">Lifetime Movie Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="logo">Logo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="lol-network">LOL Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="magellantv">MagellanTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="magnolia-network">Magnolia Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mavtv">MAVTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="max">Max</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="merit-street">Merit Street</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="metv">MeTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="metv-plus">MeTV+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="metv-toons">MeTV Toons</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mgm-plus">MGM+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mgm-plus-drive-in">MGM+ Drive-In</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mgm-plus-hits">MGM+ Hits</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mgm-plus-marquee">MGM+ Marquee</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mhz-choice">MHz Choice</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="military-history">Military History</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mlb-network">MLB Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="more-max">More MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="motortrend">MotorTrend</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="moviemax">Movie MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="movieplex">MoviePlex</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="movies">Movies!</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="msg">MSG</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="msnbc">MSNBC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mtv">MTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mtv2">MTV2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mtv-classic">MTV Classic</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mtv-live">MTV Live</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mubi">Mubi</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="mynetworktv">MyNetworkTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nasa-tv">NASA TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nat-geo">Nat Geo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nat-geo-wild">Nat Geo Wild</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nba-tv">NBA TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nbc">NBC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nbc-news-now">NBC News Now</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nbc-sports-bay-area">NBC Sports Bay Area</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nbc-sports-chicago">NBC Sports Chicago</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nbc-sports-philadelphia">NBC Sports Philadelphia</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="necn">NECN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="netflix">Netflix</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="new-england-sports-network">NESN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="newsmax">Newsmax</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="newsnation">NewsNation</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="next-level-sports">Next Level Sports</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nfl-network">NFL Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nhk-world">NHK World</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nhl-network">NHL Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nick-jr">Nick Jr.</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nickelodeon">Nickelodeon</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="nicktoons">Nicktoons</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="oan">OAN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="open-tv">Open TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="outdoor-channel">Outdoor Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="outer-max">Outer MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="outlaw-the-western-channel">Outlaw</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ovation">Ovation</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="own">OWN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="oxygen">Oxygen</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pac-12-network">Pac-12 Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="paramount-network">Paramount Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="paramount-plus">Paramount+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pay-per-view">Pay-Per-View</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pbs">PBS</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pbs-kids">PBS Kids</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="peacock">Peacock</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pets">Pets</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pivot">Pivot</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="playstation-network">PlayStation Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pluto-tv-drama">Pluto TV Drama</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pop">Pop TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="prime-time-entertainment-network">PTEN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="primo-tv">Primo TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pure-flix">Pure Flix</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="pursuit">Pursuit</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="quibi">Quibi</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="qvc">QVC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="rakuten-viki">Rakuten Viki</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="real-americas-voice">Real America&apos;s Voice</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="recipe-tv">Recipe TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="reelz">Reelz</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="retrocrush">RetroCrush</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="retroplex">RetroPlex</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="revolt">Revolt</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="rewind-tv">Rewind TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="rfd-tv">RFD-TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="ride-tv">Ride TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="rooster-teeth">Rooster Teeth</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="russia-today">Russia Today</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="sbn">SBN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="sbs">SBS</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="science-channel">Science Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="scripps-news">Scripps News</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="sec-network">SEC Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="seeso">Seeso</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="shophq">ShopHQ</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime">Showtime</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime-2">Showtime 2</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime-extreme">Showtime Extreme</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime-familyzone">Showtime FamilyZone</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime-showcase">Showtime Showcase</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="showtime-women">Showtime Women</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="shoxbet">SHOxBET</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="shudder">Shudder</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="smile">Smile</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="smithsonian-channel">Smithsonian Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="snap-originals">Snap Originals</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="soapnet">Soapnet</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="spectrum-originals">Spectrum Originals</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="spike">Spike</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="start-tv">Start TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz">Starz</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-cinema">Starz Cinema</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-comedy">Starz Comedy</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-edge">Starz Edge</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore">Starz Encore</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-action">Starz Encore Action</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-black">Starz Encore Black</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-classic">Starz Encore Classic</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-family">Starz Encore Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-suspense">Starz Encore Suspense</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-encore-westerns">Starz Encore Westerns</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-in-black">Starz In Black</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="starz-kids-family">Starz Kids &amp; Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="story-television">Story Television</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="sundance">Sundance</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="sundance-now">Sundance Now</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="syfy">Syfy</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="syndicated">Syndicated</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tastemade">Tastemade</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tbd">TBD</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tbs">TBS</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="teennick">TeenNick</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="telemundo">Telemundo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="telexitos">TeleXitos</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tennis-channel">Tennis Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the365">The365</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-cowboy-channel">The Cowboy Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-criterion-channel">The Criterion Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-cw">The CW</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-design-network">The Design Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-first">The First</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-movie-channel">The Movie Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-movie-channel-extra">The Movie Channel Extra</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-network">The Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-roku-channel">The Roku Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-wb">The WB</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="the-weather-channel">The Weather Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="thegrio">TheGrio</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="this-tv">This TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="thrillermax">Thriller MAX</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="thrillertv">ThrillerTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tinder">Tinder</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tlc">TLC</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tnt">TNT</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="topic">Topic</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="travel-channel">Travel Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="trinity-broadcast-network">Trinity Broadcast Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="true-crime-network">True Crime Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="true-royalty-tv">True Royalty TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="trutv">truTV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tubi">Tubi</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tudn">TUDN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="turner-classic-movies">Turner Classic Movies</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tv-japan">TV Japan</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tv-land">TV Land</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="tv-one">TV One</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="twist">Twist</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="unimas">UniMás</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="universal-kids">Universal Kids</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="universo">Universo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="univision">Univision</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="up-faith-family">UP Faith &amp; Family</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="upn">UPN</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="uptv">UPtv</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="usa-network">USA Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="venu-sports">Venu Sports</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="vh1">VH1</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="viaplay">Viaplay</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="vice-tv">Vice TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="vimeo">Vimeo</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="vizio-watchfree">Vizio WatchFree+</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="vod-rent">VOD/Rent</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="we-tv">We TV</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="wgn">WGN America</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="willow">Willow</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="world-channel">World Channel</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="world-fishing-network">World Fishing Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="wwe-network">WWE Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="yankee-entertainment-sports">YES Network</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="youtube">YouTube</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="z-living">Z Living</channel>
+  <channel site="tvinsider.com" lang="en" xmltv_id="" site_id="zoomoo">ZooMoo</channel>
+</channels>

--- a/sites/tvinsider.com/tvinsider.com.config.js
+++ b/sites/tvinsider.com/tvinsider.com.config.js
@@ -1,0 +1,97 @@
+const cheerio = require('cheerio')
+const axios = require('axios')
+const { DateTime } = require('luxon')
+
+module.exports = {
+  site: 'tvinsider.com',
+  days: 2,
+  url({ channel }) {
+    return `https://www.tvinsider.com/network/${channel.site_id}/schedule/`
+  },
+  parser({ content, date }) {
+    const programs = []
+    const items = parseItems(content, date)
+    items.forEach(item => {
+      const prev = programs[programs.length - 1]
+      const $item = cheerio.load(item)
+      let start = parseStart($item, date)
+      if (!start) return
+      if (prev) {
+        prev.stop = start
+      }
+      const stop = start.plus({ minute: 30 })
+
+      programs.push({
+        title: parseTitle($item),
+        description: parseDescription($item),
+        category: parseCategory($item),
+        date: parseDate($item),
+        start,
+        stop
+      })
+    })
+
+    return programs
+  },
+  async channels() {
+    const html = await axios
+      .get('https://www.tvinsider.com/network/5-star-max/')
+      .then(r => r.data)
+      .catch(console.log)
+    const $ = cheerio.load(html)
+    const items = $('body > main > section > select > option').toArray()
+
+    const channels = []
+    items.forEach(item => {
+      const name = $(item).text().trim()
+      const path = $(item).attr('value')
+      if (!path) return
+      const [, , site_id] = path.split('/') || [null, null, null]
+      if (!site_id) return
+
+      channels.push({
+        lang: 'en',
+        site_id,
+        name
+      })
+    })
+
+    return channels
+  }
+}
+
+function parseTitle($item) {
+  return $item('h3').text().trim()
+}
+
+function parseDescription($item) {
+  return $item('p').text().trim()
+}
+
+function parseCategory($item) {
+  const [category] = $item('h4').text().trim().split(' • ')
+
+  return category
+}
+
+function parseDate($item) {
+  const [, date] = $item('h4').text().trim().split(' • ')
+
+  return date
+}
+
+function parseStart($item, date) {
+  let time = $item('time').text().trim()
+  time = `${date.format('YYYY-MM-DD')} ${time}`
+
+  return DateTime.fromFormat(time, 'yyyy-MM-dd t', { zone: 'America/New_York' }).toUTC()
+}
+
+function parseItems(content, date) {
+  const $ = cheerio.load(content)
+
+  return $(`#${date.format('MM-DD-YYYY')}`)
+    .next()
+    .find('a')
+    .toArray()
+}

--- a/sites/tvinsider.com/tvinsider.com.test.js
+++ b/sites/tvinsider.com/tvinsider.com.test.js
@@ -1,0 +1,56 @@
+const { parser, url } = require('./tvinsider.com.config.js')
+const fs = require('fs')
+const path = require('path')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2025-01-18', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: 'movieplex',
+  xmltv_id: 'MoviePlexEast.us'
+}
+
+it('can generate valid url', () => {
+  expect(url({ channel })).toBe('https://www.tvinsider.com/network/movieplex/schedule/')
+})
+
+it('can parse response', () => {
+  const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.html'))
+  const results = parser({ content, date }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(results.length).toBe(15)
+  expect(results[0]).toMatchObject({
+    start: '2025-01-18T05:45:00.000Z',
+    stop: '2025-01-18T07:12:00.000Z',
+    title: 'Wild Oats',
+    category: 'Feature Film',
+    date: '2016',
+    description:
+      'Two best friends travel to the Canary Islands after one mistakenly receives a large amount of money.'
+  })
+  expect(results[14]).toMatchObject({
+    start: '2025-01-19T04:42:00.000Z',
+    stop: '2025-01-19T05:12:00.000Z',
+    title: 'Trading Mom',
+    category: 'Feature Film',
+    date: '1994',
+    description:
+      'Kids (Anna Chlumsky, Aaron Michael Metchik) under magic spell shop for another mother.'
+  })
+})
+
+it('can handle empty guide', () => {
+  const results = parser({
+    date,
+    content: fs.readFileSync(path.resolve(__dirname, '__data__/no_content.html'))
+  })
+
+  expect(results).toMatchObject([])
+})


### PR DESCRIPTION
Closes https://github.com/iptv-org/epg/issues/2538

```sh
npm test --- tvinsider.com

> test
> run-script-os tvinsider.com


> test:default
> TZ=Pacific/Nauru npx jest --runInBand tvinsider.com

 PASS  sites/tvinsider.com/tvinsider.com.test.js
  ✓ can generate valid url (4 ms)
  ✓ can parse response (243 ms)
  ✓ can handle empty guide (36 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.2 s
Ran all test suites matching /tvinsider.com/i.
```

```sh
npm run grab --- --site=tvinsider.com --maxConnections=10

> grab
> npx tsx scripts/commands/epg/grab.ts --site=tvinsider.com --maxConnections=10

starting...
config:
  output: guide.xml
  maxConnections: 10
  gzip: false
  site: tvinsider.com
loading channels...
  found 374 channel(s)
run #1:
  [1/748] tvinsider.com (en) - acorn-tv - Jan 16, 2025 (0 programs)
  [2/748] tvinsider.com (en) - abc - Jan 15, 2025 (16 programs)
  [3/748] tvinsider.com (en) - abc - Jan 16, 2025 (25 programs)
  [4/748] tvinsider.com (en) - 5-star-max - Jan 16, 2025 (14 programs)
  [5/748] tvinsider.com (en) - acc-network - Jan 15, 2025 (15 programs)
  [6/748] tvinsider.com (en) - acorn-tv - Jan 15, 2025 (0 programs)
  [7/748] tvinsider.com (en) - action-max - Jan 15, 2025 (13 programs)
  [8/748] tvinsider.com (en) - 5-star-max - Jan 15, 2025 (10 programs)
  [9/748] tvinsider.com (en) - action-max - Jan 16, 2025 (13 programs)
...
  [748/748] tvinsider.com (en) - showtime-showcase - Jan 16, 2025 (12 programs)
  saving to "guide.xml"...
  done in 00h 00m 36s
```