### PR TITLE
Update mi.tv.config.js

### DIFF
--- a/sites/mi.tv/mi.tv.config.js
+++ b/sites/mi.tv/mi.tv.config.js
@@ -6,12 +6,21 @@ const customParseFormat = require('dayjs/plugin/customParseFormat')
 dayjs.extend(utc)
 dayjs.extend(customParseFormat)
 
+const headers = {
+  "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+  "accept-language": "en",
+  "sec-fetch-site": "same-origin",
+  "sec-fetch-user": "?1",
+  "upgrade-insecure-requests": "1",
+  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+}
+
 module.exports = {
   site: 'mi.tv',
   days: 2,
+  request: { headers },
   url({ date, channel }) {
     const [country, id] = channel.site_id.split('#')
-
     return `https://mi.tv/${country}/async/channel/${id}/${date.format('YYYY-MM-DD')}/0`
   },
   parser({ content, date }) {


### PR DESCRIPTION
Fixes #2785

```js
npm test --- mi.tv

> test
> run-script-os mi.tv


> test:win32
> SET "TZ=Pacific/Nauru" && npx jest --runInBand mi.tv

 PASS  sites/mi.tv/mi.tv.test.js
  √ can generate valid url (10 ms)
  √ can parse response (52 ms)
  √ can handle empty guide (4 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        2.744 s, estimated 3 s
Ran all test suites matching /mi.tv/i.
```


```js

npm run grab --- --channels=sites/mi.tv/mi.tv_ar.channels.xml

> grab
> npx tsx scripts/commands/epg/grab.ts --channels=sites/mi.tv/mi.tv_ar.channels.xml

starting...
config:
  output: guide.xml
  maxConnections: 1
  gzip: false
  channels: sites/mi.tv/mi.tv_ar.channels.xml
loading channels...
  found 210 channel(s)
run:
  [1/420] mi.tv (es) - ar#axn - Jun 24, 2025 (26 programs)
  [2/420] mi.tv (es) - ar#axn - Jun 25, 2025 (26 programs)
  [3/420] mi.tv (es) - ar#boomerang-cartoon - Jun 25, 2025 (146 programs)
  [4/420] mi.tv (es) - ar#cinemax-sur - Jun 25, 2025 (15 programs)
  [5/420] mi.tv (es) - ar#disney-xd - Jun 25, 2025 (0 programs)
  [6/420] mi.tv (es) - ar#disney-xd - Jun 24, 2025 (0 programs)
  [7/420] mi.tv (es) - ar#cinemax-sur - Jun 24, 2025 (18 programs)
  [8/420] mi.tv (es) - ar#disney-jr - Jun 25, 2025 (59 programs)
  [9/420] mi.tv (es) - ar#disney-jr - Jun 24, 2025 (62 programs)
  [10/420] mi.tv (es) - ar#boomerang-cartoon - Jun 24, 2025 (150 programs)
  [11/420] mi.tv (es) - ar#canal-7-hd - Jun 25, 2025 (16 programs)
  [12/420] mi.tv (es) - ar#discovery-hd-charvz - Jun 25, 2025 (25 programs)
  [13/420] mi.tv (es) - ar#discovery-hd-charvz - Jun 24, 2025 (29 programs)
  [14/420] mi.tv (es) - ar#canal-7-hd - Jun 24, 2025 (16 programs)

```