### PR TITLE
Adding User-Agent for `skyperfectv.co.jp`

### DIFF
--- a/sites/skyperfectv.co.jp/skyperfectv.co.jp.config.js
+++ b/sites/skyperfectv.co.jp/skyperfectv.co.jp.config.js
@@ -28,7 +28,7 @@ const exported = {
   request: {
     headers: {
       Cookie: 'adult_auth=true',
-      'User-Agent': USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)],
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'
     }
   },
   parser({ content, date }) {


### PR DESCRIPTION
The site now requires a valid and “normal” User-Agent. Also placed the Cookie in the right place so it really works.