### PR TITLE
Fix:  GitHub rate limit

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,6 +32,8 @@ jobs:
         run: npm run channels:lint
       - name: update sites.md
         run: npm run sites:update
+        env:
+          GH_TOKEN: ${{ steps.create-app-token.outputs.token }}
       - run: git status
       - name: commit changes to sites.md
         if: ${{ !env.ACT && github.ref == 'refs/heads/master' }}

--- a/scripts/core/utils.ts
+++ b/scripts/core/utils.ts
@@ -80,7 +80,9 @@ export async function loadJs(filepath: string) {
 
 export async function loadIssues(props?: { labels: string[] | string }) {
   const CustomOctokit = Octokit.plugin(paginateRest, restEndpointMethods)
-  const octokit = new CustomOctokit()
+  const octokit = new CustomOctokit({
+    auth: process.env.GH_TOKEN
+  })
 
   let labels = ''
   if (props && props.labels) {


### PR DESCRIPTION
**Why**

Update action is failing due to rate limiting, this is because requests are not authenticated:

See [Update #773](https://github.com/iptv-org/epg/actions/runs/20386702743/job/58588912606)

**What**

Unauthenticated requests by worker nodes are rate limited after a small amount of requests. However this can be avoided by authenticating requests [Rate Limits for the Rest API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)

**Test**

I do not have access to the projects GitHub token, but I tested locally by generating a temporary classic PAT, and running the update script locally like so:

GH_TOKEN=your_token_here npx tsx scripts/commands/sites/update.ts