### PR TITLE
Update meo.pt

### DIFF
--- a/sites/meo.pt/meo.pt.config.js
+++ b/sites/meo.pt/meo.pt.config.js
@@ -7,7 +7,8 @@ module.exports = {
   request: {
     method: 'POST',
     headers: {
-      Origin: 'https://www.meo.pt'
+      Origin: 'https://www.meo.pt',
+      'User-Agent': 'Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; en-US Trident/4.0)'
     },
     data: function ({ channel, date }) {
       return {


### PR DESCRIPTION
Fixes https://github.com/iptv-org/epg/issues/2678

```sh
npm test --- meo.pt       

> test
> run-script-os meo.pt


> test:default
> TZ=Pacific/Nauru npx jest --runInBand meo.pt

 PASS  sites/meo.pt/meo.pt.test.js
  ✓ can generate valid url (3 ms)
  ✓ can generate valid request method
  ✓ can generate valid request headers (1 ms)
  ✓ can generate valid request method (4 ms)
  ✓ can parse response (65 ms)
  ✓ can handle empty guide

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.644 s, estimated 1 s
Ran all test suites matching /meo.pt/i.
```

```sh
npm run grab --- --site=meo.pt

> grab
> npx tsx scripts/commands/epg/grab.ts --site=meo.pt

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  site: meo.pt
loading channels...
  found 216 channel(s)
run #1:
  [1/432] meo.pt (en) - EuronewsGerman.fr - Feb 8, 2025 (85 programs)
  [2/432] meo.pt (en) - EuronewsGerman.fr - Feb 9, 2025 (84 programs)
  [3/432] meo.pt (en) - France24English.fr - Feb 9, 2025 (124 programs)
  [4/432] meo.pt (en) - MTV00s.uk - Feb 9, 2025 (9 programs)
  [5/432] meo.pt (en) - TPAi.ao - Feb 9, 2025 (8 programs)
  [6/432] meo.pt (en) - TPAi.ao - Feb 8, 2025 (8 programs)
  [7/432] meo.pt (en) - MTV00s.uk - Feb 8, 2025 (9 programs)
  [8/432] meo.pt (en) - SkyNewsInternational.uk - Feb 9, 2025 (46 programs)
  [9/432] meo.pt (en) - SkyNewsInternational.uk - Feb 8, 2025 (49 programs)
...
```