### PR TITLE
[tvplus.com.tr] simplify & fix channel grab

### DIFF
--- a/sites/tvplus.com.tr/tvplus.com.tr.channels.xml
+++ b/sites/tvplus.com.tr/tvplus.com.tr.channels.xml
@@ -1,146 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="blutv-play-1/4300">BluTV Play 1</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="blutv-play-2/4302">BluTV Play 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="ekol-tv/4355">EKOL TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="gzt-tv/4461">GZT TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="kibris-ada-tv/67">KIBRIS ADA TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tabii-spor/4399">tabii spor</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tabii-tv/4400">tabii TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="trt-eba/2300">TRT EBA</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tv-2020/4301">TV 2020</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="24TV.tr" site_id="24-hd/32">24</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="360.tr" site_id="360-hd/86">360</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="A2TV.tr" site_id="a2-hd/2">A2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AHaber.tr" site_id="a-haber-hd/160">A HABER</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AkitTV.tr" site_id="akit-tv-hd/13">AKİT TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AlJazeera.qa" site_id="al-jazeera-arabic-hd/140">AL JAZEERA ARABIC</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AlJazeera.qa@English" site_id="al-jazeera-english/6">AL JAZEERA ENGLISH</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ANews.tr" site_id="a-news-hd/101">A NEWS</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="APara.tr" site_id="a-para-hd/79">A PARA</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ASpor.tr" site_id="a-spor-hd/3">A SPOR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ATV.tr" site_id="atv-hd/124">ATV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BabyTV.uk" site_id="babytv/29">BABYTV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BBCNews.uk" site_id="bbc-news/4460">BBC News</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BenguturkTV.tr" site_id="benguturk/47">BENGÜTÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BeyazTV.tr" site_id="beyaz-tv-hd/135">BEYAZ TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BizimevTV.tr" site_id="bizim-ev-tv/118">BİZİM EV TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BloombergHT.tr" site_id="bloomberg-ht-hd/96">BLOOMBERG HT</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BloombergTV.us@Europe" site_id="bloomberg/4459">Bloomberg</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BRT1.cy" site_id="brt-1-hd/133">BRT 1</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BRT2.cy" site_id="brt-2-hd/203">BRT 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Cartoonito.uk" site_id="cartoonito/4279">CARTOONITO</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CartoonNetwork.tr" site_id="cartoon-network/20">CARTOON NETWORK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CiftciTV.tr" site_id="ciftci-tv/2279">ÇİFTÇİ TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNBCEurope.uk" site_id="cnbce/4362">CNBC-E</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNNInternational.us@MENA" site_id="cnn-international/4454">CNN International</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNNTurk.tr" site_id="cnn-turk-hd/158">CNN TÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DaVinci.de" site_id="da-vinci-hd/208">DA VINCI</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DiscoveryChannel.tr" site_id="discovery-channel-hd/8">DISCOVERY CHANNEL</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DisneyJr.tr" site_id="disney-junior/149">DISNEY JUNIOR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DiyanetTV.tr" site_id="diyanet-tv/175">DİYANET TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DMAX.tr" site_id="dmax-hd/180">DMAX</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DreamTurk.tr" site_id="dream-turk/153">DREAM TÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ducktv.sk" site_id="duck-tv-hd/37">DUCK TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DW.de@English" site_id="deutsche-welle-english/94">DEUTSCHE WELLE ENGLISH</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Ekoturk.tr" site_id="ekoturk-hd/100">EKOTÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EnglishClubTV.uk" site_id="english-club-tv/107">ENGLISH CLUB TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EpicDrama.uk@Sweden" site_id="epic-drama/167">EPIC DRAMA</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EuronewsEnglish.fr" site_id="euronews/171">EURONEWS</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Eurosport1.fr" site_id="eurosport-1-hd/77">EUROSPORT 1</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Eurosport2.fr" site_id="eurosport-2-hd/106">EUROSPORT 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FBTV.tr" site_id="fb-tv/148">FB TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FlashTV.tr" site_id="flash-tv/2979">FLASH TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FMTV.tr" site_id="fm-tv/163">FM TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="France24.fr@Arabic" site_id="france-24-arabic/161">FRANCE 24 ARABIC</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="France24.fr@English" site_id="france-24-english/16">FRANCE 24 ENGLISH</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FX.us" site_id="fx-hd/131">FX</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HaberGlobal.tr" site_id="haber-global-hd/5">HABER GLOBAL</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HaberturkTV.tr" site_id="haberturk-hd/87">HABERTÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HalkTV.tr" site_id="halk-tv/91">HALK TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HTSporTV.tr" site_id="ht-spor/4396">HT SPOR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KadirgaTV.tr" site_id="kadirga-tv/110">KADIRGA TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal7.tr" site_id="kanal-7-hd/90">KANAL 7</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal23.tr" site_id="kanal-23/2359">KANAL 23</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal26.tr" site_id="kanal-26/143">KANAL 26</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal33.tr" site_id="kanal-33/146">KANAL 33</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KanalD.tr" site_id="kanal-d-hd/88">KANAL D</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KanalV.tr" site_id="kanal-v/114">KANAL V</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisGencTV.cy" site_id="kibris-genc-tv/112">KIBRIS GENC TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisKanalT.cy" site_id="kanal-t/42">KANAL T</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisTV.cy" site_id="kibris-tv/113">KIBRIS TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KonTV.tr" site_id="kontv-hd/63">KONTV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KRT.tr" site_id="krt-tv/111">KRT TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="LoveNature.ca" site_id="love-nature-hd/45">LOVE NATURE</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MeltemTV.tr" site_id="meltem-tv/138">MELTEM TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MinikaCocuk.tr" site_id="minika-cocuk/102">MİNİKA ÇOCUK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MinikaGo.tr" site_id="minika-go/7">MİNİKA GO</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MoonbugKids.uk" site_id="moonbug-kids-tv/4266">MOONBUG KIDS TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NationalGeographic.tr" site_id="national-geographic-hd/2799">NATIONAL GEOGRAPHIC</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NationalGeographicWild.tr" site_id="national-geographic-wild-hd/139">NATIONAL GEOGRAPHIC WILD</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NBATV.us" site_id="nba-tv-hd/18">NBA TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NickJr.tr" site_id="nick-jr/4353">Nick JR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Nicktoons.tr" site_id="nicktoons/2739">NICKTOONS</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NOWTV.tr" site_id="now/93">NOW</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NTV.tr" site_id="ntv-hd/81">NTV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1Damar.tr" site_id="nr1-damar-hd/41">NR1 DAMAR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1Turk.tr" site_id="number1-turk-hd/98">NUMBER1 TURK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1TV.tr" site_id="number1-tv-hd/204">NUMBER1 TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="On6.tr" site_id="on6/169">ON6</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="PowerTurkTV.tr" site_id="power-turk-hd/202">POWER TURK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="PowerTV.tr" site_id="power-tv-hd/172">POWER TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SemerkandTV.tr" site_id="semerkand-hd/97">SEMERKAND</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ShowTV.tr" site_id="show-tv-hd/130">SHOW TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema2.tr" site_id="sinema-tv-2-hd/199">SİNEMA TV 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema1001.tr" site_id="sinema-tv-1001-hd/181">SİNEMA TV 1001</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema1002.tr" site_id="sinema-1002-hd/190">SİNEMA 1002</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAile2.tr" site_id="sinema-aile-2-hd/182">SİNEMA AİLE 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAile.tr" site_id="sinema-aile-hd/155">SİNEMA AİLE</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAksiyon2.tr" site_id="sinema-aksiyon-2-hd/196">SİNEMA AKSİYON 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAksiyon.tr" site_id="sinema-tv-aksiyon-hd/129">SİNEMA TV AKSİYON</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaKomedi.tr" site_id="sinema-komedi-hd/154">SİNEMA KOMEDİ</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaTV.tr" site_id="sinema-tv-hd/166">SİNEMA TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaYerli2.tr" site_id="sinema-yerli-2-hd/61">SİNEMA YERLİ 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaYerli.tr" site_id="sinema-yerli-hd/12">SİNEMA YERLİ</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SkyNewsArabia.ae" site_id="sky-news-arabia/142">SKY NEWS ARABIA</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SozcuTV.tr" site_id="sozcu-tv/4294">SÖZCÜ TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SportsTV.tr" site_id="sports-tv-hd/173">SPORTS TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SSport2.tr" site_id="s-sport-2/170">S SPORT 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SSport.tr" site_id="s-sport/11">S SPORT</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="StarTV.tr" site_id="star-tv-hd/89">STAR TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TarihTV.tr" site_id="tarih-tv/4253">TARIH TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TarimTV.tr" site_id="tarim-tv/141">TARIM TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Tele1.tr" site_id="tele1/189">TELE1</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Teve2.tr" site_id="teve2-hd/95">TEVE2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TGRTHaber.tr" site_id="tgrt-haber-hd/34">TGRT HABER</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TLC.tr" site_id="tlc/174">TLC</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TMB.tr" site_id="tmb-tv/2280">TMB TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT1.tr" site_id="trt1-hd/144">TRT1</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT2.tr" site_id="trt-2-hd/83">TRT 2</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT3.tr" site_id="trt-3/116">TRT 3</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTArabi.tr" site_id="trt-arabi/76">TRT ARABI</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTAvaz.tr" site_id="trt-avaz/193">TRT AVAZ</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTBelgesel.tr" site_id="trt-belgesel-hd/21">TRT BELGESEL</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTCocuk.tr" site_id="trt-cocuk-hd/99">TRT ÇOCUK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTDiyanetCocuk.tr" site_id="trt-diyanet-cocuk/4319">TRT DIYANET COCUK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTHaber.tr" site_id="trt-haber-hd/30">TRT HABER</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTKurdi.tr" site_id="trt-kurdi/10">TRT KURDİ</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTMuzik.tr" site_id="trt-muzik/159">TRT MÜZİK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTSpor.tr" site_id="trt-spor-hd/31">TRT SPOR</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTSporYildiz.tr" site_id="trt-spor-yildiz/205">TRT SPOR YILDIZ</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTTurk.tr" site_id="trt-turk/156">TRT TÜRK</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTWorld.tr" site_id="trt-world-hd/38">TRT World</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TurkHaberTV.tr" site_id="turkhaber/4335">TURKHABER</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV4.tr" site_id="tv-4/2899">TV 4</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV5.tr" site_id="tv5/4359">TV5</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV5MondeEurope.fr" site_id="tv5-monde/36">TV5 MONDE</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV8.tr" site_id="tv8-hd/134">TV8</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV85.tr" site_id="tv85-hd/188">TV8,5</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV100.tr" site_id="tv100/179">TV100</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TVNET.tr" site_id="tvnet-hd/92">TVNET</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="UlkeTV.tr" site_id="ulke-tv-hd/145">ÜLKE TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="UlusalKanal.tr" site_id="ulusal-kanal/2240">ULUSAL KANAL</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="VavTV.tr" site_id="vav-tv/2859">VAV TV</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ViasatExplore.tr" site_id="viasat-explore/59">VIASAT EXPLORE</channel>
-  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ViasatHistory.tr" site_id="viasat-history-hd/44">VIASAT HISTORY</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="ekol-tv/4355" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/42/2119213578445eb78424_op_0_XL.webp">EKOL TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="somine-plus/2200" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202003/20200327/20200327085123135wqx_op_0_XL.png">ŞÖMİNE PLUS</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tabii-spor/4399" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/24/1010072941195eb7f426_op_0_XL.webp">tabii spor</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tabii-tv/4400" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/94/1009257324535eb9542c_op_0_XL.webp">tabii TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tv-2020/4301" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/77/1026179261295eb7f426_op_0_XL.webp">TV 2020</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="" site_id="tv-info/177" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202503/20250329/18/2043262475375eb7f426_op_0_XL.png">TV+ Info</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="24TV.tr" site_id="24/32" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/38/2121454663735eb8f42a_op_0_XL.webp">24</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="360.tr" site_id="360/86" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/45/0909261639285eb88428_op_0_XL.webp">360</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="A2TV.tr" site_id="a2/2" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/1/0914264009815eb8f42a_op_0_XL.webp">A2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AdaTV.cy" site_id="kibris-ada-tv/67" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/68/0818385552045eb9542c_op_0_XL.webp">KIBRIS ADA TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AHaber.tr" site_id="a-haber/160" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/78/0910272687595eb78424_op_0_XL.webp">A HABER</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AkitTV.tr" site_id="akit-tv/13" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/14/2121266488455eb78424_op_0_XL.webp">AKİT TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AlJazeera.qa" site_id="al-jazeera-arabic/140" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/58/0819428388165eb88428_op_0_XL.webp">AL JAZEERA ARABIC</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="AlJazeera.qa@English" site_id="al-jazeera-english/6" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/71/0820434232935eb7f426_op_0_XL.webp">AL JAZEERA ENGLISH</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ANews.tr" site_id="a-news/101" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/52/0911261163695eb9542c_op_0_XL.webp">A NEWS</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="APara.tr" site_id="a-para/79" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/87/0912202162025eb7f426_op_0_XL.webp">A PARA</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ASpor.tr" site_id="a-spor/3" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/97/0913405847615eb78424_op_0_XL.webp">A SPOR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ASTV.tr" site_id="as-tv/4466" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/43/0915190429835eb8f42a_op_0_XL.webp">AS TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ATV.tr" site_id="atv/124" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/71/0916028009315eb88428_op_0_XL.webp">ATV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BabyTV.uk" site_id="babytv/29" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/96/0916453279325eb88428_op_0_XL.webp">BABYTV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BBCNews.uk" site_id="bbc-news/4460" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202411/20241127/10/1907261733715eb8f42a_op_0_XL.png">BBC News</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BenguturkTV.tr" site_id="benguturk/47" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/15/2122541200635eb9542c_op_0_XL.webp">BENGÜTÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BeyazTV.tr" site_id="beyaz-tv/135" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/53/2113355458665eb9b42e_op_0_XL.webp">BEYAZ TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BizimevTV.tr" site_id="bizim-ev-tv/118" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/91/2117080969825eb88428_op_0_XL.webp">BİZİM EV TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BloombergHT.tr" site_id="bloomberg-ht/96" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/89/0918582099855eb8f42a_op_0_XL.webp">BLOOMBERG HT</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BloombergTV.us@Europe" site_id="bloomberg/4459" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/2/0918173833795eb9b42e_op_0_XL.webp">Bloomberg</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BluTVPlay1.tr" site_id="blutv-play-1/4300" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/62/0919583039865eb8f42a_op_0_XL.webp">BluTV Play 1</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BluTVPlay2.tr" site_id="blutv-play-2/4302" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/23/0920366513735eb9542c_op_0_XL.webp">BluTV Play 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BRT1.cy" site_id="brt-1/133" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/15/0821315646215eb78424_op_0_XL.webp">BRT 1</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="BRT2.cy" site_id="brt-2/203" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/84/0823388142255eb9b42e_op_0_XL.webp">BRT 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Cartoonito.uk" site_id="cartoonito/4279" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/64/0922254149885eb8f42a_op_0_XL.webp">CARTOONITO</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CartoonNetwork.tr" site_id="cartoon-network/20" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/15/0921355543825eb9b42e_op_0_XL.webp">CARTOON NETWORK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CiftciTV.tr" site_id="ciftci-tv/2279" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/34/1051257598535eb78424_op_0_XL.webp">ÇİFTÇİ TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNBCEurope.uk" site_id="cnbc-e/4362" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/56/2111144680585eb9542c_op_0_XL.webp">CNBC-E</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNNInternational.us@MENA" site_id="cnn-international/4454" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/87/0923191703835eb9b42e_op_0_XL.webp">CNN International</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="CNNTurk.tr" site_id="cnn-turk/158" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/60/0924025077665eb78424_op_0_XL.webp">CNN TÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DaVinci.de" site_id="da-vinci/208" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/98/1054078408545eb78424_op_0_XL.webp">DA VINCI</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DiscoveryChannel.tr" site_id="discovery-channel/8" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/10/0926268422105eb7f426_op_0_XL.webp">DISCOVERY CHANNEL</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DisneyJr.tr" site_id="disney-junior/149" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250624/88/1037336465695eb9542c_op_0_XL.webp">DISNEY JUNIOR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DiyanetTV.tr" site_id="diyanet-tv/175" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/70/0927578653785eb9542c_op_0_XL.webp">DİYANET TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DMAX.tr" site_id="dmax/180" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/14/0929073243795eb9542c_op_0_XL.webp">DMAX</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DreamTurk.tr" site_id="dream-turk/153" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/43/1057170303285eb7f426_op_0_XL.webp">DREAM TÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ducktv.sk" site_id="duck-tv/37" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/63/1058038718565eb78424_op_0_XL.webp">DUCK TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="DW.de@English" site_id="deutsche-welle-english/94" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/98/1056125708555eb78424_op_0_XL.webp">DEUTSCHE WELLE ENGLISH</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Ekoturk.tr" site_id="ekoturk/100" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/52/2116555980605eb9542c_op_0_XL.webp">EKOTÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EnglishClubTV.uk" site_id="english-club-tv/107" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/2/1058469624635eb9542c_op_0_XL.webp">ENGLISH CLUB TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EpicDrama.uk@Sweden" site_id="epic-drama/167" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/73/0930179339405eb88428_op_0_XL.webp">EPIC DRAMA</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="EuronewsEnglish.fr" site_id="euronews/171" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/71/1108497213305eb7f426_op_0_XL.webp">EURONEWS</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Eurosport1.fr" site_id="eurosport-1/77" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/40/0931177763815eb9542c_op_0_XL.webp">EUROSPORT 1</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Eurosport2.fr" site_id="eurosport-2/106" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/35/0932019372255eb7f426_op_0_XL.webp">EUROSPORT 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FBTV.tr" site_id="fb-tv/148" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/26/1110480969645eb88428_op_0_XL.webp">FB TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FlashHaberTV.tr" site_id="flash-haber/2979" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/18/1157538350925eb78424_op_0_XL.png">FLASH HABER</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FMTV.tr" site_id="fm-tv/163" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/39/1111559559655eb88428_op_0_XL.webp">FM TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="France24.fr@Arabic" site_id="france-24-arabic/161" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/0/1112466594665eb9542c_op_0_XL.webp">FRANCE 24 ARABIC</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="France24.fr@English" site_id="france-24-english/16" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/40/1113421345165eb8f42a_op_0_XL.webp">FRANCE 24 ENGLISH</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="FX.tr" site_id="fx/131" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/52/0932479388255eb78424_op_0_XL.webp">FX</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="GZT.tr" site_id="gzt-tv/4461" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/80/0934306822275eb7f426_op_0_XL.webp">GZT TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HaberGlobal.tr" site_id="haber-global/5" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202507/20250704/34/1109555471285eb88428_op_0_XL.png">HABER GLOBAL</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HaberturkTV.tr" site_id="haberturk/87" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/27/0935195248285eb78424_op_0_XL.webp">HABERTÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HalkTV.tr" site_id="halk-tv/91" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/57/2112191538425eb78424_op_0_XL.webp">HALK TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="HTSporTV.tr" site_id="ht-spor/4396" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/58/0936073763845eb9542c_op_0_XL.webp">HT SPOR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KadirgaTV.tr" site_id="kadirga-tv/110" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/18/1116313949665eb88428_op_0_XL.webp">KADIRGA TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal7.tr" site_id="kanal-7/90" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/7/2112241317575eb7f426_op_0_XL.webp">KANAL 7</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal23.tr" site_id="kanal-23/2359" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/45/2121305491855eb9542c_op_0_XL.webp">KANAL 23</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal26.tr" site_id="kanal-26/143" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/63/1117501270845eb78424_op_0_XL.webp">KANAL 26</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Kanal33.tr" site_id="kanal-33/146" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250528/34/1114359774675eb9542c_op_0_XL.webp">KANAL 33</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KanalD.tr" site_id="kanal-d/88" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/87/0937065579965eb8f42a_op_0_XL.webp">KANAL D</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KanalV.tr" site_id="kanal-v/114" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/66/2118544642045eb7f426_op_0_XL.webp">KANAL V</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisGencTV.cy" site_id="kibris-genc-tv/112" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/69/2122339446995eb9b42e_op_0_XL.webp">KIBRIS GENC TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisKanalT.cy" site_id="kanal-t/42" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/3/2117410647765eb88428_op_0_XL.webp">KANAL T</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KibrisTV.cy" site_id="kibris-tv/113" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/23/2123403057805eb88428_op_0_XL.webp">KIBRIS TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KonTV.tr" site_id="kontv/63" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/52/2124482441865eb9542c_op_0_XL.webp">KONTV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="KRT.tr" site_id="krt-tv/111" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/65/2126065527005eb9b42e_op_0_XL.webp">KRT TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="LoveNature.ca" site_id="love-nature/45" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/31/0937564329435eb88428_op_0_XL.webp">LOVE NATURE</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MeltemTV.tr" site_id="meltem-tv/138" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/12/2126585812715eb7f426_op_0_XL.webp">MELTEM TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MinikaCocuk.tr" site_id="minika-cocuk/102" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/81/0940064012305eb7f426_op_0_XL.webp">MİNİKA ÇOCUK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MinikaGo.tr" site_id="minika-go/7" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/44/0939270193905eb9b42e_op_0_XL.webp">MİNİKA GO</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="MoonbugKids.uk" site_id="moonbug-kids-tv/4266" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/42/0941321873925eb9b42e_op_0_XL.webp">MOONBUG KIDS TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NationalGeographic.tr" site_id="national-geographic/2799" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/38/0942210759995eb8f42a_op_0_XL.webp">NATIONAL GEOGRAPHIC</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NationalGeographicWild.tr" site_id="national-geographic-wild/139" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/21/0942554483955eb9b42e_op_0_XL.webp">NATIONAL GEOGRAPHIC WILD</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NBATVInternational.us" site_id="nba-tv/18" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/27/0943415418325eb78424_op_0_XL.webp">NBA TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Nickelodeon.tr" site_id="nickelodeon/4487" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/20/0944434563965eb9b42e_op_0_XL.webp">NICKELODEON</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NickJr.tr" site_id="nick-jr/4353" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/20/0945187882335eb7f426_op_0_XL.webp">Nick JR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Nicktoons.tr" site_id="nicktoons/2739" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/67/0946174419505eb88428_op_0_XL.webp">NICKTOONS</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NOWTV.tr" site_id="now/93" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/82/0947057422345eb7f426_op_0_XL.webp">NOW</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="NTV.tr" site_id="ntv/81" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/36/0947520532355eb7f426_op_0_XL.webp">NTV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1Damar.tr" site_id="nr1-damar/41" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/50/1242091951035eb9542c_op_0_XL.webp">NR1 DAMAR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1Turk.tr" site_id="number1-turk/98" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/95/2128070137985eb9542c_op_0_XL.webp">NUMBER1 TURK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Number1TV.tr" site_id="number1-tv/204" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/11/2128474286475eb8f42a_op_0_XL.webp">NUMBER1 TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="On6.tr" site_id="on6/169" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/51/1055071280965eb88428_op_0_XL.webp">ON6</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="PowerTurkTV.tr" site_id="power-turk/202" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/95/2130277456505eb8f42a_op_0_XL.webp">POWER TURK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="PowerTV.tr" site_id="power-tv/172" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/30/2131106038015eb9542c_op_0_XL.webp">POWER TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SemerkandTV.tr" site_id="semerkand/97" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/95/2131471279245eb9b42e_op_0_XL.webp">SEMERKAND</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ShowTV.tr" site_id="show-tv/130" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/96/0948464043915eb9542c_op_0_XL.webp">SHOW TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema2.tr" site_id="sinema-tv-2/199" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/9/0953500773955eb9542c_op_0_XL.webp">SİNEMA TV 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema1001.tr" site_id="sinema-tv-1001/181" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/8/0952164683935eb9542c_op_0_XL.webp">SİNEMA TV 1001</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Sinema1002.tr" site_id="sinema-1002/190" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/76/0952594953945eb9542c_op_0_XL.webp">SİNEMA 1002</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAile2.tr" site_id="sinema-aile-2/182" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/11/0955122162395eb7f426_op_0_XL.webp">SİNEMA AİLE 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAile.tr" site_id="sinema-aile/155" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/84/0954337290115eb8f42a_op_0_XL.webp">SİNEMA AİLE</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAksiyon2.tr" site_id="sinema-aksiyon-2/196" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/12/0956240722405eb7f426_op_0_XL.webp">SİNEMA AKSİYON 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaAksiyon.tr" site_id="sinema-tv-aksiyon/129" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/15/0955472569555eb88428_op_0_XL.webp">SİNEMA TV AKSİYON</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaKomedi.tr" site_id="sinema-komedi/154" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/2/0957104452425eb7f426_op_0_XL.webp">SİNEMA KOMEDİ</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaTV.tr" site_id="sinema-tv/166" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/0/0959572110155eb8f42a_op_0_XL.webp">SİNEMA TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaYerli2.tr" site_id="sinema-yerli-2/61" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/33/0958538189585eb88428_op_0_XL.webp">SİNEMA YERLİ 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SinemaYerli.tr" site_id="sinema-yerli/12" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/24/0958196154045eb9b42e_op_0_XL.webp">SİNEMA YERLİ</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SkyNewsArabia.ae" site_id="sky-news-arabia/142" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/91/2132258447085eb88428_op_0_XL.webp">SKY NEWS ARABIA</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SozcuTV.tr" site_id="sozcu-tv/4294" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/54/1000562034815eb9b42e_op_0_XL.webp">SÖZCÜ TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SpacetoonTurkey.tr" site_id="spacetoon/4465" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/18/1001382772445eb7f426_op_0_XL.webp">SPACETOON</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SportsTV.tr" site_id="sports-tv/173" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/64/2133190739265eb9b42e_op_0_XL.webp">SPORTS TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SSport2.tr" site_id="s-sport-2/170" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/45/1003073844435eb9542c_op_0_XL.webp">S SPORT 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="SSport.tr" site_id="s-sport/11" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/54/1002317544415eb9542c_op_0_XL.webp">S SPORT</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="StarTV.tr" site_id="star-tv/89" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/64/1003520560175eb8f42a_op_0_XL.webp">STAR TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TarihTV.tr" site_id="tarih-tv/4253" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/65/1010519852495eb8f42a_op_0_XL.webp">TARIH TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TarimTV.tr" site_id="tarim-tv/141" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/86/2134066126545eb8f42a_op_0_XL.webp">TARIM TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Tele1.tr" site_id="tele1/189" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/40/2113584033685eb8f42a_op_0_XL.webp">TELE1</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Teve2.tr" site_id="teve2/95" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/38/1011266014555eb9542c_op_0_XL.webp">TEVE2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TGRTHaber.tr" site_id="tgrt-haber/34" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/48/2119142499835eb88428_op_0_XL.webp">TGRT HABER</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="Tivi6.tr" site_id="tivi6/4481" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/6/1012063131215eb7f426_op_0_XL.webp">TİVİ6</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TLC.tr" site_id="tlc/174" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/19/1012439745095eb78424_op_0_XL.webp">TLC</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TMB.tr" site_id="tmb-tv/2280" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/42/2134458558035eb9542c_op_0_XL.webp">TMB TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT1.tr" site_id="trt1/144" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/6/1025405808145eb9b42e_op_0_XL.webp">TRT1</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT2.tr" site_id="trt-2/83" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/49/1013374195105eb78424_op_0_XL.webp">TRT 2</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRT3.tr" site_id="trt-3/116" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/10/1014401672515eb8f42a_op_0_XL.webp">TRT 3</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTArabi.tr" site_id="trt-arabi/76" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/75/1019317040685eb88428_op_0_XL.webp">TRT ARABI</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTAvaz.tr" site_id="trt-avaz/193" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/94/1016079562535eb8f42a_op_0_XL.webp">TRT AVAZ</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTBelgesel.tr" site_id="trt-belgesel/21" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/64/1016467574585eb9542c_op_0_XL.webp">TRT BELGESEL</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTCocuk.tr" site_id="trt-cocuk/99" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/92/1018103992555eb8f42a_op_0_XL.webp">TRT ÇOCUK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTDiyanetCocuk.tr" site_id="trt-diyanet-cocuk/4319" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/88/1017245920655eb88428_op_0_XL.webp">TRT DIYANET COCUK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTEBA.tr" site_id="trt-eba/2300" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/71/1018448660675eb88428_op_0_XL.webp">TRT EBA</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTHaber.tr" site_id="trt-haber/30" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/0/1020177474605eb9542c_op_0_XL.webp">TRT HABER</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTKurdi.tr" site_id="trt-kurdi/10" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/13/1020562870695eb88428_op_0_XL.webp">TRT KURDİ</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTMuzik.tr" site_id="trt-muzik/159" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/97/1021361684625eb9542c_op_0_XL.webp">TRT MÜZİK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTSpor.tr" site_id="trt-spor/31" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/64/1023220948135eb9b42e_op_0_XL.webp">TRT SPOR</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTSporYildiz.tr" site_id="trt-spor-yildiz/205" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/51/1022338012585eb8f42a_op_0_XL.webp">TRT SPOR YILDIZ</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTTurk.tr" site_id="trt-turk/156" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/4/1024005375155eb78424_op_0_XL.webp">TRT TÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TRTWorld.tr" site_id="trt-world/38" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/77/1024521270725eb88428_op_0_XL.webp">TRT World</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TurkHaberTV.tr" site_id="turkhaber/4335" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/90/2120336993725eb8f42a_op_0_XL.webp">TURKHABER</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV4.tr" site_id="tv-4/2899" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/37/2118109050615eb9542c_op_0_XL.webp">TV 4</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV5.tr" site_id="tv5/4359" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/62/2136158827115eb88428_op_0_XL.webp">TV5</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV5MondeEurope.fr" site_id="tv5-monde/36" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250602/27/2135385748045eb9542c_op_0_XL.webp">TV5 MONDE</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV8.tr" site_id="tv8/134" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/98/1026575965175eb78424_op_0_XL.webp">TV8</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV85.tr" site_id="tv85/188" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/45/1027323438155eb9b42e_op_0_XL.webp">TV8,5</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TV100.tr" site_id="tv100/179" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/2/2114544793695eb8f42a_op_0_XL.webp">TV100</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TVNET.tr" site_id="tvnet/92" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/14/2120155178705eb9b42e_op_0_XL.webp">TVNET</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="TYTTurk.tr" site_id="tyt-turk/4488" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/1/1029375722595eb8f42a_op_0_XL.webp">TYT TÜRK</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="UlkeTV.tr" site_id="ulke-tv/145" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/55/2118084418435eb78424_op_0_XL.webp">ÜLKE TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="UlusalKanal.tr" site_id="ulusal-kanal/2240" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202505/20250514/67/2123485258715eb9b42e_op_0_XL.webp">ULUSAL KANAL</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="VavTV.tr" site_id="vav-tv/2859" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/38/1030132575195eb78424_op_0_XL.webp">VAV TV</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ViasatExplore.tr" site_id="viasat-explore/59" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/42/1031241804645eb9542c_op_0_XL.webp">VIASAT EXPLORE</channel>
+  <channel site="tvplus.com.tr" lang="tr" xmltv_id="ViasatHistory.tr" site_id="viasat-history/44" logo="https://gbzottvsc13.tvplus.com.tr:33207/CPS/images/universal/film/logo/202506/20250623/56/1030552152605eb8f42a_op_0_XL.webp">VIASAT HISTORY</channel>
 </channels>

--- a/sites/tvplus.com.tr/tvplus.com.tr.test.js
+++ b/sites/tvplus.com.tr/tvplus.com.tr.test.js
@@ -14,7 +14,7 @@ jest.mock('axios')
 const date = dayjs.utc('2024-12-15', 'YYYY-MM-DD').startOf('d')
 const channel = {
   lang: 'tr',
-  site_id: 'nick-jr--4353',
+  site_id: 'nick-jr/4353',
   xmltv_id: 'NickJr.tr'
 }
 

--- a/sites/tvplus.com.tr/tvplus.com.tr.test.js
+++ b/sites/tvplus.com.tr/tvplus.com.tr.test.js
@@ -14,7 +14,7 @@ jest.mock('axios')
 const date = dayjs.utc('2024-12-15', 'YYYY-MM-DD').startOf('d')
 const channel = {
   lang: 'tr',
-  site_id: 'nick-jr/4353',
+  site_id: 'nick-jr--4353',
   xmltv_id: 'NickJr.tr'
 }
 


### PR DESCRIPTION
Closes #2816

```
PS D:\GH Repos\epg\epg> npm run grab --- --site=tvplus.com.tr

> grab
> tsx scripts/commands/epg/grab.ts --site=tvplus.com.tr

◐ starting...                                                                                                                                              01:21:55
ℹ config:                                                                                                                                                 01:21:55
output: guide.xml
maxConnections: 1
gzip: false
site: tvplus.com.tr
ℹ loading channels...                                                                                                                                     01:21:55
ℹ   found 150 channel(s)                                                                                                                                  01:21:55
ℹ run:                                                                                                                                                    01:21:55   
ℹ   [1/300] tvplus.com.tr (tr) - ekol-tv/4355 - Jul 28, 2025 (14 programs)                                                                                01:22:05
ℹ   [2/300] tvplus.com.tr (tr) - ekol-tv/4355 - Jul 29, 2025 (13 programs)                                                                                01:22:07
ℹ   [3/300] tvplus.com.tr (tr) - somine-plus/2200 - Jul 29, 2025 (1 programs)                                                                             01:22:11
ℹ   [4/300] tvplus.com.tr (tr) - tabii-tv/4400 - Jul 29, 2025 (19 programs)                                                                               01:22:17
ℹ   [5/300] tvplus.com.tr (tr) - 360.tr - Jul 29, 2025 (17 programs)                                                                                      01:22:22
ℹ   [6/300] tvplus.com.tr (tr) - APara.tr - Jul 29, 2025 (32 programs)                                                                                    01:22:27
PS D:\GH Repos\epg\epg> npm test --- tvplus.com.tr

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand tvplus.com.tr

 PASS  sites/tvplus.com.tr/tvplus.com.tr.test.js
  √ can generate valid url (57 ms)
  √ can parse response (8 ms)                                                                                                                                        
  √ can handle empty guide (1 ms)                                                                                                                                    
                                                                                                                                                                     
Test Suites: 1 passed, 1 total                                                                                                                                       
Tests:       3 passed, 3 total                                                                                                                                       
Snapshots:   0 total
Time:        0.85 s, estimated 1 s
Ran all test suites matching tvplus.com.tr
```