### PR TITLE
Update ziggogo.tv.channels.xml - SBS9.nl, ViaplayTV.nl and Veronica.nl

### DIFF
--- a/sites/ziggogo.tv/ziggogo.tv.channels.xml
+++ b/sites/ziggogo.tv/ziggogo.tv.channels.xml
@@ -71,7 +71,7 @@
   <channel site="ziggogo.tv" lang="en" xmltv_id="TV5MondeEurope.fr" site_id="NL_000045_019354">TV5Monde</channel>
   <channel site="ziggogo.tv" lang="en" xmltv_id="UtsavGold.in" site_id="NL_000151_020074">Utsav Gold</channel>
   <channel site="ziggogo.tv" lang="en" xmltv_id="UtsavPlus.uk" site_id="NL_000150_020075">Utsav Plus</channel>
-  <channel site="ziggogo.tv" lang="en" xmltv_id="Veronica.nl" site_id="NL_000008_019442">Veronica / Disney XD</channel>
+  <channel site="ziggogo.tv" lang="en" xmltv_id="Veronica.nl" site_id="NL_000008_019442">Veronica / Disney Jr.</channel>
   <channel site="ziggogo.tv" lang="en" xmltv_id="XMO.nl" site_id="NL_000176_019308">X-MO</channel>
   <channel site="ziggogo.tv" lang="en" xmltv_id="ZeeCinema.in" site_id="NL_000153_020076">Zee Cinema</channel>
   <channel site="ziggogo.tv" lang="en" xmltv_id="ZeeTVUK.uk" site_id="NL_000152_020077">Zee TV</channel>
@@ -154,4 +154,5 @@
   <channel site="ziggogo.tv" lang="tr" xmltv_id="TRTTurk.tr" site_id="NL_000050_019353">TRT Türk</channel>
   <channel site="ziggogo.tv" lang="tr" xmltv_id="TV8int.tr" site_id="NL_000160_019277">TV8 Int.</channel>
 </channels>
+
 


### PR DESCRIPTION
There was some confusion on "SBS9" turning into "Viaplay TV", however they ended up to be 2 separate channels. "Disney XD" changed to "Disney Jr." on its shared channel with "Veronica".