### PR TITLE
fix(docker): updated `pm2` environment variable name for `CRON_SCHEDULE`

### DIFF
--- a/pm2.config.js
+++ b/pm2.config.js
@@ -14,7 +14,7 @@ module.exports = {
             process.env.CLANG ? `--lang=${process.env.CLANG}` : ''
           } --output=public/guide.xml`
         : 'npm run grab -- --channels=channels.xml --output=public/guide.xml',
-      cron_restart: process.env.CRON || null,
+      cron_restart: process.env.CRON_SCHEDULE || null,
       instances: 1,
       watch: false,
       autorestart: false


### PR DESCRIPTION
Running docker on a crontab schedule is currently not working.

Both the `docs` and the `Dockerfile` reference the crontab env var as `CRON_SCHEDULE` but the `pm2.config.js` is referncing it as `CRON`. Updated `pm2.config.js` to `CRON_SCHEDULE` fixed the issue