### PR TITLE
Add freetv.tv

### DIFF
--- a/sites/freetv.tv/freetv.tv.channels.xml
+++ b/sites/freetv.tv/freetv.tv.channels.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="freetv.tv" lang="ar" xmltv_id="Makan33.il" site_id="3371021">مكان</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="Kan11.il" site_id="3370462">כאן 11</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="KanEducational.il" site_id="3370497">חינוכית</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="Keshet12.il" site_id="3340020">קשת 12</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="Channel13.il" site_id="3328044">רשת 13</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="Now14.il" site_id="3457869">ערוץ 14</channel>
+  <channel site="freetv.tv" lang="he" xmltv_id="KnessetChannel.il" site_id="3362990">ערוץ הכנסת</channel>
+</channels>

--- a/sites/freetv.tv/freetv.tv.config.js
+++ b/sites/freetv.tv/freetv.tv.config.js
@@ -1,0 +1,62 @@
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const timezone = require('dayjs/plugin/timezone')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+
+module.exports = {
+  site: 'freetv.tv',
+  days: 2,
+  url: function ({ channel, date }) {
+    const localDate = dayjs(date).tz('Asia/Jerusalem')
+    const since = localDate.startOf('day').format('YYYY-MM-DDTHH:mmZZ')
+    const till = localDate.add(1, 'day').startOf('day').format('YYYY-MM-DDTHH:mmZZ')
+
+    return `https://web.freetv.tv/api/products/lives/programmes?liveId[]=${
+      channel.site_id
+    }&since=${encodeURIComponent(since)}&till=${encodeURIComponent(till)}&lang=HEB&platform=BROWSER`
+  },
+  parser: function ({ content }) {
+    const programs = []
+    let items = []
+    
+    try {
+      items = JSON.parse(content)
+    } catch {
+      return programs
+    }
+
+    items.forEach(item => {
+      const start = parseStart(item)
+      const stop = parseStop(item)
+      if (!start.isValid() || !stop.isValid()) return
+
+      programs.push({
+        title: item.title,
+        description: item.description || item.lead,
+        image: getImageUrl(item),
+        icon: getImageUrl(item),
+        start,
+        stop
+      })
+    })
+
+    return programs
+  }
+}
+
+function parseStart(item) {
+  return item.since ? dayjs.utc(item.since).tz('Asia/Jerusalem') : null
+}
+
+function parseStop(item) {
+  return item.till ? dayjs.utc(item.till).tz('Asia/Jerusalem') : null
+}
+
+function getImageUrl(item) {
+  const url = item.images?.['16x9']?.[0]?.url
+  return url ? `https:${url}` : null
+}

--- a/sites/freetv.tv/freetv.tv.test.js
+++ b/sites/freetv.tv/freetv.tv.test.js
@@ -1,0 +1,50 @@
+const { parser, url } = require('./freetv.tv.config.js')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2025-03-28', 'YYYY-MM-DD').startOf('d')
+const channel = {
+  site_id: '3370462',
+  xmltv_id: 'Kan11.il'
+}
+
+it('can generate valid url', () => {
+  expect(url({ channel, date })).toBe('https://web.freetv.tv/api/products/lives/programmes?liveId[]=3370462&since=2025-03-28T00%3A00%2B0200&till=2025-03-29T00%3A00%2B0300&lang=HEB&platform=BROWSER')
+})
+
+it('can parse response', () => {
+  const content = '[{"id":5856194,"publicUid":"f17b5a1d-3f2a-42a0-a11b-a08e5c9785fd","title":"בוש 4 - פרק 3","lead":"עונה 4 חדשה לדרמה הבלשית. 3. השטן בתוך הבית: הכוח המיוחד מנסה לחקור, ומגלה אליבי שקרי עם השלכות מרעישות. הבלש סנטיאגו רוברטסון צריך לשים את קשריו האישיים בצד למען החקירה. בוש זוכה לביקור פתע לילי.כ עב","description":"עונה 4 חדשה לדרמה הבלשית. 3. השטן בתוך הבית: הכוח המיוחד מנסה לחקור, ומגלה אליבי שקרי עם השלכות מרעישות. הבלש סנטיאגו רוברטסון צריך לשים את קשריו האישיים בצד למען החקירה. בוש זוכה לביקור פתע לילי.כ עב","rating":14,"ratingEmbedded":false,"type":"PROGRAMME","uhd":false,"since":"2025-03-27T21:26:00Z","till":"2025-03-27T22:17:00Z","images":{"16x9":[{"url":"//d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1361162/COVER/images/1361162_1736767668746.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1","templateUrl":"//d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1361162/COVER/images/1361162_1736767668746.jpg?srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1&dsth={height:177}&dstw={width:315}"}]},"genres":[],"webUrl":"https://web.freetv.tv/news,1991/rw-11,3370462/2025-03-27/bw-4---prq-3,5856194","trailer":false,"live":{"type_":"LIVE","id":3370462},"available":true,"timeshiftAvailable":false,"startoverAvailable":false,"catchupTill":"2025-04-10T21:26:00Z","npvrTill":"2025-04-10T21:26:00Z","programRecordingId":7068534,"audio":false,"video":true,"showRecommendations":false,"recommended":false,"premiere":false,"liveBroadcast":false,"slug":"bw-4---prq-3"},{"id":5858584,"publicUid":"1dc296c9-0c28-4202-8b20-cbef56a763f5","title":"אבא משתדל - 5. חבר","lead":"סדרה קומית. יוסי מכיר אב לילד עם צרכים מיוחדים ובין השניים מתפתח קשר בסגנון חיזור גורלי שמערער את יוסי. כ עב.","description":"סדרה קומית. יוסי מכיר אב לילד עם צרכים מיוחדים ובין השניים מתפתח קשר בסגנון חיזור גורלי שמערער את יוסי. כ עב.","ratingEmbedded":false,"type":"PROGRAMME","uhd":false,"since":"2025-03-27T22:17:00Z","till":"2025-03-27T22:43:00Z","images":{"16x9":[{"url":"//d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1070668/COVER/images/1070668_1742202219830.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1","templateUrl":"//d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1070668/COVER/images/1070668_1742202219830.jpg?srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1&dsth={height:177}&dstw={width:315}"}]},"genres":[],"webUrl":"https://web.freetv.tv/news,1991/rw-11,3370462/2025-03-27/b-mdl---5-br,5858584","trailer":false,"live":{"type_":"LIVE","id":3370462},"available":true,"timeshiftAvailable":false,"startoverAvailable":false,"catchupTill":"2025-04-10T22:17:00Z","npvrTill":"2025-04-10T22:17:00Z","programRecordingId":7071052,"audio":false,"video":true,"showRecommendations":false,"recommended":false,"premiere":false,"liveBroadcast":false,"slug":"b-mdl---5-br"}]'
+
+  const results = parser({ content }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(results.length).toBe(2)
+  expect(results[0]).toMatchObject({
+    title: 'בוש 4 - פרק 3',
+    description: 'עונה 4 חדשה לדרמה הבלשית. 3. השטן בתוך הבית: הכוח המיוחד מנסה לחקור, ומגלה אליבי שקרי עם השלכות מרעישות. הבלש סנטיאגו רוברטסון צריך לשים את קשריו האישיים בצד למען החקירה. בוש זוכה לביקור פתע לילי.כ עב',
+    image: 'https://d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1361162/COVER/images/1361162_1736767668746.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1',
+    icon: 'https://d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1361162/COVER/images/1361162_1736767668746.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1',
+    start: '2025-03-27T21:26:00.000Z',
+    stop: '2025-03-27T22:17:00.000Z'
+  })
+  expect(results[1]).toMatchObject({
+    title: 'אבא משתדל - 5. חבר',
+    description: 'סדרה קומית. יוסי מכיר אב לילד עם צרכים מיוחדים ובין השניים מתפתח קשר בסגנון חיזור גורלי שמערער את יוסי. כ עב.',
+    image: 'https://d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1070668/COVER/images/1070668_1742202219830.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1',
+    icon: 'https://d1zqtf09wb8nt5.cloudfront.net/scale/oil/freetv/upload/programme/1070668/COVER/images/1070668_1742202219830.jpg?dsth=177&dstw=315&srcmode=0&srcx=0&srcy=0&quality=65&type=1&srcw=1/1&srch=1/1',
+    start: '2025-03-27T22:17:00.000Z',
+    stop: '2025-03-27T22:43:00.000Z'
+  })
+})
+
+it('can handle empty guide', () => {
+  const results = parser({ content: '' })
+
+  expect(results).toMatchObject([])
+})

--- a/sites/freetv.tv/readme.md
+++ b/sites/freetv.tv/readme.md
@@ -1,6 +1,6 @@
 # freetv.tv
 
-https://example.com
+https://freetv.tv/
 
 ### Download the guide
 

--- a/sites/freetv.tv/readme.md
+++ b/sites/freetv.tv/readme.md
@@ -1,0 +1,21 @@
+# freetv.tv
+
+https://example.com
+
+### Download the guide
+
+```sh
+npm run grab --- --site=freetv.tv
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/freetv.tv/freetv.tv.config.js --output=./sites/freetv.tv/freetv.tv.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- freetv.tv
+```


### PR DESCRIPTION
# Grab
```bash
# npm run grab --- --site=freetv.tv

> grab
> npx tsx scripts/commands/epg/grab.ts --site=freetv.tv

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  site: freetv.tv
loading channels...
  found 7 channel(s)
run #1:
  [1/14] freetv.tv (ar) - Makan33.il - Mar 29, 2025 (33 programs)
  [2/14] freetv.tv (ar) - Makan33.il - Mar 30, 2025 (34 programs)
  [3/14] freetv.tv (he) - Kan11.il - Mar 30, 2025 (31 programs)
  [4/14] freetv.tv (he) - Keshet12.il - Mar 30, 2025 (27 programs)
  [5/14] freetv.tv (he) - Keshet12.il - Mar 29, 2025 (22 programs)
  [6/14] freetv.tv (he) - Now14.il - Mar 29, 2025 (9 programs)
  [7/14] freetv.tv (he) - Channel13.il - Mar 30, 2025 (32 programs)
  [8/14] freetv.tv (he) - Channel13.il - Mar 29, 2025 (27 programs)
  [9/14] freetv.tv (he) - Kan11.il - Mar 29, 2025 (28 programs)
  [10/14] freetv.tv (he) - KanEducational.il - Mar 30, 2025 (68 programs)
  [11/14] freetv.tv (he) - KanEducational.il - Mar 29, 2025 (65 programs)
  [12/14] freetv.tv (he) - KnessetChannel.il - Mar 29, 2025 (8 programs)
  [13/14] freetv.tv (he) - Now14.il - Mar 30, 2025 (27 programs)
  [14/14] freetv.tv (he) - KnessetChannel.il - Mar 30, 2025 (27 programs)
  saving to "guide.xml"...
  done in 00h 00m 07s
```

# Test
```bash
# npm test --- freetv.tv

> test
> run-script-os freetv.tv


> test:default
> TZ=Pacific/Nauru npx jest --runInBand freetv.tv

 PASS  sites/freetv.tv/freetv.tv.test.js
  ✓ can generate valid url (55 ms)
  ✓ can parse response (14 ms)
  ✓ can handle empty guide (4 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.908 s
Ran all test suites matching /freetv.tv/i.
```