### PR TITLE
Fix missing programs sorting.

### DIFF
--- a/scripts/commands/epg/grab.ts
+++ b/scripts/commands/epg/grab.ts
@@ -279,14 +279,16 @@ async function main() {
       return pathTemplate.format({ lang: channel.lang || 'en', site: channel.site || '' })
     })
 
-  const programsGroupedByKey = programs.groupBy((program: Program) => {
-    const lang =
-      program.titles && program.titles.length && program.titles[0].lang
-        ? program.titles[0].lang
-        : 'en'
+  const programsGroupedByKey = programs
+    .sortBy([(program: Program) => program.channel, (program: Program) => program.start])
+    .groupBy((program: Program) => {
+      const lang =
+        program.titles && program.titles.length && program.titles[0].lang
+          ? program.titles[0].lang
+          : 'en'
 
-    return pathTemplate.format({ lang, site: program.site || '' })
-  })
+      return pathTemplate.format({ lang, site: program.site || '' })
+    })
 
   const gzip = globalConfig.gzip || defaultConfig.gzip
 


### PR DESCRIPTION
Programs sorting was removed in f07af88a8cc58bddfdf4863146281259720b4373, this fix re-add the removed code.

As running `grab` would not ensure days ordering, so:

```sh
npm run grab --- --channels=./channels.xml

> grab
> tsx scripts/commands/epg/grab.ts --channels=./channels.xml

info starting...
info loading channels...
info found 5 channel(s)
info loading api data...
info creating queue...
info run:
info   [1/10] nowplayer.now.com (en) - HBOAsia.sg@SD - Nov 23, 2025 (7 programs)
info   [2/10] nowplayer.now.com (en) - HBOAsia.sg@SD - Nov 24, 2025 (19 programs)
info   [3/10] nowplayer.now.com (en) - CinemaxAsia.sg@SD - Nov 23, 2025 (7 programs)
info   [4/10] nowplayer.now.com (en) - HBOSignatureAsia.sg@SD - Nov 23, 2025 (10 programs)
info   [5/10] nowplayer.now.com (en) - HBOHitsAsia.sg@SD - Nov 24, 2025 (15 programs)
info   [6/10] nowplayer.now.com (en) - HBOHitsAsia.sg@SD - Nov 23, 2025 (8 programs)
info   [7/10] nowplayer.now.com (en) - HBOFamilyAsia.sg@SD - Nov 24, 2025 (43 programs)
info   [8/10] nowplayer.now.com (en) - HBOFamilyAsia.sg@SD - Nov 23, 2025 (8 programs)
info   [9/10] nowplayer.now.com (en) - CinemaxAsia.sg@SD - Nov 24, 2025 (16 programs)
info   [10/10] nowplayer.now.com (en) - HBOSignatureAsia.sg@SD - Nov 24, 2025 (15 programs)
info   saving to "guide.xml"...
success   done in 00h 00m 01s
```

will produce unsorted programs.
