### PR TITLE
Fix telenet.tv and add program name details to subTitle

### DIFF
--- a/sites/telenet.tv/telenet.tv.config.js
+++ b/sites/telenet.tv/telenet.tv.config.js
@@ -22,25 +22,19 @@ module.exports = {
     if (!items.length) return programs
     const promises = [
       axios.get(
-        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date
-          .add(6, 'h')
-          .format('YYYYMMDDHHmmss')}`,
+        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date.format('YYYYMMDD')}060000`,
         {
           responseType: 'arraybuffer'
         }
       ),
       axios.get(
-        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date
-          .add(12, 'h')
-          .format('YYYYMMDDHHmmss')}`,
+        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date.format('YYYYMMDD')}120000`,
         {
           responseType: 'arraybuffer'
         }
       ),
       axios.get(
-        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date
-          .add(18, 'h')
-          .format('YYYYMMDDHHmmss')}`,
+        `${API_STATIC_ENDPOINT}/${channel.lang}/events/segments/${date.format('YYYYMMDD')}180000`,
         {
           responseType: 'arraybuffer'
         }


### PR DESCRIPTION
* This fixes the generated url to not contain hours, minutes or seconds. ~~I'm not sure if this is an API change, or code change that started to include the time in the data object.~~ Without this change, I get all 404's.

* This adds the `detail.episodeName` to the EPG in the `subTitle` field as well. It contains the program episode name.

EDIT: I've tested it with an old commit (ee83dc0ff7bb9f91013b26b04be6875d43e16faf) and that seemed to work fine, so I think it's a code change to include the time now.