### PR TITLE
Patch 2025.04.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine
+ARG GIT_REPO=https://github.com/iptv-org/epg.git
+ARG GIT_BRANCH=master
+ARG WORKDIR=/epg
+ENV CRON_SCHEDULE="0 0 * * *"
+ENV GZIP=false
+ENV MAX_CONNECTIONS=1
+ENV DAYS=
+RUN apk update \
+    && apk upgrade --available \
+    && apk add curl git tzdata bash \
+    && npm install -g npm@latest \
+    && npm install pm2 -g \
+    && mkdir $(echo "${WORKDIR}") -p \
+    && cd $WORKDIR \
+    && git clone --depth 1 -b $(echo "${GIT_BRANCH} ${GIT_REPO}") . \
+    && npm install \
+    && mkdir /public
+RUN apk del git curl \
+  && rm -rf /var/cache/apk/*
+COPY pm2.config.js $WORKDIR
+WORKDIR $WORKDIR
+EXPOSE 3000
+CMD [ "pm2-runtime", "pm2.config.js" ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tools for downloading the EPG (Electronic Program Guide) for thousands of TV cha
 - ✨ [Installation](#installation)
 - 🚀 [Usage](#usage)
 - 💫 [Update](#update)
+- 🐋 [Docker](#docker)
 - 📺 [Playlists](#playlists)
 - 🗄 [Database](#database)
 - 👨‍💻 [API](#api)
@@ -145,6 +146,62 @@ And then update all the dependencies:
 ```sh
 npm install
 ```
+
+## Docker
+
+### Build an image
+
+```sh
+docker build -t iptv-org/epg --no-cache .
+```
+
+### Create and run container
+
+```sh
+docker run -p 3000:3000 -v /path/to/channels.xml:/epg/channels.xml iptv-org/epg
+```
+
+By default, the guide will be downloaded every day at 00:00 UTC and saved to the `/epg/public/guide.xml` file inside the container.
+
+From the outside, it will be available at this link:
+
+```
+http://localhost:3000/guide.xml
+```
+
+or
+
+```
+http://<your_local_ip_address>:3000/guide.xml
+```
+
+### Environment Variables
+
+To fine-tune the execution, you can pass environment variables to the container as follows:
+
+```sh
+docker run \
+-p 5000:3000 \
+-v /path/to/channels.xml:/epg/channels.xml \
+-e CRON_SCHEDULE="0 0,12 * * *" \
+-e MAX_CONNECTIONS=10 \
+-e GZIP=true \
+-e PROXY="socks5://127.0.0.1:1234" \
+-e DAYS=14 \
+-e TIMEOUT=5 \
+-e DELAY=2 \
+iptv-org/epg
+```
+
+| Variable        | Description                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| CRON_SCHEDULE   | A [cron expression](https://crontab.guru/) describing the schedule of the guide loadings (default: "0 0 \* \* \*") |
+| MAX_CONNECTIONS | Limit on the number of concurrent requests (default: 1)                                                            |
+| GZIP            | Boolean value indicating whether to create a compressed version of the guide (default: false)                      |
+| PROXY           | Use the specified proxy                                                                                            |
+| DAYS            | Number of days for which the guide will be loaded (defaults to the value from the site config)                     |
+| TIMEOUT         | Timeout for each request in milliseconds (default: 0)                                                              |
+| DELAY           | Delay between request in milliseconds (default: 0)                                                                 |
 
 ## Database
 


### PR DESCRIPTION
Adds `Dockerfile` and instructions on how to use it to [README.md](https://github.com/iptv-org/epg/blob/patch-2025.04.2/README.md#docker).

Test build:

```sh
docker build -t iptv-org/epg --no-cache --build-arg GIT_BRANCH=patch-2025.04.2 .
[+] Building 108.5s (11/11) FINISHED                                                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                                                         0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:22-alpine                                                                                                                                            2.0s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                  0.0s
 => [1/5] FROM docker.io/library/node:22-alpine@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944                                                                                     14.5s
 => => resolve docker.io/library/node:22-alpine@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944                                                                                      0.0s
 => => sha256:cb2bde55f71f84688f9eb7197e0f69aa7c4457499bdf39f34989ab16455c3369 50.34MB / 50.34MB                                                                                                             9.9s
 => => sha256:9d0e0719fbe047cc0770ba9ed1cb150a4ee9bc8a55480eeb8a84a736c8037dbc 1.26MB / 1.26MB                                                                                                               1.5s
 => => sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944 6.41kB / 6.41kB                                                                                                               0.0s
 => => sha256:01393fe5a51489b63da0ab51aa8e0a7ff9990132917cf20cfc3d46f5e36c0e48 1.72kB / 1.72kB                                                                                                               0.0s
 => => sha256:33544e83793ca080b49f5a30fb7dbe8a678765973de6ea301572a0ef53e76333 6.18kB / 6.18kB                                                                                                               0.0s
 => => sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 3.64MB / 3.64MB                                                                                                               0.8s
 => => extracting sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870                                                                                                                    0.3s
 => => sha256:6f063dbd7a5db7835273c913fc420b1082dcda3b5972d75d7478b619da284053 446B / 446B                                                                                                                   1.5s
 => => extracting sha256:cb2bde55f71f84688f9eb7197e0f69aa7c4457499bdf39f34989ab16455c3369                                                                                                                    3.1s
 => => extracting sha256:9d0e0719fbe047cc0770ba9ed1cb150a4ee9bc8a55480eeb8a84a736c8037dbc                                                                                                                    0.1s
 => => extracting sha256:6f063dbd7a5db7835273c913fc420b1082dcda3b5972d75d7478b619da284053                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                                            0.0s
 => => transferring context: 628B                                                                                                                                                                            0.0s
 => [2/5] RUN apk update     && apk upgrade --available     && apk add curl git tzdata bash     && npm install -g npm@latest     && npm install pm2 -g     && mkdir $(echo "/epg") -p     && cd /epg     &  74.8s
 => [3/5] RUN apk del git curl   && rm -rf /var/cache/apk/*                                                                                                                                                  1.5s
 => [4/5] COPY pm2.config.js /epg                                                                                                                                                                            0.1s 
 => [5/5] WORKDIR /epg                                                                                                                                                                                       0.0s 
 => exporting to image                                                                                                                                                                                      15.4s 
 => => exporting layers                                                                                                                                                                                     15.4s 
 => => writing image sha256:b9e86367954c51d3b0105bea3e5bfcc5ce858afe1b35e4ddbd2d42260a8b221b                                                                                                                 0.0s 
 => => naming to docker.io/iptv-org/epg                                                                                                                                                                      0.0s 
```

Test run (using `SITE` and `CLANG` variables):

```sh
docker run -p 3000:3000 -e SITE=allente.dk -e CLANG=sv iptv-org/epg
2025-04-07T07:48:51: PM2 log: Launching in no daemon mode
2025-04-07T07:48:51: PM2 log: App [serve:0] starting in -fork mode-
2025-04-07T07:48:51: PM2 log: App [grab:1] starting in -fork mode-
2025-04-07T07:48:51: PM2 log: App [serve:0] online
2025-04-07T07:48:51: PM2 log: App [grab:1] online
> grab
> npx tsx scripts/commands/epg/grab.ts --site=allente.dk --lang=sv --output=public/guide.xml
 INFO  Accepting connections at http://localhost:3000
starting...
config:
  output: public/guide.xml
  maxConnections: 1
  gzip: true
  site: allente.dk
  lang: sv
  days: NaN
loading channels...
  found 1 channel(s)
run:
  [1/2] allente.dk (sv) - TV4.se - Apr 7, 2025 (15 programs)
  [2/2] allente.dk (sv) - TV4.se - Apr 8, 2025 (19 programs)
  saving to "public/guide.xml"...
  saving to "public/guide.xml.gz"...
  done in 00h 00m 01s
2025-04-07T07:48:55: PM2 log: App [grab:1] exited with code [0] via signal [SIGINT]
 HTTP  4/7/2025 7:49:15 AM 172.17.0.1 GET /guide.xml
 HTTP  4/7/2025 7:49:15 AM 172.17.0.1 Returned 200 in 49 ms
```

Test run (using custom channel list):

```sh
docker run -p 3000:3000 -v /Users/freea/epg/channels.xml:/epg/channels.xml iptv-org/epg
2025-04-07T07:51:08: PM2 log: Launching in no daemon mode
2025-04-07T07:51:08: PM2 log: App [serve:0] starting in -fork mode-
2025-04-07T07:51:08: PM2 log: App [grab:1] starting in -fork mode-
2025-04-07T07:51:08: PM2 log: App [serve:0] online
2025-04-07T07:51:08: PM2 log: App [grab:1] online
> grab
> npx tsx scripts/commands/epg/grab.ts --channels=channels.xml --output=public/guide.xml
 INFO  Accepting connections at http://localhost:3000
starting...
config:
  output: public/guide.xml
  maxConnections: 1
  gzip: true
  channels: channels.xml
  days: NaN
loading channels...
  found 1 channel(s)
run:
  [1/1] chada.ma (fr) - ChadaTV.ma - Apr 7, 2025 (9 programs)
  saving to "public/guide.xml"...
  saving to "public/guide.xml.gz"...
  done in 00h 00m 04s
2025-04-07T07:51:16: PM2 log: App [grab:1] exited with code [0] via signal [SIGINT]
 HTTP  4/7/2025 7:51:26 AM 172.17.0.1 GET /guide.xml
 HTTP  4/7/2025 7:51:26 AM 172.17.0.1 Returned 200 in 48 ms
```