### PR TITLE
Update xmltv_id for dishtv.in

### DIFF
--- a/sites/dishtv.in/dishtv.in.channels.xml
+++ b/sites/dishtv.in/dishtv.in.channels.xml
@@ -1,81 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="dishtv.in" site_id="77447" lang="en" xmltv_id="">9XM</channel>
-  <channel site="dishtv.in" site_id="90009" lang="en" xmltv_id="">News24</channel>
-  <channel site="dishtv.in" site_id="90012" lang="en" xmltv_id="">9X Jhakaas</channel>
-  <channel site="dishtv.in" site_id="100869" lang="en" xmltv_id="">Discovery Channel</channel>
-  <channel site="dishtv.in" site_id="117852" lang="en" xmltv_id="">Sun TV</channel>
-  <channel site="dishtv.in" site_id="117853" lang="en" xmltv_id="">Zee Bangla</channel>
+  <channel site="dishtv.in" site_id="77447" lang="en" xmltv_id="9XM.in@SD">9XM</channel>
+  <channel site="dishtv.in" site_id="90009" lang="en" xmltv_id="News24.in@SD">News24</channel>
+  <channel site="dishtv.in" site_id="90012" lang="en" xmltv_id="9XJhakaas.in@SD">9X Jhakaas</channel>
+  <channel site="dishtv.in" site_id="100869" lang="en" xmltv_id="DiscoveryChannel.in@SD">Discovery Channel</channel>
+  <channel site="dishtv.in" site_id="117852" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
+  <channel site="dishtv.in" site_id="117853" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla</channel>
   <channel site="dishtv.in" site_id="123500" lang="en" xmltv_id="">TLC HD</channel>
   <channel site="dishtv.in" site_id="135691" lang="en" xmltv_id="">MBC TV</channel>
-  <channel site="dishtv.in" site_id="140063" lang="en" xmltv_id="">B4U Movies</channel>
+  <channel site="dishtv.in" site_id="140063" lang="en" xmltv_id="B4UMovies.in@India">B4U Movies</channel>
   <channel site="dishtv.in" site_id="140066" lang="en" xmltv_id="">Movies Active</channel>
   <channel site="dishtv.in" site_id="140067" lang="en" xmltv_id="">News Live Bangla</channel>
-  <channel site="dishtv.in" site_id="140069" lang="en" xmltv_id="">Star Movies</channel>
-  <channel site="dishtv.in" site_id="142401" lang="en" xmltv_id="">RT</channel>
-  <channel site="dishtv.in" site_id="142504" lang="en" xmltv_id="">9X Tashan</channel>
-  <channel site="dishtv.in" site_id="142507" lang="en" xmltv_id="">Aaj Tak</channel>
-  <channel site="dishtv.in" site_id="142510" lang="en" xmltv_id="">Aakash Aath</channel>
-  <channel site="dishtv.in" site_id="142514" lang="en" xmltv_id="">Aastha Bhajan</channel>
-  <channel site="dishtv.in" site_id="142518" lang="en" xmltv_id="">ABP Ananda</channel>
-  <channel site="dishtv.in" site_id="142519" lang="en" xmltv_id="">ABP Asmita</channel>
-  <channel site="dishtv.in" site_id="142521" lang="en" xmltv_id="">ABP Majha</channel>
-  <channel site="dishtv.in" site_id="142630" lang="en" xmltv_id="">Alankar</channel>
-  <channel site="dishtv.in" site_id="142635" lang="en" xmltv_id="">&amp;flix</channel>
+  <channel site="dishtv.in" site_id="140069" lang="en" xmltv_id="StarMovies.in@SD">Star Movies</channel>
+  <channel site="dishtv.in" site_id="142401" lang="en" xmltv_id="RT.ru@SD">RT</channel>
+  <channel site="dishtv.in" site_id="142504" lang="en" xmltv_id="9XTashan.in@SD">9X Tashan</channel>
+  <channel site="dishtv.in" site_id="142507" lang="en" xmltv_id="AajTak.in@SD">Aaj Tak</channel>
+  <channel site="dishtv.in" site_id="142510" lang="en" xmltv_id="AakaashAath.in@SD">Aakash Aath</channel>
+  <channel site="dishtv.in" site_id="142514" lang="en" xmltv_id="AasthaBhajan.in@SD">Aastha Bhajan</channel>
+  <channel site="dishtv.in" site_id="142518" lang="en" xmltv_id="ABPAnanda.in@SD">ABP Ananda</channel>
+  <channel site="dishtv.in" site_id="142519" lang="en" xmltv_id="ABPAsmita.in@SD">ABP Asmita</channel>
+  <channel site="dishtv.in" site_id="142521" lang="en" xmltv_id="ABPMajha.in@SD">ABP Majha</channel>
+  <channel site="dishtv.in" site_id="142630" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
+  <channel site="dishtv.in" site_id="142635" lang="en" xmltv_id="Andflix.in@SD">&amp;flix</channel>
   <channel site="dishtv.in" site_id="142636" lang="en" xmltv_id="">&amp;flix HD</channel>
-  <channel site="dishtv.in" site_id="142637" lang="en" xmltv_id="">&amp; Pictures</channel>
+  <channel site="dishtv.in" site_id="142637" lang="en" xmltv_id="Andpictures.in@SD">&amp; Pictures</channel>
   <channel site="dishtv.in" site_id="142638" lang="en" xmltv_id="">&amp; Pictures HD</channel>
-  <channel site="dishtv.in" site_id="142639" lang="en" xmltv_id="">&amp;prive HD</channel>
-  <channel site="dishtv.in" site_id="142640" lang="en" xmltv_id="">&amp;TV</channel>
+  <channel site="dishtv.in" site_id="142639" lang="en" xmltv_id="AndpriveHD.in@SD">&amp;prive HD</channel>
+  <channel site="dishtv.in" site_id="142640" lang="en" xmltv_id="AndTV.in@SD">&amp;TV</channel>
   <channel site="dishtv.in" site_id="142641" lang="en" xmltv_id="">&amp;TV HD</channel>
-  <channel site="dishtv.in" site_id="142650" lang="en" xmltv_id="">Argus</channel>
+  <channel site="dishtv.in" site_id="142650" lang="en" xmltv_id="ArgusNews.in@SD">Argus</channel>
   <channel site="dishtv.in" site_id="142651" lang="en" xmltv_id="">Dharam Sandesh</channel>
-  <channel site="dishtv.in" site_id="142683" lang="en" xmltv_id="">Assam Talks</channel>
-  <channel site="dishtv.in" site_id="142694" lang="en" xmltv_id="">B4U Bhojpuri</channel>
-  <channel site="dishtv.in" site_id="142695" lang="en" xmltv_id="">B4U Kadak</channel>
-  <channel site="dishtv.in" site_id="142697" lang="en" xmltv_id="">Balle Balle</channel>
-  <channel site="dishtv.in" site_id="142702" lang="en" xmltv_id="">Bansal News</channel>
-  <channel site="dishtv.in" site_id="142710" lang="en" xmltv_id="">Bharat 24</channel>
-  <channel site="dishtv.in" site_id="142711" lang="en" xmltv_id="">Bharat Express</channel>
-  <channel site="dishtv.in" site_id="142713" lang="en" xmltv_id="">Bhojpuri Cinema</channel>
-  <channel site="dishtv.in" site_id="142715" lang="en" xmltv_id="">BIG Magic</channel>
+  <channel site="dishtv.in" site_id="142683" lang="en" xmltv_id="AssamTalks.in@SD">Assam Talks</channel>
+  <channel site="dishtv.in" site_id="142694" lang="en" xmltv_id="B4UBhojpuri.in@SD">B4U Bhojpuri</channel>
+  <channel site="dishtv.in" site_id="142695" lang="en" xmltv_id="B4UKadak.in@SD">B4U Kadak</channel>
+  <channel site="dishtv.in" site_id="142697" lang="en" xmltv_id="BalleBalle.in@SD">Balle Balle</channel>
+  <channel site="dishtv.in" site_id="142702" lang="en" xmltv_id="BansalNews.in@SD">Bansal News</channel>
+  <channel site="dishtv.in" site_id="142710" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
+  <channel site="dishtv.in" site_id="142711" lang="en" xmltv_id="BharatExpress.in@SD">Bharat Express</channel>
+  <channel site="dishtv.in" site_id="142713" lang="en" xmltv_id="BhojpuriCinema.in@SD">Bhojpuri Cinema</channel>
+  <channel site="dishtv.in" site_id="142715" lang="en" xmltv_id="BigMagic.in@SD">BIG Magic</channel>
   <channel site="dishtv.in" site_id="142725" lang="en" xmltv_id="">Calcutta News</channel>
-  <channel site="dishtv.in" site_id="142736" lang="en" xmltv_id="">Chardikla Time TV</channel>
-  <channel site="dishtv.in" site_id="142742" lang="en" xmltv_id="">CNBC Bajar</channel>
-  <channel site="dishtv.in" site_id="142743" lang="en" xmltv_id="">CNBC TV18</channel>
-  <channel site="dishtv.in" site_id="142744" lang="en" xmltv_id="">CNBC TV18 Prime</channel>
-  <channel site="dishtv.in" site_id="142745" lang="en" xmltv_id="">CNBC-Awaaz</channel>
-  <channel site="dishtv.in" site_id="142747" lang="en" xmltv_id="">CNN-News18</channel>
-  <channel site="dishtv.in" site_id="142748" lang="en" xmltv_id="">Colors Bangla Cinema</channel>
-  <channel site="dishtv.in" site_id="142749" lang="en" xmltv_id="">Colors Cineplex Bollywood</channel>
-  <channel site="dishtv.in" site_id="142750" lang="en" xmltv_id="">Colors Cineplex Superhits</channel>
-  <channel site="dishtv.in" site_id="142751" lang="en" xmltv_id="">Colors Gujarati Cinema</channel>
-  <channel site="dishtv.in" site_id="142754" lang="en" xmltv_id="">CTVN AKD Plus</channel>
-  <channel site="dishtv.in" site_id="142769" lang="en" xmltv_id="">Dabangg</channel>
-  <channel site="dishtv.in" site_id="142771" lang="en" xmltv_id="">Dangal</channel>
+  <channel site="dishtv.in" site_id="142736" lang="en" xmltv_id="ChardiklaTimeTV.in@SD">Chardikla Time TV</channel>
+  <channel site="dishtv.in" site_id="142742" lang="en" xmltv_id="CNBCBajar.in@SD">CNBC Bajar</channel>
+  <channel site="dishtv.in" site_id="142743" lang="en" xmltv_id="CNBCTV18.in@SD">CNBC TV18</channel>
+  <channel site="dishtv.in" site_id="142744" lang="en" xmltv_id="CNBCTV18PrimeHD.in@SD">CNBC TV18 Prime</channel>
+  <channel site="dishtv.in" site_id="142745" lang="en" xmltv_id="CNBCAwaaz.in@SD">CNBC-Awaaz</channel>
+  <channel site="dishtv.in" site_id="142747" lang="en" xmltv_id="CNNNews18.in@SD">CNN-News18</channel>
+  <channel site="dishtv.in" site_id="142748" lang="en" xmltv_id="ColorsBanglaCinema.in@SD">Colors Bangla Cinema</channel>
+  <channel site="dishtv.in" site_id="142749" lang="en" xmltv_id="ColorsCineplexBollywood.in@SD">Colors Cineplex Bollywood</channel>
+  <channel site="dishtv.in" site_id="142750" lang="en" xmltv_id="ColorsCineplexSuperhits.in@SD">Colors Cineplex Superhits</channel>
+  <channel site="dishtv.in" site_id="142751" lang="en" xmltv_id="ColorsGujaratiCinema.in@SD">Colors Gujarati Cinema</channel>
+  <channel site="dishtv.in" site_id="142754" lang="en" xmltv_id="CTVNAKDPlus.in@SD">CTVN AKD Plus</channel>
+  <channel site="dishtv.in" site_id="142769" lang="en" xmltv_id="Dabangg.in@SD">Dabangg</channel>
+  <channel site="dishtv.in" site_id="142771" lang="en" xmltv_id="DangalTV.in@SD">Dangal</channel>
   <channel site="dishtv.in" site_id="142772" lang="en" xmltv_id="">Dangal 2</channel>
-  <channel site="dishtv.in" site_id="142776" lang="en" xmltv_id="">DD Arun Prabha</channel>
-  <channel site="dishtv.in" site_id="142777" lang="en" xmltv_id="">DD Assam</channel>
-  <channel site="dishtv.in" site_id="142778" lang="en" xmltv_id="">DD Bangla</channel>
-  <channel site="dishtv.in" site_id="142779" lang="en" xmltv_id="">DD Bharati</channel>
-  <channel site="dishtv.in" site_id="142780" lang="en" xmltv_id="">DD Bihar</channel>
-  <channel site="dishtv.in" site_id="142781" lang="en" xmltv_id="">DD Chandana</channel>
-  <channel site="dishtv.in" site_id="142782" lang="en" xmltv_id="">DD Girnar</channel>
-  <channel site="dishtv.in" site_id="142788" lang="en" xmltv_id="">DD Kashir</channel>
-  <channel site="dishtv.in" site_id="142789" lang="en" xmltv_id="">DD Kisan</channel>
-  <channel site="dishtv.in" site_id="142790" lang="en" xmltv_id="">DD Madhya Pradesh</channel>
-  <channel site="dishtv.in" site_id="142791" lang="en" xmltv_id="">DD Malayalam</channel>
-  <channel site="dishtv.in" site_id="142796" lang="en" xmltv_id="">DD Oriya</channel>
-  <channel site="dishtv.in" site_id="142797" lang="en" xmltv_id="">DD TAMIL</channel>
-  <channel site="dishtv.in" site_id="142800" lang="en" xmltv_id="">DD Punjabi</channel>
-  <channel site="dishtv.in" site_id="142801" lang="en" xmltv_id="">DD Rajasthan</channel>
-  <channel site="dishtv.in" site_id="142803" lang="en" xmltv_id="">DD Sahyadri</channel>
-  <channel site="dishtv.in" site_id="142804" lang="en" xmltv_id="">DD Saptagiri</channel>
-  <channel site="dishtv.in" site_id="142807" lang="en" xmltv_id="">DD UP</channel>
-  <channel site="dishtv.in" site_id="142808" lang="en" xmltv_id="">DD Urdu</channel>
-  <channel site="dishtv.in" site_id="142810" lang="en" xmltv_id="">DD Yadagiri</channel>
+  <channel site="dishtv.in" site_id="142776" lang="en" xmltv_id="DDArunPrabha.in@SD">DD Arun Prabha</channel>
+  <channel site="dishtv.in" site_id="142777" lang="en" xmltv_id="DDAssam.in@SD">DD Assam</channel>
+  <channel site="dishtv.in" site_id="142778" lang="en" xmltv_id="DDBangla.in@SD">DD Bangla</channel>
+  <channel site="dishtv.in" site_id="142779" lang="en" xmltv_id="DDBharati.in@SD">DD Bharati</channel>
+  <channel site="dishtv.in" site_id="142780" lang="en" xmltv_id="DDBihar.in@SD">DD Bihar</channel>
+  <channel site="dishtv.in" site_id="142781" lang="en" xmltv_id="DDChandana.in@SD">DD Chandana</channel>
+  <channel site="dishtv.in" site_id="142782" lang="en" xmltv_id="DDGirnar.in@SD">DD Girnar</channel>
+  <channel site="dishtv.in" site_id="142788" lang="en" xmltv_id="DDKashir.in@SD">DD Kashir</channel>
+  <channel site="dishtv.in" site_id="142789" lang="en" xmltv_id="DDKisan.in@SD">DD Kisan</channel>
+  <channel site="dishtv.in" site_id="142790" lang="en" xmltv_id="DDMadhyaPradesh.in@SD">DD Madhya Pradesh</channel>
+  <channel site="dishtv.in" site_id="142791" lang="en" xmltv_id="DDMalayalam.in@SD">DD Malayalam</channel>
+  <channel site="dishtv.in" site_id="142796" lang="en" xmltv_id="DDOdia.in@SD">DD Oriya</channel>
+  <channel site="dishtv.in" site_id="142797" lang="en" xmltv_id="DDTamil.in@SD">DD TAMIL</channel>
+  <channel site="dishtv.in" site_id="142800" lang="en" xmltv_id="DDPunjabi.in@SD">DD Punjabi</channel>
+  <channel site="dishtv.in" site_id="142801" lang="en" xmltv_id="DDRajasthan.in@SD">DD Rajasthan</channel>
+  <channel site="dishtv.in" site_id="142803" lang="en" xmltv_id="DDSahyadri.in@SD">DD Sahyadri</channel>
+  <channel site="dishtv.in" site_id="142804" lang="en" xmltv_id="DDSaptagiri.in@SD">DD Saptagiri</channel>
+  <channel site="dishtv.in" site_id="142807" lang="en" xmltv_id="DDUttarPradesh.in@SD">DD UP</channel>
+  <channel site="dishtv.in" site_id="142808" lang="en" xmltv_id="DDUrdu.in@SD">DD Urdu</channel>
+  <channel site="dishtv.in" site_id="142810" lang="en" xmltv_id="DDYadagiri.in@SD">DD Yadagiri</channel>
   <channel site="dishtv.in" site_id="142881" lang="en" xmltv_id="">Goldmines Movies</channel>
-  <channel site="dishtv.in" site_id="142882" lang="en" xmltv_id="">Dhoom Music</channel>
+  <channel site="dishtv.in" site_id="142882" lang="en" xmltv_id="DhoomMusic.in@SD">Dhoom Music</channel>
   <channel site="dishtv.in" site_id="142892" lang="en" xmltv_id="">Ayushmaan Active</channel>
   <channel site="dishtv.in" site_id="142893" lang="en" xmltv_id="">Dish Bhakti Active</channel>
   <channel site="dishtv.in" site_id="142894" lang="en" xmltv_id="">Dish Buzz</channel>
@@ -90,338 +90,338 @@
   <channel site="dishtv.in" site_id="142913" lang="en" xmltv_id="">KOREAN DRAMA ACTIVE</channel>
   <channel site="dishtv.in" site_id="142918" lang="en" xmltv_id="">Rangmanch Active</channel>
   <channel site="dishtv.in" site_id="142919" lang="en" xmltv_id="">RECHARGE REMINDER</channel>
-  <channel site="dishtv.in" site_id="142920" lang="en" xmltv_id="">Songdew</channel>
+  <channel site="dishtv.in" site_id="142920" lang="en" xmltv_id="SongdewTV.in@SD">Songdew</channel>
   <channel site="dishtv.in" site_id="142926" lang="en" xmltv_id="">Dish TV Evergreen Classic</channel>
   <channel site="dishtv.in" site_id="142986" lang="en" xmltv_id="">Zindagi Active</channel>
-  <channel site="dishtv.in" site_id="142989" lang="en" xmltv_id="">Disney International HD</channel>
-  <channel site="dishtv.in" site_id="142990" lang="en" xmltv_id="">Disney Junior</channel>
-  <channel site="dishtv.in" site_id="143010" lang="en" xmltv_id="">Divya</channel>
-  <channel site="dishtv.in" site_id="143015" lang="en" xmltv_id="">DY365</channel>
-  <channel site="dishtv.in" site_id="143018" lang="en" xmltv_id="">Enterr10 Bangla</channel>
-  <channel site="dishtv.in" site_id="143021" lang="en" xmltv_id="">ET Now</channel>
-  <channel site="dishtv.in" site_id="143022" lang="en" xmltv_id="">ET Now Swadesh</channel>
-  <channel site="dishtv.in" site_id="143025" lang="en" xmltv_id="">ETV Bal Bharat</channel>
-  <channel site="dishtv.in" site_id="143033" lang="en" xmltv_id="">ETV Telugu</channel>
-  <channel site="dishtv.in" site_id="143038" lang="en" xmltv_id="">Fakt Marathi</channel>
-  <channel site="dishtv.in" site_id="143078" lang="en" xmltv_id="">Gemini TV</channel>
+  <channel site="dishtv.in" site_id="142989" lang="en" xmltv_id="DisneyInternationalHD.in@SD">Disney International HD</channel>
+  <channel site="dishtv.in" site_id="142990" lang="en" xmltv_id="DisneyJunior.in@SD">Disney Junior</channel>
+  <channel site="dishtv.in" site_id="143010" lang="en" xmltv_id="ChannelDivya.in@SD">Divya</channel>
+  <channel site="dishtv.in" site_id="143015" lang="en" xmltv_id="DY365.in@SD">DY365</channel>
+  <channel site="dishtv.in" site_id="143018" lang="en" xmltv_id="Enterr10Bangla.in@SD">Enterr10 Bangla</channel>
+  <channel site="dishtv.in" site_id="143021" lang="en" xmltv_id="ETNow.in@SD">ET Now</channel>
+  <channel site="dishtv.in" site_id="143022" lang="en" xmltv_id="ETNowSwadesh.in@SD">ET Now Swadesh</channel>
+  <channel site="dishtv.in" site_id="143025" lang="en" xmltv_id="ETVBalaBharatMalayalam.in@SD">ETV Bal Bharat</channel>
+  <channel site="dishtv.in" site_id="143033" lang="en" xmltv_id="ETVTelugu.in@SD">ETV Telugu</channel>
+  <channel site="dishtv.in" site_id="143038" lang="en" xmltv_id="FaktMarathi.in@SD">Fakt Marathi</channel>
+  <channel site="dishtv.in" site_id="143078" lang="en" xmltv_id="GeminiTV.in@SD">Gemini TV</channel>
   <channel site="dishtv.in" site_id="143087" lang="en" xmltv_id="">Goldmines</channel>
   <channel site="dishtv.in" site_id="143089" lang="en" xmltv_id="">Goldmines Bollywood</channel>
-  <channel site="dishtv.in" site_id="143090" lang="en" xmltv_id="">Good News Today</channel>
-  <channel site="dishtv.in" site_id="143097" lang="en" xmltv_id="">Gulistan News</channel>
-  <channel site="dishtv.in" site_id="143100" lang="en" xmltv_id="">Gyandarshan</channel>
-  <channel site="dishtv.in" site_id="143102" lang="en" xmltv_id="">Hare Krsna</channel>
-  <channel site="dishtv.in" site_id="143132" lang="en" xmltv_id="">History TV18</channel>
-  <channel site="dishtv.in" site_id="143133" lang="en" xmltv_id="">History TV18 HD</channel>
-  <channel site="dishtv.in" site_id="143150" lang="en" xmltv_id="">Hungama</channel>
-  <channel site="dishtv.in" site_id="143156" lang="en" xmltv_id="">IBC24</channel>
-  <channel site="dishtv.in" site_id="143192" lang="en" xmltv_id="">India News Haryana</channel>
-  <channel site="dishtv.in" site_id="143197" lang="en" xmltv_id="">INDIA TODAY</channel>
-  <channel site="dishtv.in" site_id="143199" lang="en" xmltv_id="">India TV</channel>
+  <channel site="dishtv.in" site_id="143090" lang="en" xmltv_id="GoodNewsToday.in@SD">Good News Today</channel>
+  <channel site="dishtv.in" site_id="143097" lang="en" xmltv_id="GulistanNews.in@SD">Gulistan News</channel>
+  <channel site="dishtv.in" site_id="143100" lang="en" xmltv_id="Gyandarshan.in@SD">Gyandarshan</channel>
+  <channel site="dishtv.in" site_id="143102" lang="en" xmltv_id="HareKrsnaTV.in@SD">Hare Krsna</channel>
+  <channel site="dishtv.in" site_id="143132" lang="en" xmltv_id="HistoryTV18.in@SD">History TV18</channel>
+  <channel site="dishtv.in" site_id="143133" lang="en" xmltv_id="HistoryTV18.in@HD">History TV18 HD</channel>
+  <channel site="dishtv.in" site_id="143150" lang="en" xmltv_id="HungamaTV.in@SD">Hungama</channel>
+  <channel site="dishtv.in" site_id="143156" lang="en" xmltv_id="IBC24.in@SD">IBC24</channel>
+  <channel site="dishtv.in" site_id="143192" lang="en" xmltv_id="IndiaNewsHaryana.in@SD">India News Haryana</channel>
+  <channel site="dishtv.in" site_id="143197" lang="en" xmltv_id="IndiaToday.in@SD">INDIA TODAY</channel>
+  <channel site="dishtv.in" site_id="143199" lang="en" xmltv_id="IndiaTV.in@SD">India TV</channel>
   <channel site="dishtv.in" site_id="143213" lang="en" xmltv_id="">Ishwar TV</channel>
-  <channel site="dishtv.in" site_id="143216" lang="en" xmltv_id="">Jai Maharashtra</channel>
-  <channel site="dishtv.in" site_id="143218" lang="en" xmltv_id="">Jalsha Movies</channel>
-  <channel site="dishtv.in" site_id="143219" lang="en" xmltv_id="">Jalsha Movies HD</channel>
-  <channel site="dishtv.in" site_id="143224" lang="en" xmltv_id="">Jantantra TV</channel>
+  <channel site="dishtv.in" site_id="143216" lang="en" xmltv_id="JaiMaharashtra.in@SD">Jai Maharashtra</channel>
+  <channel site="dishtv.in" site_id="143218" lang="en" xmltv_id="JalshaMovies.in@SD">Jalsha Movies</channel>
+  <channel site="dishtv.in" site_id="143219" lang="en" xmltv_id="JalshaMovies.in@HD">Jalsha Movies HD</channel>
+  <channel site="dishtv.in" site_id="143224" lang="en" xmltv_id="JantantraTV.in@SD">Jantantra TV</channel>
   <channel site="dishtv.in" site_id="143225" lang="en" xmltv_id="">Jay Jagannath</channel>
-  <channel site="dishtv.in" site_id="143230" lang="en" xmltv_id="">Jinvani</channel>
-  <channel site="dishtv.in" site_id="143238" lang="en" xmltv_id="">Jonack</channel>
-  <channel site="dishtv.in" site_id="143250" lang="en" xmltv_id="">Kalinga TV</channel>
-  <channel site="dishtv.in" site_id="143252" lang="en" xmltv_id="">Kanak News</channel>
-  <channel site="dishtv.in" site_id="143262" lang="en" xmltv_id="">Khabrain Abhi Tak</channel>
-  <channel site="dishtv.in" site_id="143265" lang="en" xmltv_id="">Khushboo Bangla</channel>
-  <channel site="dishtv.in" site_id="143271" lang="en" xmltv_id="">Kolkata TV</channel>
-  <channel site="dishtv.in" site_id="143283" lang="en" xmltv_id="">Living India News</channel>
+  <channel site="dishtv.in" site_id="143230" lang="en" xmltv_id="JinvaniChannel.in@SD">Jinvani</channel>
+  <channel site="dishtv.in" site_id="143238" lang="en" xmltv_id="Jonack.in@SD">Jonack</channel>
+  <channel site="dishtv.in" site_id="143250" lang="en" xmltv_id="KalingaTV.in@SD">Kalinga TV</channel>
+  <channel site="dishtv.in" site_id="143252" lang="en" xmltv_id="KanakNews.in@SD">Kanak News</channel>
+  <channel site="dishtv.in" site_id="143262" lang="en" xmltv_id="KhabrainAbhiTak.in@SD">Khabrain Abhi Tak</channel>
+  <channel site="dishtv.in" site_id="143265" lang="en" xmltv_id="KhushbooBangla.in@SD">Khushboo Bangla</channel>
+  <channel site="dishtv.in" site_id="143271" lang="en" xmltv_id="KolkataTV.in@SD">Kolkata TV</channel>
+  <channel site="dishtv.in" site_id="143283" lang="en" xmltv_id="LivingIndiaNews.in@SD">Living India News</channel>
   <channel site="dishtv.in" site_id="143284" lang="en" xmltv_id="">LOKSHAHI MARATHI</channel>
   <channel site="dishtv.in" site_id="143292" lang="en" xmltv_id="">Tabbar Hits</channel>
-  <channel site="dishtv.in" site_id="143295" lang="en" xmltv_id="">Maiboli</channel>
-  <channel site="dishtv.in" site_id="143302" lang="en" xmltv_id="">Manoranjan Grand</channel>
-  <channel site="dishtv.in" site_id="143303" lang="en" xmltv_id="">Manoranjan Movies</channel>
-  <channel site="dishtv.in" site_id="143304" lang="en" xmltv_id="">Manoranjan TV</channel>
-  <channel site="dishtv.in" site_id="143308" lang="en" xmltv_id="">Mastiii</channel>
+  <channel site="dishtv.in" site_id="143295" lang="en" xmltv_id="Maiboli.in@SD">Maiboli</channel>
+  <channel site="dishtv.in" site_id="143302" lang="en" xmltv_id="ManoranjanGrand.in@SD">Manoranjan Grand</channel>
+  <channel site="dishtv.in" site_id="143303" lang="en" xmltv_id="ManoranjanMovies.in@SD">Manoranjan Movies</channel>
+  <channel site="dishtv.in" site_id="143304" lang="en" xmltv_id="ManoranjanTV.in@SD">Manoranjan TV</channel>
+  <channel site="dishtv.in" site_id="143308" lang="en" xmltv_id="Mastiii.in@SD">Mastiii</channel>
   <channel site="dishtv.in" site_id="143536" lang="en" xmltv_id="">MH One Dil Se</channel>
-  <channel site="dishtv.in" site_id="143539" lang="en" xmltv_id="">MHONE</channel>
-  <channel site="dishtv.in" site_id="143540" lang="en" xmltv_id="">MH1 News</channel>
-  <channel site="dishtv.in" site_id="143543" lang="en" xmltv_id="">Mirror Now</channel>
+  <channel site="dishtv.in" site_id="143539" lang="en" xmltv_id="Mh1Music.in@SD">MHONE</channel>
+  <channel site="dishtv.in" site_id="143540" lang="en" xmltv_id="Mh1News.in@SD">MH1 News</channel>
+  <channel site="dishtv.in" site_id="143543" lang="en" xmltv_id="MirrorNow.in@SD">Mirror Now</channel>
   <channel site="dishtv.in" site_id="143548" lang="en" xmltv_id="">MN+</channel>
-  <channel site="dishtv.in" site_id="143549" lang="en" xmltv_id="">MNX</channel>
-  <channel site="dishtv.in" site_id="143554" lang="en" xmltv_id="">Movies Now</channel>
-  <channel site="dishtv.in" site_id="143558" lang="en" xmltv_id="">MTV</channel>
-  <channel site="dishtv.in" site_id="143563" lang="en" xmltv_id="">Music India</channel>
-  <channel site="dishtv.in" site_id="143571" lang="en" xmltv_id="">Nat Geo Wild</channel>
-  <channel site="dishtv.in" site_id="143572" lang="en" xmltv_id="">Nat Geo Wild HD</channel>
-  <channel site="dishtv.in" site_id="143573" lang="en" xmltv_id="">National Geographic Channel</channel>
-  <channel site="dishtv.in" site_id="143574" lang="en" xmltv_id="">National Geographic Channel HD</channel>
-  <channel site="dishtv.in" site_id="143578" lang="en" xmltv_id="">News7</channel>
-  <channel site="dishtv.in" site_id="143584" lang="en" xmltv_id="">Nepal 1</channel>
-  <channel site="dishtv.in" site_id="143595" lang="en" xmltv_id="">News Live</channel>
-  <channel site="dishtv.in" site_id="143596" lang="en" xmltv_id="">News Nation</channel>
-  <channel site="dishtv.in" site_id="143601" lang="en" xmltv_id="">News State UK UP</channel>
-  <channel site="dishtv.in" site_id="143602" lang="en" xmltv_id="">News Time Bangla</channel>
-  <channel site="dishtv.in" site_id="143606" lang="en" xmltv_id="">News18 Assam North East</channel>
-  <channel site="dishtv.in" site_id="143607" lang="en" xmltv_id="">News18 Bangla</channel>
-  <channel site="dishtv.in" site_id="143608" lang="en" xmltv_id="">News18 Bihar Jharkhand</channel>
-  <channel site="dishtv.in" site_id="143609" lang="en" xmltv_id="">News18 Gujarati</channel>
-  <channel site="dishtv.in" site_id="143610" lang="en" xmltv_id="">News18 India</channel>
-  <channel site="dishtv.in" site_id="143611" lang="en" xmltv_id="">News18 Jammu Kashmir Ladakh Himachal Haryana</channel>
-  <channel site="dishtv.in" site_id="143614" lang="en" xmltv_id="">News18 Lokmat</channel>
-  <channel site="dishtv.in" site_id="143615" lang="en" xmltv_id="">News18 Madhya Pradesh Chhattisgarh</channel>
-  <channel site="dishtv.in" site_id="143616" lang="en" xmltv_id="">News18 Odia</channel>
-  <channel site="dishtv.in" site_id="143617" lang="en" xmltv_id="">NEWS18 PUNJAB</channel>
-  <channel site="dishtv.in" site_id="143618" lang="en" xmltv_id="">NEWS18 RAJASTHAN</channel>
+  <channel site="dishtv.in" site_id="143549" lang="en" xmltv_id="MNX.in@SD">MNX</channel>
+  <channel site="dishtv.in" site_id="143554" lang="en" xmltv_id="MoviesNow.in@SD">Movies Now</channel>
+  <channel site="dishtv.in" site_id="143558" lang="en" xmltv_id="MTV.in@SD">MTV</channel>
+  <channel site="dishtv.in" site_id="143563" lang="en" xmltv_id="MusicIndia.in@SD">Music India</channel>
+  <channel site="dishtv.in" site_id="143571" lang="en" xmltv_id="NationalGeographicWild.in@SD">Nat Geo Wild</channel>
+  <channel site="dishtv.in" site_id="143572" lang="en" xmltv_id="NationalGeographicWild.in@HD">Nat Geo Wild HD</channel>
+  <channel site="dishtv.in" site_id="143573" lang="en" xmltv_id="NationalGeographic.in@SD">National Geographic Channel</channel>
+  <channel site="dishtv.in" site_id="143574" lang="en" xmltv_id="NationalGeographic.in@HD">National Geographic Channel HD</channel>
+  <channel site="dishtv.in" site_id="143578" lang="en" xmltv_id="News7Tamil.in@SD">News7</channel>
+  <channel site="dishtv.in" site_id="143584" lang="en" xmltv_id="Nepal1.in@SD">Nepal 1</channel>
+  <channel site="dishtv.in" site_id="143595" lang="en" xmltv_id="NewsLive.in@SD">News Live</channel>
+  <channel site="dishtv.in" site_id="143596" lang="en" xmltv_id="NewsNation.in@SD">News Nation</channel>
+  <channel site="dishtv.in" site_id="143601" lang="en" xmltv_id="NewsStateUPUK.in@SD">News State UK UP</channel>
+  <channel site="dishtv.in" site_id="143602" lang="en" xmltv_id="NewsTimeBangla.in@SD">News Time Bangla</channel>
+  <channel site="dishtv.in" site_id="143606" lang="en" xmltv_id="News18AssamNorthEast.in@SD">News18 Assam North East</channel>
+  <channel site="dishtv.in" site_id="143607" lang="en" xmltv_id="News18Bangla.in@SD">News18 Bangla</channel>
+  <channel site="dishtv.in" site_id="143608" lang="en" xmltv_id="News18BiharJharkhand.in@SD">News18 Bihar Jharkhand</channel>
+  <channel site="dishtv.in" site_id="143609" lang="en" xmltv_id="News18Gujarati.in@SD">News18 Gujarati</channel>
+  <channel site="dishtv.in" site_id="143610" lang="en" xmltv_id="News18India.in@SD">News18 India</channel>
+  <channel site="dishtv.in" site_id="143611" lang="en" xmltv_id="News18JKLH.in@SD">News18 Jammu Kashmir Ladakh Himachal Haryana</channel>
+  <channel site="dishtv.in" site_id="143614" lang="en" xmltv_id="News18Lokmat.in@SD">News18 Lokmat</channel>
+  <channel site="dishtv.in" site_id="143615" lang="en" xmltv_id="News18MadhyaPradeshChhattisgarh.in@SD">News18 Madhya Pradesh Chhattisgarh</channel>
+  <channel site="dishtv.in" site_id="143616" lang="en" xmltv_id="News18Odia.in@SD">News18 Odia</channel>
+  <channel site="dishtv.in" site_id="143617" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">NEWS18 PUNJAB</channel>
+  <channel site="dishtv.in" site_id="143618" lang="en" xmltv_id="News18Rajasthan.in@SD">NEWS18 RAJASTHAN</channel>
   <channel site="dishtv.in" site_id="143620" lang="en" xmltv_id="">Prarthana Life</channel>
-  <channel site="dishtv.in" site_id="143621" lang="en" xmltv_id="">News18 Uttar Pradesh Uttarakhand</channel>
-  <channel site="dishtv.in" site_id="143624" lang="en" xmltv_id="">NewsX</channel>
-  <channel site="dishtv.in" site_id="143625" lang="en" xmltv_id="">Nick</channel>
+  <channel site="dishtv.in" site_id="143621" lang="en" xmltv_id="News18UttarPradeshUttarakhand.in@SD">News18 Uttar Pradesh Uttarakhand</channel>
+  <channel site="dishtv.in" site_id="143624" lang="en" xmltv_id="NewsX.in@SD">NewsX</channel>
+  <channel site="dishtv.in" site_id="143625" lang="en" xmltv_id="Nickelodeon.in@SD">Nick</channel>
   <channel site="dishtv.in" site_id="143630" lang="en" xmltv_id="">NKTV Plus</channel>
-  <channel site="dishtv.in" site_id="143633" lang="en" xmltv_id="">North East Live</channel>
-  <channel site="dishtv.in" site_id="143638" lang="en" xmltv_id="">Oscar Movies Bhojpuri</channel>
+  <channel site="dishtv.in" site_id="143633" lang="en" xmltv_id="NortheastLive.in@SD">North East Live</channel>
+  <channel site="dishtv.in" site_id="143638" lang="en" xmltv_id="OscarMoviesBhojpuri.in@SD">Oscar Movies Bhojpuri</channel>
   <channel site="dishtv.in" site_id="143639" lang="en" xmltv_id="">OTV</channel>
   <channel site="dishtv.in" site_id="143642" lang="en" xmltv_id="">Paras Gold One</channel>
-  <channel site="dishtv.in" site_id="143643" lang="en" xmltv_id="">Pasand</channel>
-  <channel site="dishtv.in" site_id="143646" lang="en" xmltv_id="">Peace of Mind</channel>
-  <channel site="dishtv.in" site_id="143650" lang="en" xmltv_id="">Pitaara</channel>
-  <channel site="dishtv.in" site_id="143663" lang="en" xmltv_id="">Pogo</channel>
-  <channel site="dishtv.in" site_id="143671" lang="en" xmltv_id="">Prag News</channel>
-  <channel site="dishtv.in" site_id="143673" lang="en" xmltv_id="">Pratham Khabar 24X7</channel>
-  <channel site="dishtv.in" site_id="143674" lang="en" xmltv_id="">Pratidin Time</channel>
-  <channel site="dishtv.in" site_id="143675" lang="en" xmltv_id="">Pravah Picture</channel>
-  <channel site="dishtv.in" site_id="143676" lang="en" xmltv_id="">Pravah Picture HD</channel>
-  <channel site="dishtv.in" site_id="143681" lang="en" xmltv_id="">PTC Chakde</channel>
-  <channel site="dishtv.in" site_id="143682" lang="en" xmltv_id="">PTC Music</channel>
-  <channel site="dishtv.in" site_id="143683" lang="en" xmltv_id="">PTC News</channel>
-  <channel site="dishtv.in" site_id="143684" lang="en" xmltv_id="">PTC Punjabi Gold</channel>
-  <channel site="dishtv.in" site_id="143685" lang="en" xmltv_id="">PTC Simran</channel>
-  <channel site="dishtv.in" site_id="143691" lang="en" xmltv_id="">PUNJABI HITS</channel>
-  <channel site="dishtv.in" site_id="143697" lang="en" xmltv_id="">R. Bangla</channel>
-  <channel site="dishtv.in" site_id="143713" lang="en" xmltv_id="">Sanskar</channel>
-  <channel site="dishtv.in" site_id="143717" lang="en" xmltv_id="">Ramdhenu</channel>
-  <channel site="dishtv.in" site_id="143718" lang="en" xmltv_id="">Rang</channel>
-  <channel site="dishtv.in" site_id="143722" lang="en" xmltv_id="">Rengoni TV</channel>
-  <channel site="dishtv.in" site_id="143723" lang="en" xmltv_id="">Republic TV</channel>
-  <channel site="dishtv.in" site_id="143724" lang="en" xmltv_id="">Republic Bharat</channel>
-  <channel site="dishtv.in" site_id="143729" lang="en" xmltv_id="">Romedy Now</channel>
-  <channel site="dishtv.in" site_id="143733" lang="en" xmltv_id="">Rupasi Bangla</channel>
-  <channel site="dishtv.in" site_id="143735" lang="en" xmltv_id="">Saam TV</channel>
-  <channel site="dishtv.in" site_id="143736" lang="en" xmltv_id="">Sadhna TV</channel>
+  <channel site="dishtv.in" site_id="143643" lang="en" xmltv_id="PasandTV.in@SD">Pasand</channel>
+  <channel site="dishtv.in" site_id="143646" lang="en" xmltv_id="PeaceofMindTV.in@SD">Peace of Mind</channel>
+  <channel site="dishtv.in" site_id="143650" lang="en" xmltv_id="Pitaara.in@SD">Pitaara</channel>
+  <channel site="dishtv.in" site_id="143663" lang="en" xmltv_id="Pogo.in@SD">Pogo</channel>
+  <channel site="dishtv.in" site_id="143671" lang="en" xmltv_id="PragNews.in@SD">Prag News</channel>
+  <channel site="dishtv.in" site_id="143673" lang="en" xmltv_id="PrathamKhabar24x7.in@SD">Pratham Khabar 24X7</channel>
+  <channel site="dishtv.in" site_id="143674" lang="en" xmltv_id="PratidinTime.in@SD">Pratidin Time</channel>
+  <channel site="dishtv.in" site_id="143675" lang="en" xmltv_id="PravahPicture.in@SD">Pravah Picture</channel>
+  <channel site="dishtv.in" site_id="143676" lang="en" xmltv_id="PravahPicture.in@HD">Pravah Picture HD</channel>
+  <channel site="dishtv.in" site_id="143681" lang="en" xmltv_id="PTCChakde.in@SD">PTC Chakde</channel>
+  <channel site="dishtv.in" site_id="143682" lang="en" xmltv_id="PTCMusic.in@SD">PTC Music</channel>
+  <channel site="dishtv.in" site_id="143683" lang="en" xmltv_id="PTCNews.in@SD">PTC News</channel>
+  <channel site="dishtv.in" site_id="143684" lang="en" xmltv_id="PTCPunjabiGold.in@SD">PTC Punjabi Gold</channel>
+  <channel site="dishtv.in" site_id="143685" lang="en" xmltv_id="PTCSimran.in@SD">PTC Simran</channel>
+  <channel site="dishtv.in" site_id="143691" lang="en" xmltv_id="PunjabiHits.in@SD">PUNJABI HITS</channel>
+  <channel site="dishtv.in" site_id="143697" lang="en" xmltv_id="RepublicBangla.in@SD">R. Bangla</channel>
+  <channel site="dishtv.in" site_id="143713" lang="en" xmltv_id="SanskarTV.in@SD">Sanskar</channel>
+  <channel site="dishtv.in" site_id="143717" lang="en" xmltv_id="Ramdhenu.in@SD">Ramdhenu</channel>
+  <channel site="dishtv.in" site_id="143718" lang="en" xmltv_id="Rang.in@SD">Rang</channel>
+  <channel site="dishtv.in" site_id="143722" lang="en" xmltv_id="Rengoni.in@SD">Rengoni TV</channel>
+  <channel site="dishtv.in" site_id="143723" lang="en" xmltv_id="RepublicTV.in@SD">Republic TV</channel>
+  <channel site="dishtv.in" site_id="143724" lang="en" xmltv_id="RepublicBharat.in@SD">Republic Bharat</channel>
+  <channel site="dishtv.in" site_id="143729" lang="en" xmltv_id="RomedyNow.in@SD">Romedy Now</channel>
+  <channel site="dishtv.in" site_id="143733" lang="en" xmltv_id="RupasiBangla.in@SD">Rupasi Bangla</channel>
+  <channel site="dishtv.in" site_id="143735" lang="en" xmltv_id="SaamTV.in@SD">Saam TV</channel>
+  <channel site="dishtv.in" site_id="143736" lang="en" xmltv_id="SadhnaTV.in@SD">Sadhna TV</channel>
   <channel site="dishtv.in" site_id="143742" lang="en" xmltv_id="">SAILEELA TV</channel>
-  <channel site="dishtv.in" site_id="143755" lang="en" xmltv_id="">Sandesh News</channel>
-  <channel site="dishtv.in" site_id="143756" lang="en" xmltv_id="">Sangeet Bangla</channel>
-  <channel site="dishtv.in" site_id="143757" lang="en" xmltv_id="">Sangeet Bhojpuri</channel>
-  <channel site="dishtv.in" site_id="143760" lang="en" xmltv_id="">Sansad TV 1</channel>
+  <channel site="dishtv.in" site_id="143755" lang="en" xmltv_id="SandeshNews.in@SD">Sandesh News</channel>
+  <channel site="dishtv.in" site_id="143756" lang="en" xmltv_id="SangeetBangla.in@SD">Sangeet Bangla</channel>
+  <channel site="dishtv.in" site_id="143757" lang="en" xmltv_id="SangeetBhojpuri.in@SD">Sangeet Bhojpuri</channel>
+  <channel site="dishtv.in" site_id="143760" lang="en" xmltv_id="SansadTV.in@SD">Sansad TV 1</channel>
   <channel site="dishtv.in" site_id="143761" lang="en" xmltv_id="">Sansad TV 2 HD</channel>
   <channel site="dishtv.in" site_id="143763" lang="en" xmltv_id="">Santvani TV</channel>
-  <channel site="dishtv.in" site_id="143766" lang="en" xmltv_id="">Satsang</channel>
-  <channel site="dishtv.in" site_id="143777" lang="en" xmltv_id="">Shemaroo Marathibana</channel>
-  <channel site="dishtv.in" site_id="143778" lang="en" xmltv_id="">Shemaroo TV</channel>
+  <channel site="dishtv.in" site_id="143766" lang="en" xmltv_id="SatsangTV.in@SD">Satsang</channel>
+  <channel site="dishtv.in" site_id="143777" lang="en" xmltv_id="ShemarooMarathiBana.in@SD">Shemaroo Marathibana</channel>
+  <channel site="dishtv.in" site_id="143778" lang="en" xmltv_id="ShemarooTV.in@SD">Shemaroo TV</channel>
   <channel site="dishtv.in" site_id="143779" lang="en" xmltv_id="">Shemaroo Umang</channel>
-  <channel site="dishtv.in" site_id="143783" lang="en" xmltv_id="">Shubh TV</channel>
+  <channel site="dishtv.in" site_id="143783" lang="en" xmltv_id="ShubhTV.in@SD">Shubh TV</channel>
   <channel site="dishtv.in" site_id="143785" lang="en" xmltv_id="">Sidharth Utsav</channel>
   <channel site="dishtv.in" site_id="143786" lang="en" xmltv_id="">Sidharth GOLD</channel>
   <channel site="dishtv.in" site_id="143787" lang="en" xmltv_id="">Sidharth TV</channel>
-  <channel site="dishtv.in" site_id="143790" lang="en" xmltv_id="">Siri Kannada</channel>
-  <channel site="dishtv.in" site_id="143799" lang="en" xmltv_id="">SONY BBC Earth</channel>
+  <channel site="dishtv.in" site_id="143790" lang="en" xmltv_id="SiriKannada.in@SD">Siri Kannada</channel>
+  <channel site="dishtv.in" site_id="143799" lang="en" xmltv_id="SonyBBCEarth.in@SD">SONY BBC Earth</channel>
   <channel site="dishtv.in" site_id="143800" lang="en" xmltv_id="">SONY BBC Earth HD</channel>
-  <channel site="dishtv.in" site_id="143801" lang="en" xmltv_id="">SONY MAX 2</channel>
+  <channel site="dishtv.in" site_id="143801" lang="en" xmltv_id="SonyMax2.in@SD">SONY MAX 2</channel>
   <channel site="dishtv.in" site_id="143802" lang="en" xmltv_id="">Sony Pix</channel>
-  <channel site="dishtv.in" site_id="143803" lang="en" xmltv_id="">SONY PIX HD</channel>
+  <channel site="dishtv.in" site_id="143803" lang="en" xmltv_id="SonyPix.in@SD">SONY PIX HD</channel>
   <channel site="dishtv.in" site_id="143806" lang="en" xmltv_id="">Spondon</channel>
-  <channel site="dishtv.in" site_id="143807" lang="en" xmltv_id="">Star Sports 2 Hindi</channel>
+  <channel site="dishtv.in" site_id="143807" lang="en" xmltv_id="StarSports2Hindi.in@SD">Star Sports 2 Hindi</channel>
   <channel site="dishtv.in" site_id="143808" lang="en" xmltv_id="">Star Sports 2 Hindi HD</channel>
   <channel site="dishtv.in" site_id="143809" lang="en" xmltv_id="">Star Sports Khel</channel>
-  <channel site="dishtv.in" site_id="143814" lang="en" xmltv_id="">Star Gold 2</channel>
-  <channel site="dishtv.in" site_id="143815" lang="en" xmltv_id="">Star Gold HD</channel>
-  <channel site="dishtv.in" site_id="143816" lang="en" xmltv_id="">Star Gold Select</channel>
-  <channel site="dishtv.in" site_id="143817" lang="en" xmltv_id="">Star Gold Select HD</channel>
-  <channel site="dishtv.in" site_id="143818" lang="en" xmltv_id="">Star Jalsha</channel>
-  <channel site="dishtv.in" site_id="143819" lang="en" xmltv_id="">Star Jalsha HD</channel>
-  <channel site="dishtv.in" site_id="143820" lang="en" xmltv_id="">Star Kiran</channel>
-  <channel site="dishtv.in" site_id="143821" lang="en" xmltv_id="">Star Maa</channel>
-  <channel site="dishtv.in" site_id="143825" lang="en" xmltv_id="">Star Maa Movies</channel>
-  <channel site="dishtv.in" site_id="143829" lang="en" xmltv_id="">Star Movies HD</channel>
-  <channel site="dishtv.in" site_id="143830" lang="en" xmltv_id="">Star Movies Select HD</channel>
-  <channel site="dishtv.in" site_id="143831" lang="en" xmltv_id="">STAR PLUS</channel>
-  <channel site="dishtv.in" site_id="143832" lang="en" xmltv_id="">STAR PLUS HD</channel>
-  <channel site="dishtv.in" site_id="143833" lang="en" xmltv_id="">Star Pravah</channel>
-  <channel site="dishtv.in" site_id="143834" lang="en" xmltv_id="">Star Pravah HD</channel>
-  <channel site="dishtv.in" site_id="143835" lang="en" xmltv_id="">Star Sports 1</channel>
-  <channel site="dishtv.in" site_id="143837" lang="en" xmltv_id="">Star Sports 1 HD</channel>
+  <channel site="dishtv.in" site_id="143814" lang="en" xmltv_id="StarGold2.in@SD">Star Gold 2</channel>
+  <channel site="dishtv.in" site_id="143815" lang="en" xmltv_id="StarGold.in@HD">Star Gold HD</channel>
+  <channel site="dishtv.in" site_id="143816" lang="en" xmltv_id="StarGoldSelect.in@SD">Star Gold Select</channel>
+  <channel site="dishtv.in" site_id="143817" lang="en" xmltv_id="StarGoldSelect.in@HD">Star Gold Select HD</channel>
+  <channel site="dishtv.in" site_id="143818" lang="en" xmltv_id="StarJalsha.in@SD">Star Jalsha</channel>
+  <channel site="dishtv.in" site_id="143819" lang="en" xmltv_id="StarJalsha.in@HD">Star Jalsha HD</channel>
+  <channel site="dishtv.in" site_id="143820" lang="en" xmltv_id="StarKiran.in@SD">Star Kiran</channel>
+  <channel site="dishtv.in" site_id="143821" lang="en" xmltv_id="StarMaa.in@SD">Star Maa</channel>
+  <channel site="dishtv.in" site_id="143825" lang="en" xmltv_id="StarMaaMovies.in@SD">Star Maa Movies</channel>
+  <channel site="dishtv.in" site_id="143829" lang="en" xmltv_id="StarMovies.in@HD">Star Movies HD</channel>
+  <channel site="dishtv.in" site_id="143830" lang="en" xmltv_id="StarMoviesSelect.in@HD">Star Movies Select HD</channel>
+  <channel site="dishtv.in" site_id="143831" lang="en" xmltv_id="StarPlus.in@SD">STAR PLUS</channel>
+  <channel site="dishtv.in" site_id="143832" lang="en" xmltv_id="StarPlus.in@HD">STAR PLUS HD</channel>
+  <channel site="dishtv.in" site_id="143833" lang="en" xmltv_id="StarPravah.in@SD">Star Pravah</channel>
+  <channel site="dishtv.in" site_id="143834" lang="en" xmltv_id="StarPravah.in@HD">Star Pravah HD</channel>
+  <channel site="dishtv.in" site_id="143835" lang="en" xmltv_id="StarSports1.in@SD">Star Sports 1</channel>
+  <channel site="dishtv.in" site_id="143837" lang="en" xmltv_id="StarSports1.in@HD">Star Sports 1 HD</channel>
   <channel site="dishtv.in" site_id="143838" lang="en" xmltv_id="">Star Sports 1 HD Hindi</channel>
-  <channel site="dishtv.in" site_id="143839" lang="en" xmltv_id="">Star Sports 1 Hindi</channel>
-  <channel site="dishtv.in" site_id="143844" lang="en" xmltv_id="">Star Sports 2</channel>
-  <channel site="dishtv.in" site_id="143845" lang="en" xmltv_id="">Star Sports 2 HD</channel>
-  <channel site="dishtv.in" site_id="143846" lang="en" xmltv_id="">Star Sports 3</channel>
+  <channel site="dishtv.in" site_id="143839" lang="en" xmltv_id="StarSports1Hindi.in@SD">Star Sports 1 Hindi</channel>
+  <channel site="dishtv.in" site_id="143844" lang="en" xmltv_id="StarSports2.in@SD">Star Sports 2</channel>
+  <channel site="dishtv.in" site_id="143845" lang="en" xmltv_id="StarSports2.in@HD">Star Sports 2 HD</channel>
+  <channel site="dishtv.in" site_id="143846" lang="en" xmltv_id="StarSports3.in@SD">Star Sports 3</channel>
   <channel site="dishtv.in" site_id="143847" lang="en" xmltv_id="">Star Sports 2 Kannada</channel>
-  <channel site="dishtv.in" site_id="143848" lang="en" xmltv_id="">Star Sports Select 1</channel>
+  <channel site="dishtv.in" site_id="143848" lang="en" xmltv_id="StarSportsSelect1.in@SD">Star Sports Select 1</channel>
   <channel site="dishtv.in" site_id="143849" lang="en" xmltv_id="">Star Sports Select 1 HD</channel>
-  <channel site="dishtv.in" site_id="143850" lang="en" xmltv_id="">Star Sports Select 2</channel>
+  <channel site="dishtv.in" site_id="143850" lang="en" xmltv_id="StarSportsSelect2.in@SD">Star Sports Select 2</channel>
   <channel site="dishtv.in" site_id="143851" lang="en" xmltv_id="">Star Sports Select 2 HD</channel>
-  <channel site="dishtv.in" site_id="143856" lang="en" xmltv_id="">Star Utsav Movies</channel>
-  <channel site="dishtv.in" site_id="143870" lang="en" xmltv_id="">Sudarshan News</channel>
-  <channel site="dishtv.in" site_id="143871" lang="en" xmltv_id="">Sun Bangla</channel>
-  <channel site="dishtv.in" site_id="143875" lang="en" xmltv_id="">SUN MARATHI</channel>
+  <channel site="dishtv.in" site_id="143856" lang="en" xmltv_id="StarUtsavMovies.in@SD">Star Utsav Movies</channel>
+  <channel site="dishtv.in" site_id="143870" lang="en" xmltv_id="SudarshanNews.in@SD">Sudarshan News</channel>
+  <channel site="dishtv.in" site_id="143871" lang="en" xmltv_id="SunBangla.in@SD">Sun Bangla</channel>
+  <channel site="dishtv.in" site_id="143875" lang="en" xmltv_id="SunMarathi.in@SD">SUN MARATHI</channel>
   <channel site="dishtv.in" site_id="143883" lang="en" xmltv_id="">Super Hungama</channel>
-  <channel site="dishtv.in" site_id="143926" lang="en" xmltv_id="">Tarang Music</channel>
-  <channel site="dishtv.in" site_id="143927" lang="en" xmltv_id="">Tarang</channel>
-  <channel site="dishtv.in" site_id="144002" lang="en" xmltv_id="">TheQ</channel>
-  <channel site="dishtv.in" site_id="144006" lang="en" xmltv_id="">Times Now</channel>
-  <channel site="dishtv.in" site_id="144007" lang="en" xmltv_id="">Times Now Navbharat</channel>
-  <channel site="dishtv.in" site_id="144008" lang="en" xmltv_id="">Times Now World HD</channel>
+  <channel site="dishtv.in" site_id="143926" lang="en" xmltv_id="TarangMusic.in@SD">Tarang Music</channel>
+  <channel site="dishtv.in" site_id="143927" lang="en" xmltv_id="TarangTV.in@SD">Tarang</channel>
+  <channel site="dishtv.in" site_id="144002" lang="en" xmltv_id="TheQIndia.us@SD">TheQ</channel>
+  <channel site="dishtv.in" site_id="144006" lang="en" xmltv_id="TimesNow.in@SD">Times Now</channel>
+  <channel site="dishtv.in" site_id="144007" lang="en" xmltv_id="TimesNowNavbharat.in@SD">Times Now Navbharat</channel>
+  <channel site="dishtv.in" site_id="144008" lang="en" xmltv_id="TimesNowWorld.in@SD">Times Now World HD</channel>
   <channel site="dishtv.in" site_id="144015" lang="en" xmltv_id="">Travel XP HD</channel>
-  <channel site="dishtv.in" site_id="144026" lang="en" xmltv_id="">TV9 Bangla</channel>
-  <channel site="dishtv.in" site_id="144027" lang="en" xmltv_id="">TV9 Bharatvarsh</channel>
-  <channel site="dishtv.in" site_id="144028" lang="en" xmltv_id="">TV9 Gujarati</channel>
-  <channel site="dishtv.in" site_id="144030" lang="en" xmltv_id="">TV9 Marathi</channel>
-  <channel site="dishtv.in" site_id="144031" lang="en" xmltv_id="">TV9 Telugu</channel>
-  <channel site="dishtv.in" site_id="144069" lang="en" xmltv_id="">Vedic</channel>
-  <channel site="dishtv.in" site_id="144083" lang="en" xmltv_id="">VTV Gujarati</channel>
-  <channel site="dishtv.in" site_id="144087" lang="en" xmltv_id="">WION</channel>
-  <channel site="dishtv.in" site_id="144153" lang="en" xmltv_id="">Zee Bihar Jharkhand</channel>
-  <channel site="dishtv.in" site_id="144209" lang="en" xmltv_id="">Zee Biskope</channel>
-  <channel site="dishtv.in" site_id="144431" lang="en" xmltv_id="">Zee 24 Ghanta</channel>
-  <channel site="dishtv.in" site_id="144432" lang="en" xmltv_id="">Zee 24 Kalak</channel>
-  <channel site="dishtv.in" site_id="144433" lang="en" xmltv_id="">Zee 24 Taas</channel>
+  <channel site="dishtv.in" site_id="144026" lang="en" xmltv_id="TV9Bangla.in@SD">TV9 Bangla</channel>
+  <channel site="dishtv.in" site_id="144027" lang="en" xmltv_id="TV9Bharatvarsh.in@SD">TV9 Bharatvarsh</channel>
+  <channel site="dishtv.in" site_id="144028" lang="en" xmltv_id="TV9Gujarati.in@SD">TV9 Gujarati</channel>
+  <channel site="dishtv.in" site_id="144030" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
+  <channel site="dishtv.in" site_id="144031" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu</channel>
+  <channel site="dishtv.in" site_id="144069" lang="en" xmltv_id="Vedic.in@SD">Vedic</channel>
+  <channel site="dishtv.in" site_id="144083" lang="en" xmltv_id="VTVNews.in@SD">VTV Gujarati</channel>
+  <channel site="dishtv.in" site_id="144087" lang="en" xmltv_id="WION.in@SD">WION</channel>
+  <channel site="dishtv.in" site_id="144153" lang="en" xmltv_id="ZeeBiharJharkhand.in@SD">Zee Bihar Jharkhand</channel>
+  <channel site="dishtv.in" site_id="144209" lang="en" xmltv_id="ZeeBiskope.in@SD">Zee Biskope</channel>
+  <channel site="dishtv.in" site_id="144431" lang="en" xmltv_id="Zee24Ghanta.in@SD">Zee 24 Ghanta</channel>
+  <channel site="dishtv.in" site_id="144432" lang="en" xmltv_id="Zee24Kalak.in@SD">Zee 24 Kalak</channel>
+  <channel site="dishtv.in" site_id="144433" lang="en" xmltv_id="Zee24Taas.in@SD">Zee 24 Taas</channel>
   <channel site="dishtv.in" site_id="144434" lang="en" xmltv_id="">Action Cinema</channel>
-  <channel site="dishtv.in" site_id="144435" lang="en" xmltv_id="">Anmol TV</channel>
-  <channel site="dishtv.in" site_id="144436" lang="en" xmltv_id="">Anmol Cinema</channel>
-  <channel site="dishtv.in" site_id="144437" lang="en" xmltv_id="">Zee Bangla Sonar</channel>
-  <channel site="dishtv.in" site_id="144438" lang="en" xmltv_id="">Zee Bollywood</channel>
-  <channel site="dishtv.in" site_id="144439" lang="en" xmltv_id="">Zee Business</channel>
-  <channel site="dishtv.in" site_id="144440" lang="en" xmltv_id="">Zee Cafe</channel>
+  <channel site="dishtv.in" site_id="144435" lang="en" xmltv_id="AnmolTV.in@SD">Anmol TV</channel>
+  <channel site="dishtv.in" site_id="144436" lang="en" xmltv_id="AnmolCinema.in@SD">Anmol Cinema</channel>
+  <channel site="dishtv.in" site_id="144437" lang="en" xmltv_id="ZeeBanglaSonar.in@SD">Zee Bangla Sonar</channel>
+  <channel site="dishtv.in" site_id="144438" lang="en" xmltv_id="ZeeBollywood.in@SD">Zee Bollywood</channel>
+  <channel site="dishtv.in" site_id="144439" lang="en" xmltv_id="ZeeBusiness.in@SD">Zee Business</channel>
+  <channel site="dishtv.in" site_id="144440" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe</channel>
   <channel site="dishtv.in" site_id="144441" lang="en" xmltv_id="">Zee Cafe HD</channel>
-  <channel site="dishtv.in" site_id="144442" lang="en" xmltv_id="">ZEE Chitramandir</channel>
+  <channel site="dishtv.in" site_id="144442" lang="en" xmltv_id="ZeeChitramandir.in@SD">ZEE Chitramandir</channel>
   <channel site="dishtv.in" site_id="144443" lang="en" xmltv_id="">Zee Cinema HD</channel>
-  <channel site="dishtv.in" site_id="144445" lang="en" xmltv_id="">Zee Cinemalu</channel>
-  <channel site="dishtv.in" site_id="144447" lang="en" xmltv_id="">Zee Classic</channel>
-  <channel site="dishtv.in" site_id="144448" lang="en" xmltv_id="">Zee Delhi NCR Haryana</channel>
-  <channel site="dishtv.in" site_id="144449" lang="en" xmltv_id="">Anmol Cinema 2</channel>
-  <channel site="dishtv.in" site_id="144450" lang="en" xmltv_id="">Zee Bharat</channel>
-  <channel site="dishtv.in" site_id="144451" lang="en" xmltv_id="">Zee Kannada</channel>
-  <channel site="dishtv.in" site_id="144455" lang="en" xmltv_id="">Zee Madhya Pradesh Chhattisgarh</channel>
-  <channel site="dishtv.in" site_id="144457" lang="en" xmltv_id="">Zee Marathi</channel>
+  <channel site="dishtv.in" site_id="144445" lang="en" xmltv_id="ZeeCinemalu.in@SD">Zee Cinemalu</channel>
+  <channel site="dishtv.in" site_id="144447" lang="en" xmltv_id="ZeeClassic.in@SD">Zee Classic</channel>
+  <channel site="dishtv.in" site_id="144448" lang="en" xmltv_id="ZeeDelhiNCRHaryana.in@SD">Zee Delhi NCR Haryana</channel>
+  <channel site="dishtv.in" site_id="144449" lang="en" xmltv_id="AnmolCinema2.in@SD">Anmol Cinema 2</channel>
+  <channel site="dishtv.in" site_id="144450" lang="en" xmltv_id="ZeeBharat.in@SD">Zee Bharat</channel>
+  <channel site="dishtv.in" site_id="144451" lang="en" xmltv_id="ZeeKannada.in@SD">Zee Kannada</channel>
+  <channel site="dishtv.in" site_id="144455" lang="en" xmltv_id="ZeeMadhyaPradeshChhattisgarh.in@SD">Zee Madhya Pradesh Chhattisgarh</channel>
+  <channel site="dishtv.in" site_id="144457" lang="en" xmltv_id="ZeeMarathi.in@SD">Zee Marathi</channel>
   <channel site="dishtv.in" site_id="144458" lang="en" xmltv_id="">Zee Marathi HD</channel>
-  <channel site="dishtv.in" site_id="144463" lang="en" xmltv_id="">Zee Punjab Haryana Himachal</channel>
-  <channel site="dishtv.in" site_id="144464" lang="en" xmltv_id="">Zee Punjabi</channel>
-  <channel site="dishtv.in" site_id="144465" lang="en" xmltv_id="">Zee Rajasthan</channel>
-  <channel site="dishtv.in" site_id="144466" lang="en" xmltv_id="">Salaam TV</channel>
-  <channel site="dishtv.in" site_id="144467" lang="en" xmltv_id="">Zee Sarthak</channel>
-  <channel site="dishtv.in" site_id="144468" lang="en" xmltv_id="">Zee Talkies</channel>
+  <channel site="dishtv.in" site_id="144463" lang="en" xmltv_id="ZeePunjabHaryanaHimachal.in@SD">Zee Punjab Haryana Himachal</channel>
+  <channel site="dishtv.in" site_id="144464" lang="en" xmltv_id="ZeePunjabi.in@SD">Zee Punjabi</channel>
+  <channel site="dishtv.in" site_id="144465" lang="en" xmltv_id="ZeeRajasthan.in@SD">Zee Rajasthan</channel>
+  <channel site="dishtv.in" site_id="144466" lang="en" xmltv_id="SalaamTV.in@SD">Salaam TV</channel>
+  <channel site="dishtv.in" site_id="144467" lang="en" xmltv_id="ZeeSarthak.in@SD">Zee Sarthak</channel>
+  <channel site="dishtv.in" site_id="144468" lang="en" xmltv_id="ZeeTalkies.in@SD">Zee Talkies</channel>
   <channel site="dishtv.in" site_id="144469" lang="en" xmltv_id="">Zee Talkies HD</channel>
-  <channel site="dishtv.in" site_id="144473" lang="en" xmltv_id="">Zee Telugu</channel>
+  <channel site="dishtv.in" site_id="144473" lang="en" xmltv_id="ZeeTelugu.in@SD">Zee Telugu</channel>
   <channel site="dishtv.in" site_id="144478" lang="en" xmltv_id="">Zee TV</channel>
-  <channel site="dishtv.in" site_id="144479" lang="en" xmltv_id="">Zee TV HD</channel>
-  <channel site="dishtv.in" site_id="144480" lang="en" xmltv_id="">Zee Uttar Pradesh Uttarakhand</channel>
-  <channel site="dishtv.in" site_id="144481" lang="en" xmltv_id="">Zee Yuva</channel>
-  <channel site="dishtv.in" site_id="144482" lang="en" xmltv_id="">Zee Zest</channel>
-  <channel site="dishtv.in" site_id="144484" lang="en" xmltv_id="">Zing</channel>
-  <channel site="dishtv.in" site_id="144935" lang="en" xmltv_id="">Zing Home</channel>
-  <channel site="dishtv.in" site_id="145426" lang="en" xmltv_id="">Sansad TV 2</channel>
-  <channel site="dishtv.in" site_id="147570" lang="en" xmltv_id="">MNX HD</channel>
-  <channel site="dishtv.in" site_id="147571" lang="en" xmltv_id="">Movies Now HD</channel>
+  <channel site="dishtv.in" site_id="144479" lang="en" xmltv_id="ZeeTV.in@SD">Zee TV HD</channel>
+  <channel site="dishtv.in" site_id="144480" lang="en" xmltv_id="ZeeUttarPradeshUttarakhand.in@SD">Zee Uttar Pradesh Uttarakhand</channel>
+  <channel site="dishtv.in" site_id="144481" lang="en" xmltv_id="ZeeYuva.in@SD">Zee Yuva</channel>
+  <channel site="dishtv.in" site_id="144482" lang="en" xmltv_id="ZeeZest.in@SD">Zee Zest</channel>
+  <channel site="dishtv.in" site_id="144484" lang="en" xmltv_id="Zing.in@SD">Zing</channel>
+  <channel site="dishtv.in" site_id="144935" lang="en" xmltv_id="ZingHome.in@SD">Zing Home</channel>
+  <channel site="dishtv.in" site_id="145426" lang="en" xmltv_id="SansadTV.in@SD">Sansad TV 2</channel>
+  <channel site="dishtv.in" site_id="147570" lang="en" xmltv_id="MNX.in@SD">MNX HD</channel>
+  <channel site="dishtv.in" site_id="147571" lang="en" xmltv_id="MoviesNow.in@SD">Movies Now HD</channel>
   <channel site="dishtv.in" site_id="153079" lang="en" xmltv_id="">Sony Sports Ten 3 Hindi</channel>
   <channel site="dishtv.in" site_id="154892" lang="en" xmltv_id="">Manoranjan Prime</channel>
-  <channel site="dishtv.in" site_id="154895" lang="en" xmltv_id="">NDTV 24x7</channel>
-  <channel site="dishtv.in" site_id="157574" lang="en" xmltv_id="">Animal Planet</channel>
-  <channel site="dishtv.in" site_id="157576" lang="en" xmltv_id="">Cartoon Network</channel>
-  <channel site="dishtv.in" site_id="157577" lang="en" xmltv_id="">Colors Bangla</channel>
-  <channel site="dishtv.in" site_id="157578" lang="en" xmltv_id="">Colors Infinity</channel>
-  <channel site="dishtv.in" site_id="157580" lang="en" xmltv_id="">Colors Marathi</channel>
-  <channel site="dishtv.in" site_id="157588" lang="en" xmltv_id="">NDTV India</channel>
-  <channel site="dishtv.in" site_id="157589" lang="en" xmltv_id="">SET</channel>
+  <channel site="dishtv.in" site_id="154895" lang="en" xmltv_id="NDTV24x7.in@SD">NDTV 24x7</channel>
+  <channel site="dishtv.in" site_id="157574" lang="en" xmltv_id="AnimalPlanet.in@SD">Animal Planet</channel>
+  <channel site="dishtv.in" site_id="157576" lang="en" xmltv_id="CartoonNetwork.in@SD">Cartoon Network</channel>
+  <channel site="dishtv.in" site_id="157577" lang="en" xmltv_id="ColorsBangla.in@SD">Colors Bangla</channel>
+  <channel site="dishtv.in" site_id="157578" lang="en" xmltv_id="ColorsInfinity.in@SD">Colors Infinity</channel>
+  <channel site="dishtv.in" site_id="157580" lang="en" xmltv_id="ColorsMarathi.in@SD">Colors Marathi</channel>
+  <channel site="dishtv.in" site_id="157588" lang="en" xmltv_id="NDTVIndia.in@SD">NDTV India</channel>
+  <channel site="dishtv.in" site_id="157589" lang="en" xmltv_id="SonyEntertainmentTelevision.in@SD">SET</channel>
   <channel site="dishtv.in" site_id="157590" lang="en" xmltv_id="">SONY MAX</channel>
-  <channel site="dishtv.in" site_id="157591" lang="en" xmltv_id="">Sony Sports Ten 1</channel>
-  <channel site="dishtv.in" site_id="157592" lang="en" xmltv_id="">Sony Sports Ten 2</channel>
-  <channel site="dishtv.in" site_id="157593" lang="en" xmltv_id="">Sony Sports Ten 5</channel>
-  <channel site="dishtv.in" site_id="157600" lang="en" xmltv_id="">Zoom</channel>
-  <channel site="dishtv.in" site_id="157679" lang="en" xmltv_id="">CNN International</channel>
-  <channel site="dishtv.in" site_id="157802" lang="en" xmltv_id="">EUROSPORT</channel>
-  <channel site="dishtv.in" site_id="157803" lang="en" xmltv_id="">Filamchi Bhojpuri</channel>
-  <channel site="dishtv.in" site_id="157811" lang="en" xmltv_id="">Investigation Discovery</channel>
+  <channel site="dishtv.in" site_id="157591" lang="en" xmltv_id="SonySportsTen1.in@SD">Sony Sports Ten 1</channel>
+  <channel site="dishtv.in" site_id="157592" lang="en" xmltv_id="SonySportsTen2.in@SD">Sony Sports Ten 2</channel>
+  <channel site="dishtv.in" site_id="157593" lang="en" xmltv_id="SonySportsTen5.in@SD">Sony Sports Ten 5</channel>
+  <channel site="dishtv.in" site_id="157600" lang="en" xmltv_id="Zoom.in@SD">Zoom</channel>
+  <channel site="dishtv.in" site_id="157679" lang="en" xmltv_id="CNNInternational.us@MENA">CNN International</channel>
+  <channel site="dishtv.in" site_id="157802" lang="en" xmltv_id="Eurosport.in@SD">EUROSPORT</channel>
+  <channel site="dishtv.in" site_id="157803" lang="en" xmltv_id="FilamchiBhojpuri.in@SD">Filamchi Bhojpuri</channel>
+  <channel site="dishtv.in" site_id="157811" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery</channel>
   <channel site="dishtv.in" site_id="157820" lang="en" xmltv_id="">Nick Junior</channel>
-  <channel site="dishtv.in" site_id="157960" lang="en" xmltv_id="">Shorts TV</channel>
-  <channel site="dishtv.in" site_id="157968" lang="en" xmltv_id="">Sony AATH</channel>
-  <channel site="dishtv.in" site_id="157970" lang="en" xmltv_id="">Sony Marathi</channel>
-  <channel site="dishtv.in" site_id="157973" lang="en" xmltv_id="">SONY PAL</channel>
-  <channel site="dishtv.in" site_id="157974" lang="en" xmltv_id="">Sony Wah</channel>
+  <channel site="dishtv.in" site_id="157960" lang="en" xmltv_id="ShortsTV.uk@SD">Shorts TV</channel>
+  <channel site="dishtv.in" site_id="157968" lang="en" xmltv_id="SonyAath.in@SD">Sony AATH</channel>
+  <channel site="dishtv.in" site_id="157970" lang="en" xmltv_id="SonyMarathi.in@SD">Sony Marathi</channel>
+  <channel site="dishtv.in" site_id="157973" lang="en" xmltv_id="SonyPal.in@SD">SONY PAL</channel>
+  <channel site="dishtv.in" site_id="157974" lang="en" xmltv_id="SonyWah.in@SD">Sony Wah</channel>
   <channel site="dishtv.in" site_id="158023" lang="en" xmltv_id="">TLC</channel>
-  <channel site="dishtv.in" site_id="158049" lang="en" xmltv_id="">Zee Bangla HD</channel>
-  <channel site="dishtv.in" site_id="158133" lang="en" xmltv_id="">Aastha</channel>
-  <channel site="dishtv.in" site_id="158134" lang="en" xmltv_id="">Aastha Kannada</channel>
+  <channel site="dishtv.in" site_id="158049" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla HD</channel>
+  <channel site="dishtv.in" site_id="158133" lang="en" xmltv_id="Aastha.in@SD">Aastha</channel>
+  <channel site="dishtv.in" site_id="158134" lang="en" xmltv_id="AasthaKannada.in@SD">Aastha Kannada</channel>
   <channel site="dishtv.in" site_id="158135" lang="en" xmltv_id="">Aastha Gujarati</channel>
-  <channel site="dishtv.in" site_id="158136" lang="en" xmltv_id="">Aastha Telugu</channel>
-  <channel site="dishtv.in" site_id="158138" lang="en" xmltv_id="">ABP News</channel>
+  <channel site="dishtv.in" site_id="158136" lang="en" xmltv_id="AasthaTelugu.in@SD">Aastha Telugu</channel>
+  <channel site="dishtv.in" site_id="158138" lang="en" xmltv_id="ABPNews.in@SD">ABP News</channel>
   <channel site="dishtv.in" site_id="158140" lang="en" xmltv_id="">Animal Planet HD</channel>
-  <channel site="dishtv.in" site_id="158141" lang="en" xmltv_id="">B4U Music</channel>
-  <channel site="dishtv.in" site_id="158142" lang="en" xmltv_id="">BBC News</channel>
-  <channel site="dishtv.in" site_id="158144" lang="en" xmltv_id="">Colors</channel>
-  <channel site="dishtv.in" site_id="158145" lang="en" xmltv_id="">Colors Bangla HD</channel>
+  <channel site="dishtv.in" site_id="158141" lang="en" xmltv_id="B4UMusic.in@India">B4U Music</channel>
+  <channel site="dishtv.in" site_id="158142" lang="en" xmltv_id="BBCNews.uk@SouthAsia">BBC News</channel>
+  <channel site="dishtv.in" site_id="158144" lang="en" xmltv_id="Colors.in@SD">Colors</channel>
+  <channel site="dishtv.in" site_id="158145" lang="en" xmltv_id="ColorsBangla.in@SD">Colors Bangla HD</channel>
   <channel site="dishtv.in" site_id="158146" lang="en" xmltv_id="">Colors Cineplex</channel>
-  <channel site="dishtv.in" site_id="158147" lang="en" xmltv_id="">Colors Cineplex HD</channel>
-  <channel site="dishtv.in" site_id="158148" lang="en" xmltv_id="">Colors Gujarati</channel>
+  <channel site="dishtv.in" site_id="158147" lang="en" xmltv_id="ColorsCineplex.in@SD">Colors Cineplex HD</channel>
+  <channel site="dishtv.in" site_id="158148" lang="en" xmltv_id="ColorsGujarati.in@SD">Colors Gujarati</channel>
   <channel site="dishtv.in" site_id="158149" lang="en" xmltv_id="">Colors HD</channel>
-  <channel site="dishtv.in" site_id="158150" lang="en" xmltv_id="">Colors Infinity HD</channel>
-  <channel site="dishtv.in" site_id="158237" lang="en" xmltv_id="">Colors Marathi HD</channel>
-  <channel site="dishtv.in" site_id="158239" lang="en" xmltv_id="">Colors Rishtey</channel>
-  <channel site="dishtv.in" site_id="158251" lang="en" xmltv_id="">DD India</channel>
-  <channel site="dishtv.in" site_id="158252" lang="en" xmltv_id="">DD National</channel>
-  <channel site="dishtv.in" site_id="158254" lang="en" xmltv_id="">DD News</channel>
-  <channel site="dishtv.in" site_id="158255" lang="en" xmltv_id="">DD Sports</channel>
-  <channel site="dishtv.in" site_id="158297" lang="en" xmltv_id="">Star Gold 2 HD</channel>
-  <channel site="dishtv.in" site_id="158298" lang="en" xmltv_id="">Star Gold Romance</channel>
+  <channel site="dishtv.in" site_id="158150" lang="en" xmltv_id="ColorsInfinity.in@SD">Colors Infinity HD</channel>
+  <channel site="dishtv.in" site_id="158237" lang="en" xmltv_id="ColorsMarathi.in@SD">Colors Marathi HD</channel>
+  <channel site="dishtv.in" site_id="158239" lang="en" xmltv_id="ColorsRishteyAsia.in@SD">Colors Rishtey</channel>
+  <channel site="dishtv.in" site_id="158251" lang="en" xmltv_id="DDIndia.in@SD">DD India</channel>
+  <channel site="dishtv.in" site_id="158252" lang="en" xmltv_id="DDNational.in@SD">DD National</channel>
+  <channel site="dishtv.in" site_id="158254" lang="en" xmltv_id="DDNews.in@SD">DD News</channel>
+  <channel site="dishtv.in" site_id="158255" lang="en" xmltv_id="DDSports.in@SD">DD Sports</channel>
+  <channel site="dishtv.in" site_id="158297" lang="en" xmltv_id="StarGold2.in@HD">Star Gold 2 HD</channel>
+  <channel site="dishtv.in" site_id="158298" lang="en" xmltv_id="StarGoldRomance.in@SD">Star Gold Romance</channel>
   <channel site="dishtv.in" site_id="158301" lang="en" xmltv_id="">Hollywood Indie Active</channel>
-  <channel site="dishtv.in" site_id="158303" lang="en" xmltv_id="">Nazara</channel>
-  <channel site="dishtv.in" site_id="158324" lang="en" xmltv_id="">NDTV MPCG</channel>
-  <channel site="dishtv.in" site_id="158325" lang="en" xmltv_id="">NDTV Rajasthan</channel>
-  <channel site="dishtv.in" site_id="158328" lang="en" xmltv_id="">Pudhari News</channel>
+  <channel site="dishtv.in" site_id="158303" lang="en" xmltv_id="Nazara.in@SD">Nazara</channel>
+  <channel site="dishtv.in" site_id="158324" lang="en" xmltv_id="NDTVMadhyaPradeshChhattisgarh.in@SD">NDTV MPCG</channel>
+  <channel site="dishtv.in" site_id="158325" lang="en" xmltv_id="NDTVRajasthan.in@SD">NDTV Rajasthan</channel>
+  <channel site="dishtv.in" site_id="158328" lang="en" xmltv_id="PudhariNews.in@SD">Pudhari News</channel>
   <channel site="dishtv.in" site_id="158336" lang="en" xmltv_id="">Raapchik</channel>
   <channel site="dishtv.in" site_id="158351" lang="en" xmltv_id="">Star Sports 2 Telugu</channel>
   <channel site="dishtv.in" site_id="158352" lang="en" xmltv_id="">Star Sports 2 Tamil</channel>
   <channel site="dishtv.in" site_id="158792" lang="en" xmltv_id="">TNP News HD</channel>
   <channel site="dishtv.in" site_id="158796" lang="en" xmltv_id="">NB News</channel>
-  <channel site="dishtv.in" site_id="158797" lang="en" xmltv_id="">Zing Home</channel>
-  <channel site="dishtv.in" site_id="158822" lang="en" xmltv_id="">Star Gold Thrills</channel>
+  <channel site="dishtv.in" site_id="158797" lang="en" xmltv_id="ZingHome.in@SD">Zing Home</channel>
+  <channel site="dishtv.in" site_id="158822" lang="en" xmltv_id="StarGoldThrills.in@SD">Star Gold Thrills</channel>
   <channel site="dishtv.in" site_id="158825" lang="en" xmltv_id="">India Daily 24x7</channel>
-  <channel site="dishtv.in" site_id="158843" lang="en" xmltv_id="">Disney Channel HD</channel>
+  <channel site="dishtv.in" site_id="158843" lang="en" xmltv_id="DisneyChannel.in@HD">Disney Channel HD</channel>
   <channel site="dishtv.in" site_id="158844" lang="en" xmltv_id="">Unique TV</channel>
-  <channel site="dishtv.in" site_id="158861" lang="en" xmltv_id="">Chumbak TV</channel>
-  <channel site="dishtv.in" site_id="158863" lang="en" xmltv_id="">Star Movies Select</channel>
+  <channel site="dishtv.in" site_id="158861" lang="en" xmltv_id="ShemarooJosh.in@SD">Chumbak TV</channel>
+  <channel site="dishtv.in" site_id="158863" lang="en" xmltv_id="StarMoviesSelect.in@SD">Star Movies Select</channel>
   <channel site="dishtv.in" site_id="158865" lang="en" xmltv_id="">Daily Post- Punjab Haryana Himachal</channel>
   <channel site="dishtv.in" site_id="159010" lang="en" xmltv_id="">EUROSPORT HD</channel>
-  <channel site="dishtv.in" site_id="159011" lang="en" xmltv_id="">Discovery Kids</channel>
-  <channel site="dishtv.in" site_id="159012" lang="en" xmltv_id="">Disney Channel</channel>
-  <channel site="dishtv.in" site_id="159013" lang="en" xmltv_id="">Epic TV</channel>
+  <channel site="dishtv.in" site_id="159011" lang="en" xmltv_id="DiscoveryKids.in@SD">Discovery Kids</channel>
+  <channel site="dishtv.in" site_id="159012" lang="en" xmltv_id="DisneyChannel.in@SD">Disney Channel</channel>
+  <channel site="dishtv.in" site_id="159013" lang="en" xmltv_id="EpicTV.in@SD">Epic TV</channel>
   <channel site="dishtv.in" site_id="159014" lang="en" xmltv_id="">Gubbare TV</channel>
-  <channel site="dishtv.in" site_id="159015" lang="en" xmltv_id="">ISHARA</channel>
+  <channel site="dishtv.in" site_id="159015" lang="en" xmltv_id="IsharaTV.in@SD">ISHARA</channel>
   <channel site="dishtv.in" site_id="159093" lang="en" xmltv_id="">MTV HD</channel>
   <channel site="dishtv.in" site_id="159096" lang="en" xmltv_id="">SET HD</channel>
-  <channel site="dishtv.in" site_id="159097" lang="en" xmltv_id="">Showbox</channel>
+  <channel site="dishtv.in" site_id="159097" lang="en" xmltv_id="ShowBox.in@SD">Showbox</channel>
   <channel site="dishtv.in" site_id="159098" lang="en" xmltv_id="">SONY MAX HD</channel>
   <channel site="dishtv.in" site_id="159099" lang="en" xmltv_id="">Sony SAB HD</channel>
-  <channel site="dishtv.in" site_id="159100" lang="en" xmltv_id="">SONY YAY</channel>
-  <channel site="dishtv.in" site_id="159101" lang="en" xmltv_id="">Star Bharat HD</channel>
-  <channel site="dishtv.in" site_id="159104" lang="en" xmltv_id="">Zee Cinema</channel>
+  <channel site="dishtv.in" site_id="159100" lang="en" xmltv_id="SonyYay.in@SD">SONY YAY</channel>
+  <channel site="dishtv.in" site_id="159101" lang="en" xmltv_id="StarBharat.in@HD">Star Bharat HD</channel>
+  <channel site="dishtv.in" site_id="159104" lang="en" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
   <channel site="dishtv.in" site_id="159106" lang="en" xmltv_id="">Discovery HD World</channel>
-  <channel site="dishtv.in" site_id="159107" lang="en" xmltv_id="">Discovery Science</channel>
-  <channel site="dishtv.in" site_id="159108" lang="en" xmltv_id="">Discovery Turbo</channel>
-  <channel site="dishtv.in" site_id="159111" lang="en" xmltv_id="">France 24</channel>
-  <channel site="dishtv.in" site_id="159121" lang="en" xmltv_id="">Nick HD+</channel>
-  <channel site="dishtv.in" site_id="159123" lang="en" xmltv_id="">PTC Punjabi</channel>
-  <channel site="dishtv.in" site_id="159124" lang="en" xmltv_id="">Sonic</channel>
-  <channel site="dishtv.in" site_id="159125" lang="en" xmltv_id="">Sony SAB</channel>
+  <channel site="dishtv.in" site_id="159107" lang="en" xmltv_id="DiscoveryScience.in@SD">Discovery Science</channel>
+  <channel site="dishtv.in" site_id="159108" lang="en" xmltv_id="DiscoveryTurbo.in@SD">Discovery Turbo</channel>
+  <channel site="dishtv.in" site_id="159111" lang="en" xmltv_id="France24.fr@English">France 24</channel>
+  <channel site="dishtv.in" site_id="159121" lang="en" xmltv_id="NickHDPlus.in@SD">Nick HD+</channel>
+  <channel site="dishtv.in" site_id="159123" lang="en" xmltv_id="PTCPunjabi.in@SD">PTC Punjabi</channel>
+  <channel site="dishtv.in" site_id="159124" lang="en" xmltv_id="Sonic.in@SD">Sonic</channel>
+  <channel site="dishtv.in" site_id="159125" lang="en" xmltv_id="SonySAB.in@SD">Sony SAB</channel>
   <channel site="dishtv.in" site_id="159126" lang="en" xmltv_id="">Sony Sports Ten 1 HD</channel>
   <channel site="dishtv.in" site_id="159127" lang="en" xmltv_id="">Sony Sports Ten 2 HD</channel>
   <channel site="dishtv.in" site_id="159128" lang="en" xmltv_id="">Sony Sports Ten 3 Hindi HD</channel>
   <channel site="dishtv.in" site_id="159129" lang="en" xmltv_id="">Sony Sports Ten 5 HD</channel>
-  <channel site="dishtv.in" site_id="159130" lang="en" xmltv_id="">Star Bharat</channel>
-  <channel site="dishtv.in" site_id="159131" lang="en" xmltv_id="">Star Gold</channel>
-  <channel site="dishtv.in" site_id="159132" lang="en" xmltv_id="">Star Utsav</channel>
-  <channel site="dishtv.in" site_id="159135" lang="en" xmltv_id="">Al Jazeera English</channel>
-  <channel site="dishtv.in" site_id="159298" lang="en" xmltv_id="">Zee News</channel>
+  <channel site="dishtv.in" site_id="159130" lang="en" xmltv_id="StarBharat.in@SD">Star Bharat</channel>
+  <channel site="dishtv.in" site_id="159131" lang="en" xmltv_id="StarGold.in@SD">Star Gold</channel>
+  <channel site="dishtv.in" site_id="159132" lang="en" xmltv_id="StarUtsav.in@SD">Star Utsav</channel>
+  <channel site="dishtv.in" site_id="159135" lang="en" xmltv_id="AlJazeera.qa@English">Al Jazeera English</channel>
+  <channel site="dishtv.in" site_id="159298" lang="en" xmltv_id="ZeeNews.in@SD">Zee News</channel>
   <channel site="dishtv.in" site_id="159339" lang="en" xmltv_id="">DISH BUZZ HD Duplicate</channel>
   <channel site="dishtv.in" site_id="159340" lang="en" xmltv_id="">DISH BUZZ HD Duplicate1</channel>
   <channel site="dishtv.in" site_id="159391" lang="en" xmltv_id="">Buzz SD Duplicate</channel>
   <channel site="dishtv.in" site_id="159392" lang="en" xmltv_id="">Buzz SD Duplicate 1</channel>
   <channel site="dishtv.in" site_id="160750" lang="en" xmltv_id="">All Time Movies</channel>
-  <channel site="dishtv.in" site_id="160751" lang="en" xmltv_id="">Sun Neo</channel>
+  <channel site="dishtv.in" site_id="160751" lang="en" xmltv_id="SunNeo.in@SD">Sun Neo</channel>
   <channel site="dishtv.in" site_id="166275" lang="en" xmltv_id="">Sansad TV 1 HD</channel>
   <channel site="dishtv.in" site_id="166276" lang="en" xmltv_id="">NDTV Marathi</channel>
   <channel site="dishtv.in" site_id="169160" lang="en" xmltv_id="">Live Times</channel>
@@ -432,6 +432,6 @@
   <channel site="dishtv.in" site_id="181408" lang="en" xmltv_id="">Live Times</channel>
   <channel site="dishtv.in" site_id="181723" lang="en" xmltv_id="">Zee News Duplicate</channel>
   <channel site="dishtv.in" site_id="185336" lang="en" xmltv_id="">NFDC - Cinemas of India</channel>
-  <channel site="dishtv.in" site_id="185737" lang="en" xmltv_id="">MKN News</channel>
+  <channel site="dishtv.in" site_id="185737" lang="en" xmltv_id="MKNMarathi.in@SD">MKN News</channel>
   <channel site="dishtv.in" site_id="192071" lang="en" xmltv_id="">Crunchyroll Anime Top Active</channel>
 </channels>


### PR DESCRIPTION
This site contains data on both HD and SD streams/versions of many Indian channels.
Mapped channels in 'sites/dishtv.in/dishtv.in.channels.xml'

While I tested the above, the time zone seemed to be mismatched. UTC shows +0000, but the programme is ahead by 0530 hours resulting in the actual present programme being behind. I'll be opening a separate issue for the same. Thank you.