### PR TITLE
tv2go.t-2.net : update

### DIFF
--- a/sites/tv2go.t-2.net/tv2go.t-2.net.channels.xml
+++ b/sites/tv2go.t-2.net/tv2go.t-2.net.channels.xml
@@ -1,338 +1,345 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="14">RTS Maribor</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="17">TV Veseljak Golica</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="26">Discovery Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="110">Hayat Plus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000028">AMC</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000043">History Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000048">History Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000074">Disney Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000080">Folk Plus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000155">Disney Junior</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000181">Alfa TV MAK</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000223">MTV 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000224">Naša TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000267">Alfa TV BiH</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000283">INFO TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000291">Animal Planet</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000302">Nickelodeon</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000470">TV Nakupi</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000477">HBO</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000478">HBO 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000479">HBO 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000480">Cinemax</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000481">Cinemax 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000503">RT Doc</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000505">Discovery Science</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000506">DTX</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000507">ID</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000517">Freedom</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000547">Filmbox Premium</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000615">E!</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000765">Pink Serije</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000766">Pink Koncert</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000767">Pink’n’Roll</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000792">Sonce TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000793">Prva World</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000794">Prva Max</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000795">Happy Reality</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000796">Happy Reality 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000797">Prva Files</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000798">Prva Kick</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000799">Prva Life</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000800">Prva Plus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000801">Adria</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000802">One Adria</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000803">Folx Slovenija</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000807">BBC News</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000808">Dom TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000812">Espreso TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000813">Duck TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000814">Non Stop</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000815">Hit TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000816">Bloomberg Adria</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000817">Arena Sport 1 Premium</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000818">Megafon TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000820">CineStar TV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000821">LH TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000825">English Club TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000826">Harmonika TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000827">GLAM</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000828">XXXTazy</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000829">Angels</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000830">BooB</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000831">Capable Hole</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000832">Devils Home</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000833">Foxy Dolls</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000834">MIxxx</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000835">Prva TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000868">BIR TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000870">KIC TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000871">Kitchen TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000874">Mediaset Italia</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000875">TgCom24</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="2000000001">R Kanal+</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="2000000039">Cartoon Network</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="2000000041">RTV Shqiptar</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="2000000045">Europe by Satellite</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="2000000050">RTV Atlas</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="3sat.de" site_id="1000640">3SAT</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="24Kitchen.us@Slovenia" site_id="1000307">24Kitchen Adria</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="360TuneBox.nl" site_id="1000558">360 Tunebox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="AgroTV.rs" site_id="1000686">Agro TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="AlJazeeraBalkans.ba" site_id="1000180">Al Jazeera Balkans</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Alsat.mk" site_id="1000219">Alsat Macedoniae</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="AMCEurope.uk@Portugal@Slovenia" site_id="1000523">AMC</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="AnixeHDSerie.de" site_id="1000057">Anixe</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaEsport.rs" site_id="1000683">TV Arena Esport</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaFight.rs" site_id="1000777">Arena Fight</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaSport1.rs" site_id="1000688">Arena Sport 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaSport2.rs" site_id="1000689">Arena Sport 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaSport3.rs" site_id="1000787">Arena Sport 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ArenaSport4.rs" site_id="1000788">Arena Sport 4</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="arte.fr" site_id="1000026">Arte</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ATMTV.si" site_id="1000001">ATM Kranjska Gora</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="B92.rs" site_id="1000207">B92</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BabyTV.uk" site_id="82">Baby TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BalkanErotic.si" site_id="1000645">Balkan Erotic</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BalkanikaTV.bg" site_id="2000000027">Balkanika Music TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BalkanTripTV.rs" site_id="1000685">TV Balkan Trip</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BBCEarth.uk@Romania" site_id="1000482">BBC Earth</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BBCFirst.uk@Poland" site_id="1000652">BBC First</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BHT1.ba" site_id="1000182">BHT 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BKTV.si" site_id="1000265">BK TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BN2.ba" site_id="129">BN TV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BNMusic.ba" site_id="1000067">BN Music</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CartoonitoCEE.uk" site_id="2000000032">Cartoonito</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BoomTV.si" site_id="124">Aktual TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="BRIO.si" site_id="1000368">BRIO</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Carousel.ru" site_id="1000273">Karousel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CBSRealityEMEA.uk" site_id="44">CBS Reality</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CGTN.cn" site_id="125">CGTN</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ChannelOne.ru" site_id="1000272">Channel One Russia</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTV1.rs" site_id="1000085">CineStar TV 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTVAction.rs" site_id="1000427">Cinestar Action &amp; Thriller</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTVComedy.hr" site_id="1000617">Cinestar Comedy</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTVFantasy.hr" site_id="1000618">Cinestar Fantasy</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTVPremiere1.hr" site_id="1000431">Cinestar Premiere</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CineStarTVPremiere2.hr" site_id="1000430">Cinestar Premiere 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ClubMTVEurope.uk" site_id="126">Club MTV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CMCTV.hr" site_id="1000156">CMC - Croatian Music Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CNNInternational.us@MENA" site_id="25">CNN International</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="CrimePlusInvestigation.uk" site_id="1000153">Crime &amp; Investigation Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DasErste.de" site_id="1000059">Das Erste (ARD)</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DaVinci.de" site_id="1000055">Da Vinci</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DivaAdria.us" site_id="2000000040">Diva</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DMSat.rs" site_id="2000000026">DM SAT Televizija</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DocuBox.nl" site_id="1000551">Docubox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Domkino.ru" site_id="1000274">Dom Kino</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DorcelXXX.nl" site_id="1000486">Dorcel TV XXX</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Duna.hu" site_id="1000648">Duna</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DunaWorld.hu" site_id="1000786">Duna World</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="DuskTV.nl" site_id="1000373">Dusk</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ELTA2.ba" site_id="1000179">Elta 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ELTA1HD.ba" site_id="1000240">Elta TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="EpicDrama.uk@Sweden" site_id="1000501">Epic Drama</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ePosavjeTV.si" site_id="1000651">ePosavje TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="EroX.nl" site_id="1000559">Erox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="EroXXX.nl" site_id="1000553">Eroxxx</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ETV.si" site_id="1000641">ETV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="EuronewsEnglish.fr" site_id="1000764">Euronews</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Eurosport1.fr@Germany" site_id="1000044">Eurosport (NEM)</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Eurosport1.fr" site_id="1000025">Eurosport</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Eurosport2.fr" site_id="1000504">Eurosport 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Eurosport4K.fr" site_id="1000728">Eurosport</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="EWTN.us@Europe" site_id="36">EWTN Europe</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ExodusTV.si" site_id="1000455">Exodus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Extreme.si" site_id="1000646">Extreme</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ExtremeSportsChannel.nl" site_id="37">Extreme Sports</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FashionBox.nl" site_id="1000556">Fashionbox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FashionTVEurope.fr" site_id="1000056">Fashion TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FastFunBox.nl" site_id="1000552">Fastnfunbox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Federalnatelevizija.ba" site_id="1000183">FTV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FenFolkTV.bg" site_id="1000545">FenFolk TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FenTV.bg" site_id="1000544">FEN TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FightBox.nl" site_id="1000550">Fightbox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FilmBoxArthouse.nl" site_id="1000557">Filmbox Art House</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FilmBoxExtra.nl@Bulgaria" site_id="1000548">Filmbox Extra</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FilmBoxStars.nl@Bulgaria" site_id="1000549">Filmbox Stars</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Fox.rs" site_id="1000308">STAR</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FoxCrime.rs" site_id="1000310">STAR Crime</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FoxLife.rs" site_id="1000309">STAR Life</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FoxMovies.si" site_id="1000311">STAR Movies</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="France2.fr" site_id="1000639">FR2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="France24.fr@English" site_id="1000159">France 24 English</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="France24.fr@French" site_id="1000158">France 24 French</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="FunBoxUHD.nl" site_id="1000521">Funbox</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Gametoon.nl" site_id="1000554">Gametoon</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="GeaTV.si" site_id="1000034">Gea TV Plus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="GOLDTV.si" site_id="1000407">GOLD TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="GolicaTV.si" site_id="2000000056">TV Zlati zvoki</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Happy.rs" site_id="1000209">Happy TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Hayat.ba" site_id="1000236">Hayat</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HayatFolk.ba" site_id="1000284">Hayat Folk</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HemaTV.ba" site_id="1000233">Hema</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HGTVLatinAmerica.us@Panregional" site_id="1000730">HGTV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="History2.pl" site_id="1000619">H2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HotPleasure.si" site_id="1000644">Hot Pleasure</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HotXXL.si" site_id="1000643">Hot XXL</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HRT1.hr" site_id="105">HRT 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HRT2.hr" site_id="106">HRT 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HustlerHD.nl" site_id="1000306">Hustler TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="HustlerTVEurope.nl" site_id="1000018">Hustler TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="JimJamEurope.uk" site_id="1000509">Jim Jam</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000285">Jugoton TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="kabeleins.de" site_id="61">Kabel 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Kanal5.mk" site_id="1000268">Kanal 5</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="KanalA.si" site_id="1000370">Kanal A</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Kanali7.al" site_id="1000174">Tring 7</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="KINO.si" site_id="1000366">KINO</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Klasik.hr" site_id="1000154">Klasik</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="KoroskaTV.si" site_id="1000474">Koroška TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="M1.hu" site_id="1000647">M1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="M2.hu" site_id="1000050">M2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="M5.hu" site_id="1000650">M5</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Mezzo.fr" site_id="91">Mezzo</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MezzoLive.fr" site_id="1000518">Mezzo Live</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MilfTV.si" site_id="1000491">Milf TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MinimaxCEE.cz" site_id="1000262">Minimax</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MrezaTV.hr" site_id="1000193">Mreža TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MRT1.mk" site_id="1000222">MTV 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MRT2.mk" site_id="1000199">MTV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTV00s.uk" site_id="50">MTV 00s</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTV80s.uk" site_id="51">MTV 80s</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTV90s.uk" site_id="136">MTV 90s</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTVGlobal.uk" site_id="1000496">MTV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTVHitsEurope.uk" site_id="127">MTV Hits</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MTVLive.uk" site_id="1000497">MTV Live</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="MuzykaPervogo.ru" site_id="1000275">Muzika Pervogo</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NarodnaTV.rs" site_id="1000269">Narodna TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NationalGeographic.si" site_id="1000049">National Geographic</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NationalGeographicWild.si" site_id="1000167">National Geographic Wild</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NetTV.si" site_id="12">Net TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NetXXL.si" site_id="1000228">Net XXL</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NHKWorldJapan.jp" site_id="1000102">NHK World</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Nickelodeon.si" site_id="1000301">Nickelodeon</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NickJr.si" site_id="1000426">Nick JR</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Nova24TV2.si" site_id="1000531">Nova 24 TV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Nova24TV.si" site_id="1000432">Nova 24 TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="NTVICKakanj.ba" site_id="1000235">NTV IC Kakanj</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OBN.ba" site_id="152">OBN</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OKanal.ba" site_id="1000186">O Kanal</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ORF1.at" site_id="66">ORF1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ORF2Europe.at" site_id="67">ORF2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OronTV.si" site_id="1000360">TV Oron</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OTO.si" site_id="1000365">OTO</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OTV.hr" site_id="1000190">OTV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="OTVValentino.ba" site_id="1000073">OTV Valentino</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PeTV.si" site_id="1000101">PETV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkExtra.rs" site_id="1000095">Pink Extra</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkFilm.rs" site_id="1000096">Pink Film</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000094">Pink Folk</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkHits.rs" site_id="1000789">Pink Hits</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkMusic.rs" site_id="1000097">Pink Music</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkPlus.rs" site_id="107">Pink Plus</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkReality.rs" site_id="1000351">Pink Reality</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkSI.rs" site_id="1000361">Pink SI</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkWorld.rs" site_id="1000352">Pink World</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PinkZabava.rs" site_id="1000353">Pink Zabava</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PlanetEva.si" site_id="1000494">Planet Eva</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PlanetTV2.si" site_id="1000485">Planet TV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PlanetTV.si" site_id="1000278">Planet TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="PlayHouse.si" site_id="1000294">Play House</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="POPTV.si" site_id="1000371">POP TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ProSieben.de" site_id="69">Pro 7</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Prva.rs" site_id="1000210">Prva</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Rai1.it" site_id="1000625">RAI 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Rai2.it" site_id="1000626">RAI 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Rai3.it" site_id="1000627">RAI 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="REDxxx.si" site_id="1000490">RED xxx</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RT.ru" site_id="2000000028">RT</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTK1.xk" site_id="2000000015">RTK Kosova</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTL2.hr" site_id="1000322">RTL 2 HR</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTL.de" site_id="70">RTL</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTL.hr" site_id="1000314">RTL Televizija</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTLKetto.hu" site_id="71">RTL2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTLKockica.hr" site_id="1000355">RTL Kockica</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTLLiving.de" site_id="1000323">RTL Living</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTLSuper.de" site_id="73">Super RTL</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTRSTV.ba" site_id="1000185">RTRS</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTS1.rs" site_id="1000211">RTS 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTS2.rs" site_id="1000212">RTS 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTSKlasika.rs" site_id="108">RTS</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTVi.ru" site_id="1000666">RTVi</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="RTVVikom.ba" site_id="1000188">Vikom TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SAT1.de" site_id="72">SAT1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SciFi.rs" site_id="1000614">Sci Fi</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ServusTV.at" site_id="1000086">Servus TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SexationTV.si" site_id="1000408">Sexation</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SIPTV.si" site_id="1000498">SIP TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Sitel.mk" site_id="1000201">TV Sitel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SkyNewsInternational.uk" site_id="2000000002">Sky News</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Sport1.de" site_id="60">SPORT1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SportTV1.si" site_id="1000338">Šport TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SportTV2.si" site_id="1000339">Šport TV 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SportTV3.si" site_id="1000384">Šport TV 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="StingrayFestival4K.ca" site_id="1000527">Festival</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="SuperONE.hu@HD" site_id="1000342">Super One</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="T2Info.si" site_id="1000543">T-2 Info</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Telecafe.ru" site_id="1000456">Telecafe</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TelmaTV.mk" site_id="1000226">Telma TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TLCBalkan.us" site_id="1000763">TLC</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TlnovelasEuropa.mx" site_id="100">TL Novelas Europe</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TNTMusic.ru" site_id="1000664">TNT Music</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TopTV.si" site_id="1000356">TOP TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ToxicTV.rs" site_id="1000684">TV Toxic</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TraceSportStars.fr" site_id="1000169">Trace Sport Stars</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TraceUrban.fr" site_id="47">Trace Urban</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TravelChannelEMEA.uk" site_id="1000168">Travel Channel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000511">Travelxp 4K</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Travelxp.in" site_id="1000500">Travelxp</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TringAction.al" site_id="1000227">Tring Action</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TringShqip.al" site_id="1000216">Tring Shqip</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TringTring.al" site_id="1000217">Tring Tring</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TrzicTV.si" site_id="1000620">Tržič TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TV3.si" site_id="1000510">TV 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="1000405">TV 8</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TV24.mk" site_id="1000772">24 Vesti</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVArena.si" site_id="1000529">Arena TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="" site_id="122">TV AS</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVCelje.si" site_id="1000065">TV Celje</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVCGMNE.me" site_id="109">MNE</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVDugaPlus.rs" site_id="1000035">TV Duga Novi Sad</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVEInternacionalEuropeAsia.es" site_id="98">TVE</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVGaleja.si" site_id="1000343">TV Galeja</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVIDEA.si" site_id="123">TV IDEA</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVJadran.hr" site_id="1000194">TV Jadran</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVKCN1.rs" site_id="1000078">KCN</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVKCN2.rs" site_id="1000103">KCN Music</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVKCN3.rs" site_id="2000000046">KCN 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVKoperCapodistria.si" site_id="1000624">TV Koper</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVMaribor.si" site_id="1000623">TV Maribor</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVMiklavz.si" site_id="1000727">TV Miklavž</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVSA.ba" site_id="1000187">TV Sarajevo</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVSLO1.si" site_id="1000259">SLO 1</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVSLO2.si" site_id="1000260">SLO 2</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVSLO3.si" site_id="1000555">SLO 3</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVSlonExtra.ba" site_id="1000776">TV Slon</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="TVVijesti.me" site_id="1000775">Vijesti</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Vaskanal.si" site_id="1000002">Vaš kanal</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VeseljakTV.si" site_id="13">Best TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ViasatExplore.se" site_id="1000045">Viasat Explore</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ViasatHistory.se" site_id="1000046">Viasat History</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ViasatNature.se" site_id="1000081">Viasat Nature</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="vijuTV1000.ru" site_id="1000010">TV1000</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Vitel.si" site_id="2000000048">Vitel</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VividRedHD.us" site_id="1000508">Vivid Red</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VividTVEurope.uk" site_id="1000489">Vivid TV</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VizionPlus.al" site_id="1000079">Tring Vizion+</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VOX.de" site_id="78">VOX</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Vremya.ru" site_id="1000276">Vremya</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="VTV.si" site_id="2000000044">VTV Velenje</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="vZIVOsi.si" site_id="2000000043">vŽivo.si</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="Z1.hr" site_id="151">Z1 televizija</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ZDF.de" site_id="1000064">ZDF</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ZdravaTV7.hr" site_id="1000266">Zdrava Televizija</channel>
-  <channel site="tv2go.t-2.net" lang="sl" xmltv_id="ZdravaTV.si" site_id="1000616">Zdrava TV</channel>
+  <channel site="tv2go.t-2.net" site_id="14" lang="sl" xmltv_id="">RTS Maribor</channel>
+  <channel site="tv2go.t-2.net" site_id="17" lang="sl" xmltv_id="">TV Veseljak Golica</channel>
+  <channel site="tv2go.t-2.net" site_id="26" lang="sl" xmltv_id="">Discovery Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="110" lang="sl" xmltv_id="">Hayat 2</channel>
+  <channel site="tv2go.t-2.net" site_id="122" lang="sl" xmltv_id="">TV AS</channel>
+  <channel site="tv2go.t-2.net" site_id="1000028" lang="sl" xmltv_id="">AMC</channel>
+  <channel site="tv2go.t-2.net" site_id="1000043" lang="sl" xmltv_id="">History Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000048" lang="sl" xmltv_id="">History Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000074" lang="sl" xmltv_id="">Disney Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000080" lang="sl" xmltv_id="">Folk Plus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000094" lang="sl" xmltv_id="">Pink Folk</channel>
+  <channel site="tv2go.t-2.net" site_id="1000155" lang="sl" xmltv_id="">Disney Junior</channel>
+  <channel site="tv2go.t-2.net" site_id="1000181" lang="sl" xmltv_id="">Alfa TV MAK</channel>
+  <channel site="tv2go.t-2.net" site_id="1000223" lang="sl" xmltv_id="">MTV 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000224" lang="sl" xmltv_id="">Naša TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000267" lang="sl" xmltv_id="">Alfa TV BiH</channel>
+  <channel site="tv2go.t-2.net" site_id="1000283" lang="sl" xmltv_id="">INFO TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000285" lang="sl" xmltv_id="">Jugoton TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000291" lang="sl" xmltv_id="">Animal Planet</channel>
+  <channel site="tv2go.t-2.net" site_id="1000302" lang="sl" xmltv_id="">Nickelodeon</channel>
+  <channel site="tv2go.t-2.net" site_id="1000405" lang="sl" xmltv_id="">TV 8</channel>
+  <channel site="tv2go.t-2.net" site_id="1000470" lang="sl" xmltv_id="">TV Nakupi</channel>
+  <channel site="tv2go.t-2.net" site_id="1000477" lang="sl" xmltv_id="">HBO</channel>
+  <channel site="tv2go.t-2.net" site_id="1000478" lang="sl" xmltv_id="">HBO 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000479" lang="sl" xmltv_id="">HBO 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000480" lang="sl" xmltv_id="">Cinemax</channel>
+  <channel site="tv2go.t-2.net" site_id="1000481" lang="sl" xmltv_id="">Cinemax 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000503" lang="sl" xmltv_id="">RT Doc</channel>
+  <channel site="tv2go.t-2.net" site_id="1000507" lang="sl" xmltv_id="">ID</channel>
+  <channel site="tv2go.t-2.net" site_id="1000511" lang="sl" xmltv_id="">Travelxp</channel>
+  <channel site="tv2go.t-2.net" site_id="1000517" lang="sl" xmltv_id="">Freedom</channel>
+  <channel site="tv2go.t-2.net" site_id="1000547" lang="sl" xmltv_id="">FilmBox Premium</channel>
+  <channel site="tv2go.t-2.net" site_id="1000615" lang="sl" xmltv_id="">E!</channel>
+  <channel site="tv2go.t-2.net" site_id="1000682" lang="sl" xmltv_id="">Extasy</channel>
+  <channel site="tv2go.t-2.net" site_id="1000765" lang="sl" xmltv_id="">Pink Serije</channel>
+  <channel site="tv2go.t-2.net" site_id="1000766" lang="sl" xmltv_id="">Pink Koncert</channel>
+  <channel site="tv2go.t-2.net" site_id="1000767" lang="sl" xmltv_id="">Pink’n’Roll</channel>
+  <channel site="tv2go.t-2.net" site_id="1000792" lang="sl" xmltv_id="">Sonce TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000793" lang="sl" xmltv_id="">Prva World</channel>
+  <channel site="tv2go.t-2.net" site_id="1000794" lang="sl" xmltv_id="">Prva Max</channel>
+  <channel site="tv2go.t-2.net" site_id="1000795" lang="sl" xmltv_id="">Happy Reality</channel>
+  <channel site="tv2go.t-2.net" site_id="1000796" lang="sl" xmltv_id="">Happy Reality 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000797" lang="sl" xmltv_id="">Prva Files</channel>
+  <channel site="tv2go.t-2.net" site_id="1000798" lang="sl" xmltv_id="">Prva Kick</channel>
+  <channel site="tv2go.t-2.net" site_id="1000799" lang="sl" xmltv_id="">Prva Life</channel>
+  <channel site="tv2go.t-2.net" site_id="1000800" lang="sl" xmltv_id="">Prva Plus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000801" lang="sl" xmltv_id="">Adria</channel>
+  <channel site="tv2go.t-2.net" site_id="1000802" lang="sl" xmltv_id="">One Adria</channel>
+  <channel site="tv2go.t-2.net" site_id="1000803" lang="sl" xmltv_id="">Folx Slovenija</channel>
+  <channel site="tv2go.t-2.net" site_id="1000807" lang="sl" xmltv_id="">BBC News</channel>
+  <channel site="tv2go.t-2.net" site_id="1000808" lang="sl" xmltv_id="">Dim</channel>
+  <channel site="tv2go.t-2.net" site_id="1000812" lang="sl" xmltv_id="">Espreso TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000813" lang="sl" xmltv_id="">Duck TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000814" lang="sl" xmltv_id="">Non Stop</channel>
+  <channel site="tv2go.t-2.net" site_id="1000815" lang="sl" xmltv_id="">Hit TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000816" lang="sl" xmltv_id="">Bloomberg Adria</channel>
+  <channel site="tv2go.t-2.net" site_id="1000817" lang="sl" xmltv_id="">Arena Sport 1 Premium</channel>
+  <channel site="tv2go.t-2.net" site_id="1000818" lang="sl" xmltv_id="">Megafon TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000820" lang="sl" xmltv_id="">CineStar TV 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000821" lang="sl" xmltv_id="">LH TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000825" lang="sl" xmltv_id="">English Club TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000826" lang="sl" xmltv_id="">Harmonik TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000827" lang="sl" xmltv_id="">GLAM</channel>
+  <channel site="tv2go.t-2.net" site_id="1000828" lang="sl" xmltv_id="">XXXTazy</channel>
+  <channel site="tv2go.t-2.net" site_id="1000829" lang="sl" xmltv_id="">Angels</channel>
+  <channel site="tv2go.t-2.net" site_id="1000830" lang="sl" xmltv_id="">BooB</channel>
+  <channel site="tv2go.t-2.net" site_id="1000831" lang="sl" xmltv_id="">Capable Hole</channel>
+  <channel site="tv2go.t-2.net" site_id="1000832" lang="sl" xmltv_id="">Devils Home</channel>
+  <channel site="tv2go.t-2.net" site_id="1000833" lang="sl" xmltv_id="">Foxy Dolls</channel>
+  <channel site="tv2go.t-2.net" site_id="1000834" lang="sl" xmltv_id="">MIxxx</channel>
+  <channel site="tv2go.t-2.net" site_id="1000835" lang="sl" xmltv_id="">Prva TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000868" lang="sl" xmltv_id="">BIR TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000871" lang="sl" xmltv_id="">Kitchen TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000874" lang="sl" xmltv_id="">Mediaset Italia</channel>
+  <channel site="tv2go.t-2.net" site_id="1000875" lang="sl" xmltv_id="">TgCom24</channel>
+  <channel site="tv2go.t-2.net" site_id="1000877" lang="sl" xmltv_id="">Astra</channel>
+  <channel site="tv2go.t-2.net" site_id="1000878" lang="sl" xmltv_id="">Klape i tambure</channel>
+  <channel site="tv2go.t-2.net" site_id="1000879" lang="sl" xmltv_id="">TinyTeen</channel>
+  <channel site="tv2go.t-2.net" site_id="1000913" lang="sl" xmltv_id="">Hayat Stil i život</channel>
+  <channel site="tv2go.t-2.net" site_id="1000915" lang="sl" xmltv_id="">Gea TV Plus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000916" lang="sl" xmltv_id="">Gasscore</channel>
+  <channel site="tv2go.t-2.net" site_id="1000917" lang="sl" xmltv_id="">Purple Pills</channel>
+  <channel site="tv2go.t-2.net" site_id="1000918" lang="sl" xmltv_id="">Hayat Love box</channel>
+  <channel site="tv2go.t-2.net" site_id="1000921" lang="sl" xmltv_id="">Redlight</channel>
+  <channel site="tv2go.t-2.net" site_id="1000922" lang="sl" xmltv_id="">Passion XXX</channel>
+  <channel site="tv2go.t-2.net" site_id="1000923" lang="sl" xmltv_id="">Ljubljana TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000924" lang="sl" xmltv_id="">HIT TV Plus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000932" lang="sl" xmltv_id="">Viasat True Crime</channel>
+  <channel site="tv2go.t-2.net" site_id="1000933" lang="sl" xmltv_id="">Zdrava TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000935" lang="sl" xmltv_id="">Motorvision+</channel>
+  <channel site="tv2go.t-2.net" site_id="1000937" lang="sl" xmltv_id="">Nick Music</channel>
+  <channel site="tv2go.t-2.net" site_id="1000938" lang="sl" xmltv_id="">NickToons</channel>
+  <channel site="tv2go.t-2.net" site_id="1000939" lang="sl" xmltv_id="">Classic Music</channel>
+  <channel site="tv2go.t-2.net" site_id="1000940" lang="sl" xmltv_id="">Fashion &amp; Style</channel>
+  <channel site="tv2go.t-2.net" site_id="1000941" lang="sl" xmltv_id="">Fashion &amp; Style</channel>
+  <channel site="tv2go.t-2.net" site_id="1000942" lang="sl" xmltv_id="">TV Zlati zvoki</channel>
+  <channel site="tv2go.t-2.net" site_id="1000943" lang="sl" xmltv_id="">RTV Cazin</channel>
+  <channel site="tv2go.t-2.net" site_id="1000944" lang="sl" xmltv_id="">RTV TK</channel>
+  <channel site="tv2go.t-2.net" site_id="1000945" lang="sl" xmltv_id="">LangLab</channel>
+  <channel site="tv2go.t-2.net" site_id="1000946" lang="sl" xmltv_id="">LingoToons</channel>
+  <channel site="tv2go.t-2.net" site_id="1000947" lang="sl" xmltv_id="">San Marino RTV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000948" lang="sl" xmltv_id="">Hype TV</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000001" lang="sl" xmltv_id="">R Kanal+</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000039" lang="sl" xmltv_id="">Cartoon Network</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000041" lang="sl" xmltv_id="">RTV Shqiptar</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000045" lang="sl" xmltv_id="">Europe by Satellite</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000050" lang="sl" xmltv_id="">RTV Atlas</channel>
+  <channel site="tv2go.t-2.net" site_id="1000640" lang="sl" xmltv_id="3sat.de">3SAT</channel>
+  <channel site="tv2go.t-2.net" site_id="1000307" lang="sl" xmltv_id="24Kitchen.us@Slovenia">24Kitchen Adria</channel>
+  <channel site="tv2go.t-2.net" site_id="1000558" lang="sl" xmltv_id="360TuneBox.nl">360 Tunebox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000686" lang="sl" xmltv_id="AgroTV.rs">Agro TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000219" lang="sl" xmltv_id="Alsat.mk">Alsat Macedoniae</channel>
+  <channel site="tv2go.t-2.net" site_id="1000523" lang="sl" xmltv_id="AMCEurope.uk@Portugal@Slovenia">AMC</channel>
+  <channel site="tv2go.t-2.net" site_id="1000057" lang="sl" xmltv_id="AnixeHDSerie.de">Anixe</channel>
+  <channel site="tv2go.t-2.net" site_id="1000683" lang="sl" xmltv_id="ArenaEsport.rs">TV Arena Esport</channel>
+  <channel site="tv2go.t-2.net" site_id="1000777" lang="sl" xmltv_id="ArenaFight.rs">Arena Fight</channel>
+  <channel site="tv2go.t-2.net" site_id="1000688" lang="sl" xmltv_id="ArenaSport1.rs">Arena Sport 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000689" lang="sl" xmltv_id="ArenaSport2.rs">Arena Sport 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000787" lang="sl" xmltv_id="ArenaSport3.rs">Arena Sport 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000788" lang="sl" xmltv_id="ArenaSport4.rs">Arena Sport 4</channel>
+  <channel site="tv2go.t-2.net" site_id="1000026" lang="sl" xmltv_id="arte.fr">Arte</channel>
+  <channel site="tv2go.t-2.net" site_id="1000001" lang="sl" xmltv_id="ATMTV.si">ATM Kranjska Gora</channel>
+  <channel site="tv2go.t-2.net" site_id="1000207" lang="sl" xmltv_id="B92.rs">B92</channel>
+  <channel site="tv2go.t-2.net" site_id="82" lang="sl" xmltv_id="BabyTV.uk">Baby TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000645" lang="sl" xmltv_id="BalkanErotic.si">Balkan Erotic</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000027" lang="sl" xmltv_id="BalkanikaTV.bg">Balkanika Music TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000685" lang="sl" xmltv_id="BalkanTripTV.rs">TV Balkan Trip</channel>
+  <channel site="tv2go.t-2.net" site_id="1000482" lang="sl" xmltv_id="BBCEarth.uk@Romania">BBC Earth</channel>
+  <channel site="tv2go.t-2.net" site_id="1000652" lang="sl" xmltv_id="BBCFirst.uk@Poland">BBC First</channel>
+  <channel site="tv2go.t-2.net" site_id="1000182" lang="sl" xmltv_id="BHT1.ba">BHT 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000265" lang="sl" xmltv_id="BKTV.si">BK TV</channel>
+  <channel site="tv2go.t-2.net" site_id="129" lang="sl" xmltv_id="BN2.ba">BN TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000067" lang="sl" xmltv_id="BNMusic.ba">BN Music</channel>
+  <channel site="tv2go.t-2.net" site_id="124" lang="sl" xmltv_id="BoomTV.si">Aktual TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000368" lang="sl" xmltv_id="BRIO.si">BRIO</channel>
+  <channel site="tv2go.t-2.net" site_id="1000273" lang="sl" xmltv_id="Carousel.ru">Karousel</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000032" lang="sl" xmltv_id="CartoonitoCEE.uk">Cartoonito</channel>
+  <channel site="tv2go.t-2.net" site_id="125" lang="sl" xmltv_id="CGTN.cn">CGTN</channel>
+  <channel site="tv2go.t-2.net" site_id="1000085" lang="sl" xmltv_id="CineStarTV1.rs">CineStar TV 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000427" lang="sl" xmltv_id="CineStarTVAction.rs">Cinestar Action &amp; Thriller</channel>
+  <channel site="tv2go.t-2.net" site_id="1000617" lang="sl" xmltv_id="CineStarTVComedy.hr">Cinestar Comedy</channel>
+  <channel site="tv2go.t-2.net" site_id="1000618" lang="sl" xmltv_id="CineStarTVFantasy.hr">Cinestar Fantasy</channel>
+  <channel site="tv2go.t-2.net" site_id="1000431" lang="sl" xmltv_id="CineStarTVPremiere1.hr">Cinestar Premiere</channel>
+  <channel site="tv2go.t-2.net" site_id="1000430" lang="sl" xmltv_id="CineStarTVPremiere2.hr">Cinestar Premiere 2</channel>
+  <channel site="tv2go.t-2.net" site_id="126" lang="sl" xmltv_id="ClubMTVEurope.uk">Club MTV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000156" lang="sl" xmltv_id="CMCTV.hr">CMC - Croatian Music Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="25" lang="sl" xmltv_id="CNNInternational.us@MENA">CNN International</channel>
+  <channel site="tv2go.t-2.net" site_id="1000153" lang="sl" xmltv_id="CrimePlusInvestigation.uk">Crime &amp; Investigation Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000059" lang="sl" xmltv_id="DasErste.de">Das Erste (ARD)</channel>
+  <channel site="tv2go.t-2.net" site_id="1000055" lang="sl" xmltv_id="DaVinci.de">Da Vinci</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000040" lang="sl" xmltv_id="DivaAdria.us">Diva</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000026" lang="sl" xmltv_id="DMSat.rs">DM SAT Televizija</channel>
+  <channel site="tv2go.t-2.net" site_id="1000551" lang="sl" xmltv_id="DocuBox.nl">Docubox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000274" lang="sl" xmltv_id="Domkino.ru">Dom Kino</channel>
+  <channel site="tv2go.t-2.net" site_id="1000486" lang="sl" xmltv_id="DorcelXXX.nl">Dorcel TV XXX</channel>
+  <channel site="tv2go.t-2.net" site_id="1000648" lang="sl" xmltv_id="Duna.hu">Duna</channel>
+  <channel site="tv2go.t-2.net" site_id="1000786" lang="sl" xmltv_id="DunaWorld.hu">Duna World</channel>
+  <channel site="tv2go.t-2.net" site_id="1000373" lang="sl" xmltv_id="DuskTV.nl">Dusk</channel>
+  <channel site="tv2go.t-2.net" site_id="1000501" lang="sl" xmltv_id="EpicDrama.uk@Sweden">Epic Drama</channel>
+  <channel site="tv2go.t-2.net" site_id="1000559" lang="sl" xmltv_id="EroX.nl">Erox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000553" lang="sl" xmltv_id="EroXXX.nl">Eroxxx</channel>
+  <channel site="tv2go.t-2.net" site_id="1000641" lang="sl" xmltv_id="ETV.si">ETV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000764" lang="sl" xmltv_id="EuronewsEnglish.fr">Euronews</channel>
+  <channel site="tv2go.t-2.net" site_id="1000025" lang="sl" xmltv_id="Eurosport1.fr">Eurosport</channel>
+  <channel site="tv2go.t-2.net" site_id="1000044" lang="sl" xmltv_id="Eurosport1.fr@Germany">Eurosport (NEM)</channel>
+  <channel site="tv2go.t-2.net" site_id="1000504" lang="sl" xmltv_id="Eurosport2.fr">Eurosport 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000728" lang="sl" xmltv_id="Eurosport4K.fr">Eurosport</channel>
+  <channel site="tv2go.t-2.net" site_id="36" lang="sl" xmltv_id="EWTN.us@Europe">EWTN Europe</channel>
+  <channel site="tv2go.t-2.net" site_id="1000455" lang="sl" xmltv_id="ExodusTV.si">Exodus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000646" lang="sl" xmltv_id="Extreme.si">Extreme</channel>
+  <channel site="tv2go.t-2.net" site_id="1000556" lang="sl" xmltv_id="FashionBox.nl">Fashionbox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000552" lang="sl" xmltv_id="FastFunBox.nl">Fastnfunbox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000545" lang="sl" xmltv_id="FenFolkTV.bg">FenFolk TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000544" lang="sl" xmltv_id="FenTV.bg">FEN TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000550" lang="sl" xmltv_id="FightBox.nl">Fightbox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000557" lang="sl" xmltv_id="FilmBoxArthouse.nl">FilmBox Arthouse</channel>
+  <channel site="tv2go.t-2.net" site_id="1000548" lang="sl" xmltv_id="FilmBoxExtra.nl@Bulgaria">FilmBox Extra</channel>
+  <channel site="tv2go.t-2.net" site_id="1000549" lang="sl" xmltv_id="FilmBoxStars.nl@Bulgaria">FilmBox Stars</channel>
+  <channel site="tv2go.t-2.net" site_id="1000308" lang="sl" xmltv_id="Fox.rs">STAR</channel>
+  <channel site="tv2go.t-2.net" site_id="1000310" lang="sl" xmltv_id="FoxCrime.rs">STAR Crime</channel>
+  <channel site="tv2go.t-2.net" site_id="1000309" lang="sl" xmltv_id="FoxLife.rs">STAR Life</channel>
+  <channel site="tv2go.t-2.net" site_id="1000311" lang="sl" xmltv_id="FoxMovies.si">STAR Movies</channel>
+  <channel site="tv2go.t-2.net" site_id="1000639" lang="sl" xmltv_id="France2.fr">FR2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000159" lang="sl" xmltv_id="France24.fr@English">France 24 English</channel>
+  <channel site="tv2go.t-2.net" site_id="1000158" lang="sl" xmltv_id="France24.fr@French">France 24 French</channel>
+  <channel site="tv2go.t-2.net" site_id="1000521" lang="sl" xmltv_id="FunBoxUHD.nl">Funbox</channel>
+  <channel site="tv2go.t-2.net" site_id="1000554" lang="sl" xmltv_id="Gametoon.nl">Gametoon</channel>
+  <channel site="tv2go.t-2.net" site_id="1000407" lang="sl" xmltv_id="GOLDTV.si">GOLD TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000209" lang="sl" xmltv_id="Happy.rs">Happy TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000236" lang="sl" xmltv_id="Hayat.ba">Hayat</channel>
+  <channel site="tv2go.t-2.net" site_id="1000284" lang="sl" xmltv_id="HayatFolk.ba">Hayat Folk Box</channel>
+  <channel site="tv2go.t-2.net" site_id="1000233" lang="sl" xmltv_id="HemaTV.ba">Hema</channel>
+  <channel site="tv2go.t-2.net" site_id="1000730" lang="sl" xmltv_id="HGTVLatinAmerica.us@Panregional">HGTV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000619" lang="sl" xmltv_id="History2.pl">H2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000644" lang="sl" xmltv_id="HotPleasure.si">Hot Pleasure</channel>
+  <channel site="tv2go.t-2.net" site_id="1000643" lang="sl" xmltv_id="HotXXL.si">Hot XXL</channel>
+  <channel site="tv2go.t-2.net" site_id="105" lang="sl" xmltv_id="HRT1.hr">HRT 1</channel>
+  <channel site="tv2go.t-2.net" site_id="106" lang="sl" xmltv_id="HRT2.hr">HRT 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000306" lang="sl" xmltv_id="HustlerHD.nl">Hustler TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000018" lang="sl" xmltv_id="HustlerTVEurope.nl">Hustler TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000509" lang="sl" xmltv_id="JimJamEurope.uk">Jim Jam</channel>
+  <channel site="tv2go.t-2.net" site_id="61" lang="sl" xmltv_id="kabeleins.de">Kabel 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000268" lang="sl" xmltv_id="Kanal5.mk">Kanal 5</channel>
+  <channel site="tv2go.t-2.net" site_id="1000370" lang="sl" xmltv_id="KanalA.si">Kanal A</channel>
+  <channel site="tv2go.t-2.net" site_id="1000174" lang="sl" xmltv_id="Kanali7.al">Tring 7</channel>
+  <channel site="tv2go.t-2.net" site_id="1000366" lang="sl" xmltv_id="KINO.si">KINO</channel>
+  <channel site="tv2go.t-2.net" site_id="1000154" lang="sl" xmltv_id="Klasik.hr">Klasik</channel>
+  <channel site="tv2go.t-2.net" site_id="1000474" lang="sl" xmltv_id="KoroskaTV.si">Koroška TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000647" lang="sl" xmltv_id="M1.hu">M1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000050" lang="sl" xmltv_id="M2.hu">M2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000650" lang="sl" xmltv_id="M5.hu">M5</channel>
+  <channel site="tv2go.t-2.net" site_id="91" lang="sl" xmltv_id="Mezzo.fr">Mezzo</channel>
+  <channel site="tv2go.t-2.net" site_id="1000491" lang="sl" xmltv_id="MilfTV.si">Milf TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000262" lang="sl" xmltv_id="MinimaxCEE.cz">Minimax</channel>
+  <channel site="tv2go.t-2.net" site_id="1000193" lang="sl" xmltv_id="MrezaTV.hr">Mreža TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000222" lang="sl" xmltv_id="MRT1.mk">MTV 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000199" lang="sl" xmltv_id="MRT2.mk">MTV 2</channel>
+  <channel site="tv2go.t-2.net" site_id="50" lang="sl" xmltv_id="MTV00s.uk">MTV 00s</channel>
+  <channel site="tv2go.t-2.net" site_id="51" lang="sl" xmltv_id="MTV80s.uk">MTV 80s</channel>
+  <channel site="tv2go.t-2.net" site_id="136" lang="sl" xmltv_id="MTV90s.uk">MTV 90s</channel>
+  <channel site="tv2go.t-2.net" site_id="1000496" lang="sl" xmltv_id="MTVGlobal.uk">MTV</channel>
+  <channel site="tv2go.t-2.net" site_id="127" lang="sl" xmltv_id="MTVHitsEurope.uk">MTV Hits</channel>
+  <channel site="tv2go.t-2.net" site_id="1000497" lang="sl" xmltv_id="MTVLive.uk">MTV Live</channel>
+  <channel site="tv2go.t-2.net" site_id="1000275" lang="sl" xmltv_id="MuzykaPervogo.ru">Muzika Pervogo</channel>
+  <channel site="tv2go.t-2.net" site_id="1000269" lang="sl" xmltv_id="NarodnaTV.rs">Narodna TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000049" lang="sl" xmltv_id="NationalGeographic.si">National Geographic</channel>
+  <channel site="tv2go.t-2.net" site_id="1000167" lang="sl" xmltv_id="NationalGeographicWild.si">National Geographic Wild</channel>
+  <channel site="tv2go.t-2.net" site_id="12" lang="sl" xmltv_id="NetTV.si">Net TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000228" lang="sl" xmltv_id="NetXXL.si">Net XXL</channel>
+  <channel site="tv2go.t-2.net" site_id="1000102" lang="sl" xmltv_id="NHKWorldJapan.jp">NHK World</channel>
+  <channel site="tv2go.t-2.net" site_id="1000301" lang="sl" xmltv_id="Nickelodeon.si">Nickelodeon</channel>
+  <channel site="tv2go.t-2.net" site_id="1000426" lang="sl" xmltv_id="NickJr.si">Nick JR</channel>
+  <channel site="tv2go.t-2.net" site_id="1000531" lang="sl" xmltv_id="Nova24TV2.si">Nova 24 TV 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000432" lang="sl" xmltv_id="Nova24TV.si">Nova 24 TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000235" lang="sl" xmltv_id="NTVICKakanj.ba">NTV IC Kakanj</channel>
+  <channel site="tv2go.t-2.net" site_id="152" lang="sl" xmltv_id="OBN.ba">OBN</channel>
+  <channel site="tv2go.t-2.net" site_id="66" lang="sl" xmltv_id="ORF1.at">ORF1</channel>
+  <channel site="tv2go.t-2.net" site_id="67" lang="sl" xmltv_id="ORF2Europe.at">ORF2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000360" lang="sl" xmltv_id="OronTV.si">TV Oron</channel>
+  <channel site="tv2go.t-2.net" site_id="1000365" lang="sl" xmltv_id="OTO.si">OTO</channel>
+  <channel site="tv2go.t-2.net" site_id="1000190" lang="sl" xmltv_id="OTV.hr">OTV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000101" lang="sl" xmltv_id="PeTV.si">PETV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000095" lang="sl" xmltv_id="PinkExtra.rs">Pink Extra</channel>
+  <channel site="tv2go.t-2.net" site_id="1000096" lang="sl" xmltv_id="PinkFilm.rs">Pink Film</channel>
+  <channel site="tv2go.t-2.net" site_id="1000789" lang="sl" xmltv_id="PinkHits.rs">Pink Hits</channel>
+  <channel site="tv2go.t-2.net" site_id="1000097" lang="sl" xmltv_id="PinkMusic.rs">Pink Music</channel>
+  <channel site="tv2go.t-2.net" site_id="107" lang="sl" xmltv_id="PinkPlus.rs">Pink Plus</channel>
+  <channel site="tv2go.t-2.net" site_id="1000351" lang="sl" xmltv_id="PinkReality.rs">Pink Reality</channel>
+  <channel site="tv2go.t-2.net" site_id="1000361" lang="sl" xmltv_id="PinkSI.rs">Pink SI</channel>
+  <channel site="tv2go.t-2.net" site_id="1000352" lang="sl" xmltv_id="PinkWorld.rs">Pink World</channel>
+  <channel site="tv2go.t-2.net" site_id="1000353" lang="sl" xmltv_id="PinkZabava.rs">Pink Zabava</channel>
+  <channel site="tv2go.t-2.net" site_id="1000494" lang="sl" xmltv_id="PlanetEva.si">Planet Eva</channel>
+  <channel site="tv2go.t-2.net" site_id="1000485" lang="sl" xmltv_id="PlanetTV2.si">Planet TV 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000278" lang="sl" xmltv_id="PlanetTV.si">Planet TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000294" lang="sl" xmltv_id="PlayHouse.si">Play House</channel>
+  <channel site="tv2go.t-2.net" site_id="1000371" lang="sl" xmltv_id="POPTV.si">POP TV</channel>
+  <channel site="tv2go.t-2.net" site_id="69" lang="sl" xmltv_id="ProSieben.de">Pro 7</channel>
+  <channel site="tv2go.t-2.net" site_id="1000210" lang="sl" xmltv_id="Prva.rs">Prva</channel>
+  <channel site="tv2go.t-2.net" site_id="1000625" lang="sl" xmltv_id="Rai1.it">RAI 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000626" lang="sl" xmltv_id="Rai2.it">RAI 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000627" lang="sl" xmltv_id="Rai3.it">RAI 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000490" lang="sl" xmltv_id="REDxxx.si">RED xxx</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000028" lang="sl" xmltv_id="RT.ru">RT</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000015" lang="sl" xmltv_id="RTK1.xk">RTK Kosova</channel>
+  <channel site="tv2go.t-2.net" site_id="1000322" lang="sl" xmltv_id="RTL2.hr">RTL 2 HR</channel>
+  <channel site="tv2go.t-2.net" site_id="70" lang="sl" xmltv_id="RTL.de">RTL</channel>
+  <channel site="tv2go.t-2.net" site_id="1000314" lang="sl" xmltv_id="RTL.hr">RTL Televizija</channel>
+  <channel site="tv2go.t-2.net" site_id="71" lang="sl" xmltv_id="RTLKetto.hu">RTL2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000355" lang="sl" xmltv_id="RTLKockica.hr">RTL Kockica</channel>
+  <channel site="tv2go.t-2.net" site_id="1000323" lang="sl" xmltv_id="RTLLiving.de">RTL Living</channel>
+  <channel site="tv2go.t-2.net" site_id="73" lang="sl" xmltv_id="RTLSuper.de">Super RTL</channel>
+  <channel site="tv2go.t-2.net" site_id="1000185" lang="sl" xmltv_id="RTRSTV.ba">RTRS</channel>
+  <channel site="tv2go.t-2.net" site_id="1000211" lang="sl" xmltv_id="RTS1.rs">RTS 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000212" lang="sl" xmltv_id="RTS2.rs">RTS 2</channel>
+  <channel site="tv2go.t-2.net" site_id="108" lang="sl" xmltv_id="RTSKlasika.rs">RTS</channel>
+  <channel site="tv2go.t-2.net" site_id="1000188" lang="sl" xmltv_id="RTVVikom.ba">Vikom TV</channel>
+  <channel site="tv2go.t-2.net" site_id="72" lang="sl" xmltv_id="SAT1.de">SAT1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000614" lang="sl" xmltv_id="SciFi.rs">Sci Fi</channel>
+  <channel site="tv2go.t-2.net" site_id="1000408" lang="sl" xmltv_id="SexationTV.si">Sexation</channel>
+  <channel site="tv2go.t-2.net" site_id="1000498" lang="sl" xmltv_id="SIPTV.si">SIP TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000201" lang="sl" xmltv_id="Sitel.mk">TV Sitel</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000002" lang="sl" xmltv_id="SkyNewsInternational.uk">Sky News</channel>
+  <channel site="tv2go.t-2.net" site_id="60" lang="sl" xmltv_id="Sport1.de">SPORT1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000338" lang="sl" xmltv_id="SportTV1.si">Šport TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000339" lang="sl" xmltv_id="SportTV2.si">Šport TV 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000384" lang="sl" xmltv_id="SportTV3.si">Šport TV 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000527" lang="sl" xmltv_id="StingrayFestival4K.ca">Festival</channel>
+  <channel site="tv2go.t-2.net" site_id="1000342" lang="sl" xmltv_id="SuperONE.hu@HD">Super One</channel>
+  <channel site="tv2go.t-2.net" site_id="1000543" lang="sl" xmltv_id="T2Info.si">T-2 Info</channel>
+  <channel site="tv2go.t-2.net" site_id="1000456" lang="sl" xmltv_id="Telecafe.ru">Telecafe</channel>
+  <channel site="tv2go.t-2.net" site_id="1000226" lang="sl" xmltv_id="TelmaTV.mk">Telma TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000763" lang="sl" xmltv_id="TLCBalkan.us">TLC</channel>
+  <channel site="tv2go.t-2.net" site_id="100" lang="sl" xmltv_id="TlnovelasEuropa.mx">TL Novelas Europe</channel>
+  <channel site="tv2go.t-2.net" site_id="1000664" lang="sl" xmltv_id="TNTMusic.ru">TNT Music</channel>
+  <channel site="tv2go.t-2.net" site_id="1000356" lang="sl" xmltv_id="TopTV.si">TOP TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000684" lang="sl" xmltv_id="ToxicTV.rs">TV Toxic</channel>
+  <channel site="tv2go.t-2.net" site_id="1000169" lang="sl" xmltv_id="TraceSportStars.fr">Trace Sport Stars</channel>
+  <channel site="tv2go.t-2.net" site_id="47" lang="sl" xmltv_id="TraceUrban.fr">Trace Urban</channel>
+  <channel site="tv2go.t-2.net" site_id="1000168" lang="sl" xmltv_id="TravelChannelEMEA.uk">Travel Channel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000500" lang="sl" xmltv_id="Travelxp.in">Travelxp</channel>
+  <channel site="tv2go.t-2.net" site_id="1000227" lang="sl" xmltv_id="TringAction.al">Tring Action</channel>
+  <channel site="tv2go.t-2.net" site_id="1000216" lang="sl" xmltv_id="TringShqip.al">Tring Shqip</channel>
+  <channel site="tv2go.t-2.net" site_id="1000217" lang="sl" xmltv_id="TringTring.al">Tring Tring</channel>
+  <channel site="tv2go.t-2.net" site_id="1000620" lang="sl" xmltv_id="TrzicTV.si">Tržič TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000510" lang="sl" xmltv_id="TV3.si">TV 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000772" lang="sl" xmltv_id="TV24.mk">24 Vesti</channel>
+  <channel site="tv2go.t-2.net" site_id="1000529" lang="sl" xmltv_id="TVArena.si">Arena TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000065" lang="sl" xmltv_id="TVCelje.si">TV Celje</channel>
+  <channel site="tv2go.t-2.net" site_id="109" lang="sl" xmltv_id="TVCGMNE.me">MNE</channel>
+  <channel site="tv2go.t-2.net" site_id="1000035" lang="sl" xmltv_id="TVDugaPlus.rs">TV Duga Novi Sad</channel>
+  <channel site="tv2go.t-2.net" site_id="98" lang="sl" xmltv_id="TVEInternacionalEuropeAsia.es">TVE</channel>
+  <channel site="tv2go.t-2.net" site_id="1000343" lang="sl" xmltv_id="TVGaleja.si">TV Galeja</channel>
+  <channel site="tv2go.t-2.net" site_id="123" lang="sl" xmltv_id="TVIDEA.si">TV IDEA</channel>
+  <channel site="tv2go.t-2.net" site_id="1000194" lang="sl" xmltv_id="TVJadran.hr">TV Jadran</channel>
+  <channel site="tv2go.t-2.net" site_id="1000078" lang="sl" xmltv_id="TVKCN1.rs">KCN</channel>
+  <channel site="tv2go.t-2.net" site_id="1000103" lang="sl" xmltv_id="TVKCN2.rs">KCN Music</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000046" lang="sl" xmltv_id="TVKCN3.rs">KCN 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000624" lang="sl" xmltv_id="TVKoperCapodistria.si">TV Koper</channel>
+  <channel site="tv2go.t-2.net" site_id="1000623" lang="sl" xmltv_id="TVMaribor.si">TV Maribor</channel>
+  <channel site="tv2go.t-2.net" site_id="1000727" lang="sl" xmltv_id="TVMiklavz.si">TV Miklavž</channel>
+  <channel site="tv2go.t-2.net" site_id="1000187" lang="sl" xmltv_id="TVSA.ba">TV Sarajevo</channel>
+  <channel site="tv2go.t-2.net" site_id="1000259" lang="sl" xmltv_id="TVSLO1.si">SLO 1</channel>
+  <channel site="tv2go.t-2.net" site_id="1000260" lang="sl" xmltv_id="TVSLO2.si">SLO 2</channel>
+  <channel site="tv2go.t-2.net" site_id="1000555" lang="sl" xmltv_id="TVSLO3.si">SLO 3</channel>
+  <channel site="tv2go.t-2.net" site_id="1000776" lang="sl" xmltv_id="TVSlonExtra.ba">TV Slon</channel>
+  <channel site="tv2go.t-2.net" site_id="1000775" lang="sl" xmltv_id="TVVijesti.me">Vijesti</channel>
+  <channel site="tv2go.t-2.net" site_id="1000002" lang="sl" xmltv_id="Vaskanal.si">Vaš kanal</channel>
+  <channel site="tv2go.t-2.net" site_id="13" lang="sl" xmltv_id="VeseljakTV.si">Best TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000045" lang="sl" xmltv_id="ViasatExplore.se">Viasat Explore</channel>
+  <channel site="tv2go.t-2.net" site_id="1000046" lang="sl" xmltv_id="ViasatHistory.se">Viasat History</channel>
+  <channel site="tv2go.t-2.net" site_id="1000081" lang="sl" xmltv_id="ViasatNature.se">Viasat Nature</channel>
+  <channel site="tv2go.t-2.net" site_id="1000010" lang="sl" xmltv_id="vijuTV1000.ru">Viasat Kino</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000048" lang="sl" xmltv_id="Vitel.si">Vitel</channel>
+  <channel site="tv2go.t-2.net" site_id="1000508" lang="sl" xmltv_id="VividRedHD.us">Vivid Red</channel>
+  <channel site="tv2go.t-2.net" site_id="1000489" lang="sl" xmltv_id="VividTVEurope.uk">Vivid TV</channel>
+  <channel site="tv2go.t-2.net" site_id="1000079" lang="sl" xmltv_id="VizionPlus.al">Tring Vizion+</channel>
+  <channel site="tv2go.t-2.net" site_id="78" lang="sl" xmltv_id="VOX.de">VOX</channel>
+  <channel site="tv2go.t-2.net" site_id="1000276" lang="sl" xmltv_id="Vremya.ru">Vremya</channel>
+  <channel site="tv2go.t-2.net" site_id="2000000044" lang="sl" xmltv_id="VTV.si">VTV Velenje</channel>
+  <channel site="tv2go.t-2.net" site_id="151" lang="sl" xmltv_id="Z1.hr">Z1 televizija</channel>
+  <channel site="tv2go.t-2.net" site_id="1000064" lang="sl" xmltv_id="ZDF.de">ZDF</channel>
+  <channel site="tv2go.t-2.net" site_id="1000266" lang="sl" xmltv_id="ZdravaTV7.hr">Zdrava Televizija</channel>
 </channels>

--- a/sites/tv2go.t-2.net/tv2go.t-2.net.config.js
+++ b/sites/tv2go.t-2.net/tv2go.t-2.net.config.js
@@ -1,13 +1,13 @@
 const axios = require('axios')
 const dayjs = require('dayjs')
-const md5 = require('./jquery.md5')
+const crypto = require('crypto')
 
 const API = {
   locale: 'sl-SI',
-  version: '9.4',
+  version: '10.8',
   format: 'json',
-  uuid: '464830403846070',
-  token: '6dace810-55d5-11e3-949a-0800200c9a66'
+  uuid: '7971845803564301055', // from application
+  token: 'f8cce4e4-3ccc-486d-ac02-73cf231e3a2b' // from application
 }
 
 const config = {
@@ -120,7 +120,7 @@ function parseItems(content) {
 function generateHash(data, endpoint) {
   const salt = `${API.token}${API.version}${API.format}${API.uuid}`
 
-  return md5(salt + endpoint + JSON.stringify(data))
+  return crypto.createHash('md5').update(salt + endpoint + JSON.stringify(data)).digest('hex')
 }
 
 module.exports = config

--- a/sites/tv2go.t-2.net/tv2go.t-2.net.test.js
+++ b/sites/tv2go.t-2.net/tv2go.t-2.net.test.js
@@ -15,7 +15,7 @@ const channel = {
 
 it('can generate valid url', () => {
   expect(url({ date, channel })).toBe(
-    'https://tv2go.t-2.net/Catherine/api/9.4/json/464830403846070/d79cf4dc84f2131689f426956b8d40de/client/tv/getEpg'
+    'https://tv2go.t-2.net/Catherine/api/10.8/json/7971845803564301055/c82189625b4689c4dec55a452741a012/client/tv/getEpg'
   )
 })
 


### PR DESCRIPTION
## Changed files

```
tv2go.t-2.net.channels.xml
tv2go.t-2.net.config.js
tv2go.t-2.net.test.js
```

## Explanation

The API info was outdated, they've since moved to another API version, which might cause discrepancies if it was to be shut down. I haven't verified if the old API version was still working, but the app source seemed to tell that there was possibilities to use an older API version. But to which extent ?

## What was done

This PR aims to upgrade the API data to make the program grabbing prosper. It *can* be automatised with a few checks onto the Perception JS data, in which they do "leak" certain crucial API information (including the UUID and token).

The jQuery external dependency was ditched for a Node.js native alternative. Better, especially since the repository that had the jQuery version got deleted.

Also update the channels list.

## Potential optimizations

-> Automatise the API data gathering with a few checkups onto the minified JS data (perception.min.js)

## Grab & Test results 

```
npm run grab --- --site=tv2go.t-2.net                                                                              

> grab
> tsx scripts/commands/epg/grab.ts --site=tv2go.t-2.net

ℹ starting...                                                                                                               13:00:11
ℹ config:                                                                                                                   13:00:11
output: guide.xml
maxConnections: 1
gzip: false
curl: false
site: tv2go.t-2.net
ℹ loading channels...                                                                                                       13:00:11   
ℹ found 342 channel(s)                                                                                                      13:00:11
ℹ loading api data...                                                                                                       13:00:11
ℹ creating queue...                                                                                                         13:00:12
ℹ run:                                                                                                                      13:00:12
ℹ   [1/684] tv2go.t-2.net (sl) - 14 - Oct 26, 2025 (21 programs)                                                            13:00:16
ℹ   [2/684] tv2go.t-2.net (sl) - 14 - Oct 27, 2025 (21 programs)                                                            13:00:19
ℹ   [3/684] tv2go.t-2.net (sl) - 17 - Oct 27, 2025 (63 programs)                                                            13:00:22
ℹ   [4/684] tv2go.t-2.net (sl) - 110 - Oct 27, 2025 (37 programs)                                                           13:00:25
ℹ   [5/684] tv2go.t-2.net (sl) - 1000048 - Oct 27, 2025 (36 programs)                                                       13:00:28
ℹ   [6/684] tv2go.t-2.net (sl) - 1000267 - Oct 27, 2025 (28 programs)                                                       13:00:31
ℹ   [7/684] tv2go.t-2.net (sl) - 1000547 - Oct 27, 2025 (15 programs)                                                       13:00:34
ℹ   [8/684] tv2go.t-2.net (sl) - 1000547 - Oct 26, 2025 (15 programs)                                                       13:00:37
ℹ   [9/684] tv2go.t-2.net (sl) - 1000267 - Oct 26, 2025 (29 programs)                                                       13:00:40
<truncated>
```

```
npm run test --- tv2go.t-2.net                                                                                     

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand tv2go.t-2.net

 PASS  sites/tv2go.t-2.net/tv2go.t-2.net.test.js
  √ can generate valid url (4 ms)
  √ can generate valid request headers (2 ms)
  √ can generate valid request data (2 ms)
  √ can parse response (2 ms)                                                                                                          
  √ can handle empty guide (1 ms)                                                                                                      
                                                                                                                                       
Test Suites: 1 passed, 1 total                                                                                                         
Tests:       5 passed, 5 total                                                                                                         
Snapshots:   0 total
Time:        0.668 s, estimated 1 s
Ran all test suites matching tv2go.t-2.net.
```