### PR TITLE
Update musor.tv

### DIFF
--- a/sites/musor.tv/__data__/content.html
+++ b/sites/musor.tv/__data__/content.html
@@ -4291,7 +4291,7 @@ body {
   <div class="progentry_progshortdesc" itemprop="description">magyar dokumentumfilm,2016</div> <div class="progentry_additional">
   <img src="/images/etc/pg_16_old.svg" class="progentry_rating" width="22" height="22" alt="TV műsor 16 év felettieknek!" title="A TV műsor megtekintése 16 év felettieknek ajánlott!">
  </div>
-<div class="progentrylong">Lévai Balázs több mint egy éven át forgatott a Tankcsapdával.</div><span itemprop="location" itemscope itemtype="http://schema.org/Place"><span itemprop="address" content="Magyar Mozi TV "></span></span></div>
+<div class="progentrylong">19/3.<br><br>2006-ban a Harsányi Levente és Korda György alkotta páros volt az egyik legnépszerűbb zenés tévéműsor házigazdája. A műsorban klasszikus nagy slágerek versenyeznek közkedvelt művészek előadásában a nézők szavazataiért.</div><span itemprop="location" itemscope itemtype="http://schema.org/Place"><span itemprop="address" content="Magyar Mozi TV "></span></span></div>
 </div>
 <div class="progentry progentry_old" itemscope itemtype="https://schema.org/BroadcastEvent" title="Tovább a részletes műsorinformációhoz" onclick="clickOn(event,'sa_54075014');">
 <div class="progentry_internal">  <time class="progentry_time progentry_time_old" itemprop="startDate" content="2025-10-11GMT00:50:00"> 02:50</time>

--- a/sites/musor.tv/musor.tv.config.js
+++ b/sites/musor.tv/musor.tv.config.js
@@ -31,9 +31,11 @@ module.exports = {
       let start = parseStart($item)
       if (prev) prev.stop = start
       const stop = start.add(30, 'm')
+      const details = parseDetails($item)
       programs.push({
         title: parseTitle($item),
-        description: parseDescription($item),
+        subTitle: details.subTitle,
+        description: details.description,
         image: parseImage($item),
         start,
         stop
@@ -80,8 +82,20 @@ function parseTitle($item) {
   return $item.find('h3 > a').text().trim()
 }
 
-function parseDescription($item) {
-  return $item.find('div.progentrylong').text().trim()
+function parseDetails($item) {
+  const details = $item.find('div.progentrylong').html().split('<br>').filter(Boolean)
+
+  if (details.length === 1)
+    return {
+      description: details[0]
+    }
+
+  const [subTitle, description] = details
+
+  return {
+    subTitle,
+    description
+  }
 }
 
 function parseStart($item) {

--- a/sites/musor.tv/musor.tv.test.js
+++ b/sites/musor.tv/musor.tv.test.js
@@ -11,7 +11,7 @@ dayjs.extend(utc)
 const date = dayjs.utc('2025-10-11', 'YYYY-MM-DD').startOf('d')
 const channel = {
   site_id: 'MAGYAR_MOZI_TV',
-  xmltv_id: 'MagyarMoziTV.hu',
+  xmltv_id: 'MagyarMoziTV.hu'
 }
 
 it('can generate valid url', () => {
@@ -36,14 +36,17 @@ it('can parse response', () => {
     start: '2025-10-10T23:05:00.000Z',
     stop: '2025-10-11T00:50:00.000Z',
     title: 'A 25. év - Három rohadék rockcsempész (Tankcsapda road movie)',
-    description: 'Lévai Balázs több mint egy éven át forgatott a Tankcsapdával.'
+    subTitle: '19/3.',
+    description:
+      '2006-ban a Harsányi Levente és Korda György alkotta páros volt az egyik legnépszerűbb zenés tévéműsor házigazdája. A műsorban klasszikus nagy slágerek versenyeznek közkedvelt művészek előadásában a nézők szavazataiért.'
   })
 
   expect(results[1]).toMatchObject({
     start: '2025-10-11T00:50:00.000Z',
     stop: '2025-10-11T01:45:00.000Z',
     title: 'Megbélyegzetten - 1968',
-    description: 'Néhány tinédzser diák, egy csalinak szánt újságcikk nyomán levelet írt Ausztriába 1968-ban.'
+    description:
+      'Néhány tinédzser diák, egy csalinak szánt újságcikk nyomán levelet írt Ausztriába 1968-ban.'
   })
 })
 


### PR DESCRIPTION
Added `subTitle` to the output.

Fixes https://github.com/iptv-org/epg/issues/2904

```sh
npm test --- musor.tv            

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand musor.tv

 PASS  sites/musor.tv/musor.tv.test.js
  ✓ can generate valid url (7 ms)
  ✓ can generate valid url for today (2 ms)
  ✓ can parse response (206 ms)
  ✓ can handle empty guide (1 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.166 s
Ran all test suites matching musor.tv.
```