### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,16 +146,16 @@ npm install
 
 ## Docker
 
-### Build an image
+### Pull an image
 
 ```sh
-docker build -t iptv-org/epg --no-cache .
+docker pull ghcr.io/iptv-org/epg:master
 ```
 
 ### Create and run container
 
 ```sh
-docker run -p 3000:3000 -v /path/to/channels.xml:/epg/channels.xml iptv-org/epg
+docker run -p 3000:3000 -v /path/to/channels.xml:/epg/channels.xml ghcr.io/iptv-org/epg:master
 ```
 
 By default, the guide will be downloaded every day at 00:00 UTC and saved to the `/epg/public/guide.xml` file inside the container.
@@ -201,7 +201,7 @@ iptv-org/epg
 | DAYS            | Number of days for which the guide will be loaded (defaults to the value from the site config)                     |
 | TIMEOUT         | Timeout for each request in milliseconds (default: 0)                                                              |
 | DELAY           | Delay between request in milliseconds (default: 0)                                                                 |
-| RUN_AT_STARTUP  | Run grab on container startup (default: true)                                                                 |
+| RUN_AT_STARTUP  | Run grab on container startup (default: true)                                                                      |
 
 ## Database
 


### PR DESCRIPTION
Changes:

- updated instructions for Docker
- replaced line endings with CRLF

Test run:

```sh
docker pull ghcr.io/iptv-org/epg:master
master: Pulling from iptv-org/epg
9824c27679d3: Already exists 
f4c26c8fab28: Pull complete 
8eb1ff6ad740: Pull complete 
568251d7904d: Pull complete 
c17bda8b77b3: Pull complete 
2b1ed83b610e: Pull complete 
d1aa154f3f28: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:88df56e25229d02807e476795d0bc18ec4b3e149573ff23cc6001ff0b3182235
Status: Downloaded newer image for ghcr.io/iptv-org/epg:master
ghcr.io/iptv-org/epg:master
```

```sh
docker run -p 3000:3000 -v /sites/allente.no/allente.no_dk.channels.xml:/epg/channels.xml ghcr.io/iptv-org/epg:master
2025-10-01T10:48:56: PM2 log: Launching in no daemon mode
2025-10-01T10:48:56: PM2 log: App [serve:0] starting in -fork mode-
2025-10-01T10:48:56: PM2 log: App [grab:1] starting in -fork mode-
2025-10-01T10:48:56: PM2 log: App [serve:0] online
2025-10-01T10:48:56: PM2 log: App [grab:1] online
2025-10-01T10:48:56: PM2 log: App [grab-at-startup:2] starting in -fork mode-
2025-10-01T10:48:56: PM2 log: App [grab-at-startup:2] online
> grab
> tsx scripts/commands/epg/grab.ts --channels=channels.xml --output=public/guide.xml
started...
 INFO  Accepting connections at http://localhost:3000
◐ starting...
ℹ config:
output: public/guide.xml
maxConnections: 1
gzip: true
curl: false
channels: channels.xml
days: NaN
ℹ loading channels...
ℹ   found 72 channel(s)
ℹ run:
ℹ   [1/144] allente.no (da) - dk#0016 - Oct 1, 2025 (61 programs)
ℹ   [2/144] allente.no (da) - dk#0016 - Oct 2, 2025 (61 programs)
ℹ   [3/144] allente.no (da) - dk#0028 - Oct 2, 2025 (113 programs)
...
```

Resolves https://github.com/orgs/iptv-org/discussions/1330