### PR TITLE
Fix tvpassport.com timezone to be dynamic from the content

### DIFF
--- a/sites/tvpassport.com/tvpassport.com.config.js
+++ b/sites/tvpassport.com/tvpassport.com.config.js
@@ -133,11 +133,11 @@ function parseTitle($item) {
 }
 
 function parseSubTitle($item) {
-  return $item('*').data('episodetitle').toString() || null
+  return $item('*').data('episodetitle')?.toString() || null
 }
 
 function parseYear($item) {
-  return $item('*').data('year').toString() || null
+  return $item('*').data('year')?.toString() || null
 }
 
 function parseCategory($item) {
@@ -200,3 +200,4 @@ function parseCurrentTimezone(content) {
 
   return $('#timezone_selector').val()
 }
+


### PR DESCRIPTION
Uses the timezone from the selected timezone of the dropdown on the page, instead of always hardcoding America/New_York. This fixes an offset I was having from pulling the guide from an IP address in the central timezone.

<details>
<summary>Tests</summary>

```console
npm test --- tvpassport.com

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand tvpassport.com

 PASS  sites/tvpassport.com/tvpassport.com.test.js
  ✓ can generate valid url (3 ms)
  ✓ can parse response (184 ms)
  ✓ can handle empty guide

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.545 s
Ran all test suites matching tvpassport.com.
```

</details>

<details>
<summary>Grab (73 errors, 19287 channels) * - Showing errors only</summary>

```console
npm run grab --- --channels=sites/tvpassport.com/tvpassport.com.channels.xml --output=tvpassport_guide.xml --days=1

> grab
> tsx scripts/commands/epg/grab.ts --channels=sites/tvpassport.com/tvpassport.com.channels.xml --output=tvpassport_guide.xml --days=1

info starting...
info loading channels...
info found 19287 channel(s)
info loading api data...
info creating queue...
info run:
info   [1/19287] tvpassport.com (en) - 2m-maroc/13668 - Feb 24, 2026 (44 programs)
info   [2/19287] tvpassport.com (en) - 2m-tv/19885 - Feb 24, 2026 (44 programs)
info   [3/19287] tvpassport.com (en) - 3abn-dare-to-dream-k21do-d3-palm-spring-ca/17794 - Feb 24, 2026 (15 programs)
info   [4/19287] tvpassport.com (en) - 3abn-dare-to-dream-k17ji-d3-fresno-ca/17793 - Feb 24, 2026 (6 programs)
info   [5/19287] tvpassport.com (en) - 3abn-dare-to-dream-k43fo-d3-las-vegas-nv/17795 - Feb 24, 2026 (11 programs)
info   [6/19287] tvpassport.com (en) - 3abn-dare-to-dream-k36ku-d3-twin-falls-id/36880 - Feb 24, 2026 (49 programs)
info   [7/19287] tvpassport.com (en) - 3-news-now-wcax-tv6-burlington-vt/36205 - Feb 24, 2026 (36 programs)
info   [8/19287] tvpassport.com (en) - 3abn-dare-to-dream-k17du-d3-christmas-valley-or/37331 - Feb 24, 2026 (49 programs)
info   [9/19287] tvpassport.com (en) - 3abn-dare-to-dream-k08ou-d3-seattle-wa/16753 - Feb 24, 2026 (49 programs)
info   [10/19287] tvpassport.com (en) - 3abn-dare-to-dream-kcyh-ld3-sherman-tx/17796 - Feb 24, 2026 (49 programs)
...
info   [366/19287] tvpassport.com (en) - almavision-ktvs-ld2-albuquerque-nm/18390 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [430/19287] tvpassport.com (en) - ABCSpark.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [441/19287] tvpassport.com (en) - ABCSpark.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1075/19287] tvpassport.com (en) - bounce-w23bz-columbus-oh/15688 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1282/19287] tvpassport.com (en) - bet--canada/4386 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [1283/19287] tvpassport.com (en) - bet--canada-hd/33448 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1342/19287] tvpassport.com (en) - bell-nfl-sunday-ticket-1-hd/20088 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1350/19287] tvpassport.com (en) - bell-nfl-sunday-ticket-1/20074 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1442/19287] tvpassport.com (en) - bein-sports-xtra-kzcz7-college-station-tx/33842 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [1471/19287] tvpassport.com (en) - beetv-network-wcac-lagrange-ga/5906 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [1520/19287] tvpassport.com (en) - bally-sports-southwest--dallas/32617 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [1521/19287] tvpassport.com (en) - bally-sports-southwest--dallas-hd/32618 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [1830/19287] tvpassport.com (en) - aquarium-channel/7819 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [2077/19287] tvpassport.com (en) - CBSSportsNetworkCanada.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [2081/19287] tvpassport.com (en) - CBSSportsNetworkCanada.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [2633/19287] tvpassport.com (en) - capital-networks-disney-xd/6670 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [2880/19287] tvpassport.com (en) - chat-medicine-hat-ab-hd/10861 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [3070/19287] tvpassport.com (en) - cctv-4-wxny-ld2-new-york-ny/16443 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [3609/19287] tvpassport.com (en) - cooking-channel-canada/7406 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [3610/19287] tvpassport.com (en) - cooking-channel-canada-hd/10210 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [3800/19287] tvpassport.com (en) - comcast-network-michigan/32393 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [4981/19287] tvpassport.com (en) - daystar-wmwd-ld2-madison-wi/35938 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5024/19287] tvpassport.com (en) - daystar-sd-wkdc-ld2-columbia-sc/31149 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5063/19287] tvpassport.com (en) - daystar-klvd-ld2-las-vegas-nv/18655 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5070/19287] tvpassport.com (en) - daystar-kdph-ld2-phoenix-az/18021 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5086/19287] tvpassport.com (en) - daystar-espanol-wilc-cd-sugar-grove-il/37448 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5189/19287] tvpassport.com (en) - dabl-krzg-harlingen-tx/18462 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [5795/19287] tvpassport.com (en) - hbo-family--pacific-feed-hd/8250 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [5796/19287] tvpassport.com (en) - hbo-east-panamerica/34316 - Feb 24, 2026 (14 programs)
...
info   [6114/19287] tvpassport.com (en) - god-tv-k11vz-d2-chico-ca/18239 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [6311/19287] tvpassport.com (en) - gettv-wrnt-ld2-hartford-ct/17580 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [6876/19287] tvpassport.com (en) - fox-kwbm-dt2-springfield-mo/2329 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [7272/19287] tvpassport.com (en) - FamilyJr.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [7278/19287] tvpassport.com (en) - family-jr-hd/9189 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [7492/19287] tvpassport.com (en) - espn-goal-line/8307 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [7493/19287] tvpassport.com (en) - espn-goal-line-hd/8308 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [7790/19287] tvpassport.com (en) - DisneyXD.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [7794/19287] tvpassport.com (en) - DisneyXD.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [8735/19287] tvpassport.com (en) - infomercials-wqeo-ld4-memphis-tn/36619 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [9246/19287] tvpassport.com (en) - hitz-2/34657 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [9247/19287] tvpassport.com (en) - hitz/34656 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [9250/19287] tvpassport.com (en) - hitz-3/34658 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [9868/19287] tvpassport.com (en) - outermax-hd--eastern/7098 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [10373/19287] tvpassport.com (en) - newsnet-wivm-ld4-canton-oh/34694 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [10923/19287] tvpassport.com (en) - nbc-sports-chicago/4020 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [10928/19287] tvpassport.com (en) - nbc-sports-chicago-plus-2-hd/31656 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [10930/19287] tvpassport.com (en) - nbc-sports-chicago-plus-hd/14414 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [10933/19287] tvpassport.com (en) - nbc-sports-chicago-plus-2/31655 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [11596/19287] tvpassport.com (en) - mtv-espanol-hd/30993 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [12535/19287] tvpassport.com (en) - magnolia-network-canada-hd/19839 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [13242/19287] tvpassport.com (en) - iqra-kegs-dt5-las-vegas-nv/15596 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [13446/19287] tvpassport.com (en) - localish-hd-network/8859 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [13534/19287] tvpassport.com (en) - pbs-wneo-alliance-oh-hd/8820 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [13537/19287] tvpassport.com (en) - pbs-wneo-alliance-oh/3014 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [14281/19287] tvpassport.com (en) - sonlife-network-knla-los-angeles-ca/11169 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [14729/19287] tvpassport.com (en) - pbs-weao-akron-oh/3015 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [14735/19287] tvpassport.com (en) - pbs-weao-akron-oh-hd/4737 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [14755/19287] tvpassport.com (en) - pbs-w44cr-youngstown-oh/12585 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [16070/19287] tvpassport.com (en) - telemar-wost-mayaguez-puerto-rico/18797 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [18051/19287] tvpassport.com (en) - wwe-network-hd/14155 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18195/19287] tvpassport.com (en) - wwe-network/14154 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18208/19287] tvpassport.com (en) - wildbraintv-on-demand/10818 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18225/19287] tvpassport.com (en) - wwe-network-canada/14230 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18293/19287] tvpassport.com (en) - wwe-network-hd-canada/14184 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18343/19287] tvpassport.com (en) - wildbraintv-west/31992 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18368/19287] tvpassport.com (en) - wildbraintv-hd/10240 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18438/19287] tvpassport.com (en) - univision-kwnl-cd-winslow-ar/30494 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18506/19287] tvpassport.com (en) - universal-kids--pacific/35310 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [18827/19287] tvpassport.com (en) - wild-tv-hd/6781 - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [19219/19287] tvpassport.com (en) - universal-kids-hd--pacific/35313 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [19255/19287] tvpassport.com (en) - wildbraintv-west-hd/33688 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [19257/19287] tvpassport.com (en) - your-world-this-week-hd/10290 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
...
info   [19259/19287] tvpassport.com (en) - WildTV.ca@SD - Feb 24, 2026 (0 programs)
info     ERR: Cannot read properties of undefined (reading 'toString')
...
info   [19276/19287] tvpassport.com (en) - wildbraintv/10176 - Feb 24, 2026 (0 programs)
info     ERR: Request failed with status code 404
info   [19277/19287] tvpassport.com (en) - your-tv-pembroke-hd/19678 - Feb 24, 2026 (24 programs)
info   [19278/19287] tvpassport.com (en) - ynn-your-news-now-on-demand/10431 - Feb 24, 2026 (4 programs)
info   [19279/19287] tvpassport.com (en) - youtoo-america-kgcs-joplin-mo/4380 - Feb 24, 2026 (31 programs)
info   [19280/19287] tvpassport.com (en) - ynn-your-news-now-weather-radar/10424 - Feb 24, 2026 (4 programs)
info   [19281/19287] tvpassport.com (en) - twist-ksdk5-st-louis-mo/36081 - Feb 24, 2026 (26 programs)
info   [19282/19287] tvpassport.com (en) - wnho-lp--defiance-oh/11022 - Feb 24, 2026 (25 programs)
info   [19283/19287] tvpassport.com (en) - unimas-kver-indio-ca/2613 - Feb 24, 2026 (25 programs)
info   [19284/19287] tvpassport.com (en) - true-crime-network-wlnm-ld6-lansing-mi/35135 - Feb 24, 2026 (45 programs)
info   [19285/19287] tvpassport.com (en) - uni-kuns-seattle-wa-hd/19150 - Feb 24, 2026 (25 programs)
info   [19286/19287] tvpassport.com (en) - v-me-wipm-tv4-mayaguez-pr/31463 - Feb 24, 2026 (39 programs)
info   [19287/19287] tvpassport.com (en) - twist-kluz-tv6-albuquerque-nm/36653 - Feb 24, 2026 (29 programs)
info   saving to "tvpassport_guide.xml"...
info   saving to "tvpassport_guide.xml.gz"...
success   done in 00h 11m 27s
```

</details>
