### PR TITLE
fix(programetv.ro): correct site_id for HGTV

### DIFF
--- a/sites/programetv.ro/programetv.ro.channels.xml
+++ b/sites/programetv.ro/programetv.ro.channels.xml
@@ -153,7 +153,7 @@
   <channel site="programetv.ro" site_id="hbo-3" lang="ro" xmltv_id="HBO3.ro@SD">HBO 3</channel>
   <channel site="programetv.ro" site_id="hbo-3-hd" lang="ro" xmltv_id="">HBO 3 HD</channel>
   <channel site="programetv.ro" site_id="hbo-hd" lang="ro" xmltv_id="">HBO HD</channel>
-  <channel site="programetv.ro" site_id="hgtv" lang="ro" xmltv_id="">HGTV</channel>
+  <channel site="programetv.ro" site_id="hgtv-hd" lang="ro" xmltv_id="">HGTV HD</channel>
   <channel site="programetv.ro" site_id="history" lang="ro" xmltv_id="History.ro@SD">History</channel>
   <channel site="programetv.ro" site_id="history-hd" lang="ro" xmltv_id="">History HD</channel>
   <channel site="programetv.ro" site_id="hit-music-channel" lang="ro" xmltv_id="HtMusicChannel.ro@SD">H!T Music Channel</channel>


### PR DESCRIPTION
HGTV's page on programetv.ro is listed under `hgtv-hd`, not `hgtv`:
https://www.programetv.ro/program-tv/hgtv-hd/
The current `site_id="hgtv"` returns 0 programs. Changed to `site_id="hgtv-hd"`.