### PR TITLE
Patch 2025.02.1

### DIFF
--- a/scripts/commands/channels/lint.mts
+++ b/scripts/commands/channels/lint.mts
@@ -76,6 +76,18 @@ async function main() {
       localErrors = localErrors.concat(error.details)
     }
 
+    xml.split('\n').forEach((line: string, lineIndex: number) => {
+      const found = line.match(/='/)
+      if (found) {
+        const colIndex = found.index || 0
+        localErrors.push({
+          line: lineIndex + 1,
+          col: colIndex + 1,
+          message: 'Single quotes cannot be used in attributes'
+        })
+      }
+    })
+
     if (localErrors.length) {
       console.log(`\n${chalk.underline(filepath)}`)
       localErrors.forEach((error: ErrorDetail) => {

--- a/tests/__data__/input/channels-lint/single_quotes.channels.xml
+++ b/tests/__data__/input/channels-lint/single_quotes.channels.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding="UTF-8"?>
+<channels>
+  <channel site="singlequotes.com" lang="en" xmltv_id="" site_id="140">Bravo 2</channel>
+</channels>

--- a/tests/__data__/input/channels-lint/valid.channels.xml
+++ b/tests/__data__/input/channels-lint/valid.channels.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="valid.com" lang="en" xmltv_id="BravoEast.us" site_id="140#Tes't">Bravo's</channel>
+</channels>

--- a/tests/commands/channels/lint.test.ts
+++ b/tests/commands/channels/lint.test.ts
@@ -53,4 +53,31 @@ describe('channels:lint', () => {
       expect((error as ExecError).stdout).toContain('2 error(s)')
     }
   })
+
+  it('will show a message if the file contains single quotes', () => {
+    try {
+      const cmd =
+        'npm run channels:lint --- tests/__data__/input/channels-lint/single_quotes.channels.xml'
+      const stdout = execSync(cmd, { encoding: 'utf8' })
+      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+      process.exit(1)
+    } catch (error) {
+      expect((error as ExecError).status).toBe(1)
+      expect((error as ExecError).stdout).toContain('single_quotes.channels.xml')
+      expect((error as ExecError).stdout).toContain(
+        '1:14 Single quotes cannot be used in attributes'
+      )
+    }
+  })
+
+  it('does not display errors if there are none', () => {
+    try {
+      const cmd = 'npm run channels:lint --- tests/__data__/input/channels-lint/valid.channels.xml'
+      const stdout = execSync(cmd, { encoding: 'utf8' })
+      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
+    } catch (error) {
+      if (process.env.DEBUG === 'true') console.log((error as ExecError).stdout)
+      process.exit(1)
+    }
+  })
 })


### PR DESCRIPTION
Updated the `channels:lint` script. It will generate an error if single quotes are used around attribute values. 

Examples:

_FAIL_

```xml
site-id='5af09e645'
```

_PASS_

```xml
site-id="Wild 'N Out"
```

Test results:

```sh
npm test --- commands

> test
> run-script-os commands


> test:default
> TZ=Pacific/Nauru npx jest --runInBand commands

 PASS  tests/commands/epg/grab.test.ts (20.429 s)
 PASS  tests/commands/channels/lint.test.ts (9.931 s)
 PASS  tests/commands/channels/validate.test.ts
 PASS  tests/commands/channels/edit.test.ts
 PASS  tests/commands/sites/update.test.ts
 PASS  tests/commands/channels/parse.test.ts
 PASS  tests/commands/api/generate.test.ts
 PASS  tests/commands/sites/init.test.ts

Test Suites: 8 passed, 8 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        46.573 s, estimated 48 s
Ran all test suites matching /commands/i.
```