### PR TITLE
Update web.magentatv.de

### DIFF
--- a/sites/web.magentatv.de/web.magentatv.de.config.js
+++ b/sites/web.magentatv.de/web.magentatv.de.config.js
@@ -46,6 +46,7 @@ module.exports = {
         title: item.name,
         description: item.introduce,
         image: parseImage(item),
+        icon: parseImage(item),
         category: parseCategory(item),
         start: parseStart(item),
         stop: parseStop(item),
@@ -176,7 +177,7 @@ async function fetchCookieAndToken() {
         T: 'Windows_chrome_118'
       },
       method: 'POST',
-      data: '{"terminalid":"00:00:00:00:00:00","mac":"00:00:00:00:00:00","terminaltype":"WEBTV","utcEnable":1,"timezone":"Etc/GMT0","userType":3,"terminalvendor":"Unknown"}',
+      data: '{"terminalid":"00:00:00:00:00:00","mac":"00:00:00:00:00:00","terminaltype":"WEBTV","utcEnable":1,"timezone":"Etc/GMT0","userType":3,"terminalvendor":"Unknown"}'
     })
 
     // Extract the cookies specified in cookiesToExtract
@@ -200,8 +201,7 @@ async function fetchCookieAndToken() {
 
     X_CSRFTOKEN = response.data.csrfToken
     Cookie = extractedCookies.join(' ')
-
-  } catch(error) {
+  } catch (error) {
     console.error(error)
   }
 }

--- a/sites/web.magentatv.de/web.magentatv.de.test.js
+++ b/sites/web.magentatv.de/web.magentatv.de.test.js
@@ -27,7 +27,7 @@ axios.request.mockImplementation(req => {
           'JSESSIONID=2147EBA9C59BCDC33822CFD2764E5C0B; Path=/EPG/; HttpOnly; SameSite=None; Secure',
           'CSESSIONID=1CF187ABCA12ED1B01ADF84C691048ED; Path=/EPG/; Secure; HttpOnly; SameSite=None',
           'CSRFSESSION=ea2329ba213271192bffd77c2fa276086a8e828c1a4ee379; Path=/EPG/; SameSite=None; Secure'
-        ] 
+        ]
       },
       data: {
         csrfToken: '6f678415702493d2c28813747c413aa05c87d8f87ecf05fe'
@@ -94,6 +94,7 @@ it('can parse response', () => {
         'Die besten Big-Wave-Surfer werden bei ihrer Suche nach der nächsten großen Welle begleitet.',
       image:
         'http://ngiss.t-online.de/cm1s/media/gracenote/2/4/p24832950_e_h9_aa_2023-06-22T10_12_01.jpg',
+      icon: 'http://ngiss.t-online.de/cm1s/media/gracenote/2/4/p24832950_e_h9_aa_2023-06-22T10_12_01.jpg',
       category: ['Sport']
     },
     {
@@ -106,6 +107,8 @@ it('can parse response', () => {
       season: '7',
       episode: '5',
       image:
+        'http://ngiss.t-online.de/cm1s/media/gracenote/1/0/p10262968_e_h9_ah_2021-10-20T07_16_16.jpg',
+      icon:
         'http://ngiss.t-online.de/cm1s/media/gracenote/1/0/p10262968_e_h9_ah_2021-10-20T07_16_16.jpg',
       category: ['Sitcom'],
       directors: ['Mark Cendrowski'],


### PR DESCRIPTION
Closes https://github.com/iptv-org/epg/issues/2995

```sh
npm test --- web.magentatv.de

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand web.magentatv.de

 PASS  sites/web.magentatv.de/web.magentatv.de.test.js
  ✓ can generate valid url (5 ms)
  ✓ can generate valid request method (1 ms)
  ✓ can generate valid request headers (3 ms)
  ✓ can generate valid request data (5 ms)
  ✓ can parse response (4 ms)
  ✓ can handle empty guide

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.623 s, estimated 1 s
Ran all test suites matching web.magentatv.de.
```