### PR TITLE
Patch 2025.07.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,12 +1103,11 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
-      "license": "Apache-2.0",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -11156,11 +11155,11 @@
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="
     },
     "@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "requires": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       }
     },

--- a/scripts/commands/channels/validate.ts
+++ b/scripts/commands/channels/validate.ts
@@ -32,6 +32,7 @@ async function main() {
 
   let totalFiles = 0
   let totalErrors = 0
+  let totalWarnings = 0
 
   const storage = new Storage()
   const files = program.args.length ? program.args : await storage.list('sites/**/*.channels.xml')
@@ -63,14 +64,14 @@ async function main() {
       const foundChannel = channelsKeyById.get(channelId)
       if (!foundChannel) {
         errors.push({ type: 'wrong_channel_id', ...channel })
-        totalErrors++
+        totalWarnings++
       }
 
       if (feedId) {
         const foundFeed = feedsKeyByStreamId.get(channel.xmltv_id)
         if (!foundFeed) {
           errors.push({ type: 'wrong_feed_id', ...channel })
-          totalErrors++
+          totalWarnings++
         }
       }
     })
@@ -83,8 +84,13 @@ async function main() {
     }
   }
 
-  if (totalErrors > 0) {
-    console.log(chalk.red(`${totalErrors} error(s) in ${totalFiles} file(s)`))
+  const totalProblems = totalWarnings + totalErrors
+  if (totalProblems > 0) {
+    console.log(
+      chalk.red(
+        `${totalProblems} problems (${totalErrors} errors, ${totalWarnings} warnings) in ${totalFiles} file(s)`
+      )
+    )
     process.exit(1)
   }
 }

--- a/scripts/commands/channels/validate.ts
+++ b/scripts/commands/channels/validate.ts
@@ -91,7 +91,9 @@ async function main() {
         `${totalProblems} problems (${totalErrors} errors, ${totalWarnings} warnings) in ${totalFiles} file(s)`
       )
     )
-    process.exit(1)
+    if (totalErrors > 0) {
+      process.exit(1)
+    }
   }
 }
 

--- a/tests/commands/channels/validate.test.ts
+++ b/tests/commands/channels/validate.test.ts
@@ -29,14 +29,9 @@ describe('channels:validate', () => {
   })
 
   it('will show a message if the file contains a channel with wrong channel id', () => {
-    try {
-      const cmd = `${ENV_VAR} npm run channels:validate --- tests/__data__/input/channels_validate/wrong_channel_id.channels.xml`
-      const stdout = execSync(cmd, { encoding: 'utf8' })
-      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
-      process.exit(1)
-    } catch (error) {
-      expect((error as ExecError).status).toBe(1)
-      expect((error as ExecError).stdout).toContain(`
+    const cmd = `${ENV_VAR} npm run channels:validate --- tests/__data__/input/channels_validate/wrong_channel_id.channels.xml`
+    const stdout = execSync(cmd, { encoding: 'utf8' })
+    expect(stdout).toContain(`
 ┌─────────┬────────────────────┬──────┬────────────────────┬─────────┬─────────────────────┐
 │ (index) │ type               │ lang │ xmltv_id           │ site_id │ name                │
 ├─────────┼────────────────────┼──────┼────────────────────┼─────────┼─────────────────────┤
@@ -45,18 +40,12 @@ describe('channels:validate', () => {
 
 1 problems (0 errors, 1 warnings) in 1 file(s)
 `)
-    }
   })
 
   it('will show a message if the file contains a channel with wrong feed id', () => {
-    try {
-      const cmd = `${ENV_VAR} npm run channels:validate --- tests/__data__/input/channels_validate/wrong_feed_id.channels.xml`
-      const stdout = execSync(cmd, { encoding: 'utf8' })
-      if (process.env.DEBUG === 'true') console.log(cmd, stdout)
-      process.exit(1)
-    } catch (error) {
-      expect((error as ExecError).status).toBe(1)
-      expect((error as ExecError).stdout).toContain(`
+    const cmd = `${ENV_VAR} npm run channels:validate --- tests/__data__/input/channels_validate/wrong_feed_id.channels.xml`
+    const stdout = execSync(cmd, { encoding: 'utf8' })
+    expect(stdout).toContain(`
 ┌─────────┬─────────────────┬──────┬─────────────────┬─────────┬─────────┐
 │ (index) │ type            │ lang │ xmltv_id        │ site_id │ name    │
 ├─────────┼─────────────────┼──────┼─────────────────┼─────────┼─────────┤
@@ -65,6 +54,5 @@ describe('channels:validate', () => {
 
 1 problems (0 errors, 1 warnings) in 1 file(s)
 `)
-    }
   })
 })

--- a/tests/commands/channels/validate.test.ts
+++ b/tests/commands/channels/validate.test.ts
@@ -23,7 +23,7 @@ describe('channels:validate', () => {
 │ 0       │ 'duplicate' │ 'en' │ 'Bravo.us@East' │ '140'   │ 'Bravo' │
 └─────────┴─────────────┴──────┴─────────────────┴─────────┴─────────┘
 
-1 error(s) in 1 file(s)
+1 problems (1 errors, 0 warnings) in 1 file(s)
 `)
     }
   })
@@ -43,7 +43,7 @@ describe('channels:validate', () => {
 │ 0       │ 'wrong_channel_id' │ 'en' │ 'CNNInternational' │ '140'   │ 'CNN International' │
 └─────────┴────────────────────┴──────┴────────────────────┴─────────┴─────────────────────┘
 
-1 error(s) in 1 file(s)
+1 problems (0 errors, 1 warnings) in 1 file(s)
 `)
     }
   })
@@ -63,7 +63,7 @@ describe('channels:validate', () => {
 │ 0       │ 'wrong_feed_id' │ 'en' │ 'Bravo.us@West' │ '150'   │ 'Bravo' │
 └─────────┴─────────────────┴──────┴─────────────────┴─────────┴─────────┘
 
-1 error(s) in 1 file(s)
+1 problems (0 errors, 1 warnings) in 1 file(s)
 `)
     }
   })


### PR DESCRIPTION
Incorrect channel or feed ID now displays a warning instead of an error in `channels:validate`.

This should prevent PR from being blocked by unrelated changes in the database (For example: https://github.com/iptv-org/epg/actions/runs/16557637513/job/46821539062?pr=2810).

Test results:

```sh
npm test --- commands

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand commands

 PASS  tests/commands/epg/grab.test.ts (17.865 s)
 PASS  tests/commands/channels/lint.test.ts (7.469 s)
 PASS  tests/commands/channels/validate.test.ts
 PASS  tests/commands/channels/edit.test.ts
 PASS  tests/commands/sites/update.test.ts
 PASS  tests/commands/api/generate.test.ts
 PASS  tests/commands/channels/parse.test.ts
 PASS  tests/commands/sites/init.test.ts

Test Suites: 8 passed, 8 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        38.22 s
Ran all test suites matching commands.
```