### PR TITLE
Update rts.ch source with SRF and RSI channels

### DIFF
--- a/sites/rsi.ch/readme.md
+++ b/sites/rsi.ch/readme.md
@@ -1,0 +1,21 @@
+# rsi.ch
+
+https://rsi.ch
+
+### Download the guide
+
+```sh
+npm run grab --- --site=rsi.ch
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/rsi.ch/rsi.ch.config.js --output=./sites/rsi.ch/rsi.ch.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- rsi.ch
+```

--- a/sites/rsi.ch/rsi.ch.channels.xml
+++ b/sites/rsi.ch/rsi.ch.channels.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="rsi.ch" site_id="la1" lang="it" xmltv_id="RSILa1.ch">La 1</channel>
+  <channel site="rsi.ch" site_id="la2" lang="it" xmltv_id="RSILa2.ch">La 2</channel>
+</channels>

--- a/sites/rsi.ch/rsi.ch.config.js
+++ b/sites/rsi.ch/rsi.ch.config.js
@@ -1,0 +1,42 @@
+const axios = require('axios')
+const dayjs = require('dayjs')
+
+module.exports = {
+  site: 'rsi.ch',
+  days: 2,
+
+  url({ channel, date }) {
+    return `https://il.srgssr.ch/integrationlayer/2.0/rsi/programGuide/tv/byDate/${date.format('YYYY-MM-DD')}?reduced=false&channelId=${channel.site_id}`
+  },
+
+  parser({ content }) {
+    try {
+      const { programGuide } = JSON.parse(content)
+      if (!programGuide?.[0]?.programList) return []
+
+      return programGuide[0].programList.map(program => ({
+        title:       program.title || '',
+        subTitle:    program.subtitle || undefined,
+        description: program.description || program.show?.description || undefined,
+        start:       new Date(program.startTime).toISOString(),
+        stop:        new Date(program.endTime).toISOString(),
+        icon:        program.imageUrl ? { src: program.imageUrl } : undefined,
+        category:    program.genre || undefined,
+      }))
+    } catch {
+      return []
+    }
+  },
+
+  async channels() {
+    const today = dayjs().format('YYYY-MM-DD')
+    const { data } = await axios.get(
+      `https://www.rsi.ch/play/v3/api/rsi/production/tv-program-guide?date=${today}`
+    )
+    return data.data.map(entry => ({
+      site_id: entry.channel.id,
+      name:    entry.channel.title,
+      lang:    'it',
+    }))
+  }
+}

--- a/sites/rsi.ch/rsi.ch.test.js
+++ b/sites/rsi.ch/rsi.ch.test.js
@@ -1,0 +1,77 @@
+const { parser, url } = require('./rsi.ch.config.js')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2026-03-23', 'YYYY-MM-DD').startOf('d')
+const channel = { site_id: 'la1', name: 'La 1', lang: 'it' }
+
+it('can generate valid url', () => {
+  expect(url({ channel, date })).toBe(
+    'https://il.srgssr.ch/integrationlayer/2.0/rsi/programGuide/tv/byDate/2026-03-23?reduced=false&channelId=la1'
+  )
+})
+
+it('can parse response', () => {
+  const content = JSON.stringify({
+    programGuide: [
+      {
+        channel: { id: 'la1', vendor: 'RSI', title: 'La 1' },
+        programList: [
+          {
+            title: 'TG',
+            startTime: '2026-03-23T20:00:00+01:00',
+            endTime: '2026-03-23T20:30:00+01:00',
+            imageUrl: 'https://www.rsi.ch/programm/tv/image/redirect/abc123.jpg',
+            genre: 'Informazione',
+            subtitle: 'Edizione serale',
+          },
+          {
+            title: 'Meteo',
+            startTime: '2026-03-23T20:30:00+01:00',
+            endTime: '2026-03-23T20:35:00+01:00',
+            imageUrl: 'https://www.rsi.ch/programm/tv/image/redirect/def456.jpg',
+            genre: 'Informazione',
+            description: 'Le previsioni del tempo.',
+          },
+        ],
+      },
+    ],
+  })
+
+  const results = parser({ content })
+
+  expect(results[0]).toMatchObject({
+    title: 'TG',
+    subTitle: 'Edizione serale',
+    start: '2026-03-23T19:00:00.000Z',
+    stop: '2026-03-23T19:30:00.000Z',
+    category: 'Informazione',
+    icon: { src: 'https://www.rsi.ch/programm/tv/image/redirect/abc123.jpg' },
+  })
+  expect(results[1]).toMatchObject({
+    title: 'Meteo',
+    start: '2026-03-23T19:30:00.000Z',
+    stop: '2026-03-23T19:35:00.000Z',
+    description: 'Le previsioni del tempo.',
+  })
+})
+
+it('can handle empty programList', () => {
+  const content = JSON.stringify({
+    programGuide: [
+      { channel: { id: 'la1', vendor: 'RSI', title: 'La 1' }, programList: [] },
+    ],
+  })
+  expect(parser({ content })).toMatchObject([])
+})
+
+it('can handle empty guide', () => {
+  expect(parser({ content: '' })).toMatchObject([])
+})
+
+it('can handle malformed JSON', () => {
+  expect(parser({ content: 'not-json' })).toMatchObject([])
+})

--- a/sites/srf.ch/readme.md
+++ b/sites/srf.ch/readme.md
@@ -1,0 +1,21 @@
+# srf.ch
+
+https://srf.ch
+
+### Download the guide
+
+```sh
+npm run grab --- --site=srf.ch
+```
+
+### Update channel list
+
+```sh
+npm run channels:parse --- --config=./sites/srf.ch/srf.ch.config.js --output=./sites/srf.ch/srf.ch.channels.xml
+```
+
+### Test
+
+```sh
+npm test --- srf.ch
+```

--- a/sites/srf.ch/srf.ch.channels.xml
+++ b/sites/srf.ch/srf.ch.channels.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<channels>
+  <channel site="srf.ch" site_id="23FFBE1B-65CE-4188-ADD2-C724186C2C9F" lang="de" xmltv_id="SRF1.ch@SD">SRF 1</channel>
+  <channel site="srf.ch" site_id="E4D5AD08-C1E8-46A3-BB58-4875051D60D2" lang="de" xmltv_id="SRFzwei.ch@SD">SRF zwei</channel>
+  <channel site="srf.ch" site_id="34c2819e-e715-43d7-9026-40a443152a97" lang="de" xmltv_id="SRFinfo.ch">SRF info</channel>
+</channels>

--- a/sites/srf.ch/srf.ch.config.js
+++ b/sites/srf.ch/srf.ch.config.js
@@ -1,0 +1,42 @@
+const axios = require('axios')
+const dayjs = require('dayjs')
+
+module.exports = {
+  site: 'srf.ch',
+  days: 2,
+  
+  url({ channel, date }) {
+    return `https://il.srgssr.ch/integrationlayer/2.0/srf/programGuide/tv/byDate/${date.format('YYYY-MM-DD')}?reduced=false&channelId=${channel.site_id}`
+  },
+
+  parser({ content }) {
+    try {
+      const { programGuide } = JSON.parse(content)
+      if (!programGuide?.[0]?.programList) return []
+
+      return programGuide[0].programList.map(program => ({
+        title:       program.title || '',
+        subTitle:    program.subtitle || undefined,
+        description: program.description || program.show?.description || undefined,
+        start:       new Date(program.startTime).toISOString(),
+        stop:        new Date(program.endTime).toISOString(),
+        icon:        program.imageUrl ? { src: program.imageUrl } : undefined,
+        category:    program.genre || undefined,
+      }))
+    } catch {
+      return []
+    }
+  },
+
+  async channels() {
+    const today = dayjs().format('YYYY-MM-DD')
+    const { data } = await axios.get(
+      `https://www.srf.ch/play/v3/api/srf/production/tv-program-guide?date=${today}`
+    )
+    return data.data.map(entry => ({
+      site_id: entry.channel.id,
+      name:    entry.channel.title,
+      lang:    'de',
+    }))
+  }
+}

--- a/sites/srf.ch/srf.ch.test.js
+++ b/sites/srf.ch/srf.ch.test.js
@@ -1,0 +1,77 @@
+const { parser, url } = require('./srf.ch.config.js')
+const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const customParseFormat = require('dayjs/plugin/customParseFormat')
+dayjs.extend(customParseFormat)
+dayjs.extend(utc)
+
+const date = dayjs.utc('2026-03-23', 'YYYY-MM-DD').startOf('d')
+const channel = { site_id: '23FFBE1B-65CE-4188-ADD2-C724186C2C9F', name: 'SRF 1', lang: 'de' }
+
+it('can generate valid url', () => {
+  expect(url({ channel, date })).toBe(
+    'https://il.srgssr.ch/integrationlayer/2.0/srf/programGuide/tv/byDate/2026-03-23?reduced=false&channelId=23FFBE1B-65CE-4188-ADD2-C724186C2C9F'
+  )
+})
+
+it('can parse response', () => {
+  const content = JSON.stringify({
+    programGuide: [
+      {
+        channel: { id: '23FFBE1B-65CE-4188-ADD2-C724186C2C9F', vendor: 'SRF', title: 'SRF 1' },
+        programList: [
+          {
+            title: 'Tagesschau',
+            startTime: '2026-03-23T19:30:00+01:00',
+            endTime: '2026-03-23T19:55:00+01:00',
+            imageUrl: 'https://www.srf.ch/programm/tv/image/redirect/abc123.jpg',
+            genre: 'Nachrichten',
+            subtitle: 'Hauptausgabe',
+          },
+          {
+            title: 'Meteo',
+            startTime: '2026-03-23T19:55:00+01:00',
+            endTime: '2026-03-23T20:10:00+01:00',
+            imageUrl: 'https://www.srf.ch/programm/tv/image/redirect/def456.jpg',
+            genre: 'Nachrichten',
+            description: 'Das Wetter für die Schweiz.',
+          },
+        ],
+      },
+    ],
+  })
+
+  const results = parser({ content })
+
+  expect(results[0]).toMatchObject({
+    title: 'Tagesschau',
+    subTitle: 'Hauptausgabe',
+    start: '2026-03-23T18:30:00.000Z',
+    stop: '2026-03-23T18:55:00.000Z',
+    category: 'Nachrichten',
+    icon: { src: 'https://www.srf.ch/programm/tv/image/redirect/abc123.jpg' },
+  })
+  expect(results[1]).toMatchObject({
+    title: 'Meteo',
+    start: '2026-03-23T18:55:00.000Z',
+    stop: '2026-03-23T19:10:00.000Z',
+    description: 'Das Wetter für die Schweiz.',
+  })
+})
+
+it('can handle empty programList', () => {
+  const content = JSON.stringify({
+    programGuide: [
+      { channel: { id: '23FFBE1B-65CE-4188-ADD2-C724186C2C9F', vendor: 'SRF', title: 'SRF 1' }, programList: [] },
+    ],
+  })
+  expect(parser({ content })).toMatchObject([])
+})
+
+it('can handle empty guide', () => {
+  expect(parser({ content: '' })).toMatchObject([])
+})
+
+it('can handle malformed JSON', () => {
+  expect(parser({ content: 'not-json' })).toMatchObject([])
+})


### PR DESCRIPTION
I've just added SRF and RSI channels, to be comprehensive with this source, here's the log for a build run:

info starting...
info loading channels...
info found 8 channel(s)
info loading api data...
info creating queue...
info run:
info   [1/16] rts.ch (fr) - RTS1.ch - Mar 24, 2026 (42 programs)
info   [2/16] rts.ch (fr) - RTS1.ch - Mar 25, 2026 (39 programs)
info   [3/16] rts.ch (it) - RSILa2.ch - Mar 25, 2026 (39 programs)
info   [4/16] rts.ch (it) - RSILa2.ch - Mar 24, 2026 (36 programs)
info   [5/16] rts.ch (it) - RSILa1.ch - Mar 25, 2026 (41 programs)
info   [6/16] rts.ch (it) - RSILa1.ch - Mar 24, 2026 (38 programs)
info   [7/16] rts.ch (de) - SRFinfo.ch - Mar 25, 2026 (98 programs)
info   [8/16] rts.ch (de) - SRFinfo.ch - Mar 24, 2026 (83 programs)
info   [9/16] rts.ch (de) - SRFzwei.ch - Mar 25, 2026 (25 programs)
info   [10/16] rts.ch (de) - SRFzwei.ch - Mar 24, 2026 (28 programs)
info   [11/16] rts.ch (de) - SRF1.ch - Mar 25, 2026 (49 programs)
info   [12/16] rts.ch (de) - SRF1.ch - Mar 24, 2026 (43 programs)
info   [13/16] rts.ch (fr) - RTSInfo.ch - Mar 25, 2026 (3 programs)
info   [14/16] rts.ch (fr) - RTSInfo.ch - Mar 24, 2026 (3 programs)
info   [15/16] rts.ch (fr) - RTS2.ch - Mar 25, 2026 (43 programs)
info   [16/16] rts.ch (fr) - RTS2.ch - Mar 24, 2026 (43 programs)
info   saving to "guide.xml"...
success   done in 00h 00m 00s