### PR TITLE
Feat: Add container layer caching

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:


### PR DESCRIPTION
**Why**

Currently each release creates builds from scratch on a fresh worker node.

Caching layers can speed up future releases; if some layers are unchanged, they do not need to be rebuilt.

**What**

Dockerfile uses layers which can be cached between releases. GitHub has a way of utilising this with [GitHub Actions cache](https://docs.docker.com/build/cache/backends/gha/) to cache build layers.

I am not completely familiar with this project, but the limit for caching is 10GB per repository:

Please see [Usage limits and eviction policy](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy)

As the Image for this repository is only 300MB, it seems sensible to take advantage of caching layers to speed up future builds.

If there is any reason why this should not be used here, please let me know and we can close this :) ( e.g. cache is being used for other entities )