### PR TITLE
Update starhubtvplus.com

### DIFF
--- a/sites/starhubtvplus.com/starhubtvplus.com.config.js
+++ b/sites/starhubtvplus.com/starhubtvplus.com.config.js
@@ -46,8 +46,8 @@ module.exports = {
 
     return programs.map(item => {
       return {
-        title: item.title,
-        subTitle: item.serie_title,
+        title: item.serie_title || item.title,
+        subTitle: (item.serie_title && item.title && item.serie_title !== item.title) ? item.title : null,
         description: item.description,
         category: item.genres,
         image: item.pictures?.map(img => img.url),

--- a/sites/starhubtvplus.com/starhubtvplus.com.test.js
+++ b/sites/starhubtvplus.com/starhubtvplus.com.test.js
@@ -33,8 +33,8 @@ it('can parse response', async () => {
     {
       start: '2024-12-03T17:25:00.000Z',
       stop: '2024-12-03T18:20:00.000Z',
-      title: 'Northern Rexposure',
-      subTitle: 'Hudson & Rex (Season 5)',
+      title: 'Hudson & Rex (Season 5)',
+      subTitle: 'Northern Rexposure',
       description:
         "When Jesse's sister contacts him for help, he, Sarah and Rex head to Northern Ontario and find themselves in the middle of a deadly situation.",
       category: ['Drama'],

--- a/sites/starhubtvplus.com/starhubtvplus.com_en.channels.xml
+++ b/sites/starhubtvplus.com/starhubtvplus.com_en.channels.xml
@@ -1,121 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="en" xmltv_id="">SONY MAX</channel>
-  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="en" xmltv_id="">ONE HD</channel>
-  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="en" xmltv_id="">TV5MONDE HD</channel>
-  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="en" xmltv_id="">HBO Signature HD</channel>
-  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="en" xmltv_id="">ADITHYA TV</channel>
-  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="en" xmltv_id="">SPOTV2</channel>
+  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="en" xmltv_id="SonyMaxSingapore.sg@SD">SONY MAX</channel>
+  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="en" xmltv_id="ONE.sg@HD">ONE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5MONDE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="en" xmltv_id="HBOSignatureAsia.sg@HD">HBO Signature HD</channel>
+  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="en" xmltv_id="AdithyaTV.in@APAC">ADITHYA TV</channel>
+  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="en" xmltv_id="SPOTV2.id@SD">SPOTV2</channel>
   <channel site="starhubtvplus.com" site_id="1b01afd8-24c2-4736-82a2-1ad6802dc61c" lang="en" xmltv_id="">Hub Sports 8 HD</channel>
-  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="en" xmltv_id="">Sun TV</channel>
-  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="en" xmltv_id="">KTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="en" xmltv_id="">Cinemax HD</channel>
-  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="en" xmltv_id="">Phoenix Chinese Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="en" xmltv_id="">NHK World Premium HD</channel>
+  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="en" xmltv_id="SunTVMalaysia.my@SD">Sun TV</channel>
+  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="en" xmltv_id="KTV.in@Malaysia">KTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="en" xmltv_id="CinemaxAsia.sg@HD">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="en" xmltv_id="PhoenixChineseChannel.hk@SD">Phoenix Chinese Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="en" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium HD</channel>
   <channel site="starhubtvplus.com" site_id="3f4bb488-1eae-4b02-8d13-04931b021e09" lang="en" xmltv_id="">TestChannel 996</channel>
-  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="en" xmltv_id="">Hub Premier 6</channel>
-  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="en" xmltv_id="">Arirang TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="en" xmltv_id="">Vannathirai</channel>
-  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="en" xmltv_id="">Hub Premier 8</channel>
-  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="en" xmltv_id="">Hub Sports 3 HD</channel>
-  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="en" xmltv_id="">Hub Premier 1</channel>
-  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="en" xmltv_id="">Zee Cinema HD</channel>
-  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="en" xmltv_id="">Premier Sports</channel>
-  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="en" xmltv_id="">Hub Premier 2 (HD)</channel>
-  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="en" xmltv_id="">beIN SPORTS 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="en" xmltv_id="">Kalaignar TV</channel>
-  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="en" xmltv_id="">NHK WORLD - JAPAN HD</channel>
-  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="en" xmltv_id="">Preview Channel</channel>
-  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="en" xmltv_id="">TVB Xing He HD</channel>
-  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="en" xmltv_id="">Crime + Investigation HD</channel>
-  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="en" xmltv_id="">beIN SPORTS 4 HD</channel>
-  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="en" xmltv_id="">beIN SPORTS HD</channel>
-  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="en" xmltv_id="">Sun Music</channel>
-  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="en" xmltv_id="">Hub Premier 3</channel>
+  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="en" xmltv_id="HubPremier6.sg@SD">Hub Premier 6</channel>
+  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="en" xmltv_id="ArirangTV.kr@HD">Arirang TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="en" xmltv_id="Vannathirai.sg@SD">Vannathirai</channel>
+  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="en" xmltv_id="HubPremier8.sg@SD">Hub Premier 8</channel>
+  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="en" xmltv_id="HubSports3.sg@SD">Hub Sports 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="en" xmltv_id="HubPremier1.sg@SD">Hub Premier 1</channel>
+  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="en" xmltv_id="ZeeCinema.in@APAC">Zee Cinema HD</channel>
+  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="en" xmltv_id="PremierSports1Asia.ie@SD">Premier Sports</channel>
+  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="en" xmltv_id="HubPremier2.sg@SD">Hub Premier 2 (HD)</channel>
+  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="en" xmltv_id="beINSports2.qa@MENA">beIN SPORTS 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="en" xmltv_id="KalaignarTV.in@SD">Kalaignar TV</channel>
+  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="en" xmltv_id="NHKWorldJapan.jp@HD">NHK WORLD - JAPAN HD</channel>
+  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="en" xmltv_id="PreviewChannel.sg@SD">Preview Channel</channel>
+  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="en" xmltv_id="TVBXingHe.hk@SD">TVB Xing He HD</channel>
+  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="en" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime + Investigation HD</channel>
+  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="en" xmltv_id="beINSports4.qa@MENA">beIN SPORTS 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="en" xmltv_id="beINSports.qa@MENA">beIN SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="en" xmltv_id="SunMusic.in@APAC">Sun Music</channel>
+  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="en" xmltv_id="HubPremier3.sg@SD">Hub Premier 3</channel>
   <channel site="starhubtvplus.com" site_id="12f8f777-7671-486d-a26b-5727cd9a5ff9" lang="en" xmltv_id="">TestChannel2</channel>
-  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="en" xmltv_id="">Nick Jr. HD</channel>
+  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="en" xmltv_id="NickJrAsia.sg@HD">Nick Jr. HD</channel>
   <channel site="starhubtvplus.com" site_id="38df8124-1bcd-49b6-abb3-ee230a1f40d2" lang="en" xmltv_id="">Hub Sports 5 HD</channel>
   <channel site="starhubtvplus.com" site_id="39a2d989-f51d-45de-b4e3-90cc58aa54f4" lang="en" xmltv_id="">ETTV ASIA HD</channel>
-  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="en" xmltv_id="">BBC Lifestyle HD</channel>
-  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="en" xmltv_id="">Cinema One Global</channel>
-  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="en" xmltv_id="">Zee TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="en" xmltv_id="">KBS World HD</channel>
-  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="en" xmltv_id="">ABC Australia HD</channel>
-  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="en" xmltv_id="">HITS NOW</channel>
-  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="en" xmltv_id="">beIN SPORTS 5 HD</channel>
-  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="en" xmltv_id="">AXN HD</channel>
+  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="en" xmltv_id="BBCLifestyle.uk@Singapore">BBC Lifestyle HD</channel>
+  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="en" xmltv_id="CinemaOneGlobal.ph@SD">Cinema One Global</channel>
+  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="en" xmltv_id="ZeeTV.in@APAC">Zee TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="en" xmltv_id="KBSWorld.kr@HD">KBS World HD</channel>
+  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="en" xmltv_id="ABCAustralia.au@SD">ABC Australia HD</channel>
+  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="en" xmltv_id="HITSNOW.sg@SD">HITS NOW</channel>
+  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="en" xmltv_id="beINSports5.qa@MENA">beIN SPORTS 5 HD</channel>
+  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="en" xmltv_id="AXNAsia.sg@Singapore">AXN HD</channel>
   <channel site="starhubtvplus.com" site_id="9e1ef59d-d235-497b-93b0-063c2231cae5" lang="en" xmltv_id="">Test 998</channel>
-  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="en" xmltv_id="">Hub Premier 4</channel>
-  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="en" xmltv_id="">CNBC HD</channel>
-  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="en" xmltv_id="">Cbeebies HD</channel>
-  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="en" xmltv_id="">beIN SPORTS 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="en" xmltv_id="HubPremier4.sg@SD">Hub Premier 4</channel>
+  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="en" xmltv_id="CNBC.us@SD">CNBC HD</channel>
+  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="en" xmltv_id="CBeebiesAsia.uk@SD">Cbeebies HD</channel>
+  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="en" xmltv_id="beINSports3.qa@MENA">beIN SPORTS 3 HD</channel>
   <channel site="starhubtvplus.com" site_id="295f6562-21ae-498f-9971-0f5b76fae79d" lang="en" xmltv_id="">Hub Ruyi</channel>
-  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="en" xmltv_id="">Hub Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="en" xmltv_id="">Asianet</channel>
-  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="en" xmltv_id="">ONE (Malay)</channel>
-  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="en" xmltv_id="">CTI Asia HD</channel>
-  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="en" xmltv_id="">Hub Sports 4 HD</channel>
-  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="en" xmltv_id="">Cartoon Network</channel>
+  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="en" xmltv_id="HubSports2.sg@SD">Hub Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="en" xmltv_id="Asianet.in@HD">Asianet</channel>
+  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="en" xmltv_id="ONE.sg@Malaysia">ONE (Malay)</channel>
+  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="en" xmltv_id="CTiAsia.tw@SD">CTI Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="en" xmltv_id="HubSports4.sg@SD">Hub Sports 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="en" xmltv_id="CartoonNetworkAsia.sg@SD">Cartoon Network</channel>
   <channel site="starhubtvplus.com" site_id="792aa2b5-cb06-45b9-bf37-e919c27c097e" lang="en" xmltv_id="">Hub VV Drama HD</channel>
-  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="en" xmltv_id="">DreamWorks HD</channel>
-  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="en" xmltv_id="">BBC News HD</channel>
-  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="en" xmltv_id="">Astro Warna HD</channel>
-  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="en" xmltv_id="">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="en" xmltv_id="">ANC</channel>
-  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="en" xmltv_id="">Karisma</channel>
+  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="en" xmltv_id="DreamWorksChannelAsia.us@SD">DreamWorks HD</channel>
+  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="en" xmltv_id="BBCNews.uk@AsiaPacific">BBC News HD</channel>
+  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="en" xmltv_id="AstroWarna.my@SD">Astro Warna HD</channel>
+  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="en" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="en" xmltv_id="ANC.ph@SD">ANC</channel>
+  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="en" xmltv_id="Karisma.id@SD">Karisma</channel>
   <channel site="starhubtvplus.com" site_id="14104a82-aecb-457a-a5c5-2d134c852ba2" lang="en" xmltv_id="">AFN</channel>
-  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="en" xmltv_id="">Sky News HD</channel>
-  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="en" xmltv_id="">DW English HD</channel>
-  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="en" xmltv_id="">TVB Jade HD</channel>
-  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="en" xmltv_id="">Animax HD</channel>
+  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="en" xmltv_id="SkyNews.uk@HD">Sky News HD</channel>
+  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="en" xmltv_id="DW.de@English">DW English HD</channel>
+  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="en" xmltv_id="Jade.hk@SD">TVB Jade HD</channel>
+  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="en" xmltv_id="AnimaxAsia.sg@SD">Animax HD</channel>
   <channel site="starhubtvplus.com" site_id="85289efc-7559-49d6-86ab-b9e775dd4931" lang="en" xmltv_id="">Hub Sports 7 HD</channel>
-  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="en" xmltv_id="">CNN HD</channel>
-  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="en" xmltv_id="">COLORS Tamil HD</channel>
-  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="en" xmltv_id="">France24</channel>
-  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="en" xmltv_id="">Dragon TV</channel>
-  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="en" xmltv_id="">Lifetime HD</channel>
+  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="en" xmltv_id="CNNInternational.us@AsiaPacific">CNN HD</channel>
+  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="en" xmltv_id="ColorsTamil.in@APAc">COLORS Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="en" xmltv_id="France24.fr@English">France24</channel>
+  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="en" xmltv_id="DragonTV.cn@SD">Dragon TV</channel>
+  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime HD</channel>
   <channel site="starhubtvplus.com" site_id="a68f6d1e-0141-4f5a-bbbc-fa81888e08a8" lang="en" xmltv_id="">Cricbuzz 2</channel>
-  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="en" xmltv_id="">FashionTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="en" xmltv_id="">FIGHT SPORTS HD</channel>
-  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="en" xmltv_id="">The Filipino Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="en" xmltv_id="">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="en" xmltv_id="">Hub Premier 5</channel>
-  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="en" xmltv_id="">Asianet Movies</channel>
-  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="en" xmltv_id="">Zee Tamil HD</channel>
-  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="en" xmltv_id="">Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="en" xmltv_id="">Hub Sports 1 HD</channel>
-  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="en" xmltv_id="">Celestial Movies HD</channel>
-  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="en" xmltv_id="">CGTN</channel>
+  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="en" xmltv_id="FashionTVAsia.fr@SD">FashionTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="en" xmltv_id="FightSports.us@SD">FIGHT SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="en" xmltv_id="TheFilipinoChannelAsia.us@SD">The Filipino Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="en" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="en" xmltv_id="HubPremier5.sg@SD">Hub Premier 5</channel>
+  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="en" xmltv_id="AsianetMovies.in@APAC">Asianet Movies</channel>
+  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="en" xmltv_id="ZeeTamil.in@APAC">Zee Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="en" xmltv_id="HITS.sg@SD">Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="en" xmltv_id="HubSports1.sg@SD">Hub Sports 1 HD</channel>
+  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="en" xmltv_id="CelestialMovies.hk@SD">Celestial Movies HD</channel>
+  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="en" xmltv_id="CGTN.cn@SD">CGTN</channel>
   <channel site="starhubtvplus.com" site_id="c1b5b301-8e85-4ad3-a0f4-cd1a49ffbd4d" lang="en" xmltv_id="">Cricbuzz</channel>
-  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="en" xmltv_id="">Vijay TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="en" xmltv_id="">COLORS</channel>
-  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="en" xmltv_id="">Nickelodeon Asia HD</channel>
-  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="en" xmltv_id="">ROCK Entertainment HD</channel>
-  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="en" xmltv_id="">HGTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="en" xmltv_id="">CCTV-4</channel>
-  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="en" xmltv_id="">Bloomberg Originals</channel>
+  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="en" xmltv_id="StarVijay.in@APAC">Vijay TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="en" xmltv_id="ColorsAsiaPacific.in@SD">COLORS</channel>
+  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="en" xmltv_id="NickelodeonAsia.sg@SD">Nickelodeon Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="en" xmltv_id="ROCKEntertainment.sg@SD">ROCK Entertainment HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="en" xmltv_id="HGTVAsia.us@SD">HGTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="en" xmltv_id="CCTV4Asia.cn@SD">CCTV-4</channel>
+  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="en" xmltv_id="BloombergOriginals.us@SD">Bloomberg Originals</channel>
   <channel site="starhubtvplus.com" site_id="cc214bae-ddf2-4c17-84e2-7690fe4e65db" lang="en" xmltv_id="">Hub Sports 6 HD</channel>
-  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="en" xmltv_id="">Hub Premier 7</channel>
-  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="en" xmltv_id="">CCM</channel>
-  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="en" xmltv_id="">HBO Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="en" xmltv_id="">Sony Entertainment Television</channel>
-  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="en" xmltv_id="">Discovery HD</channel>
-  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="en" xmltv_id="">Phoenix InfoNews Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="en" xmltv_id="">HBO Family HD</channel>
-  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="en" xmltv_id="">HBO HD</channel>
-  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="en" xmltv_id="">HISTORY HD</channel>
-  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="en" xmltv_id="">TVBS Asia</channel>
+  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="en" xmltv_id="HubPremier7.sg@SD">Hub Premier 7</channel>
+  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="en" xmltv_id="CCM.hk@SD">CCM</channel>
+  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="en" xmltv_id="HBOHitsAsia.sg@HD">HBO Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="en" xmltv_id="SonyEntertainmentTelevisionAsia.in@HD">Sony Entertainment Television</channel>
+  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="en" xmltv_id="DiscoveryAsia.sg@SD">Discovery HD</channel>
+  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="en" xmltv_id="PhoenixInfoNewsChannel.hk@SD">Phoenix InfoNews Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="en" xmltv_id="HBOFamilyAsia.sg@HD">HBO Family HD</channel>
+  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="en" xmltv_id="HBOAsia.sg@HD">HBO HD</channel>
+  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="en" xmltv_id="HistoryAsia.us@SD">HISTORY HD</channel>
+  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="en" xmltv_id="TVBSAsia.tw@SD">TVBS Asia</channel>
   <channel site="starhubtvplus.com" site_id="e2ae3508-e262-4046-abbf-bfbdfc3ef898" lang="en" xmltv_id="">TestChannel 993</channel>
   <channel site="starhubtvplus.com" site_id="e8eac44e-2007-4cb2-88dd-9b3842f29638" lang="en" xmltv_id="">Channel 251</channel>
-  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="en" xmltv_id="">SPOTV</channel>
-  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="en" xmltv_id="">Zee Thirai</channel>
-  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="en" xmltv_id="">TVBS-NEWS</channel>
-  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="en" xmltv_id="">Fox News Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="en" xmltv_id="">Astro Sensasi HD</channel>
-  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="en" xmltv_id="">Travelxp HD</channel>
-  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="en" xmltv_id="">Citra Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="en" xmltv_id="">HITS MOVIES HD</channel>
-  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="en" xmltv_id="">Bloomberg Television HD</channel>
-  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="en" xmltv_id="">Euronews HD</channel>
-  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="en" xmltv_id="">BBC Earth HD</channel>
+  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="en" xmltv_id="SPOTV.kr@SD">SPOTV</channel>
+  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="en" xmltv_id="ZeeThirai.in@APAC">Zee Thirai</channel>
+  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="en" xmltv_id="TVBSNews.tw@SD">TVBS-NEWS</channel>
+  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="en" xmltv_id="FoxNewsChannel.us@SD">Fox News Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="en" xmltv_id="AstroSensasi.sg@SD">Astro Sensasi HD</channel>
+  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="en" xmltv_id="Travelxp.in@APAC">Travelxp HD</channel>
+  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="en" xmltv_id="CitraEntertainment.id@SD">Citra Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="en" xmltv_id="HITSMovies.sg@HD">HITS MOVIES HD</channel>
+  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg Television HD</channel>
+  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="en" xmltv_id="EuronewsEnglish.fr@HD">Euronews HD</channel>
+  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="en" xmltv_id="BBCEarth.uk@AsiaHD">BBC Earth HD</channel>
 </channels>

--- a/sites/starhubtvplus.com/starhubtvplus.com_en.channels.xml
+++ b/sites/starhubtvplus.com/starhubtvplus.com_en.channels.xml
@@ -1,119 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="starhubtvplus.com" site_id="0ec5072f-b6dc-4676-a683-c32c5db2c3a1" lang="en" xmltv_id="PremierSports1Asia.ie@SD">Premier Sports</channel>
-  <channel site="starhubtvplus.com" site_id="1b8e6f65-e3f0-4369-bf33-c56212eb269e" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews HD</channel>
-  <channel site="starhubtvplus.com" site_id="1ed77994-5ab6-4d38-88f2-d662f3cfe5b0" lang="en" xmltv_id="SonyEntertainmentTelevision.in@SD">Sony Entertainment Television</channel>
-  <channel site="starhubtvplus.com" site_id="2cd14827-0816-400d-b868-62985ec8b627" lang="en" xmltv_id="HGTVAsia.us@SD">HGTV</channel>
-  <channel site="starhubtvplus.com" site_id="2cea0112-a03d-4fa1-a4c2-276da4d3c908" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5MONDE HD</channel>
-  <channel site="starhubtvplus.com" site_id="2d16335e-aea6-47ab-b688-b3c694a27cf6" lang="en" xmltv_id="HubPremier3.sg@SD">Hub Premier 3</channel>
-  <channel site="starhubtvplus.com" site_id="3c3228b3-3388-4aa1-8535-6f2ed17432af" lang="en" xmltv_id="ABCAustralia.au@SD">ABC Australia HD</channel>
-  <channel site="starhubtvplus.com" site_id="3c292157-4cf2-48bf-9608-c0ef8ab79cc5" lang="en" xmltv_id="HubSports2.sg@SD">Hub Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="4c646df4-59ab-4e03-9de8-d36a95127266" lang="en" xmltv_id="DW.de@English">DW English HD</channel>
-  <channel site="starhubtvplus.com" site_id="4db9b282-0e8d-456e-ba83-89b4eaf173d7" lang="en" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
-  <channel site="starhubtvplus.com" site_id="5b36348e-1669-4883-9821-6b336cff0d58" lang="en" xmltv_id="HistoryAsia.us@SD">HISTORY HD</channel>
-  <channel site="starhubtvplus.com" site_id="5bc5b18c-b12c-462f-b49a-8056b74d72a3" lang="en" xmltv_id="Jade.hk@SD">TVB Jade HD</channel>
-  <channel site="starhubtvplus.com" site_id="5f50648a-3b0f-4d13-b0ac-056e722a647a" lang="en" xmltv_id="TVBXingHe.hk@SD">TVB Xing He</channel>
-  <channel site="starhubtvplus.com" site_id="6a59cb8b-182d-4038-b315-cf35cf7c5ac7" lang="en" xmltv_id="CitraEntertainment.id@SD">Citra Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="6c1be2bc-47c4-45b5-b027-fce49322f34c" lang="en" xmltv_id="beINSports4.qa@MENA">beIN Sports 4</channel>
-  <channel site="starhubtvplus.com" site_id="6f6c5d20-18b3-4023-b505-726b9c36b6e9" lang="en" xmltv_id="Asianet.in@SD">Asianet</channel>
-  <channel site="starhubtvplus.com" site_id="7c0ee1eb-5f74-4f5a-a338-69eb125badb4" lang="en" xmltv_id="">ETTV ASIA HD</channel>
-  <channel site="starhubtvplus.com" site_id="7cad02e2-086a-49c8-bf6a-737d1f30c680" lang="en" xmltv_id="CTiTV.tw@SD">CTI TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="8a28afbc-74bb-4c02-9bba-eb623358a9b8" lang="en" xmltv_id="BBCNews.uk@AsiaPacific">BBC World News HD</channel>
-  <channel site="starhubtvplus.com" site_id="8ade3211-6836-4e95-80f7-5aca573b8b75" lang="en" xmltv_id="ZeeTV.in@SD">Zee TV</channel>
-  <channel site="starhubtvplus.com" site_id="9abfbba5-24c8-4e3f-8e00-f75902c7675b" lang="en" xmltv_id="France24.fr@English">France24</channel>
-  <channel site="starhubtvplus.com" site_id="9b01c864-5bcc-46e6-ba8e-3ba6c33ca8fb" lang="en" xmltv_id="HubPremier7.sg@SD">Hub Premier 7</channel>
-  <channel site="starhubtvplus.com" site_id="9bf114df-42db-4815-9b73-efa05d0b9f94" lang="en" xmltv_id="AstroWarna.my@SD">Astro Warna HD</channel>
-  <channel site="starhubtvplus.com" site_id="9c7414bb-cd6c-4cdf-b019-1c85b7511d32" lang="en" xmltv_id="PreviewChannel.sg@SD">Preview Channel</channel>
-  <channel site="starhubtvplus.com" site_id="9fc55c89-3eb4-4516-a5c4-c6193eb71f57" lang="en" xmltv_id="Cartoonito.uk@SD">Cartoonito HD</channel>
-  <channel site="starhubtvplus.com" site_id="12efa598-4bae-4d64-afc0-a4e7340de74e" lang="en" xmltv_id="beINSports.qa@MENA">beIN Sports HD</channel>
-  <channel site="starhubtvplus.com" site_id="14a563d5-d406-4094-907e-ec452c658de9" lang="en" xmltv_id="Travelxp.in@SD">Travelxp HD</channel>
-  <channel site="starhubtvplus.com" site_id="21bf30fb-2800-4761-aee8-452bdb68aff6" lang="en" xmltv_id="DiscoveryChannelSoutheastAsia.sg@SD">Discovery HD</channel>
-  <channel site="starhubtvplus.com" site_id="30a6b23c-0657-4e8f-b26b-de9273e394d7" lang="en" xmltv_id="CBeebiesAsia.uk@SD">Cbeebies HD</channel>
-  <channel site="starhubtvplus.com" site_id="36dae5f2-147d-4aab-a7bd-e9b7d9501734" lang="en" xmltv_id="KTV.in@SD">KTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="54f4de25-3575-44c4-92dd-b4a1c3c5b088" lang="en" xmltv_id="CartoonNetworkAsia.sg@SD">Cartoon Network</channel>
-  <channel site="starhubtvplus.com" site_id="57f9281b-3c13-456c-aa52-a1e410706933" lang="en" xmltv_id="DragonTVInternational.cn@SD">Dragon TV</channel>
-  <channel site="starhubtvplus.com" site_id="61fcfb0b-514a-47a0-8400-ed8b9221188c" lang="en" xmltv_id="ColorsTamil.in@SD">COLORS Tamil HD</channel>
-  <channel site="starhubtvplus.com" site_id="64ddc417-c35c-4b95-84ca-67b0d6c77265" lang="en" xmltv_id="CinemaOneGlobal.ph@SD">Cinema One Global</channel>
-  <channel site="starhubtvplus.com" site_id="68bbd5d8-379d-4646-a1e3-e204cc9c2f54" lang="en" xmltv_id="AstroSensasi.sg@SD">Astro Sensasi HD</channel>
-  <channel site="starhubtvplus.com" site_id="68c4d3c4-93d9-4cb3-ba14-8918142bfbdc" lang="en" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
-  <channel site="starhubtvplus.com" site_id="71da87e9-5d3f-4544-8b6f-e9a374e05bc7" lang="en" xmltv_id="FightSports.us@SD">FIGHT SPORTS HD</channel>
-  <channel site="starhubtvplus.com" site_id="072f2bcf-99f1-48fe-8806-7a217e4bb372" lang="en" xmltv_id="AdithyaTV.in@SD">ADITHYA TV</channel>
-  <channel site="starhubtvplus.com" site_id="73d6b697-f5f1-4a04-a788-ece67c31ed1c" lang="en" xmltv_id="ArirangTV.kr@SD">Arirang TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="77da4ed7-09ed-455a-9c09-8d75000fe942" lang="en" xmltv_id="CGTN.cn@SD">CGTN</channel>
-  <channel site="starhubtvplus.com" site_id="94ec2a65-eae1-4cdc-95a6-1ed67b17f4e4" lang="en" xmltv_id="ZeeThirai.in@SD">Zee Thirai</channel>
-  <channel site="starhubtvplus.com" site_id="99ee7b2d-1a7d-4fb1-8fbe-7903e028a87b" lang="en" xmltv_id="HubPremier1.sg@SD">Hub Premier 1</channel>
-  <channel site="starhubtvplus.com" site_id="206f755c-f417-4eb4-9631-ed21ae11f2e8" lang="en" xmltv_id="SkyNewsAustralia.au@SD">Sky News HD</channel>
-  <channel site="starhubtvplus.com" site_id="207a516d-2dbc-49f9-8d98-32d31bd89d3a" lang="en" xmltv_id="Vannathirai.sg@SD">Vannathirai</channel>
-  <channel site="starhubtvplus.com" site_id="210ba103-0d19-4b26-bb9f-36d531d7471f" lang="en" xmltv_id="">TestChannel 996</channel>
-  <channel site="starhubtvplus.com" site_id="263c311c-4b74-4fc0-bb7b-7762cce99a8a" lang="en" xmltv_id="NHKWorldJapan.jp@SD">NHK WORLD - JAPAN HD</channel>
-  <channel site="starhubtvplus.com" site_id="265c0f76-c798-496d-aca1-f540a70952ec" lang="en" xmltv_id="TheFilipinoChannelAsia.us@SD">The Filipino Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="354def1b-701e-4703-a279-5ef4204847a1" lang="en" xmltv_id="beINSports5.qa@MENA">beIN Sports 5</channel>
-  <channel site="starhubtvplus.com" site_id="578cfccf-634d-4beb-a167-741cb91a068e" lang="en" xmltv_id="HubPremier8.sg@SD">Hub Premier 8</channel>
-  <channel site="starhubtvplus.com" site_id="0610cb3d-8521-44a1-8d90-7029ac428e8c" lang="en" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime + Investigation HD</channel>
-  <channel site="starhubtvplus.com" site_id="628ba4e0-4239-46c3-a5a2-b15273c82009" lang="en" xmltv_id="FoxNewsChannel.us@SD">Fox News Channel</channel>
-  <channel site="starhubtvplus.com" site_id="740ad097-ae3d-4a16-9e67-69e308509b9a" lang="en" xmltv_id="">ONE (Malay)</channel>
-  <channel site="starhubtvplus.com" site_id="895ebe38-5cfe-43da-9847-a7088cc3aca7" lang="en" xmltv_id="Colors.in@SD">COLORS</channel>
-  <channel site="starhubtvplus.com" site_id="9e2f39ab-95ba-4031-bfeb-6b9b41491b08" lang="en" xmltv_id="FashionTVAsia.fr@SD">FashionTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="1944dfe8-b8e6-46c2-a700-78d5b680e2ac" lang="en" xmltv_id="HubSports4.sg@SD">Hub Sports 4 HD</channel>
-  <channel site="starhubtvplus.com" site_id="4431c255-e2a9-45db-b43b-27cc19c14cb9" lang="en" xmltv_id="ONE.sg@SD">ONE HD</channel>
-  <channel site="starhubtvplus.com" site_id="05384f9f-6241-4712-80ab-2c3f2d8ac7d5" lang="en" xmltv_id="HITS.sg@SD">Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="6269ba33-cee1-4dc9-8728-2b82dc73e252" lang="en" xmltv_id="BBCEarth.uk@Asia">BBC Earth HD</channel>
-  <channel site="starhubtvplus.com" site_id="06830f4b-1684-42d1-a29a-616b2e34b0ae" lang="en" xmltv_id="">Bloomberg Originals</channel>
-  <channel site="starhubtvplus.com" site_id="9511afb0-2af8-4a1a-9d54-1395924edf91" lang="en" xmltv_id="HubSports3.sg@SD">Hub Sports 3 HD</channel>
-  <channel site="starhubtvplus.com" site_id="30970c17-8498-4c05-9174-a49c0fc33fad" lang="en" xmltv_id="AsianetMovies.in@SD">Asianet Movies</channel>
-  <channel site="starhubtvplus.com" site_id="62954bd1-435e-4929-a78a-90c12c99e3eb" lang="en" xmltv_id="SPOTV.kr@SD">SPOTV</channel>
-  <channel site="starhubtvplus.com" site_id="64178eae-3ca3-4048-99e4-fce9556b2812" lang="en" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium HD</channel>
-  <channel site="starhubtvplus.com" site_id="082041a8-9ba1-41ab-9e01-6741f01f4e34" lang="en" xmltv_id="SunMusic.in@SD">Sun Music</channel>
-  <channel site="starhubtvplus.com" site_id="93114f35-0f46-4404-98c1-07019a2d2c15" lang="en" xmltv_id="CNNInternational.us@AsiaPacific">CNN HD</channel>
-  <channel site="starhubtvplus.com" site_id="6e5e72ef-9fa6-4007-9537-74e7d08f51c4" lang="en" xmltv_id="HubSports1.sg@SD">Hub Sports 1 HD</channel>
-  <channel site="starhubtvplus.com" site_id="21184422-bbcd-4641-aeb6-fef337b5cc7a" lang="en" xmltv_id="HBOSignatureAsia.sg@SD">HBO Signature HD</channel>
-  <channel site="starhubtvplus.com" site_id="85611254-47a9-4f7c-9469-a4ee8b9f65b1" lang="en" xmltv_id="BBCLifestyle.uk@Asia">BBC Lifestyle</channel>
-  <channel site="starhubtvplus.com" site_id="9e7d5a33-39dd-4e66-809f-c6099dc81d26" lang="en" xmltv_id="TVBSAsia.tw@SD">TVBS Asia</channel>
-  <channel site="starhubtvplus.com" site_id="705e08d5-dec6-4da2-858a-fd29e6b884d2" lang="en" xmltv_id="CelestialMovies.hk@SD">Celestial Movies HD</channel>
-  <channel site="starhubtvplus.com" site_id="71278e7f-bdd5-43ac-b3ca-01d6fad180f5" lang="en" xmltv_id="AnimaxAsia.sg@SD">Animax HD</channel>
-  <channel site="starhubtvplus.com" site_id="37e180c8-9f91-41b2-80fe-237b8eba0d8b" lang="en" xmltv_id="HubPremier5.sg@SD">Hub Premier 5</channel>
-  <channel site="starhubtvplus.com" site_id="a162afe8-8990-4d43-8c9a-c29d844ba2fb" lang="en" xmltv_id="HBOFamilyAsia.sg@SD">HBO Family HD</channel>
-  <channel site="starhubtvplus.com" site_id="aab336e8-ef09-4e27-91d4-81c35b802a0a" lang="en" xmltv_id="HubPremier4.sg@SD">Hub Premier 4</channel>
-  <channel site="starhubtvplus.com" site_id="ac52e93d-814b-40cb-9a3f-688765341bda" lang="en" xmltv_id="">Test 998</channel>
-  <channel site="starhubtvplus.com" site_id="ace578ac-0996-4941-877c-58abe2ff3851" lang="en" xmltv_id="">TestChannel2</channel>
-  <channel site="starhubtvplus.com" site_id="ae1685eb-3ef0-4d14-9c89-8955bcc2bc02" lang="en" xmltv_id="SPOTV2.kr@SD">SPOTV2</channel>
-  <channel site="starhubtvplus.com" site_id="b4cdf669-f16c-4f74-ad4c-accde9fc77d3" lang="en" xmltv_id="TVBSNews.tw@SD">TVBS-NEWS</channel>
-  <channel site="starhubtvplus.com" site_id="b4ff91f4-7aa6-4e06-ab58-d3932bcbb496" lang="en" xmltv_id="">Hub Sports 7</channel>
-  <channel site="starhubtvplus.com" site_id="b8953e43-4fea-4a1a-833c-06de1fcb5db7" lang="en" xmltv_id="tvNAsia.hk@SD">tvN HD</channel>
-  <channel site="starhubtvplus.com" site_id="baa219e7-6b9a-4b1c-aba3-c77f26b7cf49" lang="en" xmltv_id="">TestChannel 993</channel>
-  <channel site="starhubtvplus.com" site_id="c2c8034f-2897-4944-afb6-bdfcb6e9a536" lang="en" xmltv_id="BloombergTV.us@Asia">Bloomberg Television HD</channel>
-  <channel site="starhubtvplus.com" site_id="c25a38ab-772d-41e7-b0eb-83021f1d309c" lang="en" xmltv_id="NickelodeonAsia.sg@SD">Nickelodeon Asia HD</channel>
-  <channel site="starhubtvplus.com" site_id="c290bc2f-bff6-485e-ad81-cba439754d16" lang="en" xmltv_id="">TestChannel1</channel>
-  <channel site="starhubtvplus.com" site_id="c691a121-f6a9-450d-bd1c-cb41107b65b6" lang="en" xmltv_id="">Hub Sports 6</channel>
-  <channel site="starhubtvplus.com" site_id="c993aa99-5dd3-446e-9e55-62393353058a" lang="en" xmltv_id="KBSWorld.kr@SD">KBS World HD</channel>
-  <channel site="starhubtvplus.com" site_id="c4162998-26a4-4296-ae78-34d56086e604" lang="en" xmltv_id="VijayTVAsia.in@SD">Vijay TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="c5693796-e108-4a13-9319-eb793bb408c3" lang="en" xmltv_id="Karisma.id@SD">Karisma</channel>
-  <channel site="starhubtvplus.com" site_id="ce5ca9b4-9dca-412f-ac30-252144c124e3" lang="en" xmltv_id="HubVVDrama.sg@SD">Hub VVDrama</channel>
-  <channel site="starhubtvplus.com" site_id="cef88e25-64c6-402e-a6d5-36688708c40f" lang="en" xmltv_id="HITSMovies.sg@SD">HITS MOVIES HD</channel>
-  <channel site="starhubtvplus.com" site_id="d27cd0f4-85c1-4c08-91cd-808643e7cec9" lang="en" xmltv_id="HBOHitsAsia.sg@SD">HBO Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="d99214cd-fcdf-4613-8106-55e248d3b608" lang="en" xmltv_id="KalaignarTV.in@SD">Kalaignar TV</channel>
-  <channel site="starhubtvplus.com" site_id="d258444e-b66b-4cbe-88db-e09f31ab8a1f" lang="en" xmltv_id="AXNAsia.sg@Singapore">AXN HD</channel>
-  <channel site="starhubtvplus.com" site_id="dc1af464-7877-46dd-95f0-f81ecd1e3677" lang="en" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="dca44244-ee28-4372-b502-888c8795624b" lang="en" xmltv_id="PhoenixInfoNewsChannel.hk@SD">Phoenix InfoNews Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="dceea37a-621c-4ba5-a818-68ec6154e538" lang="en" xmltv_id="beINSports2.qa@MENA">beIN Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="dd211710-85e9-45f6-b3c8-482dbda2d261" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
-  <channel site="starhubtvplus.com" site_id="df762cf1-6b2b-4e0c-9e23-427efde82020" lang="en" xmltv_id="SEAToday.id@SD">SEA Today</channel>
-  <channel site="starhubtvplus.com" site_id="df4507d8-292d-4036-b14e-b8343360dcaa" lang="en" xmltv_id="beINSports3.qa@MENA">beIN Sports 3</channel>
-  <channel site="starhubtvplus.com" site_id="dfb315cf-fbda-479a-87f0-ab35e65dd7aa" lang="en" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="dff489d0-abee-4b61-a684-e283ba799ce6" lang="en" xmltv_id="SonyMaxSingapore.sg@SD">SONY MAX</channel>
-  <channel site="starhubtvplus.com" site_id="e2cf7307-0e1d-4dba-a94f-5a0fac85b262" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime HD</channel>
-  <channel site="starhubtvplus.com" site_id="e21e78cb-6be3-4ec6-888f-39d3d365710c" lang="en" xmltv_id="">TestChannel 995</channel>
-  <channel site="starhubtvplus.com" site_id="e070be44-cd6f-4fab-b34d-948a979d5564" lang="en" xmltv_id="ANC.ph@SD">ANC</channel>
-  <channel site="starhubtvplus.com" site_id="e3141ae3-758b-4393-bd9c-9260babbca00" lang="en" xmltv_id="PhoenixChineseChannel.hk@SD">Phoenix Chinese Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="e774692b-b038-4615-9148-d9cbbdbebb5b" lang="en" xmltv_id="CCTV4Asia.cn@SD">CCTV-4</channel>
-  <channel site="starhubtvplus.com" site_id="eac9d5cf-9291-4900-adbd-b81551cbeeb3" lang="en" xmltv_id="">Hub Sports 5 HD</channel>
-  <channel site="starhubtvplus.com" site_id="ee7f8151-6ddb-4f5a-b651-aa19597ab57b" lang="en" xmltv_id="HubPremier6.sg@SD">Hub Premier 6</channel>
-  <channel site="starhubtvplus.com" site_id="ef624c07-6e36-4619-87fd-138a443aac1a" lang="en" xmltv_id="CCM.hk@SD">CCM</channel>
-  <channel site="starhubtvplus.com" site_id="f0de7c83-f946-492e-b02b-960b65928ec9" lang="en" xmltv_id="CNBCAsia.sg@SD">CNBC HD</channel>
-  <channel site="starhubtvplus.com" site_id="f1e89c2d-232c-4204-8cf1-e3107ad6b8e8" lang="en" xmltv_id="HBOAsia.sg@Vietnam">HBO HD</channel>
-  <channel site="starhubtvplus.com" site_id="f8ae363f-51f1-4063-808b-406947018b51" lang="en" xmltv_id="ZeeTamil.in@SD">Zee Tamil</channel>
-  <channel site="starhubtvplus.com" site_id="f9f14a80-9556-4ef8-af7c-5f13279dd83c" lang="en" xmltv_id="DreamWorksChannelAsia.us@SD">DreamWorks Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="f83d356b-7169-48c9-a411-b5e05511a462" lang="en" xmltv_id="ROCKEntertainment.sg@SD">ROCK Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="fbb0e7b8-649b-4c98-9bbe-713971282d8c" lang="en" xmltv_id="HubPremier2.sg@SD">Hub Premier 2 (HD)</channel>
-  <channel site="starhubtvplus.com" site_id="fd510962-c830-490f-be97-0ecadf2bcc11" lang="en" xmltv_id="CinemaxAsia.sg@SD">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="en" xmltv_id="">SONY MAX</channel>
+  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="en" xmltv_id="">ONE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="en" xmltv_id="">TV5MONDE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="en" xmltv_id="">HBO Signature HD</channel>
+  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="en" xmltv_id="">ADITHYA TV</channel>
+  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="en" xmltv_id="">SPOTV2</channel>
+  <channel site="starhubtvplus.com" site_id="1b01afd8-24c2-4736-82a2-1ad6802dc61c" lang="en" xmltv_id="">Hub Sports 8 HD</channel>
+  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="en" xmltv_id="">Sun TV</channel>
+  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="en" xmltv_id="">KTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="en" xmltv_id="">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="en" xmltv_id="">Phoenix Chinese Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="en" xmltv_id="">NHK World Premium HD</channel>
+  <channel site="starhubtvplus.com" site_id="3f4bb488-1eae-4b02-8d13-04931b021e09" lang="en" xmltv_id="">TestChannel 996</channel>
+  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="en" xmltv_id="">Hub Premier 6</channel>
+  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="en" xmltv_id="">Arirang TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="en" xmltv_id="">Vannathirai</channel>
+  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="en" xmltv_id="">Hub Premier 8</channel>
+  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="en" xmltv_id="">Hub Sports 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="en" xmltv_id="">Hub Premier 1</channel>
+  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="en" xmltv_id="">Zee Cinema HD</channel>
+  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="en" xmltv_id="">Premier Sports</channel>
+  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="en" xmltv_id="">Hub Premier 2 (HD)</channel>
+  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="en" xmltv_id="">beIN SPORTS 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="en" xmltv_id="">Kalaignar TV</channel>
+  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="en" xmltv_id="">NHK WORLD - JAPAN HD</channel>
+  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="en" xmltv_id="">Preview Channel</channel>
+  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="en" xmltv_id="">TVB Xing He HD</channel>
+  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="en" xmltv_id="">Crime + Investigation HD</channel>
+  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="en" xmltv_id="">beIN SPORTS 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="en" xmltv_id="">beIN SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="en" xmltv_id="">Sun Music</channel>
+  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="en" xmltv_id="">Hub Premier 3</channel>
+  <channel site="starhubtvplus.com" site_id="12f8f777-7671-486d-a26b-5727cd9a5ff9" lang="en" xmltv_id="">TestChannel2</channel>
+  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="en" xmltv_id="">Nick Jr. HD</channel>
+  <channel site="starhubtvplus.com" site_id="38df8124-1bcd-49b6-abb3-ee230a1f40d2" lang="en" xmltv_id="">Hub Sports 5 HD</channel>
+  <channel site="starhubtvplus.com" site_id="39a2d989-f51d-45de-b4e3-90cc58aa54f4" lang="en" xmltv_id="">ETTV ASIA HD</channel>
+  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="en" xmltv_id="">BBC Lifestyle HD</channel>
+  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="en" xmltv_id="">Cinema One Global</channel>
+  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="en" xmltv_id="">Zee TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="en" xmltv_id="">KBS World HD</channel>
+  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="en" xmltv_id="">ABC Australia HD</channel>
+  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="en" xmltv_id="">HITS NOW</channel>
+  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="en" xmltv_id="">beIN SPORTS 5 HD</channel>
+  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="en" xmltv_id="">AXN HD</channel>
+  <channel site="starhubtvplus.com" site_id="9e1ef59d-d235-497b-93b0-063c2231cae5" lang="en" xmltv_id="">Test 998</channel>
+  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="en" xmltv_id="">Hub Premier 4</channel>
+  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="en" xmltv_id="">CNBC HD</channel>
+  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="en" xmltv_id="">Cbeebies HD</channel>
+  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="en" xmltv_id="">beIN SPORTS 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="295f6562-21ae-498f-9971-0f5b76fae79d" lang="en" xmltv_id="">Hub Ruyi</channel>
+  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="en" xmltv_id="">Hub Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="en" xmltv_id="">Asianet</channel>
+  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="en" xmltv_id="">ONE (Malay)</channel>
+  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="en" xmltv_id="">CTI Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="en" xmltv_id="">Hub Sports 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="en" xmltv_id="">Cartoon Network</channel>
+  <channel site="starhubtvplus.com" site_id="792aa2b5-cb06-45b9-bf37-e919c27c097e" lang="en" xmltv_id="">Hub VV Drama HD</channel>
+  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="en" xmltv_id="">DreamWorks HD</channel>
+  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="en" xmltv_id="">BBC News HD</channel>
+  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="en" xmltv_id="">Astro Warna HD</channel>
+  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="en" xmltv_id="">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="en" xmltv_id="">ANC</channel>
+  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="en" xmltv_id="">Karisma</channel>
+  <channel site="starhubtvplus.com" site_id="14104a82-aecb-457a-a5c5-2d134c852ba2" lang="en" xmltv_id="">AFN</channel>
+  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="en" xmltv_id="">Sky News HD</channel>
+  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="en" xmltv_id="">DW English HD</channel>
+  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="en" xmltv_id="">TVB Jade HD</channel>
+  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="en" xmltv_id="">Animax HD</channel>
+  <channel site="starhubtvplus.com" site_id="85289efc-7559-49d6-86ab-b9e775dd4931" lang="en" xmltv_id="">Hub Sports 7 HD</channel>
+  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="en" xmltv_id="">CNN HD</channel>
+  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="en" xmltv_id="">COLORS Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="en" xmltv_id="">France24</channel>
+  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="en" xmltv_id="">Dragon TV</channel>
+  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="en" xmltv_id="">Lifetime HD</channel>
+  <channel site="starhubtvplus.com" site_id="a68f6d1e-0141-4f5a-bbbc-fa81888e08a8" lang="en" xmltv_id="">Cricbuzz 2</channel>
+  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="en" xmltv_id="">FashionTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="en" xmltv_id="">FIGHT SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="en" xmltv_id="">The Filipino Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="en" xmltv_id="">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="en" xmltv_id="">Hub Premier 5</channel>
+  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="en" xmltv_id="">Asianet Movies</channel>
+  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="en" xmltv_id="">Zee Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="en" xmltv_id="">Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="en" xmltv_id="">Hub Sports 1 HD</channel>
+  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="en" xmltv_id="">Celestial Movies HD</channel>
+  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="en" xmltv_id="">CGTN</channel>
+  <channel site="starhubtvplus.com" site_id="c1b5b301-8e85-4ad3-a0f4-cd1a49ffbd4d" lang="en" xmltv_id="">Cricbuzz</channel>
+  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="en" xmltv_id="">Vijay TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="en" xmltv_id="">COLORS</channel>
+  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="en" xmltv_id="">Nickelodeon Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="en" xmltv_id="">ROCK Entertainment HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="en" xmltv_id="">HGTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="en" xmltv_id="">CCTV-4</channel>
+  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="en" xmltv_id="">Bloomberg Originals</channel>
+  <channel site="starhubtvplus.com" site_id="cc214bae-ddf2-4c17-84e2-7690fe4e65db" lang="en" xmltv_id="">Hub Sports 6 HD</channel>
+  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="en" xmltv_id="">Hub Premier 7</channel>
+  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="en" xmltv_id="">CCM</channel>
+  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="en" xmltv_id="">HBO Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="en" xmltv_id="">Sony Entertainment Television</channel>
+  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="en" xmltv_id="">Discovery HD</channel>
+  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="en" xmltv_id="">Phoenix InfoNews Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="en" xmltv_id="">HBO Family HD</channel>
+  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="en" xmltv_id="">HBO HD</channel>
+  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="en" xmltv_id="">HISTORY HD</channel>
+  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="en" xmltv_id="">TVBS Asia</channel>
+  <channel site="starhubtvplus.com" site_id="e2ae3508-e262-4046-abbf-bfbdfc3ef898" lang="en" xmltv_id="">TestChannel 993</channel>
+  <channel site="starhubtvplus.com" site_id="e8eac44e-2007-4cb2-88dd-9b3842f29638" lang="en" xmltv_id="">Channel 251</channel>
+  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="en" xmltv_id="">SPOTV</channel>
+  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="en" xmltv_id="">Zee Thirai</channel>
+  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="en" xmltv_id="">TVBS-NEWS</channel>
+  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="en" xmltv_id="">Fox News Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="en" xmltv_id="">Astro Sensasi HD</channel>
+  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="en" xmltv_id="">Travelxp HD</channel>
+  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="en" xmltv_id="">Citra Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="en" xmltv_id="">HITS MOVIES HD</channel>
+  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="en" xmltv_id="">Bloomberg Television HD</channel>
+  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="en" xmltv_id="">Euronews HD</channel>
+  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="en" xmltv_id="">BBC Earth HD</channel>
 </channels>

--- a/sites/starhubtvplus.com/starhubtvplus.com_zh.channels.xml
+++ b/sites/starhubtvplus.com/starhubtvplus.com_zh.channels.xml
@@ -1,121 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="zh" xmltv_id="">SONY MAX</channel>
-  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="zh" xmltv_id="">ONE HD</channel>
-  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="zh" xmltv_id="">TV5MONDE HD</channel>
-  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="zh" xmltv_id="">HBO Signature HD</channel>
-  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="zh" xmltv_id="">ADITHYA TV</channel>
-  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="zh" xmltv_id="">SPOTV2</channel>
+  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="zh" xmltv_id="SonyMaxSingapore.sg@SD">SONY MAX</channel>
+  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="zh" xmltv_id="ONE.sg@HD">ONE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="zh" xmltv_id="TV5MondeAsia.fr@SD">TV5MONDE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="zh" xmltv_id="HBOSignatureAsia.sg@HD">HBO Signature HD</channel>
+  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="zh" xmltv_id="AdithyaTV.in@APAC">ADITHYA TV</channel>
+  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="zh" xmltv_id="SPOTV2.id@SD">SPOTV2</channel>
   <channel site="starhubtvplus.com" site_id="1b01afd8-24c2-4736-82a2-1ad6802dc61c" lang="zh" xmltv_id="">Hub Sports 8</channel>
-  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="zh" xmltv_id="">Sun TV</channel>
-  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="zh" xmltv_id="">KTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="zh" xmltv_id="">Cinemax HD</channel>
-  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="zh" xmltv_id="">Phoenix Chinese Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="zh" xmltv_id="">NHK World Premium HD</channel>
+  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="zh" xmltv_id="SunTVMalaysia.my@SD">Sun TV</channel>
+  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="zh" xmltv_id="KTV.in@Malaysia">KTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="zh" xmltv_id="CinemaxAsia.sg@HD">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="zh" xmltv_id="PhoenixChineseChannel.hk@SD">Phoenix Chinese Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="zh" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium HD</channel>
   <channel site="starhubtvplus.com" site_id="3f4bb488-1eae-4b02-8d13-04931b021e09" lang="zh" xmltv_id="">TestChannel 996</channel>
-  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="zh" xmltv_id="">Hub Premier 6</channel>
-  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="zh" xmltv_id="">Arirang TV</channel>
-  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="zh" xmltv_id="">Vannathirai</channel>
-  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="zh" xmltv_id="">Hub Premier 8</channel>
-  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="zh" xmltv_id="">Hub Sports 3 HD</channel>
-  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="zh" xmltv_id="">Hub Premier 1</channel>
-  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="zh" xmltv_id="">Zee Cinema</channel>
-  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="zh" xmltv_id="">Premier Sports</channel>
-  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="zh" xmltv_id="">Hub Premier 2 (HD)</channel>
-  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="zh" xmltv_id="">beIN Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="zh" xmltv_id="">Kalaignar TV</channel>
-  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="zh" xmltv_id="">NHK WORLD - JAPAN</channel>
-  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="zh" xmltv_id="">Preview Channel</channel>
-  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="zh" xmltv_id="">TVB Xing He</channel>
-  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="zh" xmltv_id="">Crime + Investigation HD</channel>
-  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="zh" xmltv_id="">beIN SPORTS MAX 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="zh" xmltv_id="">beIN Sports HD</channel>
-  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="zh" xmltv_id="">Sun Music</channel>
-  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="zh" xmltv_id="">Hub Premier 3</channel>
+  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="zh" xmltv_id="HubPremier6.sg@SD">Hub Premier 6</channel>
+  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="zh" xmltv_id="ArirangTV.kr@HD">Arirang TV</channel>
+  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="zh" xmltv_id="Vannathirai.sg@SD">Vannathirai</channel>
+  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="zh" xmltv_id="HubPremier8.sg@SD">Hub Premier 8</channel>
+  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="zh" xmltv_id="HubSports3.sg@SD">Hub Sports 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="zh" xmltv_id="HubPremier1.sg@SD">Hub Premier 1</channel>
+  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="zh" xmltv_id="ZeeCinema.in@APAC">Zee Cinema</channel>
+  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="zh" xmltv_id="PremierSports1Asia.ie@SD">Premier Sports</channel>
+  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="zh" xmltv_id="HubPremier2.sg@SD">Hub Premier 2 (HD)</channel>
+  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="zh" xmltv_id="beINSports2.qa@MENA">beIN Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="zh" xmltv_id="KalaignarTV.in@SD">Kalaignar TV</channel>
+  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="zh" xmltv_id="NHKWorldJapan.jp@HD">NHK WORLD - JAPAN</channel>
+  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="zh" xmltv_id="PreviewChannel.sg@SD">Preview Channel</channel>
+  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="zh" xmltv_id="TVBXingHe.hk@SD">TVB Xing He</channel>
+  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="zh" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime + Investigation HD</channel>
+  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="zh" xmltv_id="beINSports4.qa@MENA">beIN SPORTS MAX 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="zh" xmltv_id="beINSports.qa@MENA">beIN Sports HD</channel>
+  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="zh" xmltv_id="SunMusic.in@APAC">Sun Music</channel>
+  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="zh" xmltv_id="HubPremier3.sg@SD">Hub Premier 3</channel>
   <channel site="starhubtvplus.com" site_id="12f8f777-7671-486d-a26b-5727cd9a5ff9" lang="zh" xmltv_id="">TestChannel2</channel>
-  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="zh" xmltv_id="">Nick Jr</channel>
+  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="zh" xmltv_id="NickJrAsia.sg@HD">Nick Jr</channel>
   <channel site="starhubtvplus.com" site_id="38df8124-1bcd-49b6-abb3-ee230a1f40d2" lang="zh" xmltv_id="">Hub Sports 5 HD</channel>
   <channel site="starhubtvplus.com" site_id="39a2d989-f51d-45de-b4e3-90cc58aa54f4" lang="zh" xmltv_id="">ETTV ASIA HD</channel>
-  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="zh" xmltv_id="">BBC Lifestyle</channel>
-  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="zh" xmltv_id="">Cinema One Global</channel>
-  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="zh" xmltv_id="">Zee TV</channel>
-  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="zh" xmltv_id="">KBS World HD</channel>
-  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="zh" xmltv_id="">ABC Australia</channel>
-  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="zh" xmltv_id="">HITSNOW</channel>
-  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="zh" xmltv_id="">beIN SPORTS MAX 3 HD</channel>
-  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="zh" xmltv_id="">AXN HD</channel>
+  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="zh" xmltv_id="BBCLifestyle.uk@Singapore">BBC Lifestyle</channel>
+  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="zh" xmltv_id="CinemaOneGlobal.ph@SD">Cinema One Global</channel>
+  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="zh" xmltv_id="ZeeTV.in@APAC">Zee TV</channel>
+  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="zh" xmltv_id="KBSWorld.kr@HD">KBS World HD</channel>
+  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="zh" xmltv_id="ABCAustralia.au@SD">ABC Australia</channel>
+  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="zh" xmltv_id="HITSNOW.sg@SD">HITSNOW</channel>
+  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="zh" xmltv_id="beINSports5.qa@MENA">beIN SPORTS MAX 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="zh" xmltv_id="AXNAsia.sg@Singapore">AXN HD</channel>
   <channel site="starhubtvplus.com" site_id="9e1ef59d-d235-497b-93b0-063c2231cae5" lang="zh" xmltv_id="">Test 998</channel>
-  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="zh" xmltv_id="">Hub Premier 4</channel>
-  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="zh" xmltv_id="">CNBC HD</channel>
-  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="zh" xmltv_id="">Cbeebies HD</channel>
-  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="zh" xmltv_id="">beIN Sports 3</channel>
+  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="zh" xmltv_id="HubPremier4.sg@SD">Hub Premier 4</channel>
+  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="zh" xmltv_id="CNBC.us@SD">CNBC HD</channel>
+  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="zh" xmltv_id="CBeebiesAsia.uk@SD">Cbeebies HD</channel>
+  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="zh" xmltv_id="beINSports3.qa@MENA">beIN Sports 3</channel>
   <channel site="starhubtvplus.com" site_id="295f6562-21ae-498f-9971-0f5b76fae79d" lang="zh" xmltv_id="">Hub Ruyi</channel>
-  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="zh" xmltv_id="">Hub Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="zh" xmltv_id="">Asianet</channel>
-  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="zh" xmltv_id="">ONE (Malay)</channel>
-  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="zh" xmltv_id="">CTI TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="zh" xmltv_id="">Hub Sports 4 HD</channel>
-  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="zh" xmltv_id="">Cartoon Network</channel>
+  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="zh" xmltv_id="HubSports2.sg@SD">Hub Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="zh" xmltv_id="Asianet.in@HD">Asianet</channel>
+  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="zh" xmltv_id="ONE.sg@Malaysia">ONE (Malay)</channel>
+  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="zh" xmltv_id="CTiAsia.tw@SD">CTI TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="zh" xmltv_id="HubSports4.sg@SD">Hub Sports 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="zh" xmltv_id="CartoonNetworkAsia.sg@SD">Cartoon Network</channel>
   <channel site="starhubtvplus.com" site_id="792aa2b5-cb06-45b9-bf37-e919c27c097e" lang="zh" xmltv_id="">Hub VVDrama</channel>
-  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="zh" xmltv_id="">DreamWorks Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="zh" xmltv_id="">BBC World News HD</channel>
-  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="zh" xmltv_id="">Astro Warna</channel>
-  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="zh" xmltv_id="">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="zh" xmltv_id="">ANC</channel>
-  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="zh" xmltv_id="">Karisma</channel>
+  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="zh" xmltv_id="DreamWorksChannelAsia.us@SD">DreamWorks Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="zh" xmltv_id="BBCNews.uk@AsiaPacific">BBC World News HD</channel>
+  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="zh" xmltv_id="AstroWarna.my@SD">Astro Warna</channel>
+  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="zh" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="zh" xmltv_id="ANC.ph@SD">ANC</channel>
+  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="zh" xmltv_id="Karisma.id@SD">Karisma</channel>
   <channel site="starhubtvplus.com" site_id="14104a82-aecb-457a-a5c5-2d134c852ba2" lang="zh" xmltv_id="">AFN</channel>
-  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="zh" xmltv_id="">Sky News HD</channel>
-  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="zh" xmltv_id="">DW (Deutsch)</channel>
-  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="zh" xmltv_id="">TVB Jade HD</channel>
-  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="zh" xmltv_id="">Animax HD</channel>
+  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="zh" xmltv_id="SkyNews.uk@HD">Sky News HD</channel>
+  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="zh" xmltv_id="DW.de@English">DW (Deutsch)</channel>
+  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="zh" xmltv_id="Jade.hk@SD">TVB Jade HD</channel>
+  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="zh" xmltv_id="AnimaxAsia.sg@SD">Animax HD</channel>
   <channel site="starhubtvplus.com" site_id="85289efc-7559-49d6-86ab-b9e775dd4931" lang="zh" xmltv_id="">Hub Sports 7</channel>
-  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="zh" xmltv_id="">CNN HD</channel>
-  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="zh" xmltv_id="">COLORS Tamil HD</channel>
-  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="zh" xmltv_id="">France24</channel>
-  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="zh" xmltv_id="">Dragon TV</channel>
-  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="zh" xmltv_id="">Lifetime HD</channel>
+  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="zh" xmltv_id="CNNInternational.us@AsiaPacific">CNN HD</channel>
+  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="zh" xmltv_id="ColorsTamil.in@APAc">COLORS Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="zh" xmltv_id="France24.fr@English">France24</channel>
+  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="zh" xmltv_id="DragonTV.cn@SD">Dragon TV</channel>
+  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="zh" xmltv_id="LifetimeAsia.us@SD">Lifetime HD</channel>
   <channel site="starhubtvplus.com" site_id="a68f6d1e-0141-4f5a-bbbc-fa81888e08a8" lang="zh" xmltv_id="">Cricbuzz 2</channel>
-  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="zh" xmltv_id="">FashionTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="zh" xmltv_id="">FIGHT SPORTS HD</channel>
-  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="zh" xmltv_id="">The Filipino Channel</channel>
-  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="zh" xmltv_id="">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="zh" xmltv_id="">Hub Premier 5</channel>
-  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="zh" xmltv_id="">Asianet Movies</channel>
-  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="zh" xmltv_id="">Zee Tamil</channel>
-  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="zh" xmltv_id="">Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="zh" xmltv_id="">Hub Sports 1 HD</channel>
-  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="zh" xmltv_id="">Celestial Movies HD</channel>
-  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="zh" xmltv_id="">CGTN</channel>
+  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="zh" xmltv_id="FashionTVAsia.fr@SD">FashionTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="zh" xmltv_id="FightSports.us@SD">FIGHT SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="zh" xmltv_id="TheFilipinoChannelAsia.us@SD">The Filipino Channel</channel>
+  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="zh" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="zh" xmltv_id="HubPremier5.sg@SD">Hub Premier 5</channel>
+  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="zh" xmltv_id="AsianetMovies.in@APAC">Asianet Movies</channel>
+  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="zh" xmltv_id="ZeeTamil.in@APAC">Zee Tamil</channel>
+  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="zh" xmltv_id="HITS.sg@SD">Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="zh" xmltv_id="HubSports1.sg@SD">Hub Sports 1 HD</channel>
+  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="zh" xmltv_id="CelestialMovies.hk@SD">Celestial Movies HD</channel>
+  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="zh" xmltv_id="CGTN.cn@SD">CGTN</channel>
   <channel site="starhubtvplus.com" site_id="c1b5b301-8e85-4ad3-a0f4-cd1a49ffbd4d" lang="zh" xmltv_id="">Cricbuzz</channel>
-  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="zh" xmltv_id="">Vijay TV</channel>
-  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="zh" xmltv_id="">COLORS</channel>
-  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="zh" xmltv_id="">Nickelodeon Asia HD</channel>
-  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="zh" xmltv_id="">ROCK Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="zh" xmltv_id="">HGTV</channel>
-  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="zh" xmltv_id="">CCTV-4</channel>
-  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="zh" xmltv_id="">Bloomberg Quicktake</channel>
+  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="zh" xmltv_id="StarVijay.in@APAC">Vijay TV</channel>
+  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="zh" xmltv_id="ColorsAsiaPacific.in@SD">COLORS</channel>
+  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="zh" xmltv_id="NickelodeonAsia.sg@SD">Nickelodeon Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="zh" xmltv_id="ROCKEntertainment.sg@SD">ROCK Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="zh" xmltv_id="HGTVAsia.us@SD">HGTV</channel>
+  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="zh" xmltv_id="CCTV4Asia.cn@SD">CCTV-4</channel>
+  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="zh" xmltv_id="BloombergOriginals.us@SD">Bloomberg Quicktake</channel>
   <channel site="starhubtvplus.com" site_id="cc214bae-ddf2-4c17-84e2-7690fe4e65db" lang="zh" xmltv_id="">Hub Sports 6</channel>
-  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="zh" xmltv_id="">Hub Premier 7</channel>
-  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="zh" xmltv_id="">CCM</channel>
-  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="zh" xmltv_id="">HBO Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="zh" xmltv_id="">Sony Entertainment Television</channel>
-  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="zh" xmltv_id="">Discovery HD</channel>
-  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="zh" xmltv_id="">Phoenix InfoNews Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="zh" xmltv_id="">HBO Family HD</channel>
-  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="zh" xmltv_id="">HBO HD</channel>
-  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="zh" xmltv_id="">HISTORY HD</channel>
-  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="zh" xmltv_id="">TVBS Asia</channel>
+  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="zh" xmltv_id="HubPremier7.sg@SD">Hub Premier 7</channel>
+  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="zh" xmltv_id="CCM.hk@SD">CCM</channel>
+  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="zh" xmltv_id="HBOHitsAsia.sg@HD">HBO Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="zh" xmltv_id="SonyEntertainmentTelevisionAsia.in@HD">Sony Entertainment Television</channel>
+  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="zh" xmltv_id="DiscoveryAsia.sg@SD">Discovery HD</channel>
+  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="zh" xmltv_id="PhoenixInfoNewsChannel.hk@SD">Phoenix InfoNews Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="zh" xmltv_id="HBOFamilyAsia.sg@HD">HBO Family HD</channel>
+  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="zh" xmltv_id="HBOAsia.sg@HD">HBO HD</channel>
+  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="zh" xmltv_id="HistoryAsia.us@SD">HISTORY HD</channel>
+  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="zh" xmltv_id="TVBSAsia.tw@SD">TVBS Asia</channel>
   <channel site="starhubtvplus.com" site_id="e2ae3508-e262-4046-abbf-bfbdfc3ef898" lang="zh" xmltv_id="">TestChannel 993..</channel>
   <channel site="starhubtvplus.com" site_id="e8eac44e-2007-4cb2-88dd-9b3842f29638" lang="zh" xmltv_id="">Channel 251</channel>
-  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="zh" xmltv_id="">SPOTV</channel>
-  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="zh" xmltv_id="">Zee Thirai</channel>
-  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="zh" xmltv_id="">TVBS-NEWS</channel>
-  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="zh" xmltv_id="">Fox News Channel</channel>
-  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="zh" xmltv_id="">Hub Sensasi</channel>
-  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="zh" xmltv_id="">Travelxp HD</channel>
-  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="zh" xmltv_id="">Citra Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="zh" xmltv_id="">HITS MOVIES HD</channel>
-  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="zh" xmltv_id="">Bloomberg Television HD</channel>
-  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="zh" xmltv_id="">Euronews HD</channel>
-  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="zh" xmltv_id="">BBC Earth HD</channel>
+  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="zh" xmltv_id="SPOTV.kr@SD">SPOTV</channel>
+  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="zh" xmltv_id="ZeeThirai.in@APAC">Zee Thirai</channel>
+  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="zh" xmltv_id="TVBSNews.tw@SD">TVBS-NEWS</channel>
+  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="zh" xmltv_id="FoxNewsChannel.us@SD">Fox News Channel</channel>
+  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="zh" xmltv_id="AstroSensasi.sg@SD">Hub Sensasi</channel>
+  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="zh" xmltv_id="Travelxp.in@APAC">Travelxp HD</channel>
+  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="zh" xmltv_id="CitraEntertainment.id@SD">Citra Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="zh" xmltv_id="HITSMovies.sg@HD">HITS MOVIES HD</channel>
+  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="zh" xmltv_id="BloombergTV.us@Plus">Bloomberg Television HD</channel>
+  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="zh" xmltv_id="EuronewsEnglish.fr@HD">Euronews HD</channel>
+  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="zh" xmltv_id="BBCEarth.uk@AsiaHD">BBC Earth HD</channel>
 </channels>

--- a/sites/starhubtvplus.com/starhubtvplus.com_zh.channels.xml
+++ b/sites/starhubtvplus.com/starhubtvplus.com_zh.channels.xml
@@ -1,119 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="starhubtvplus.com" site_id="0ec5072f-b6dc-4676-a683-c32c5db2c3a1" lang="zh" xmltv_id="PremierSports1Asia.ie@SD">Premier Sports</channel>
-  <channel site="starhubtvplus.com" site_id="1b8e6f65-e3f0-4369-bf33-c56212eb269e" lang="zh" xmltv_id="EuronewsEnglish.fr@SD">Euronews HD</channel>
-  <channel site="starhubtvplus.com" site_id="1ed77994-5ab6-4d38-88f2-d662f3cfe5b0" lang="zh" xmltv_id="SonyEntertainmentTelevision.in@SD">Sony Entertainment Television</channel>
-  <channel site="starhubtvplus.com" site_id="2cd14827-0816-400d-b868-62985ec8b627" lang="zh" xmltv_id="HGTVAsia.us@SD">HGTV</channel>
-  <channel site="starhubtvplus.com" site_id="2cea0112-a03d-4fa1-a4c2-276da4d3c908" lang="zh" xmltv_id="TV5MondeAsia.fr@SD">TV5MONDE HD</channel>
-  <channel site="starhubtvplus.com" site_id="2d16335e-aea6-47ab-b688-b3c694a27cf6" lang="zh" xmltv_id="HubPremier3.sg@SD">Hub Premier 3</channel>
-  <channel site="starhubtvplus.com" site_id="3c3228b3-3388-4aa1-8535-6f2ed17432af" lang="zh" xmltv_id="ABCAustralia.au@SD">ABC Australia HD</channel>
-  <channel site="starhubtvplus.com" site_id="3c292157-4cf2-48bf-9608-c0ef8ab79cc5" lang="zh" xmltv_id="HubSports2.sg@SD">Hub Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="4c646df4-59ab-4e03-9de8-d36a95127266" lang="zh" xmltv_id="DW.de@English">DW English HD</channel>
-  <channel site="starhubtvplus.com" site_id="4db9b282-0e8d-456e-ba83-89b4eaf173d7" lang="zh" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
-  <channel site="starhubtvplus.com" site_id="5b36348e-1669-4883-9821-6b336cff0d58" lang="zh" xmltv_id="HistoryAsia.us@SD">HISTORY HD</channel>
-  <channel site="starhubtvplus.com" site_id="5bc5b18c-b12c-462f-b49a-8056b74d72a3" lang="zh" xmltv_id="Jade.hk@SD">TVB Jade HD</channel>
-  <channel site="starhubtvplus.com" site_id="5f50648a-3b0f-4d13-b0ac-056e722a647a" lang="zh" xmltv_id="TVBXingHe.hk@SD">TVB Xing He</channel>
-  <channel site="starhubtvplus.com" site_id="6a59cb8b-182d-4038-b315-cf35cf7c5ac7" lang="zh" xmltv_id="CitraEntertainment.id@SD">Citra Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="6c1be2bc-47c4-45b5-b027-fce49322f34c" lang="zh" xmltv_id="beINSports4.qa@MENA">beIN Sports 4</channel>
-  <channel site="starhubtvplus.com" site_id="6f6c5d20-18b3-4023-b505-726b9c36b6e9" lang="zh" xmltv_id="Asianet.in@SD">Asianet</channel>
-  <channel site="starhubtvplus.com" site_id="7c0ee1eb-5f74-4f5a-a338-69eb125badb4" lang="zh" xmltv_id="">ETTV ASIA HD</channel>
-  <channel site="starhubtvplus.com" site_id="7cad02e2-086a-49c8-bf6a-737d1f30c680" lang="zh" xmltv_id="CTiTV.tw@SD">CTI TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="8a28afbc-74bb-4c02-9bba-eb623358a9b8" lang="zh" xmltv_id="BBCNews.uk@AsiaPacific">BBC World News HD</channel>
-  <channel site="starhubtvplus.com" site_id="8ade3211-6836-4e95-80f7-5aca573b8b75" lang="zh" xmltv_id="ZeeTV.in@SD">Zee TV</channel>
-  <channel site="starhubtvplus.com" site_id="9abfbba5-24c8-4e3f-8e00-f75902c7675b" lang="zh" xmltv_id="France24.fr@English">France24</channel>
-  <channel site="starhubtvplus.com" site_id="9b01c864-5bcc-46e6-ba8e-3ba6c33ca8fb" lang="zh" xmltv_id="HubPremier7.sg@SD">Hub Premier 7</channel>
-  <channel site="starhubtvplus.com" site_id="9bf114df-42db-4815-9b73-efa05d0b9f94" lang="zh" xmltv_id="AstroWarna.my@SD">Astro Warna HD</channel>
-  <channel site="starhubtvplus.com" site_id="9c7414bb-cd6c-4cdf-b019-1c85b7511d32" lang="zh" xmltv_id="PreviewChannel.sg@SD">Preview Channel</channel>
-  <channel site="starhubtvplus.com" site_id="9fc55c89-3eb4-4516-a5c4-c6193eb71f57" lang="zh" xmltv_id="Cartoonito.uk@SD">Cartoonito HD</channel>
-  <channel site="starhubtvplus.com" site_id="12efa598-4bae-4d64-afc0-a4e7340de74e" lang="zh" xmltv_id="beINSports.qa@MENA">beIN Sports HD</channel>
-  <channel site="starhubtvplus.com" site_id="14a563d5-d406-4094-907e-ec452c658de9" lang="zh" xmltv_id="Travelxp.in@SD">Travelxp HD</channel>
-  <channel site="starhubtvplus.com" site_id="21bf30fb-2800-4761-aee8-452bdb68aff6" lang="zh" xmltv_id="DiscoveryChannelSoutheastAsia.sg@SD">Discovery HD</channel>
-  <channel site="starhubtvplus.com" site_id="30a6b23c-0657-4e8f-b26b-de9273e394d7" lang="zh" xmltv_id="CBeebiesAsia.uk@SD">Cbeebies HD</channel>
-  <channel site="starhubtvplus.com" site_id="36dae5f2-147d-4aab-a7bd-e9b7d9501734" lang="zh" xmltv_id="KTV.in@SD">KTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="54f4de25-3575-44c4-92dd-b4a1c3c5b088" lang="zh" xmltv_id="CartoonNetworkAsia.sg@SD">Cartoon Network</channel>
-  <channel site="starhubtvplus.com" site_id="57f9281b-3c13-456c-aa52-a1e410706933" lang="zh" xmltv_id="DragonTVInternational.cn@SD">Dragon TV</channel>
-  <channel site="starhubtvplus.com" site_id="61fcfb0b-514a-47a0-8400-ed8b9221188c" lang="zh" xmltv_id="ColorsTamil.in@SD">COLORS Tamil HD</channel>
-  <channel site="starhubtvplus.com" site_id="64ddc417-c35c-4b95-84ca-67b0d6c77265" lang="zh" xmltv_id="CinemaOneGlobal.ph@SD">Cinema One Global</channel>
-  <channel site="starhubtvplus.com" site_id="68bbd5d8-379d-4646-a1e3-e204cc9c2f54" lang="zh" xmltv_id="AstroSensasi.sg@SD">Astro Sensasi HD</channel>
-  <channel site="starhubtvplus.com" site_id="68c4d3c4-93d9-4cb3-ba14-8918142bfbdc" lang="zh" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
-  <channel site="starhubtvplus.com" site_id="71da87e9-5d3f-4544-8b6f-e9a374e05bc7" lang="zh" xmltv_id="FightSports.us@SD">FIGHT SPORTS HD</channel>
-  <channel site="starhubtvplus.com" site_id="072f2bcf-99f1-48fe-8806-7a217e4bb372" lang="zh" xmltv_id="AdithyaTV.in@SD">ADITHYA TV</channel>
-  <channel site="starhubtvplus.com" site_id="73d6b697-f5f1-4a04-a788-ece67c31ed1c" lang="zh" xmltv_id="ArirangTV.kr@SD">Arirang TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="77da4ed7-09ed-455a-9c09-8d75000fe942" lang="zh" xmltv_id="CGTN.cn@SD">CGTN</channel>
-  <channel site="starhubtvplus.com" site_id="94ec2a65-eae1-4cdc-95a6-1ed67b17f4e4" lang="zh" xmltv_id="ZeeThirai.in@SD">Zee Thirai</channel>
-  <channel site="starhubtvplus.com" site_id="99ee7b2d-1a7d-4fb1-8fbe-7903e028a87b" lang="zh" xmltv_id="HubPremier1.sg@SD">Hub Premier 1</channel>
-  <channel site="starhubtvplus.com" site_id="206f755c-f417-4eb4-9631-ed21ae11f2e8" lang="zh" xmltv_id="SkyNewsAustralia.au@SD">Sky News HD</channel>
-  <channel site="starhubtvplus.com" site_id="207a516d-2dbc-49f9-8d98-32d31bd89d3a" lang="zh" xmltv_id="Vannathirai.sg@SD">Vannathirai</channel>
-  <channel site="starhubtvplus.com" site_id="210ba103-0d19-4b26-bb9f-36d531d7471f" lang="zh" xmltv_id="">TestChannel 996</channel>
-  <channel site="starhubtvplus.com" site_id="263c311c-4b74-4fc0-bb7b-7762cce99a8a" lang="zh" xmltv_id="NHKWorldJapan.jp@SD">NHK WORLD - JAPAN HD</channel>
-  <channel site="starhubtvplus.com" site_id="265c0f76-c798-496d-aca1-f540a70952ec" lang="zh" xmltv_id="TheFilipinoChannelAsia.us@SD">The Filipino Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="354def1b-701e-4703-a279-5ef4204847a1" lang="zh" xmltv_id="beINSports5.qa@MENA">beIN Sports 5</channel>
-  <channel site="starhubtvplus.com" site_id="578cfccf-634d-4beb-a167-741cb91a068e" lang="zh" xmltv_id="HubPremier8.sg@SD">Hub Premier 8</channel>
-  <channel site="starhubtvplus.com" site_id="0610cb3d-8521-44a1-8d90-7029ac428e8c" lang="zh" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime + Investigation HD</channel>
-  <channel site="starhubtvplus.com" site_id="628ba4e0-4239-46c3-a5a2-b15273c82009" lang="zh" xmltv_id="FoxNewsChannel.us@SD">Fox News Channel</channel>
-  <channel site="starhubtvplus.com" site_id="740ad097-ae3d-4a16-9e67-69e308509b9a" lang="zh" xmltv_id="">ONE (Malay)</channel>
-  <channel site="starhubtvplus.com" site_id="895ebe38-5cfe-43da-9847-a7088cc3aca7" lang="zh" xmltv_id="Colors.in@SD">COLORS</channel>
-  <channel site="starhubtvplus.com" site_id="9e2f39ab-95ba-4031-bfeb-6b9b41491b08" lang="zh" xmltv_id="FashionTVAsia.fr@SD">FashionTV HD</channel>
-  <channel site="starhubtvplus.com" site_id="1944dfe8-b8e6-46c2-a700-78d5b680e2ac" lang="zh" xmltv_id="HubSports4.sg@SD">Hub Sports 4 HD</channel>
-  <channel site="starhubtvplus.com" site_id="4431c255-e2a9-45db-b43b-27cc19c14cb9" lang="zh" xmltv_id="ONE.sg@SD">ONE HD</channel>
-  <channel site="starhubtvplus.com" site_id="05384f9f-6241-4712-80ab-2c3f2d8ac7d5" lang="zh" xmltv_id="HITS.sg@SD">Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="6269ba33-cee1-4dc9-8728-2b82dc73e252" lang="zh" xmltv_id="BBCEarth.uk@Asia">BBC Earth HD</channel>
-  <channel site="starhubtvplus.com" site_id="06830f4b-1684-42d1-a29a-616b2e34b0ae" lang="zh" xmltv_id="">Bloomberg Originals</channel>
-  <channel site="starhubtvplus.com" site_id="9511afb0-2af8-4a1a-9d54-1395924edf91" lang="zh" xmltv_id="HubSports3.sg@SD">Hub Sports 3 HD</channel>
-  <channel site="starhubtvplus.com" site_id="30970c17-8498-4c05-9174-a49c0fc33fad" lang="zh" xmltv_id="AsianetMovies.in@SD">Asianet Movies</channel>
-  <channel site="starhubtvplus.com" site_id="62954bd1-435e-4929-a78a-90c12c99e3eb" lang="zh" xmltv_id="SPOTV.kr@SD">SPOTV</channel>
-  <channel site="starhubtvplus.com" site_id="64178eae-3ca3-4048-99e4-fce9556b2812" lang="zh" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium HD</channel>
-  <channel site="starhubtvplus.com" site_id="082041a8-9ba1-41ab-9e01-6741f01f4e34" lang="zh" xmltv_id="SunMusic.in@SD">Sun Music</channel>
-  <channel site="starhubtvplus.com" site_id="93114f35-0f46-4404-98c1-07019a2d2c15" lang="zh" xmltv_id="CNNInternational.us@AsiaPacific">CNN HD</channel>
-  <channel site="starhubtvplus.com" site_id="6e5e72ef-9fa6-4007-9537-74e7d08f51c4" lang="zh" xmltv_id="HubSports1.sg@SD">Hub Sports 1 HD</channel>
-  <channel site="starhubtvplus.com" site_id="21184422-bbcd-4641-aeb6-fef337b5cc7a" lang="zh" xmltv_id="HBOSignatureAsia.sg@SD">HBO Signature HD</channel>
-  <channel site="starhubtvplus.com" site_id="85611254-47a9-4f7c-9469-a4ee8b9f65b1" lang="zh" xmltv_id="BBCLifestyle.uk@Asia">BBC Lifestyle</channel>
-  <channel site="starhubtvplus.com" site_id="9e7d5a33-39dd-4e66-809f-c6099dc81d26" lang="zh" xmltv_id="TVBSAsia.tw@SD">TVBS Asia</channel>
-  <channel site="starhubtvplus.com" site_id="705e08d5-dec6-4da2-858a-fd29e6b884d2" lang="zh" xmltv_id="CelestialMovies.hk@SD">Celestial Movies HD</channel>
-  <channel site="starhubtvplus.com" site_id="71278e7f-bdd5-43ac-b3ca-01d6fad180f5" lang="zh" xmltv_id="AnimaxAsia.sg@SD">Animax HD</channel>
-  <channel site="starhubtvplus.com" site_id="37e180c8-9f91-41b2-80fe-237b8eba0d8b" lang="zh" xmltv_id="HubPremier5.sg@SD">Hub Premier 5</channel>
-  <channel site="starhubtvplus.com" site_id="a162afe8-8990-4d43-8c9a-c29d844ba2fb" lang="zh" xmltv_id="HBOFamilyAsia.sg@SD">HBO Family HD</channel>
-  <channel site="starhubtvplus.com" site_id="aab336e8-ef09-4e27-91d4-81c35b802a0a" lang="zh" xmltv_id="HubPremier4.sg@SD">Hub Premier 4</channel>
-  <channel site="starhubtvplus.com" site_id="ac52e93d-814b-40cb-9a3f-688765341bda" lang="zh" xmltv_id="">Test 998</channel>
-  <channel site="starhubtvplus.com" site_id="ace578ac-0996-4941-877c-58abe2ff3851" lang="zh" xmltv_id="">TestChannel2</channel>
-  <channel site="starhubtvplus.com" site_id="ae1685eb-3ef0-4d14-9c89-8955bcc2bc02" lang="zh" xmltv_id="SPOTV2.kr@SD">SPOTV2</channel>
-  <channel site="starhubtvplus.com" site_id="b4cdf669-f16c-4f74-ad4c-accde9fc77d3" lang="zh" xmltv_id="TVBSNews.tw@SD">TVBS-NEWS</channel>
-  <channel site="starhubtvplus.com" site_id="b4ff91f4-7aa6-4e06-ab58-d3932bcbb496" lang="zh" xmltv_id="">Hub Sports 7</channel>
-  <channel site="starhubtvplus.com" site_id="b8953e43-4fea-4a1a-833c-06de1fcb5db7" lang="zh" xmltv_id="tvNAsia.hk@SD">tvN HD</channel>
-  <channel site="starhubtvplus.com" site_id="baa219e7-6b9a-4b1c-aba3-c77f26b7cf49" lang="zh" xmltv_id="">TestChannel 993</channel>
-  <channel site="starhubtvplus.com" site_id="c2c8034f-2897-4944-afb6-bdfcb6e9a536" lang="zh" xmltv_id="BloombergTV.us@Asia">Bloomberg Television HD</channel>
-  <channel site="starhubtvplus.com" site_id="c25a38ab-772d-41e7-b0eb-83021f1d309c" lang="zh" xmltv_id="NickelodeonAsia.sg@SD">Nickelodeon Asia HD</channel>
-  <channel site="starhubtvplus.com" site_id="c290bc2f-bff6-485e-ad81-cba439754d16" lang="zh" xmltv_id="">TestChannel1</channel>
-  <channel site="starhubtvplus.com" site_id="c691a121-f6a9-450d-bd1c-cb41107b65b6" lang="zh" xmltv_id="">Hub Sports 6</channel>
-  <channel site="starhubtvplus.com" site_id="c993aa99-5dd3-446e-9e55-62393353058a" lang="zh" xmltv_id="KBSWorld.kr@SD">KBS World HD</channel>
-  <channel site="starhubtvplus.com" site_id="c4162998-26a4-4296-ae78-34d56086e604" lang="zh" xmltv_id="VijayTVAsia.in@SD">Vijay TV HD</channel>
-  <channel site="starhubtvplus.com" site_id="c5693796-e108-4a13-9319-eb793bb408c3" lang="zh" xmltv_id="Karisma.id@SD">Karisma</channel>
-  <channel site="starhubtvplus.com" site_id="ce5ca9b4-9dca-412f-ac30-252144c124e3" lang="zh" xmltv_id="HubVVDrama.sg@SD">Hub VVDrama</channel>
-  <channel site="starhubtvplus.com" site_id="cef88e25-64c6-402e-a6d5-36688708c40f" lang="zh" xmltv_id="HITSMovies.sg@SD">HITS MOVIES HD</channel>
-  <channel site="starhubtvplus.com" site_id="d27cd0f4-85c1-4c08-91cd-808643e7cec9" lang="zh" xmltv_id="HBOHitsAsia.sg@SD">HBO Hits HD</channel>
-  <channel site="starhubtvplus.com" site_id="d99214cd-fcdf-4613-8106-55e248d3b608" lang="zh" xmltv_id="KalaignarTV.in@SD">Kalaignar TV</channel>
-  <channel site="starhubtvplus.com" site_id="d258444e-b66b-4cbe-88db-e09f31ab8a1f" lang="zh" xmltv_id="AXNAsia.sg@Singapore">AXN HD</channel>
-  <channel site="starhubtvplus.com" site_id="dc1af464-7877-46dd-95f0-f81ecd1e3677" lang="zh" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="dca44244-ee28-4372-b502-888c8795624b" lang="zh" xmltv_id="PhoenixInfoNewsChannel.hk@SD">Phoenix InfoNews Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="dceea37a-621c-4ba5-a818-68ec6154e538" lang="zh" xmltv_id="beINSports2.qa@MENA">beIN Sports 2 HD</channel>
-  <channel site="starhubtvplus.com" site_id="dd211710-85e9-45f6-b3c8-482dbda2d261" lang="zh" xmltv_id="SunTV.in@SD">Sun TV</channel>
-  <channel site="starhubtvplus.com" site_id="df762cf1-6b2b-4e0c-9e23-427efde82020" lang="zh" xmltv_id="SEAToday.id@SD">SEA Today</channel>
-  <channel site="starhubtvplus.com" site_id="df4507d8-292d-4036-b14e-b8343360dcaa" lang="zh" xmltv_id="beINSports3.qa@MENA">beIN Sports 3</channel>
-  <channel site="starhubtvplus.com" site_id="dfb315cf-fbda-479a-87f0-ab35e65dd7aa" lang="zh" xmltv_id="HubECity.sg@SD">Hub E City HD</channel>
-  <channel site="starhubtvplus.com" site_id="dff489d0-abee-4b61-a684-e283ba799ce6" lang="zh" xmltv_id="SonyMaxSingapore.sg@SD">SONY MAX</channel>
-  <channel site="starhubtvplus.com" site_id="e2cf7307-0e1d-4dba-a94f-5a0fac85b262" lang="zh" xmltv_id="LifetimeAsia.us@SD">Lifetime HD</channel>
-  <channel site="starhubtvplus.com" site_id="e21e78cb-6be3-4ec6-888f-39d3d365710c" lang="zh" xmltv_id="">TestChannel 995</channel>
-  <channel site="starhubtvplus.com" site_id="e070be44-cd6f-4fab-b34d-948a979d5564" lang="zh" xmltv_id="ANC.ph@SD">ANC</channel>
-  <channel site="starhubtvplus.com" site_id="e3141ae3-758b-4393-bd9c-9260babbca00" lang="zh" xmltv_id="PhoenixChineseChannel.hk@SD">Phoenix Chinese Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="e774692b-b038-4615-9148-d9cbbdbebb5b" lang="zh" xmltv_id="CCTV4Asia.cn@SD">CCTV-4</channel>
-  <channel site="starhubtvplus.com" site_id="eac9d5cf-9291-4900-adbd-b81551cbeeb3" lang="zh" xmltv_id="">Hub Sports 5 HD</channel>
-  <channel site="starhubtvplus.com" site_id="ee7f8151-6ddb-4f5a-b651-aa19597ab57b" lang="zh" xmltv_id="HubPremier6.sg@SD">Hub Premier 6</channel>
-  <channel site="starhubtvplus.com" site_id="ef624c07-6e36-4619-87fd-138a443aac1a" lang="zh" xmltv_id="CCM.hk@SD">CCM</channel>
-  <channel site="starhubtvplus.com" site_id="f0de7c83-f946-492e-b02b-960b65928ec9" lang="zh" xmltv_id="CNBCAsia.sg@SD">CNBC HD</channel>
-  <channel site="starhubtvplus.com" site_id="f1e89c2d-232c-4204-8cf1-e3107ad6b8e8" lang="zh" xmltv_id="HBOAsia.sg@Vietnam">HBO HD</channel>
-  <channel site="starhubtvplus.com" site_id="f8ae363f-51f1-4063-808b-406947018b51" lang="zh" xmltv_id="ZeeTamil.in@SD">Zee Tamil</channel>
-  <channel site="starhubtvplus.com" site_id="f9f14a80-9556-4ef8-af7c-5f13279dd83c" lang="zh" xmltv_id="DreamWorksChannelAsia.us@SD">DreamWorks Channel HD</channel>
-  <channel site="starhubtvplus.com" site_id="f83d356b-7169-48c9-a411-b5e05511a462" lang="zh" xmltv_id="ROCKEntertainment.sg@SD">ROCK Entertainment</channel>
-  <channel site="starhubtvplus.com" site_id="fbb0e7b8-649b-4c98-9bbe-713971282d8c" lang="zh" xmltv_id="HubPremier2.sg@SD">Hub Premier 2 (HD)</channel>
-  <channel site="starhubtvplus.com" site_id="fd510962-c830-490f-be97-0ecadf2bcc11" lang="zh" xmltv_id="CinemaxAsia.sg@SD">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6" lang="zh" xmltv_id="">SONY MAX</channel>
+  <channel site="starhubtvplus.com" site_id="0bde83aa-c1b1-40c0-934d-e0f541808ade" lang="zh" xmltv_id="">ONE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0c28c445-abad-467d-9559-211174718745" lang="zh" xmltv_id="">TV5MONDE HD</channel>
+  <channel site="starhubtvplus.com" site_id="0ef9316c-9b57-42fb-80d2-49297d7a7bac" lang="zh" xmltv_id="">HBO Signature HD</channel>
+  <channel site="starhubtvplus.com" site_id="0e9b041d-8880-4b3d-8f6f-3863358c7eff" lang="zh" xmltv_id="">ADITHYA TV</channel>
+  <channel site="starhubtvplus.com" site_id="0e9c2522-9489-43d9-ba57-cc8750937972" lang="zh" xmltv_id="">SPOTV2</channel>
+  <channel site="starhubtvplus.com" site_id="1b01afd8-24c2-4736-82a2-1ad6802dc61c" lang="zh" xmltv_id="">Hub Sports 8</channel>
+  <channel site="starhubtvplus.com" site_id="2a2b35a1-fbc2-44f0-8234-136fd6429b68" lang="zh" xmltv_id="">Sun TV</channel>
+  <channel site="starhubtvplus.com" site_id="2eb726de-6d6a-4af6-a1a7-08805cf783f9" lang="zh" xmltv_id="">KTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="3c85588c-262b-43de-b9c3-0f0fd51466d9" lang="zh" xmltv_id="">Cinemax HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d4b11b5-c883-44ae-921b-4d7e07fe852f" lang="zh" xmltv_id="">Phoenix Chinese Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="3d125b3f-26ea-4f0c-acb5-774b2f478352" lang="zh" xmltv_id="">NHK World Premium HD</channel>
+  <channel site="starhubtvplus.com" site_id="3f4bb488-1eae-4b02-8d13-04931b021e09" lang="zh" xmltv_id="">TestChannel 996</channel>
+  <channel site="starhubtvplus.com" site_id="3fd390ce-6190-4e1b-a05c-a1e8b3705b20" lang="zh" xmltv_id="">Hub Premier 6</channel>
+  <channel site="starhubtvplus.com" site_id="4c25cb31-4a19-4d5b-9926-a51a8b289ae5" lang="zh" xmltv_id="">Arirang TV</channel>
+  <channel site="starhubtvplus.com" site_id="4c802d42-f7e6-40cf-b424-3aab3f5f9761" lang="zh" xmltv_id="">Vannathirai</channel>
+  <channel site="starhubtvplus.com" site_id="4cbb0569-0dce-493b-9be2-9bb1c320a2ce" lang="zh" xmltv_id="">Hub Premier 8</channel>
+  <channel site="starhubtvplus.com" site_id="4ff7b357-9338-41a3-b7be-ede530555279" lang="zh" xmltv_id="">Hub Sports 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="5cee1079-1bb5-4054-ae02-0322144a248b" lang="zh" xmltv_id="">Hub Premier 1</channel>
+  <channel site="starhubtvplus.com" site_id="5f52f2b3-e45a-40a5-bcf3-2dd75a5543f8" lang="zh" xmltv_id="">Zee Cinema</channel>
+  <channel site="starhubtvplus.com" site_id="6bdd83c0-d833-42a0-896c-8a94fbb35f73" lang="zh" xmltv_id="">Premier Sports</channel>
+  <channel site="starhubtvplus.com" site_id="6f186614-28de-416a-b8a6-02fa5c579aa7" lang="zh" xmltv_id="">Hub Premier 2 (HD)</channel>
+  <channel site="starhubtvplus.com" site_id="6fb02848-2b74-4803-9661-ab4ff642764b" lang="zh" xmltv_id="">beIN Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="6ffaeb9f-2388-4f27-bd04-a71dba7c55a9" lang="zh" xmltv_id="">Kalaignar TV</channel>
+  <channel site="starhubtvplus.com" site_id="7b781d20-7138-4ffb-bd9d-6b12e473043b" lang="zh" xmltv_id="">NHK WORLD - JAPAN</channel>
+  <channel site="starhubtvplus.com" site_id="7c9126e4-f92c-42d6-a381-3ba640da04b9" lang="zh" xmltv_id="">Preview Channel</channel>
+  <channel site="starhubtvplus.com" site_id="8a0cfe88-6627-49e8-8eed-a2f73e609b5d" lang="zh" xmltv_id="">TVB Xing He</channel>
+  <channel site="starhubtvplus.com" site_id="8a1f4f2d-29a7-4914-9214-40131ecb8d69" lang="zh" xmltv_id="">Crime + Investigation HD</channel>
+  <channel site="starhubtvplus.com" site_id="9d5b8fca-145a-4491-805f-e9fedf7380fe" lang="zh" xmltv_id="">beIN SPORTS MAX 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="9f3a21bb-b934-4147-bfb9-888057ec0657" lang="zh" xmltv_id="">beIN Sports HD</channel>
+  <channel site="starhubtvplus.com" site_id="9fbf2a7c-878f-4659-91c3-0b20db468d91" lang="zh" xmltv_id="">Sun Music</channel>
+  <channel site="starhubtvplus.com" site_id="12c0203a-d5a2-426b-b6d9-e95a0f56d8e5" lang="zh" xmltv_id="">Hub Premier 3</channel>
+  <channel site="starhubtvplus.com" site_id="12f8f777-7671-486d-a26b-5727cd9a5ff9" lang="zh" xmltv_id="">TestChannel2</channel>
+  <channel site="starhubtvplus.com" site_id="29d2b788-ae5c-4307-8ac8-dd0c5911ea38" lang="zh" xmltv_id="">Nick Jr</channel>
+  <channel site="starhubtvplus.com" site_id="38df8124-1bcd-49b6-abb3-ee230a1f40d2" lang="zh" xmltv_id="">Hub Sports 5 HD</channel>
+  <channel site="starhubtvplus.com" site_id="39a2d989-f51d-45de-b4e3-90cc58aa54f4" lang="zh" xmltv_id="">ETTV ASIA HD</channel>
+  <channel site="starhubtvplus.com" site_id="047b3a4a-5094-4802-82d4-b3863b6e2cdf" lang="zh" xmltv_id="">BBC Lifestyle</channel>
+  <channel site="starhubtvplus.com" site_id="50b86b7f-084e-4ea1-8610-22e86c733c1c" lang="zh" xmltv_id="">Cinema One Global</channel>
+  <channel site="starhubtvplus.com" site_id="051b7938-b79f-4fd2-80d3-ebf3ebcea931" lang="zh" xmltv_id="">Zee TV</channel>
+  <channel site="starhubtvplus.com" site_id="52a80589-3613-4021-bcf6-6abb1c80bff4" lang="zh" xmltv_id="">KBS World HD</channel>
+  <channel site="starhubtvplus.com" site_id="64da91df-f088-48ae-9994-99a846e0c1f8" lang="zh" xmltv_id="">ABC Australia</channel>
+  <channel site="starhubtvplus.com" site_id="70c3dd0d-ccad-43ca-aed0-0c1234e0052e" lang="zh" xmltv_id="">HITSNOW</channel>
+  <channel site="starhubtvplus.com" site_id="86f5698a-3550-430e-970a-c1d99280497e" lang="zh" xmltv_id="">beIN SPORTS MAX 3 HD</channel>
+  <channel site="starhubtvplus.com" site_id="89ca2356-f022-4bc6-9ef4-be30d427988f" lang="zh" xmltv_id="">AXN HD</channel>
+  <channel site="starhubtvplus.com" site_id="9e1ef59d-d235-497b-93b0-063c2231cae5" lang="zh" xmltv_id="">Test 998</channel>
+  <channel site="starhubtvplus.com" site_id="95d31a9e-b5d3-4ac0-a1fd-7a810f4086e9" lang="zh" xmltv_id="">Hub Premier 4</channel>
+  <channel site="starhubtvplus.com" site_id="173fc873-1c01-4782-b0ee-f322fe23ef33" lang="zh" xmltv_id="">CNBC HD</channel>
+  <channel site="starhubtvplus.com" site_id="219cc587-57ab-4b55-baf3-03810f46deeb" lang="zh" xmltv_id="">Cbeebies HD</channel>
+  <channel site="starhubtvplus.com" site_id="249f5236-ca5d-416d-98b2-7e6961f1bccd" lang="zh" xmltv_id="">beIN Sports 3</channel>
+  <channel site="starhubtvplus.com" site_id="295f6562-21ae-498f-9971-0f5b76fae79d" lang="zh" xmltv_id="">Hub Ruyi</channel>
+  <channel site="starhubtvplus.com" site_id="347fa620-e966-423c-8d46-98469f0fc974" lang="zh" xmltv_id="">Hub Sports 2 HD</channel>
+  <channel site="starhubtvplus.com" site_id="385da56a-d445-4711-a6a0-6a3a80daa9a8" lang="zh" xmltv_id="">Asianet</channel>
+  <channel site="starhubtvplus.com" site_id="0526b076-2618-4d65-a255-b29b5a343d40" lang="zh" xmltv_id="">ONE (Malay)</channel>
+  <channel site="starhubtvplus.com" site_id="0629c0f2-b352-4b01-93aa-f37c91b07866" lang="zh" xmltv_id="">CTI TV HD</channel>
+  <channel site="starhubtvplus.com" site_id="753b50fe-262e-48da-9b5e-3fd9894ff531" lang="zh" xmltv_id="">Hub Sports 4 HD</channel>
+  <channel site="starhubtvplus.com" site_id="753cf54a-a4a2-4723-8709-c8ce14ec8254" lang="zh" xmltv_id="">Cartoon Network</channel>
+  <channel site="starhubtvplus.com" site_id="792aa2b5-cb06-45b9-bf37-e919c27c097e" lang="zh" xmltv_id="">Hub VVDrama</channel>
+  <channel site="starhubtvplus.com" site_id="824bd5da-016e-4e10-9c8e-2c33fbc179d4" lang="zh" xmltv_id="">DreamWorks Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="1312f58d-752b-4d8a-879e-33a43de2d941" lang="zh" xmltv_id="">BBC World News HD</channel>
+  <channel site="starhubtvplus.com" site_id="1419f892-2abd-4717-a9e9-b2299fee00f5" lang="zh" xmltv_id="">Astro Warna</channel>
+  <channel site="starhubtvplus.com" site_id="3181b9a2-f8f4-489c-b8fd-d19f923c6f62" lang="zh" xmltv_id="">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="5711b532-844b-441d-841a-18bdb1ef1094" lang="zh" xmltv_id="">ANC</channel>
+  <channel site="starhubtvplus.com" site_id="9394fd45-230a-40cc-b19b-e1ba30972c04" lang="zh" xmltv_id="">Karisma</channel>
+  <channel site="starhubtvplus.com" site_id="14104a82-aecb-457a-a5c5-2d134c852ba2" lang="zh" xmltv_id="">AFN</channel>
+  <channel site="starhubtvplus.com" site_id="36453e0d-85cc-4ee7-816c-2e147541cecf" lang="zh" xmltv_id="">Sky News HD</channel>
+  <channel site="starhubtvplus.com" site_id="37494f1f-0748-4150-bfbc-eb24b0bf1a34" lang="zh" xmltv_id="">DW (Deutsch)</channel>
+  <channel site="starhubtvplus.com" site_id="38251a1a-9368-410c-9dc5-ab806d74420f" lang="zh" xmltv_id="">TVB Jade HD</channel>
+  <channel site="starhubtvplus.com" site_id="57100d1f-5351-475e-bfef-bd9ae5793684" lang="zh" xmltv_id="">Animax HD</channel>
+  <channel site="starhubtvplus.com" site_id="85289efc-7559-49d6-86ab-b9e775dd4931" lang="zh" xmltv_id="">Hub Sports 7</channel>
+  <channel site="starhubtvplus.com" site_id="8339731a-4928-4ff0-bf9d-9202ae59aea7" lang="zh" xmltv_id="">CNN HD</channel>
+  <channel site="starhubtvplus.com" site_id="32897913-6eff-45db-90e9-948b56bddbb6" lang="zh" xmltv_id="">COLORS Tamil HD</channel>
+  <channel site="starhubtvplus.com" site_id="64864046-76a0-4de0-a65b-53fea57ee6bd" lang="zh" xmltv_id="">France24</channel>
+  <channel site="starhubtvplus.com" site_id="69303210-3157-4dd2-b923-809c5ce2371a" lang="zh" xmltv_id="">Dragon TV</channel>
+  <channel site="starhubtvplus.com" site_id="09e8b069-9fce-4a8d-b0cd-2bf77a8a71ba" lang="zh" xmltv_id="">Lifetime HD</channel>
+  <channel site="starhubtvplus.com" site_id="a68f6d1e-0141-4f5a-bbbc-fa81888e08a8" lang="zh" xmltv_id="">Cricbuzz 2</channel>
+  <channel site="starhubtvplus.com" site_id="a253b74a-ab9d-4545-9cdd-d81e2d9a056d" lang="zh" xmltv_id="">FashionTV HD</channel>
+  <channel site="starhubtvplus.com" site_id="a258cd7c-b4d2-4e45-b050-1e30a9519ef9" lang="zh" xmltv_id="">FIGHT SPORTS HD</channel>
+  <channel site="starhubtvplus.com" site_id="a16319f5-416e-4bc7-9ee0-42c7c3911f98" lang="zh" xmltv_id="">The Filipino Channel</channel>
+  <channel site="starhubtvplus.com" site_id="aa5a523d-562b-499b-b04b-1d75fbbc88f5" lang="zh" xmltv_id="">Hub E City HD</channel>
+  <channel site="starhubtvplus.com" site_id="ab0082d5-eeb5-492a-97b3-247c6b194625" lang="zh" xmltv_id="">Hub Premier 5</channel>
+  <channel site="starhubtvplus.com" site_id="aeac111e-e284-41d9-b6b5-ae13f6dbe67b" lang="zh" xmltv_id="">Asianet Movies</channel>
+  <channel site="starhubtvplus.com" site_id="aebb3170-e2ec-42cd-ae26-af914bf34045" lang="zh" xmltv_id="">Zee Tamil</channel>
+  <channel site="starhubtvplus.com" site_id="afde6766-acb5-4c69-b147-dd8b98dea9d2" lang="zh" xmltv_id="">Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="b5c3d45b-e2c9-462b-bcf1-06a149d68f25" lang="zh" xmltv_id="">Hub Sports 1 HD</channel>
+  <channel site="starhubtvplus.com" site_id="b8b921c8-3798-40b7-aab9-cb2eca3a5159" lang="zh" xmltv_id="">Celestial Movies HD</channel>
+  <channel site="starhubtvplus.com" site_id="b4554ec6-37d5-4936-943d-229e9df528e8" lang="zh" xmltv_id="">CGTN</channel>
+  <channel site="starhubtvplus.com" site_id="c1b5b301-8e85-4ad3-a0f4-cd1a49ffbd4d" lang="zh" xmltv_id="">Cricbuzz</channel>
+  <channel site="starhubtvplus.com" site_id="c7fec37a-8cbe-4b56-84e2-1428c82910a4" lang="zh" xmltv_id="">Vijay TV</channel>
+  <channel site="starhubtvplus.com" site_id="c170ab01-3fe1-453e-850f-815b29931ff7" lang="zh" xmltv_id="">COLORS</channel>
+  <channel site="starhubtvplus.com" site_id="c873d8db-2f77-4482-8074-b1d477455e91" lang="zh" xmltv_id="">Nickelodeon Asia HD</channel>
+  <channel site="starhubtvplus.com" site_id="ca5c1396-7135-426f-baf3-23e9eaef335e" lang="zh" xmltv_id="">ROCK Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="ca306145-694d-41c8-9f34-c2ce62eb06e9" lang="zh" xmltv_id="">HGTV</channel>
+  <channel site="starhubtvplus.com" site_id="cb80faa0-ad72-4bcb-a777-434464325c5f" lang="zh" xmltv_id="">CCTV-4</channel>
+  <channel site="starhubtvplus.com" site_id="cbce770a-b029-425b-ac2e-7fb9b8d5510f" lang="zh" xmltv_id="">Bloomberg Quicktake</channel>
+  <channel site="starhubtvplus.com" site_id="cc214bae-ddf2-4c17-84e2-7690fe4e65db" lang="zh" xmltv_id="">Hub Sports 6</channel>
+  <channel site="starhubtvplus.com" site_id="cd7e8ac1-fac5-43d5-8240-7cb4cff51148" lang="zh" xmltv_id="">Hub Premier 7</channel>
+  <channel site="starhubtvplus.com" site_id="d2bac03e-7024-48be-83b2-d56cc3852a7c" lang="zh" xmltv_id="">CCM</channel>
+  <channel site="starhubtvplus.com" site_id="d5fa461f-bbfc-4706-9b72-9ea67c946394" lang="zh" xmltv_id="">HBO Hits HD</channel>
+  <channel site="starhubtvplus.com" site_id="d66e833d-4c36-4989-83f7-777e7773d4bd" lang="zh" xmltv_id="">Sony Entertainment Television</channel>
+  <channel site="starhubtvplus.com" site_id="d298c58f-9710-4a8d-b802-d799cb064aff" lang="zh" xmltv_id="">Discovery HD</channel>
+  <channel site="starhubtvplus.com" site_id="d440ee6e-6f9a-4d78-b37b-5be89051145a" lang="zh" xmltv_id="">Phoenix InfoNews Channel HD</channel>
+  <channel site="starhubtvplus.com" site_id="dddf00c0-b347-472d-bc30-d44fd837cde2" lang="zh" xmltv_id="">HBO Family HD</channel>
+  <channel site="starhubtvplus.com" site_id="dea58cb4-eba4-4d53-a1c4-ff8e501e2adf" lang="zh" xmltv_id="">HBO HD</channel>
+  <channel site="starhubtvplus.com" site_id="ded93a12-883b-4ee0-9eaf-d137ebfe2da9" lang="zh" xmltv_id="">HISTORY HD</channel>
+  <channel site="starhubtvplus.com" site_id="e1b53e0d-f371-4918-8cbd-6e99a4d79c76" lang="zh" xmltv_id="">TVBS Asia</channel>
+  <channel site="starhubtvplus.com" site_id="e2ae3508-e262-4046-abbf-bfbdfc3ef898" lang="zh" xmltv_id="">TestChannel 993..</channel>
+  <channel site="starhubtvplus.com" site_id="e8eac44e-2007-4cb2-88dd-9b3842f29638" lang="zh" xmltv_id="">Channel 251</channel>
+  <channel site="starhubtvplus.com" site_id="e90f7070-37bc-431d-ae30-137a5ec5e8e4" lang="zh" xmltv_id="">SPOTV</channel>
+  <channel site="starhubtvplus.com" site_id="e0483b3c-33fe-442e-b0bd-8747f6f04f6e" lang="zh" xmltv_id="">Zee Thirai</channel>
+  <channel site="starhubtvplus.com" site_id="ea2a19ac-da50-4e86-8083-d8938112641f" lang="zh" xmltv_id="">TVBS-NEWS</channel>
+  <channel site="starhubtvplus.com" site_id="eb856acf-437e-470f-9161-eabd52e3de02" lang="zh" xmltv_id="">Fox News Channel</channel>
+  <channel site="starhubtvplus.com" site_id="ee4fe8fa-b213-4dd7-8ccf-541065bb8d12" lang="zh" xmltv_id="">Hub Sensasi</channel>
+  <channel site="starhubtvplus.com" site_id="f2c840ad-38ec-46d1-9b7b-b4d534da3c88" lang="zh" xmltv_id="">Travelxp HD</channel>
+  <channel site="starhubtvplus.com" site_id="f8b64a5d-438f-47e7-b516-2a902d7bc21d" lang="zh" xmltv_id="">Citra Entertainment</channel>
+  <channel site="starhubtvplus.com" site_id="f25d2d07-0303-4c95-be02-e9569d6c4f54" lang="zh" xmltv_id="">HITS MOVIES HD</channel>
+  <channel site="starhubtvplus.com" site_id="f946f3d4-96c3-4e0f-924d-edac62433fd2" lang="zh" xmltv_id="">Bloomberg Television HD</channel>
+  <channel site="starhubtvplus.com" site_id="f948f494-b2bd-4b92-8752-878938966e49" lang="zh" xmltv_id="">Euronews HD</channel>
+  <channel site="starhubtvplus.com" site_id="f4658135-f4b4-4185-be9a-2ff976b54a8f" lang="zh" xmltv_id="">BBC Earth HD</channel>
 </channels>


### PR DESCRIPTION
The channel list has been updated.

Fixes https://github.com/iptv-org/epg/issues/2965

Test run:

```sh
npm run grab --- --sites=starhubtvplus.com --lang=zh

> grab
> tsx scripts/commands/epg/grab.ts --sites=starhubtvplus.com --lang=zh

ℹ starting...                                                                                                                          
ℹ loading channels...                                                                                                                  
ℹ found 118 channel(s)                                                                                                                
ℹ loading api data...                                                                                                               
ℹ creating queue...                                                                                                                
ℹ run:                                                                                                                               
ℹ   [1/236] starhubtvplus.com (zh) - 0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6 - Apr 19, 2026 (15 programs)                                 
ℹ   [2/236] starhubtvplus.com (zh) - 0a9604e3-35dc-4c90-a9e4-39ea7f39c9d6 - Apr 20, 2026 (14 programs)                                 
ℹ   [3/236] starhubtvplus.com (zh) - 0bde83aa-c1b1-40c0-934d-e0f541808ade - Apr 19, 2026 (16 programs)                                 
ℹ   [4/236] starhubtvplus.com (zh) - 0bde83aa-c1b1-40c0-934d-e0f541808ade - Apr 20, 2026 (21 programs)                                 
ℹ   [5/236] starhubtvplus.com (zh) - 0c28c445-abad-467d-9559-211174718745 - Apr 19, 2026 (43 programs)                                 
ℹ   [6/236] starhubtvplus.com (zh) - 0c28c445-abad-467d-9559-211174718745 - Apr 20, 2026 (48 programs)                                 
...
```