### PR TITLE
Freeview: Pull all channels from every region

### DIFF
--- a/sites/freeview.co.uk/freeview.co.uk.channels.xml
+++ b/sites/freeview.co.uk/freeview.co.uk.channels.xml
@@ -21,13 +21,13 @@
   <channel site="freeview.co.uk" site_id="64257#15016" lang="en" xmltv_id="">Sonlife</channel>
   <channel site="freeview.co.uk" site_id="64257#15064" lang="en" xmltv_id="">On Demand 365</channel>
   <channel site="freeview.co.uk" site_id="64257#15448" lang="en" xmltv_id="">Channelbox</channel>
-  <channel site="freeview.co.uk" site_id="64257#15864" lang="en" xmltv_id="">That&apos;s Oldies</channel>
   <channel site="freeview.co.uk" site_id="64257#16164" lang="en" xmltv_id="">CNA Originals</channel>
   <channel site="freeview.co.uk" site_id="64257#16170" lang="en" xmltv_id="">GIGS</channel>
-  <channel site="freeview.co.uk" site_id="64257#16180" lang="en" xmltv_id="">EuroNews</channel>
   <channel site="freeview.co.uk" site_id="64257#16188" lang="en" xmltv_id="">Trailblazer</channel>
   <channel site="freeview.co.uk" site_id="64257#16194" lang="en" xmltv_id="">Odyssey TV</channel>
   <channel site="freeview.co.uk" site_id="64257#16216" lang="en" xmltv_id="">Ketchup Too</channel>
+  <channel site="freeview.co.uk" site_id="64257#16218" lang="en" xmltv_id="">Music &amp; Memories</channel>
+  <channel site="freeview.co.uk" site_id="64257#16224" lang="en" xmltv_id="">Outdoor Channel</channel>
   <channel site="freeview.co.uk" site_id="64257#16240" lang="en" xmltv_id="">ROK</channel>
   <channel site="freeview.co.uk" site_id="64257#16286" lang="en" xmltv_id="">Global Arabic +</channel>
   <channel site="freeview.co.uk" site_id="64257#16346" lang="en" xmltv_id="">Amazing Facts</channel>
@@ -35,7 +35,6 @@
   <channel site="freeview.co.uk" site_id="64257#16376" lang="en" xmltv_id="">Nosey</channel>
   <channel site="freeview.co.uk" site_id="64257#16394" lang="en" xmltv_id="">Shop On TV</channel>
   <channel site="freeview.co.uk" site_id="64257#16400" lang="en" xmltv_id="">Purpose Media</channel>
-  <channel site="freeview.co.uk" site_id="64257#20032" lang="en" xmltv_id="">LEGEND XTRA</channel>
   <channel site="freeview.co.uk" site_id="64257#22624" lang="en" xmltv_id="">RNIB Connect</channel>
   <channel site="freeview.co.uk" site_id="64257#22656" lang="en" xmltv_id="">Heart</channel>
   <channel site="freeview.co.uk" site_id="64257#22688" lang="en" xmltv_id="">Capital</channel>
@@ -44,24 +43,117 @@
   <channel site="freeview.co.uk" site_id="64257#23152" lang="en" xmltv_id="">That&apos;s TV 2</channel>
   <channel site="freeview.co.uk" site_id="64257#23184" lang="en" xmltv_id="">SonLife</channel>
   <channel site="freeview.co.uk" site_id="64257#23680" lang="en" xmltv_id="">Must Have Ideas</channel>
-  <channel site="freeview.co.uk" site_id="64257#23904" lang="en" xmltv_id="">That&apos;s 80s</channel>
+  <channel site="freeview.co.uk" site_id="64257#23904" lang="en" xmltv_id="">That&apos;s 70s</channel>
   <channel site="freeview.co.uk" site_id="64257#26368" lang="en" xmltv_id="">Smooth Radio</channel>
   <channel site="freeview.co.uk" site_id="64257#27232" lang="en" xmltv_id="">Hobbycraft TV</channel>
   <channel site="freeview.co.uk" site_id="64257#27744" lang="en" xmltv_id="">Rewind TV</channel>
   <channel site="freeview.co.uk" site_id="64257#27808" lang="en" xmltv_id="">Together TV IP</channel>
-  <channel site="freeview.co.uk" site_id="64257#28032" lang="en" xmltv_id="">That&apos;s Melody</channel>
+  <channel site="freeview.co.uk" site_id="64257#28032" lang="en" xmltv_id="">That&apos;s 60s</channel>
   <channel site="freeview.co.uk" site_id="64257#28160" lang="en" xmltv_id="">Premier Radio</channel>
   <channel site="freeview.co.uk" site_id="64257#28352" lang="en" xmltv_id="">Great! Player</channel>
   <channel site="freeview.co.uk" site_id="64257#28384" lang="en" xmltv_id="">Great! Romance Mix</channel>
-  <channel site="freeview.co.uk" site_id="64257#33280" lang="en" xmltv_id="">India Today</channel>
   <channel site="freeview.co.uk" site_id="64257#33664" lang="en" xmltv_id="">MBC Group</channel>
-  <channel site="freeview.co.uk" site_id="64257#33920" lang="en" xmltv_id="">wedotv movies</channel>
+  <channel site="freeview.co.uk" site_id="64257#33920" lang="en" xmltv_id="">wedotv Big Stories</channel>
   <channel site="freeview.co.uk" site_id="64257#33984" lang="en" xmltv_id="">It Is Written TV</channel>
   <channel site="freeview.co.uk" site_id="64257#34048" lang="en" xmltv_id="">OUTflix Proud</channel>
   <channel site="freeview.co.uk" site_id="64257#34176" lang="en" xmltv_id="">High Street TV</channel>
   <channel site="freeview.co.uk" site_id="64257#34432" lang="en" xmltv_id="">Cartoon Classics</channel>
   <channel site="freeview.co.uk" site_id="64257#34496" lang="en" xmltv_id="">wedotv Movies UK</channel>
   <channel site="freeview.co.uk" site_id="64257#34560" lang="en" xmltv_id="">Nolly Africa</channel>
+  <channel site="freeview.co.uk" site_id="64265#6147" lang="en" xmltv_id="">BBC Solent</channel>
+  <channel site="freeview.co.uk" site_id="64265#6211" lang="en" xmltv_id="">BBC Solent Dorset</channel>
+  <channel site="freeview.co.uk" site_id="64265#6220" lang="en" xmltv_id="">BBC Sussex</channel>
+  <channel site="freeview.co.uk" site_id="64265#6273" lang="en" xmltv_id="">BBC Wiltshire</channel>
+  <channel site="freeview.co.uk" site_id="64269#6156" lang="en" xmltv_id="">BBC Kent</channel>
+  <channel site="freeview.co.uk" site_id="64270#32870" lang="en" xmltv_id="">KMTV</channel>
+  <channel site="freeview.co.uk" site_id="64273#32851" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64274#32874" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64275#32839" lang="en" xmltv_id="">Latest TV</channel>
+  <channel site="freeview.co.uk" site_id="64289#32873" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64290#32857" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64297#6155" lang="en" xmltv_id="">BBC Oxford</channel>
+  <channel site="freeview.co.uk" site_id="64297#6209" lang="en" xmltv_id="">BBC Gloucestershire</channel>
+  <channel site="freeview.co.uk" site_id="64297#32850" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64300#6151" lang="en" xmltv_id="">BBC Norfolk</channel>
+  <channel site="freeview.co.uk" site_id="64300#6221" lang="en" xmltv_id="">BBC Northampton</channel>
+  <channel site="freeview.co.uk" site_id="64300#6285" lang="en" xmltv_id="">BBC Cambridge</channel>
+  <channel site="freeview.co.uk" site_id="64304#6215" lang="en" xmltv_id="">BBC Suffolk</channel>
+  <channel site="freeview.co.uk" site_id="64305#32841" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64313#32858" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64320#6145" lang="en" xmltv_id="">BBC Bristol</channel>
+  <channel site="freeview.co.uk" site_id="64320#6337" lang="en" xmltv_id="">BBC Somerset</channel>
+  <channel site="freeview.co.uk" site_id="64321#32834" lang="en" xmltv_id="">Bristol TV</channel>
+  <channel site="freeview.co.uk" site_id="64328#6146" lang="en" xmltv_id="">BBC Cornwall</channel>
+  <channel site="freeview.co.uk" site_id="64328#6210" lang="en" xmltv_id="">BBC Devon</channel>
+  <channel site="freeview.co.uk" site_id="64334#6158" lang="en" xmltv_id="">BBC Guernsey</channel>
+  <channel site="freeview.co.uk" site_id="64334#6222" lang="en" xmltv_id="">BBC Jersey</channel>
+  <channel site="freeview.co.uk" site_id="64336#6149" lang="en" xmltv_id="">BBC WM</channel>
+  <channel site="freeview.co.uk" site_id="64336#6213" lang="en" xmltv_id="">BBC Stoke</channel>
+  <channel site="freeview.co.uk" site_id="64336#6214" lang="en" xmltv_id="">BBC Derby</channel>
+  <channel site="freeview.co.uk" site_id="64336#6277" lang="en" xmltv_id="">BBC H&amp;W</channel>
+  <channel site="freeview.co.uk" site_id="64336#6341" lang="en" xmltv_id="">BBC Shropshire</channel>
+  <channel site="freeview.co.uk" site_id="64336#6405" lang="en" xmltv_id="">BBC CWR</channel>
+  <channel site="freeview.co.uk" site_id="64337#32846" lang="en" xmltv_id="">Birmingham TV</channel>
+  <channel site="freeview.co.uk" site_id="64342#6150" lang="en" xmltv_id="">BBC Nottingham</channel>
+  <channel site="freeview.co.uk" site_id="64342#6159" lang="en" xmltv_id="">BBC Lincolnshire</channel>
+  <channel site="freeview.co.uk" site_id="64342#6278" lang="en" xmltv_id="">BBC Leicester</channel>
+  <channel site="freeview.co.uk" site_id="64352#6218" lang="en" xmltv_id="">BBC Sheffield</channel>
+  <channel site="freeview.co.uk" site_id="64352#6223" lang="en" xmltv_id="">BBC Humberside</channel>
+  <channel site="freeview.co.uk" site_id="64353#32833" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64354#32879" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64357#6154" lang="en" xmltv_id="">BBC Leeds</channel>
+  <channel site="freeview.co.uk" site_id="64357#6282" lang="en" xmltv_id="">BBC York</channel>
+  <channel site="freeview.co.uk" site_id="64357#32848" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64361#32836" lang="en" xmltv_id="">Leeds TV</channel>
+  <channel site="freeview.co.uk" site_id="64364#32875" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64368#6153" lang="en" xmltv_id="">BBC Newcastle</channel>
+  <channel site="freeview.co.uk" site_id="64368#6217" lang="en" xmltv_id="">BBC Cumbria</channel>
+  <channel site="freeview.co.uk" site_id="64368#6281" lang="en" xmltv_id="">BBC Tees</channel>
+  <channel site="freeview.co.uk" site_id="64369#32837" lang="en" xmltv_id="">Tyne &amp; Wear TV</channel>
+  <channel site="freeview.co.uk" site_id="64370#32869" lang="en" xmltv_id="">Teesside TV</channel>
+  <channel site="freeview.co.uk" site_id="64376#6152" lang="en" xmltv_id="">BBC Manchester</channel>
+  <channel site="freeview.co.uk" site_id="64376#6216" lang="en" xmltv_id="">BBC Lancashire</channel>
+  <channel site="freeview.co.uk" site_id="64376#6280" lang="en" xmltv_id="">BBC Merseyside</channel>
+  <channel site="freeview.co.uk" site_id="64377#30081" lang="en" xmltv_id="">That&apos;s TV (UK) MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#30209" lang="en" xmltv_id="">TV Warehouse</channel>
+  <channel site="freeview.co.uk" site_id="64377#30273" lang="en" xmltv_id="">That&apos;s 60s MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#30337" lang="en" xmltv_id="">That&apos;s Oldies MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#30401" lang="en" xmltv_id="">That&apos;s TV 2 MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#30465" lang="en" xmltv_id="">TV Warehouse+1</channel>
+  <channel site="freeview.co.uk" site_id="64377#30657" lang="en" xmltv_id="">That&apos;s TV 3 MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#30721" lang="en" xmltv_id="">That&apos;s Classics MCR</channel>
+  <channel site="freeview.co.uk" site_id="64377#32843" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64378#32840" lang="en" xmltv_id="">Liverpool TV</channel>
+  <channel site="freeview.co.uk" site_id="64379#32845" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64385#32859" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64392#5692" lang="en" xmltv_id="">BBC R5L</channel>
+  <channel site="freeview.co.uk" site_id="64392#5756" lang="en" xmltv_id="">BBC 5SX</channel>
+  <channel site="freeview.co.uk" site_id="64392#5820" lang="en" xmltv_id="">BBC 6 Music</channel>
+  <channel site="freeview.co.uk" site_id="64392#5884" lang="en" xmltv_id="">BBC Radio 4 Ex</channel>
+  <channel site="freeview.co.uk" site_id="64392#5948" lang="en" xmltv_id="">BBC R1X</channel>
+  <channel site="freeview.co.uk" site_id="64392#6012" lang="en" xmltv_id="">BBC Asian Net.</channel>
+  <channel site="freeview.co.uk" site_id="64392#6076" lang="en" xmltv_id="">BBC World Sv.</channel>
+  <channel site="freeview.co.uk" site_id="64392#6204" lang="en" xmltv_id="">BBC R Scotland</channel>
+  <channel site="freeview.co.uk" site_id="64392#6268" lang="en" xmltv_id="">BBC R n Gaidheal</channel>
+  <channel site="freeview.co.uk" site_id="64392#6780" lang="en" xmltv_id="">BBC Radio 1</channel>
+  <channel site="freeview.co.uk" site_id="64392#6844" lang="en" xmltv_id="">BBC Radio 2</channel>
+  <channel site="freeview.co.uk" site_id="64392#6908" lang="en" xmltv_id="">BBC Radio 3</channel>
+  <channel site="freeview.co.uk" site_id="64392#6972" lang="en" xmltv_id="">BBC Radio 4</channel>
+  <channel site="freeview.co.uk" site_id="64401#32847" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64402#32882" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64403#32849" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64406#32881" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64409#32880" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64416#6462" lang="en" xmltv_id="">BBC Radio Wales</channel>
+  <channel site="freeview.co.uk" site_id="64416#6526" lang="en" xmltv_id="">BBC Radio Cymru</channel>
+  <channel site="freeview.co.uk" site_id="64416#6590" lang="en" xmltv_id="">BBC Radio Cymru 2</channel>
+  <channel site="freeview.co.uk" site_id="64417#32835" lang="en" xmltv_id="">Cardiff TV</channel>
+  <channel site="freeview.co.uk" site_id="64418#32878" lang="en" xmltv_id="">That&apos;s TV</channel>
+  <channel site="freeview.co.uk" site_id="64419#32871" lang="en" xmltv_id="">North Wales TV</channel>
+  <channel site="freeview.co.uk" site_id="64424#6333" lang="en" xmltv_id="">BBC Radio Ulster</channel>
+  <channel site="freeview.co.uk" site_id="64424#6397" lang="en" xmltv_id="">BBC Radio Foyle</channel>
+  <channel site="freeview.co.uk" site_id="64424#28929" lang="en" xmltv_id="">RTÉ RnaG</channel>
+  <channel site="freeview.co.uk" site_id="64425#32838" lang="en" xmltv_id="">That&apos;s TV</channel>
   <channel site="freeview.co.uk" site_id="64257#8460" lang="en" xmltv_id="4seven.uk@SD">4seven</channel>
   <channel site="freeview.co.uk" site_id="64257#16112" lang="en" xmltv_id="5Action.uk@SD">5ACTION</channel>
   <channel site="freeview.co.uk" site_id="64257#20256" lang="en" xmltv_id="5SELECT.uk@SD">5SELECT</channel>
@@ -72,20 +164,63 @@
   <channel site="freeview.co.uk" site_id="64257#16284" lang="en" xmltv_id="AlJazeera.qa@Arabic">Al Jazeera Arabic</channel>
   <channel site="freeview.co.uk" site_id="64257#16278" lang="en" xmltv_id="AlJazeera.qa@English">Al Jazeera English</channel>
   <channel site="freeview.co.uk" site_id="64257#34304" lang="en" xmltv_id="AsharqNews.sa@SD">ASHARQ NEWS</channel>
+  <channel site="freeview.co.uk" site_id="64392#4860" lang="en" xmltv_id="BBCAlba.uk@SD">BBC ALBA</channel>
   <channel site="freeview.co.uk" site_id="64257#18048" lang="en" xmltv_id="BBCFour.uk@HD">BBC FOUR HD</channel>
   <channel site="freeview.co.uk" site_id="64257#4544" lang="en" xmltv_id="BBCFour.uk@UK">BBC FOUR</channel>
   <channel site="freeview.co.uk" site_id="64257#4352" lang="en" xmltv_id="BBCNews.uk">BBC NEWS</channel>
+  <channel site="freeview.co.uk" site_id="64334#4174" lang="en" xmltv_id="BBCOne.uk@ChannelIslands">BBC ONE CI</channel>
+  <channel site="freeview.co.uk" site_id="64334#17550" lang="en" xmltv_id="BBCOne.uk@ChannelIslandsHD">BBC ONE CI HD</channel>
+  <channel site="freeview.co.uk" site_id="64300#4173" lang="en" xmltv_id="BBCOne.uk@East">BBC ONE East</channel>
+  <channel site="freeview.co.uk" site_id="64304#4167" lang="en" xmltv_id="BBCOne.uk@East">BBC ONE East</channel>
+  <channel site="freeview.co.uk" site_id="64300#17549" lang="en" xmltv_id="BBCOne.uk@EastHD">BBC ONE EastHD</channel>
+  <channel site="freeview.co.uk" site_id="64304#17543" lang="en" xmltv_id="BBCOne.uk@EastHD">BBC ONE EastHD</channel>
+  <channel site="freeview.co.uk" site_id="64342#4166" lang="en" xmltv_id="BBCOne.uk@EastMidlands">BBC ONE E Mid</channel>
+  <channel site="freeview.co.uk" site_id="64344#17542" lang="en" xmltv_id="BBCOne.uk@EastMidlandsHD">BBC ONE EMidHD</channel>
   <channel site="freeview.co.uk" site_id="64257#4164" lang="en" xmltv_id="BBCOne.uk@London">BBC ONE Lon</channel>
   <channel site="freeview.co.uk" site_id="64257#17536" lang="en" xmltv_id="BBCOne.uk@LondonHD">BBC ONE Lon HD</channel>
+  <channel site="freeview.co.uk" site_id="64368#4169" lang="en" xmltv_id="BBCOne.uk@NorthEastCumbria">BBC ONE NE&amp;C</channel>
+  <channel site="freeview.co.uk" site_id="64368#17545" lang="en" xmltv_id="BBCOne.uk@NorthEastCumbriaHD">BBC ONE NE&amp;CHD</channel>
+  <channel site="freeview.co.uk" site_id="64424#4221" lang="en" xmltv_id="BBCOne.uk@NorthernIreland">BBC ONE NI</channel>
+  <channel site="freeview.co.uk" site_id="64424#17597" lang="en" xmltv_id="BBCOne.uk@NorthernIrelandHD">BBC ONE NI HD</channel>
+  <channel site="freeview.co.uk" site_id="64376#4168" lang="en" xmltv_id="BBCOne.uk@NorthWest">BBC ONE N West</channel>
+  <channel site="freeview.co.uk" site_id="64376#17544" lang="en" xmltv_id="BBCOne.uk@NorthWestHD">BBC ONE NWstHD</channel>
+  <channel site="freeview.co.uk" site_id="64392#4220" lang="en" xmltv_id="BBCOne.uk@Scotland">BBC ONE Scot</channel>
+  <channel site="freeview.co.uk" site_id="64392#17596" lang="en" xmltv_id="BBCOne.uk@ScotlandHD">BBC 1 Scot HD</channel>
+  <channel site="freeview.co.uk" site_id="64265#4163" lang="en" xmltv_id="BBCOne.uk@South">BBC ONE South</channel>
+  <channel site="freeview.co.uk" site_id="64297#4171" lang="en" xmltv_id="BBCOne.uk@South">BBC ONE South</channel>
+  <channel site="freeview.co.uk" site_id="64269#4172" lang="en" xmltv_id="BBCOne.uk@SouthEast">BBC ONE S East</channel>
+  <channel site="freeview.co.uk" site_id="64280#17548" lang="en" xmltv_id="BBCOne.uk@SouthEastHD">BBC ONE SE HD</channel>
+  <channel site="freeview.co.uk" site_id="64272#17539" lang="en" xmltv_id="BBCOne.uk@SouthHD">BBC ONE Sth HD</channel>
+  <channel site="freeview.co.uk" site_id="64297#17547" lang="en" xmltv_id="BBCOne.uk@SouthHD">BBC ONE Sth HD</channel>
+  <channel site="freeview.co.uk" site_id="64328#4162" lang="en" xmltv_id="BBCOne.uk@SouthWest">BBC ONE S West</channel>
+  <channel site="freeview.co.uk" site_id="64328#17538" lang="en" xmltv_id="BBCOne.uk@SouthWestHD">BBC ONE SW HD</channel>
+  <channel site="freeview.co.uk" site_id="64416#4222" lang="en" xmltv_id="BBCOne.uk@Wales">BBC ONE Wales</channel>
+  <channel site="freeview.co.uk" site_id="64416#17598" lang="en" xmltv_id="BBCOne.uk@WalesHD">BBC 1 Wales HD</channel>
+  <channel site="freeview.co.uk" site_id="64320#4161" lang="en" xmltv_id="BBCOne.uk@West">BBC ONE West</channel>
+  <channel site="freeview.co.uk" site_id="64320#17537" lang="en" xmltv_id="BBCOne.uk@WestHD">BBC ONE WestHD</channel>
+  <channel site="freeview.co.uk" site_id="64336#4165" lang="en" xmltv_id="BBCOne.uk@WestMidlands">BBC ONE W Mid</channel>
+  <channel site="freeview.co.uk" site_id="64336#17541" lang="en" xmltv_id="BBCOne.uk@WestMidlandsHD">BBC ONE WMidHD</channel>
+  <channel site="freeview.co.uk" site_id="64357#4170" lang="en" xmltv_id="BBCOne.uk@Yorkshire">BBC ONE Yorks</channel>
+  <channel site="freeview.co.uk" site_id="64357#17546" lang="en" xmltv_id="BBCOne.uk@YorkshireHD">BBC ONE Yks HD</channel>
+  <channel site="freeview.co.uk" site_id="64352#4175" lang="en" xmltv_id="BBCOne.uk@YorkshireLincolnshire">BBC ONE Yk&amp;Li</channel>
+  <channel site="freeview.co.uk" site_id="64352#17551" lang="en" xmltv_id="BBCOne.uk@YorkshireLincolnshireHD">BBC ONE Yk&amp;LHD</channel>
   <channel site="freeview.co.uk" site_id="64257#4736" lang="en" xmltv_id="BBCParliament.uk@SD">BBC Parliament</channel>
   <channel site="freeview.co.uk" site_id="64257#7168" lang="en" xmltv_id="BBCRedButton1.uk@SD">BBC RB 1</channel>
+  <channel site="freeview.co.uk" site_id="64392#17212" lang="en" xmltv_id="BBCScotland.uk@HD">BBC Scotland HD</channel>
+  <channel site="freeview.co.uk" site_id="64392#4924" lang="en" xmltv_id="BBCScotland.uk@SD">BBC Scotland</channel>
   <channel site="freeview.co.uk" site_id="64257#17920" lang="en" xmltv_id="BBCThree.uk@HD">BBC THREE HD</channel>
   <channel site="freeview.co.uk" site_id="64257#4288" lang="en" xmltv_id="BBCThree.uk@SD">BBC THREE</channel>
   <channel site="freeview.co.uk" site_id="64257#4287" lang="en" xmltv_id="BBCTwo.uk@England">BBC TWO</channel>
   <channel site="freeview.co.uk" site_id="64257#17472" lang="en" xmltv_id="BBCTwo.uk@HD">BBC TWO HD</channel>
+  <channel site="freeview.co.uk" site_id="64424#4285" lang="en" xmltv_id="BBCTwo.uk@NorthernIreland">BBC TWO NI</channel>
+  <channel site="freeview.co.uk" site_id="64424#17533" lang="en" xmltv_id="BBCTwo.uk@NorthernIrelandHD">BBC TWO NI HD</channel>
+  <channel site="freeview.co.uk" site_id="64416#4286" lang="en" xmltv_id="BBCTwo.uk@Wales">BBC TWO Wales</channel>
+  <channel site="freeview.co.uk" site_id="64416#17534" lang="en" xmltv_id="BBCTwo.uk@WalesHD">BBC 2 Wales HD</channel>
   <channel site="freeview.co.uk" site_id="64257#14388" lang="en" xmltv_id="Blaze.uk@Plus1">Blaze+1</channel>
   <channel site="freeview.co.uk" site_id="64257#14384" lang="en" xmltv_id="Blaze.uk@SD">Blaze</channel>
   <channel site="freeview.co.uk" site_id="64257#18112" lang="en" xmltv_id="CBBC.uk@HD">CBBC HD</channel>
+  <channel site="freeview.co.uk" site_id="64392#18172" lang="en" xmltv_id="CBBC.uk@HD">CBBC HD</channel>
+  <channel site="freeview.co.uk" site_id="64416#18174" lang="en" xmltv_id="CBBC.uk@HD">CBBC HD</channel>
   <channel site="freeview.co.uk" site_id="64257#4608" lang="en" xmltv_id="CBBC.uk@SD">CBBC</channel>
   <channel site="freeview.co.uk" site_id="64257#18176" lang="en" xmltv_id="CBeebies.uk@HD">CBeebies HD</channel>
   <channel site="freeview.co.uk" site_id="64257#4672" lang="en" xmltv_id="CBeebies.uk@SD">CBeebies</channel>
@@ -98,26 +233,61 @@
   <channel site="freeview.co.uk" site_id="64257#8500" lang="en" xmltv_id="Channel5.uk@SD">5</channel>
   <channel site="freeview.co.uk" site_id="64257#27680" lang="en" xmltv_id="DMAX.uk@UK">DMAX</channel>
   <channel site="freeview.co.uk" site_id="64257#8458" lang="en" xmltv_id="E4.uk@Plus1">E4+1</channel>
+  <channel site="freeview.co.uk" site_id="64416#14400" lang="en" xmltv_id="E4.uk@Plus1">E4+1</channel>
   <channel site="freeview.co.uk" site_id="64257#8448" lang="en" xmltv_id="E4.uk@SD">E4</channel>
   <channel site="freeview.co.uk" site_id="64257#22368" lang="en" xmltv_id="E4Extra.uk@SD">E4 Extra</channel>
+  <channel site="freeview.co.uk" site_id="64257#16180" lang="en" xmltv_id="EuronewsEnglish.fr@SD">EuroNews</channel>
   <channel site="freeview.co.uk" site_id="64257#22464" lang="en" xmltv_id="Film4.uk@Plus1">Film4+1</channel>
   <channel site="freeview.co.uk" site_id="64257#8385" lang="en" xmltv_id="Film4.uk@SD">Film4</channel>
   <channel site="freeview.co.uk" site_id="64257#23040" lang="en" xmltv_id="FoodNetwork.uk@SD">Food Network</channel>
   <channel site="freeview.co.uk" site_id="64257#16370" lang="en" xmltv_id="France24.fr@English">FRANCE 24</channel>
   <channel site="freeview.co.uk" site_id="64257#27360" lang="en" xmltv_id="GBNews.uk@SD">GB News</channel>
   <channel site="freeview.co.uk" site_id="64257#24448" lang="en" xmltv_id="GemsTV.uk@SD">Gemporia</channel>
-  <channel site="freeview.co.uk" site_id="64257#16256" lang="en" xmltv_id="GODTV.uk@SD">God TV</channel>
   <channel site="freeview.co.uk" site_id="64257#15576" lang="en" xmltv_id="GREATaction.uk@SD">Great! Action</channel>
   <channel site="freeview.co.uk" site_id="64257#27872" lang="en" xmltv_id="GREATmovies.uk@UK">Great! Mystery</channel>
   <channel site="freeview.co.uk" site_id="64257#15584" lang="en" xmltv_id="GREATmystery.uk@SD">Great! Movies</channel>
   <channel site="freeview.co.uk" site_id="64257#27296" lang="en" xmltv_id="GREATromance.uk@UK">Great! Romance</channel>
   <channel site="freeview.co.uk" site_id="64257#27168" lang="en" xmltv_id="GREATtv.uk@SD">Great! TV</channel>
-  <channel site="freeview.co.uk" site_id="64257#28000" lang="en" xmltv_id="HGTV.uk@SD">HGTV</channel>
   <channel site="freeview.co.uk" site_id="64257#27840" lang="en" xmltv_id="HobbyMaker.uk@SD">HobbyMaker</channel>
+  <channel site="freeview.co.uk" site_id="64257#20032" lang="en" xmltv_id="HorrorXtra.uk@SD">LEGEND XTRA</channel>
   <channel site="freeview.co.uk" site_id="64257#25920" lang="en" xmltv_id="IdealWorldTV.uk@SD">Ideal World</channel>
+  <channel site="freeview.co.uk" site_id="64304#8257" lang="en" xmltv_id="ITV1.uk@Anglia">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64312#8258" lang="en" xmltv_id="ITV1.uk@Anglia">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64304#8357" lang="en" xmltv_id="ITV1.uk@AngliaPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64384#8260" lang="en" xmltv_id="ITV1.uk@BorderEngland">ITV1 Border England</channel>
+  <channel site="freeview.co.uk" site_id="64384#8360" lang="en" xmltv_id="ITV1.uk@BorderEnglandPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64392#8259" lang="en" xmltv_id="ITV1.uk@BorderScotland">ITV1 Border Scotland</channel>
+  <channel site="freeview.co.uk" site_id="64392#17659" lang="en" xmltv_id="ITV1.uk@BorderScotlandHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64336#8262" lang="en" xmltv_id="ITV1.uk@Central">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64344#8264" lang="en" xmltv_id="ITV1.uk@Central">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64336#17605" lang="en" xmltv_id="ITV1.uk@CentralHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64336#8362" lang="en" xmltv_id="ITV1.uk@CentralPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64334#8265" lang="en" xmltv_id="ITV1.uk@ChannelTelevision">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64376#8267" lang="en" xmltv_id="ITV1.uk@Granada">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64376#17608" lang="en" xmltv_id="ITV1.uk@GranadaHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64376#8367" lang="en" xmltv_id="ITV1.uk@GranadaPlus1">ITV1+1</channel>
   <channel site="freeview.co.uk" site_id="64257#17604" lang="en" xmltv_id="ITV1.uk@HD">ITV1 HD</channel>
   <channel site="freeview.co.uk" site_id="64257#8261" lang="en" xmltv_id="ITV1.uk@London">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64272#8270" lang="en" xmltv_id="ITV1.uk@Meridian">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64280#8272" lang="en" xmltv_id="ITV1.uk@Meridian">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64289#8271" lang="en" xmltv_id="ITV1.uk@Meridian">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64272#17603" lang="en" xmltv_id="ITV1.uk@MeridianHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64272#8370" lang="en" xmltv_id="ITV1.uk@MeridianPlus1">ITV1+1</channel>
   <channel site="freeview.co.uk" site_id="64257#8361" lang="en" xmltv_id="ITV1.uk@Plus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64368#8274" lang="en" xmltv_id="ITV1.uk@TyneTees">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64368#8374" lang="en" xmltv_id="ITV1.uk@TyneTeesPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64416#8269" lang="en" xmltv_id="ITV1.uk@Wales">ITV1 Wales</channel>
+  <channel site="freeview.co.uk" site_id="64416#17663" lang="en" xmltv_id="ITV1.uk@WalesHD">ITV1 Wales HD</channel>
+  <channel site="freeview.co.uk" site_id="64416#8369" lang="en" xmltv_id="ITV1.uk@WalesPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64320#8268" lang="en" xmltv_id="ITV1.uk@WestCountry">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64328#8277" lang="en" xmltv_id="ITV1.uk@WestCountry">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64320#17662" lang="en" xmltv_id="ITV1.uk@WestCountryHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64320#8368" lang="en" xmltv_id="ITV1.uk@WestCountryPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64328#8377" lang="en" xmltv_id="ITV1.uk@WestCountryPlus1">ITV1+1</channel>
+  <channel site="freeview.co.uk" site_id="64350#8283" lang="en" xmltv_id="ITV1.uk@Yorkshire">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64360#8281" lang="en" xmltv_id="ITV1.uk@Yorkshire">ITV1</channel>
+  <channel site="freeview.co.uk" site_id="64352#17609" lang="en" xmltv_id="ITV1.uk@YorkshireHD">ITV1 HD</channel>
+  <channel site="freeview.co.uk" site_id="64350#8381" lang="en" xmltv_id="ITV1.uk@YorkshirePlus1">ITV1+1</channel>
   <channel site="freeview.co.uk" site_id="64257#15952" lang="en" xmltv_id="ITV2.uk@Plus1">ITV2+1</channel>
   <channel site="freeview.co.uk" site_id="64257#8325" lang="en" xmltv_id="ITV2.uk@SD">ITV2</channel>
   <channel site="freeview.co.uk" site_id="64257#16016" lang="en" xmltv_id="ITV3.uk@Plus1">ITV3+1</channel>
@@ -137,33 +307,49 @@
   <channel site="freeview.co.uk" site_id="64257#16272" lang="en" xmltv_id="PopMax.uk@SD">POP</channel>
   <channel site="freeview.co.uk" site_id="64257#27424" lang="en" xmltv_id="PopUp.uk@SD">POP UP</channel>
   <channel site="freeview.co.uk" site_id="64257#23808" lang="en" xmltv_id="Quest.uk@Plus1">QUEST+1</channel>
+  <channel site="freeview.co.uk" site_id="64265#34752" lang="en" xmltv_id="Quest.uk@Plus1">QUEST+1</channel>
   <channel site="freeview.co.uk" site_id="64257#27328" lang="en" xmltv_id="Quest.uk@SD">QUEST</channel>
   <channel site="freeview.co.uk" site_id="64257#23744" lang="en" xmltv_id="QuestRed.uk@SD">Quest Red</channel>
   <channel site="freeview.co.uk" site_id="64257#14416" lang="en" xmltv_id="QVC2.uk@SD">QVC2</channel>
   <channel site="freeview.co.uk" site_id="64257#13120" lang="en" xmltv_id="QVC.uk@SD">QVC</channel>
   <channel site="freeview.co.uk" site_id="64257#23712" lang="en" xmltv_id="Really.uk@SD">Really</channel>
   <channel site="freeview.co.uk" site_id="64257#16248" lang="en" xmltv_id="RevelationTV.uk@SD">Revelation TV</channel>
+  <channel site="freeview.co.uk" site_id="64424#28801" lang="en" xmltv_id="RTE2.ie@SD">RTÉ Two</channel>
+  <channel site="freeview.co.uk" site_id="64424#28737" lang="en" xmltv_id="RTEOne.ie@SD">RTÉ One</channel>
+  <channel site="freeview.co.uk" site_id="64416#17792" lang="en" xmltv_id="S4C.uk@HD">S4C HD</channel>
+  <channel site="freeview.co.uk" site_id="64416#8456" lang="en" xmltv_id="S4C.uk@SD">S4C</channel>
   <channel site="freeview.co.uk" site_id="64257#22144" lang="en" xmltv_id="SkyArts.uk@SD">Sky Arts</channel>
   <channel site="freeview.co.uk" site_id="64257#22208" lang="en" xmltv_id="SkyMix.uk@SD">Sky Mix</channel>
   <channel site="freeview.co.uk" site_id="64257#22080" lang="en" xmltv_id="SkyNews.uk@SD">Sky News</channel>
+  <channel site="freeview.co.uk" site_id="64400#17856" lang="en" xmltv_id="STV.uk@HD">STV HD</channel>
+  <channel site="freeview.co.uk" site_id="64400#8373" lang="en" xmltv_id="STVCentral.uk@Plus1">STV+1</channel>
+  <channel site="freeview.co.uk" site_id="64400#8273" lang="en" xmltv_id="STVCentral.uk@SD">STV</channel>
+  <channel site="freeview.co.uk" site_id="64408#8366" lang="en" xmltv_id="STVNorth.uk@Plus1">STV+1</channel>
+  <channel site="freeview.co.uk" site_id="64408#8266" lang="en" xmltv_id="STVNorth.uk@SD">STV</channel>
   <channel site="freeview.co.uk" site_id="64257#28224" lang="en" xmltv_id="TalkingPicturesTV.uk@SD">TalkingPictures TV</channel>
   <channel site="freeview.co.uk" site_id="64257#22592" lang="en" xmltv_id="talkSPORT.uk@SD">talkSPORT</channel>
   <channel site="freeview.co.uk" site_id="64257#16406" lang="en" xmltv_id="TalkTV.uk@SD">Talk</channel>
   <channel site="freeview.co.uk" site_id="64257#20160" lang="en" xmltv_id="TBNUK.uk@SD">TBN UK</channel>
+  <channel site="freeview.co.uk" site_id="64424#28865" lang="en" xmltv_id="TG4.ie@SD">TG4</channel>
   <channel site="freeview.co.uk" site_id="64257#27936" lang="en" xmltv_id="ThatsTV.uk@SD">That&apos;s TV (UK)</channel>
+  <channel site="freeview.co.uk" site_id="64258#32863" lang="en" xmltv_id="ThatsTV.uk@SD">That&apos;s TV</channel>
   <channel site="freeview.co.uk" site_id="64257#16280" lang="en" xmltv_id="TinyPop.uk@SD">Tiny Pop</channel>
   <channel site="freeview.co.uk" site_id="64257#15592" lang="en" xmltv_id="TJC.uk@SD">TJC</channel>
+  <channel site="freeview.co.uk" site_id="64257#34688" lang="en" xmltv_id="TLC.uk@Plus1">TLC+1</channel>
+  <channel site="freeview.co.uk" site_id="64257#28000" lang="en" xmltv_id="TLC.uk@SD">TLC</channel>
   <channel site="freeview.co.uk" site_id="64257#27392" lang="en" xmltv_id="TogetherTV.uk@Plus1">Together TV+1</channel>
   <channel site="freeview.co.uk" site_id="64257#16364" lang="en" xmltv_id="TogetherTV.uk@SD">Together TV</channel>
   <channel site="freeview.co.uk" site_id="64257#14448" lang="en" xmltv_id="TrueCrime.uk@SD">TRUE CRIME</channel>
   <channel site="freeview.co.uk" site_id="64257#14456" lang="en" xmltv_id="TrueCrimeXtra.uk@SD">TRUE CRIME XTRA</channel>
   <channel site="freeview.co.uk" site_id="64257#22272" lang="en" xmltv_id="UDave.uk@SD">U&amp;Dave</channel>
-  <channel site="freeview.co.uk" site_id="64257#13008" lang="en" xmltv_id="UDaveJaVu.uk@SD">U&amp;DaveJaVu</channel>
+  <channel site="freeview.co.uk" site_id="64257#34624" lang="en" xmltv_id="UDaveJaVu.uk@SD">U&amp;DaveJaVu</channel>
   <channel site="freeview.co.uk" site_id="64257#22336" lang="en" xmltv_id="UDrama.uk@Plus1">U&amp;Drama+1</channel>
   <channel site="freeview.co.uk" site_id="64257#16208" lang="en" xmltv_id="UDrama.uk@SD">U&amp;Drama</channel>
   <channel site="freeview.co.uk" site_id="64257#19968" lang="en" xmltv_id="UEden.uk@SD">U&amp;Eden</channel>
-  <channel site="freeview.co.uk" site_id="64257#28096" lang="en" xmltv_id="UW.uk@SD">U&amp;W</channel>
+  <channel site="freeview.co.uk" site_id="64424#20096" lang="en" xmltv_id="UTV.uk@HD">UTV HD</channel>
+  <channel site="freeview.co.uk" site_id="64424#8376" lang="en" xmltv_id="UTV.uk@Plus1">UTV+1</channel>
+  <channel site="freeview.co.uk" site_id="64424#8276" lang="en" xmltv_id="UTV.uk@SD">UTV</channel>
+  <channel site="freeview.co.uk" site_id="64257#12298" lang="en" xmltv_id="UW.uk@SD">U&amp;W</channel>
   <channel site="freeview.co.uk" site_id="64257#25792" lang="en" xmltv_id="UYesterday.uk@SD">U&amp;Yesterday</channel>
   <channel site="freeview.co.uk" site_id="64257#14464" lang="en" xmltv_id="WildEarth.uk@SD">WildEarth</channel>
-  <channel site="freeview.co.uk" site_id="64257#34368" lang="en" xmltv_id="YAAAS.uk">YAAAS!</channel>
 </channels>

--- a/sites/freeview.co.uk/freeview.co.uk.config.js
+++ b/sites/freeview.co.uk/freeview.co.uk.config.js
@@ -36,18 +36,25 @@ module.exports = {
     return programs
   },
   async channels() {
-    const networkId = '64257' // Great London
     const startTimestamp = dayjs.utc().startOf('d').unix()
-    const data = await axios
-      .get(`https://www.freeview.co.uk/api/tv-guide?nid=${networkId}&start=${startTimestamp}`)
-      .then(r => r.data)
-      .catch(console.log)
+    let channels = []
+    for (let networkId = 64257; networkId <= 64425; networkId++) { // loop through all valid networkIds starting from 64257 (Greater London) to 64425 (Belfast) to ensure we can get all the channels available on freeview
+      console.log(networkId)
+      const data = await axios
+        .get(`https://www.freeview.co.uk/api/tv-guide?nid=${networkId}&start=${startTimestamp}`)
+        .then(r => r.data)
+        .catch(console.log)
 
-    return data.data.programs.map(item => ({
-      lang: 'en',
-      site_id: `${networkId}#${item.service_id}`,
-      name: item.title
-    }))
+      channels = channels.concat(data.data.programs.map(item => ({
+        lang: 'en',
+        site_id: `${networkId}#${item.service_id}`,
+        name: item.title
+      })))
+    }
+    const uniqueServiceIds = Array.from(new Set(channels.map(c => c.site_id.split('#')[1])))
+    return uniqueServiceIds.map(serviceId => {
+      return channels.find(c => c.site_id.split('#')[1] === serviceId)
+    })
   }
 }
 


### PR DESCRIPTION
this change builds one massive freeview TV guide for the entire uk, as it merges the guide for every region/transmitter group into one single guide, i have tried my best to remove duplicate channels from the guide, but, specifically with the bbc shifting some of their IDs for some regions, and 'that's tv' owning nearly all the local tv licences in the UK, it is impossible to remove all duplicates, fixes some issues reintroduced by 68ba06b6cb75f7b55c37b98aeb86482cc7bd8ef7 to do with local tv/radio (#2713), this also updates the guide to the latest as of 22-4-2026