### PR TITLE
Update indihometv.com.channels.xml - delete some channels

### DIFF
--- a/sites/indihometv.com/indihometv.com.channels.xml
+++ b/sites/indihometv.com/indihometv.com.channels.xml
@@ -128,5 +128,3 @@
   <channel site="indihometv.com" site_id="rusiatv" lang="id" xmltv_id="RT.ru@SD">RT</channel>
   <channel site="indihometv.com" site_id="tvriworld" lang="id" xmltv_id="TVRIWorld.id@SD">TVRI World</channel>
 </channels>
-
-


### PR DESCRIPTION
Remove deleted channels from indihometv: eatgo, ikonser, indonesiana, insert, rrinet, seatoday, seru, techstorm because they are no longer exist.