### PR TITLE
Fix `visionplus.id` categories and update channels.

### DIFF
--- a/sites/visionplus.id/visionplus.id.config.js
+++ b/sites/visionplus.id/visionplus.id.config.js
@@ -36,7 +36,7 @@ module.exports = {
           programs.push({
             title,
             description: ev.con && ev.con.loc ? ev.con.loc[0].syn : null,
-            categories: ev.con ? ev.con.categories : null,
+            categories: ev.con ? parseCategories(ev.con.categories) : null,
             season: season ? parseInt(season) : season,
             episode: episode ? parseInt(episode) : episode,
             start: dayjs(ev.sta),
@@ -52,7 +52,9 @@ module.exports = {
     const result = []
     const axios = require('axios')
     const json = await axios
-      .get(`https://www.visionplus.id/managetv/tvinfo/channels/get?language=${languages[lang]}`)
+      .get(`https://www.visionplus.id/managetv/tvinfo/channels/get?language=${
+        languages[lang]
+      }&partition=IndonesiaPartition&region=Indonesia`)
       .then(response => response.data)
       .catch(console.error)
 
@@ -68,4 +70,23 @@ module.exports = {
 
     return result
   }
+}
+
+function parseCategories(categories) {
+  if (Array.isArray(categories)) {
+    const f = s => (s.match(/\//g) || []).length
+    const cat = [...categories]
+      .sort((a, b) => f(a) - f(b))
+      .map(a => a.split('/'))
+    categories = []
+    for (const a of cat) {
+      for (const b of a) {
+        if (!categories.includes(b)) {
+          categories.push(b)
+        }
+      }
+    }
+  }
+
+  return categories
 }

--- a/sites/visionplus.id/visionplus.id.test.js
+++ b/sites/visionplus.id/visionplus.id.test.js
@@ -42,6 +42,7 @@ it('can parse response', () => {
     title: 'FBI: Most Wanted S4, Ep 18',
     description:
       'After two agents from the Bureau of Land Management go missing while executing a land seizure warrant in Wyoming, the Fugitive Task Force heads west to track them down in an unwelcoming county.',
+    categories: ['Series', 'Thriller'],
     season: 4,
     episode: 18
   })
@@ -60,6 +61,7 @@ it('can parse response', () => {
     title: 'FBI: Most Wanted S4, Ep 18',
     description:
       'Satgas Buronan pergi ke wilayah barat untuk melacak keberadaan dua petugas Biro Pengelolaan Lahan yang menghilang saat menjalankan perintah penyitaan lahan di negara bagian yang tak ramah, Wyoming.',
+    categories: ['Series', 'Thriller'],
     season: 4,
     episode: 18
   })

--- a/sites/visionplus.id/visionplus.id_en.channels.xml
+++ b/sites/visionplus.id/visionplus.id_en.channels.xml
@@ -1,25 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="visionplus.id" site_id="00000000000000000008" lang="en" xmltv_id="">SCTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000009" lang="en" xmltv_id="">Indosiar</channel>
-  <channel site="visionplus.id" site_id="00000000000000000016" lang="en" xmltv_id="">TVRI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000019" lang="en" xmltv_id="">Moji</channel>
-  <channel site="visionplus.id" site_id="00000000000000000020" lang="en" xmltv_id="">Mentari TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000054" lang="en" xmltv_id="">Studio Universal</channel>
-  <channel site="visionplus.id" site_id="00000000000000000057" lang="en" xmltv_id="">Moonbug</channel>
-  <channel site="visionplus.id" site_id="00000000000000000068" lang="en" xmltv_id="">HITS Now</channel>
-  <channel site="visionplus.id" site_id="00000000000000000069" lang="en" xmltv_id="">Formosa</channel>
-  <channel site="visionplus.id" site_id="00000000000000000070" lang="en" xmltv_id="">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000089" lang="en" xmltv_id="">Hanacaraka TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000114" lang="en" xmltv_id="">Sportstars 3</channel>
-  <channel site="visionplus.id" site_id="00000000000000000123" lang="en" xmltv_id="">beIN SPORTS 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000125" lang="en" xmltv_id="">beIN SPORTS 4</channel>
-  <channel site="visionplus.id" site_id="00000000000000000126" lang="en" xmltv_id="">beIN SPORTS 5</channel>
   <channel site="visionplus.id" site_id="00000000000000000201" lang="en" xmltv_id="">RCTI World</channel>
   <channel site="visionplus.id" site_id="00000000000000000202" lang="en" xmltv_id="">GTV World</channel>
   <channel site="visionplus.id" site_id="00000000000000000203" lang="en" xmltv_id="">MNCTV World</channel>
   <channel site="visionplus.id" site_id="00000000000000000204" lang="en" xmltv_id="">Drama World</channel>
-  <channel site="visionplus.id" site_id="00000000000000000205" lang="en" xmltv_id="">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001002" lang="en" xmltv_id="">V+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001008" lang="en" xmltv_id="">R+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001010" lang="en" xmltv_id="">V+ LIVE 2</channel>
@@ -44,7 +29,10 @@
   <channel site="visionplus.id" site_id="00000000000000000102" lang="en" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
   <channel site="visionplus.id" site_id="00000000000000000130" lang="en" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
   <channel site="visionplus.id" site_id="00000000000000000122" lang="en" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000123" lang="en" xmltv_id="beINSports2.qa@MENA">beIN SPORTS 2</channel>
   <channel site="visionplus.id" site_id="00000000000000000124" lang="en" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000125" lang="en" xmltv_id="beINSports4.qa@MENA">beIN SPORTS 4</channel>
+  <channel site="visionplus.id" site_id="00000000000000000126" lang="en" xmltv_id="beINSports5.qa@MENA">beIN SPORTS 5</channel>
   <channel site="visionplus.id" site_id="00000000000000000133" lang="en" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
   <channel site="visionplus.id" site_id="00000000000000000015" lang="en" xmltv_id="BTV.id@SD">BTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000058" lang="en" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
@@ -75,6 +63,7 @@
   <channel site="visionplus.id" site_id="00000000000000000121" lang="en" xmltv_id="FightSports.us@SD">Fight Sports</channel>
   <channel site="visionplus.id" site_id="00000000000000000132" lang="en" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
   <channel site="visionplus.id" site_id="00000000000000000147" lang="en" xmltv_id="France24.fr@English">France 24</channel>
+  <channel site="visionplus.id" site_id="00000000000000000069" lang="en" xmltv_id="FTV.tw@SD">Formosa</channel>
   <channel site="visionplus.id" site_id="00000000000000000049" lang="en" xmltv_id="Galaxy.id@SD">GALAXY</channel>
   <channel site="visionplus.id" site_id="00000000000000000048" lang="en" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
   <channel site="visionplus.id" site_id="00000000000000000103" lang="en" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
@@ -82,9 +71,11 @@
   <channel site="visionplus.id" site_id="00000000000000000104" lang="en" xmltv_id="HistoryAsia.us@SD">History</channel>
   <channel site="visionplus.id" site_id="00000000000000000077" lang="en" xmltv_id="HITS.sg@SD">Hits</channel>
   <channel site="visionplus.id" site_id="00000000000000000042" lang="en" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000068" lang="en" xmltv_id="HITSNOW.sg@SD">HITS Now</channel>
   <channel site="visionplus.id" site_id="00000000000000000160" lang="en" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000134" lang="en" xmltv_id="IDXChannel.id@SD">IDX</channel>
   <channel site="visionplus.id" site_id="00000000000000000050" lang="en" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
+  <channel site="visionplus.id" site_id="00000000000000000009" lang="en" xmltv_id="Indosiar.id@SD">Indosiar</channel>
   <channel site="visionplus.id" site_id="00000000000000000004" lang="en" xmltv_id="iNews.id@SD">iNews</channel>
   <channel site="visionplus.id" site_id="00000000000000000025" lang="en" xmltv_id="JakTV.id@SD">JAK TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000161" lang="en" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
@@ -95,8 +86,11 @@
   <channel site="visionplus.id" site_id="00000000000000000138" lang="en" xmltv_id="Life.id@SD">LIFE</channel>
   <channel site="visionplus.id" site_id="00000000000000000080" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
   <channel site="visionplus.id" site_id="00000000000000000105" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000020" lang="en" xmltv_id="MentariTV.id@SD">Mentari TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000014" lang="en" xmltv_id="MetroTV.id@SD">Metro TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000002" lang="en" xmltv_id="MNCTV.id@SD">MNCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000019" lang="en" xmltv_id="Moji.id@SD">Moji</channel>
+  <channel site="visionplus.id" site_id="00000000000000000057" lang="en" xmltv_id="MoonbugKids.uk@SD">Moonbug</channel>
   <channel site="visionplus.id" site_id="00000000000000000142" lang="en" xmltv_id="MusicTV.id@SD">Music TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000137" lang="en" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000023" lang="en" xmltv_id="NET.id@SD">MDTV</channel>
@@ -113,12 +107,17 @@
   <channel site="visionplus.id" site_id="00000000000000000092" lang="en" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
   <channel site="visionplus.id" site_id="00000000000000000093" lang="en" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
   <channel site="visionplus.id" site_id="00000000000000000150" lang="en" xmltv_id="RT.ru@SD">RT</channel>
+  <channel site="visionplus.id" site_id="00000000000000000008" lang="en" xmltv_id="SCTV.id@SD">SCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000070" lang="en" xmltv_id="SETTaiwan.tw@SD">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000005" lang="en" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
   <channel site="visionplus.id" site_id="00000000000000000115" lang="en" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
   <channel site="visionplus.id" site_id="00000000000000000113" lang="en" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000114" lang="en" xmltv_id="Sportstars3.id@SD">Sportstars 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000205" lang="en" xmltv_id="Sportstars3.id@SD">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000000112" lang="en" xmltv_id="Sportstars.id@SD">Sportstars</channel>
   <channel site="visionplus.id" site_id="00000000000000000120" lang="en" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
   <channel site="visionplus.id" site_id="00000000000000000119" lang="en" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
+  <channel site="visionplus.id" site_id="00000000000000000054" lang="en" xmltv_id="StudioUniversalLatinAmerica.us@Brazil">Studio Universal</channel>
   <channel site="visionplus.id" site_id="00000000000000000041" lang="en" xmltv_id="Thrill.hk@SD">Thrill</channel>
   <channel site="visionplus.id" site_id="00000000000000000007" lang="en" xmltv_id="Trans7.id@SD">Trans 7</channel>
   <channel site="visionplus.id" site_id="00000000000000000006" lang="en" xmltv_id="TransTV.id@SD">Trans TV</channel>
@@ -129,6 +128,7 @@
   <channel site="visionplus.id" site_id="00000000000000000073" lang="en" xmltv_id="tvNAsia.hk@SD">TVN</channel>
   <channel site="visionplus.id" site_id="00000000000000000046" lang="en" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
   <channel site="visionplus.id" site_id="00000000000000000012" lang="en" xmltv_id="tvOne.id@SD">TVOne</channel>
+  <channel site="visionplus.id" site_id="00000000000000000016" lang="en" xmltv_id="TVRI.id@SD">TVRI</channel>
   <channel site="visionplus.id" site_id="00000000000000000087" lang="en" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
   <channel site="visionplus.id" site_id="00000000000000000158" lang="en" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000047" lang="en" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>

--- a/sites/visionplus.id/visionplus.id_en.channels.xml
+++ b/sites/visionplus.id/visionplus.id_en.channels.xml
@@ -86,6 +86,7 @@
   <channel site="visionplus.id" site_id="00000000000000000138" lang="en" xmltv_id="Life.id@SD">LIFE</channel>
   <channel site="visionplus.id" site_id="00000000000000000080" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
   <channel site="visionplus.id" site_id="00000000000000000105" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000023" lang="en" xmltv_id="MDTV.id@HD">MDTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000020" lang="en" xmltv_id="MentariTV.id@SD">Mentari TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000014" lang="en" xmltv_id="MetroTV.id@SD">Metro TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000002" lang="en" xmltv_id="MNCTV.id@SD">MNCTV</channel>
@@ -93,7 +94,6 @@
   <channel site="visionplus.id" site_id="00000000000000000057" lang="en" xmltv_id="MoonbugKids.uk@SD">Moonbug</channel>
   <channel site="visionplus.id" site_id="00000000000000000142" lang="en" xmltv_id="MusicTV.id@SD">Music TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000137" lang="en" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000023" lang="en" xmltv_id="NET.id@SD">MDTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000162" lang="en" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
   <channel site="visionplus.id" site_id="00000000000000000076" lang="en" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
   <channel site="visionplus.id" site_id="00000000000000000064" lang="en" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>

--- a/sites/visionplus.id/visionplus.id_en.channels.xml
+++ b/sites/visionplus.id/visionplus.id_en.channels.xml
@@ -1,123 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="visionplus.id" site_id="00000000000000000001" lang="en" xmltv_id="RCTI.id@SD">RCTI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000002" lang="en" xmltv_id="MNCTV.id@SD">MNCTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000003" lang="en" xmltv_id="GTV.id@SD">GTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000004" lang="en" xmltv_id="iNews.id@SD">iNews</channel>
-  <channel site="visionplus.id" site_id="00000000000000000005" lang="en" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
-  <channel site="visionplus.id" site_id="00000000000000000006" lang="en" xmltv_id="TransTV.id@SD">Trans TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000007" lang="en" xmltv_id="Trans7.id@SD">Trans 7</channel>
-  <channel site="visionplus.id" site_id="00000000000000000010" lang="en" xmltv_id="ANTV.id@SD">ANTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000011" lang="en" xmltv_id="RajawaliTV.id@SD">RTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000012" lang="en" xmltv_id="tvOne.id@SD">TVOne</channel>
-  <channel site="visionplus.id" site_id="00000000000000000013" lang="en" xmltv_id="KompasTV.id@SD">Kompas TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000014" lang="en" xmltv_id="MetroTV.id@SD">Metro TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000015" lang="en" xmltv_id="BTV.id@SD">BTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000008" lang="en" xmltv_id="">SCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000009" lang="en" xmltv_id="">Indosiar</channel>
   <channel site="visionplus.id" site_id="00000000000000000016" lang="en" xmltv_id="">TVRI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000017" lang="en" xmltv_id="SEAToday.id@SD">SEA Today</channel>
-  <channel site="visionplus.id" site_id="00000000000000000018" lang="en" xmltv_id="DAAITV.id@SD">DAAI TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000023" lang="en" xmltv_id="NET.id@SD">Net TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000024" lang="en" xmltv_id="JTV.id@SD">JTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000025" lang="en" xmltv_id="JakTV.id@SD">JAK TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000026" lang="en" xmltv_id="BaliTV.id@SD">Bali TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000027" lang="en" xmltv_id="BandungTV.id@SD">Bandung TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000028" lang="en" xmltv_id="TV9Nusantara.id@SD">TV 9</channel>
-  <channel site="visionplus.id" site_id="00000000000000000029" lang="en" xmltv_id="TawafTV.id@SD">Tawaf</channel>
-  <channel site="visionplus.id" site_id="00000000000000000030" lang="en" xmltv_id="TVMu.id@SD">TV MU</channel>
-  <channel site="visionplus.id" site_id="00000000000000000036" lang="en" xmltv_id="Cinemachi.uk@SD">Cinemachi</channel>
-  <channel site="visionplus.id" site_id="00000000000000000037" lang="en" xmltv_id="CinemachiKids.uk@SD">Cinemachi Kids</channel>
-  <channel site="visionplus.id" site_id="00000000000000000038" lang="en" xmltv_id="CinemachiXtra.uk@SD">Cinemachi Xtra</channel>
-  <channel site="visionplus.id" site_id="00000000000000000039" lang="en" xmltv_id="CinemachiMax.uk@SD">Cinemachi Max</channel>
-  <channel site="visionplus.id" site_id="00000000000000000040" lang="en" xmltv_id="CinemachiAction.uk@SD">Cinemachi Action</channel>
-  <channel site="visionplus.id" site_id="00000000000000000041" lang="en" xmltv_id="Thrill.hk@SD">Thrill</channel>
-  <channel site="visionplus.id" site_id="00000000000000000042" lang="en" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000044" lang="en" xmltv_id="CelestialMoviesIndonesia.id@SD">Celestial Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000045" lang="en" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000046" lang="en" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000047" lang="en" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>
-  <channel site="visionplus.id" site_id="00000000000000000048" lang="en" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000049" lang="en" xmltv_id="Galaxy.id@SD">GALAXY</channel>
-  <channel site="visionplus.id" site_id="00000000000000000050" lang="en" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
-  <channel site="visionplus.id" site_id="00000000000000000051" lang="en" xmltv_id="MyFamily.id@SD">My Family Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000052" lang="en" xmltv_id="MyCinema.id@SD">My Cinema</channel>
-  <channel site="visionplus.id" site_id="00000000000000000053" lang="en" xmltv_id="MyCinemaAsia.id@SD">My Cinema Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000056" lang="en" xmltv_id="KidsTV.id@SD">Kids TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000019" lang="en" xmltv_id="">Moji</channel>
+  <channel site="visionplus.id" site_id="00000000000000000020" lang="en" xmltv_id="">Mentari TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000054" lang="en" xmltv_id="">Studio Universal</channel>
   <channel site="visionplus.id" site_id="00000000000000000057" lang="en" xmltv_id="">Moonbug</channel>
-  <channel site="visionplus.id" site_id="00000000000000000058" lang="en" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000060" lang="en" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
-  <channel site="visionplus.id" site_id="00000000000000000063" lang="en" xmltv_id="ZooMoo.sg@SD">Zoo Moo</channel>
-  <channel site="visionplus.id" site_id="00000000000000000064" lang="en" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>
-  <channel site="visionplus.id" site_id="00000000000000000065" lang="en" xmltv_id="AnimaxAsia.sg@SD">Animax</channel>
-  <channel site="visionplus.id" site_id="00000000000000000066" lang="en" xmltv_id="MyKidz.id@SD">My Kidz</channel>
-  <channel site="visionplus.id" site_id="00000000000000000067" lang="en" xmltv_id="DreamWorksChannelAsia.us@SD">Dream Works</channel>
-  <channel site="visionplus.id" site_id="00000000000000000071" lang="en" xmltv_id="OKTV.id@SD">Food Travel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000072" lang="en" xmltv_id="Entertainment.id@SD">Entertainment</channel>
-  <channel site="visionplus.id" site_id="00000000000000000073" lang="en" xmltv_id="tvNAsia.hk@SD">TVN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000074" lang="en" xmltv_id="ONE.sg@SD">One</channel>
-  <channel site="visionplus.id" site_id="00000000000000000075" lang="en" xmltv_id="KIX.hk@SD">Kix</channel>
-  <channel site="visionplus.id" site_id="00000000000000000076" lang="en" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
-  <channel site="visionplus.id" site_id="00000000000000000077" lang="en" xmltv_id="HITS.sg@SD">Hits</channel>
-  <channel site="visionplus.id" site_id="00000000000000000079" lang="en" xmltv_id="AXNAsia.sg@Indonesia">AXN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000080" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
-  <channel site="visionplus.id" site_id="00000000000000000081" lang="en" xmltv_id="FMN.id@SD">FMN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000087" lang="en" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
-  <channel site="visionplus.id" site_id="00000000000000000088" lang="en" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000068" lang="en" xmltv_id="">HITS Now</channel>
+  <channel site="visionplus.id" site_id="00000000000000000069" lang="en" xmltv_id="">Formosa</channel>
+  <channel site="visionplus.id" site_id="00000000000000000070" lang="en" xmltv_id="">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000089" lang="en" xmltv_id="">Hanacaraka TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000092" lang="en" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
-  <channel site="visionplus.id" site_id="00000000000000000093" lang="en" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
-  <channel site="visionplus.id" site_id="00000000000000000095" lang="en" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime Investigation</channel>
-  <channel site="visionplus.id" site_id="00000000000000000101" lang="en" xmltv_id="OutdoorChannel.us@SD">Outdoor Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000102" lang="en" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
-  <channel site="visionplus.id" site_id="00000000000000000103" lang="en" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
-  <channel site="visionplus.id" site_id="00000000000000000104" lang="en" xmltv_id="HistoryAsia.us@SD">History</channel>
-  <channel site="visionplus.id" site_id="00000000000000000105" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
-  <channel site="visionplus.id" site_id="00000000000000000112" lang="en" xmltv_id="Sportstars.id@SD">Sportstars</channel>
-  <channel site="visionplus.id" site_id="00000000000000000113" lang="en" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000115" lang="en" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000119" lang="en" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
-  <channel site="visionplus.id" site_id="00000000000000000120" lang="en" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000121" lang="en" xmltv_id="FightSports.us@SD">Fight Sports</channel>
-  <channel site="visionplus.id" site_id="00000000000000000122" lang="en" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000114" lang="en" xmltv_id="">Sportstars 3</channel>
   <channel site="visionplus.id" site_id="00000000000000000123" lang="en" xmltv_id="">beIN SPORTS 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000124" lang="en" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
   <channel site="visionplus.id" site_id="00000000000000000125" lang="en" xmltv_id="">beIN SPORTS 4</channel>
   <channel site="visionplus.id" site_id="00000000000000000126" lang="en" xmltv_id="">beIN SPORTS 5</channel>
-  <channel site="visionplus.id" site_id="00000000000000000130" lang="en" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
-  <channel site="visionplus.id" site_id="00000000000000000131" lang="en" xmltv_id="CNBCAsia.sg@SD">CNBC Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000132" lang="en" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
-  <channel site="visionplus.id" site_id="00000000000000000133" lang="en" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
-  <channel site="visionplus.id" site_id="00000000000000000134" lang="en" xmltv_id="IDXChannel.id@SD">IDX</channel>
-  <channel site="visionplus.id" site_id="00000000000000000137" lang="en" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000138" lang="en" xmltv_id="Life.id@SD">LIFE</channel>
-  <channel site="visionplus.id" site_id="00000000000000000139" lang="en" xmltv_id="Reformed21.id@SD">Reformed 21</channel>
-  <channel site="visionplus.id" site_id="00000000000000000142" lang="en" xmltv_id="MusicTV.id@SD">Music TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000143" lang="en" xmltv_id="MTVLive.uk@SD">MTV Live</channel>
-  <channel site="visionplus.id" site_id="00000000000000000144" lang="en" xmltv_id="MTV90s.uk@SD">MTV 90s</channel>
-  <channel site="visionplus.id" site_id="00000000000000000146" lang="en" xmltv_id="DW.de@English">DW</channel>
-  <channel site="visionplus.id" site_id="00000000000000000147" lang="en" xmltv_id="France24.fr@English">France 24</channel>
-  <channel site="visionplus.id" site_id="00000000000000000148" lang="en" xmltv_id="TRTWorld.tr@SD">TRT World</channel>
-  <channel site="visionplus.id" site_id="00000000000000000149" lang="en" xmltv_id="AlJazeera.qa@English">Aljazeera</channel>
-  <channel site="visionplus.id" site_id="00000000000000000150" lang="en" xmltv_id="RT.ru@SD">RT</channel>
-  <channel site="visionplus.id" site_id="00000000000000000151" lang="en" xmltv_id="EuronewsEnglish.fr@SD">EURONEWS</channel>
-  <channel site="visionplus.id" site_id="00000000000000000152" lang="en" xmltv_id="CNA.sg@SD">Channel News Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000153" lang="en" xmltv_id="AlQuranAlKareemTV.sa@SD">Al Quran Al Kareem</channel>
-  <channel site="visionplus.id" site_id="00000000000000000154" lang="en" xmltv_id="EWTN.us@AsiaPacific">EWTN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000155" lang="en" xmltv_id="CGTNDocumentary.cn@SD">CGTN Documentary</channel>
-  <channel site="visionplus.id" site_id="00000000000000000156" lang="en" xmltv_id="CGTN.cn@SD">CGTN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000157" lang="en" xmltv_id="AnhuiTV.cn@SD">Anhui</channel>
-  <channel site="visionplus.id" site_id="00000000000000000158" lang="en" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000159" lang="en" xmltv_id="DragonTV.cn@SD">Shanghai Dragon</channel>
-  <channel site="visionplus.id" site_id="00000000000000000160" lang="en" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000161" lang="en" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000162" lang="en" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
-  <channel site="visionplus.id" site_id="00000000000000000163" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5Monde</channel>
-  <channel site="visionplus.id" site_id="00000000000000000164" lang="en" xmltv_id="ArirangTV.kr@SD">Arirang</channel>
-  <channel site="visionplus.id" site_id="00000000000000000165" lang="en" xmltv_id="ABCAustralia.au@SD">ABC</channel>
-  <channel site="visionplus.id" site_id="00000000000000000206" lang="en" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000207" lang="en" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000251" lang="en" xmltv_id="DensFoodChannel.id@SD">DENS Food Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000252" lang="en" xmltv_id="DensPlay.id@SD">DENSPLAY Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000253" lang="en" xmltv_id="DensShowBiz.id@SD">DENS Showbizz Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000201" lang="en" xmltv_id="">RCTI World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000202" lang="en" xmltv_id="">GTV World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000203" lang="en" xmltv_id="">MNCTV World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000204" lang="en" xmltv_id="">Drama World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000205" lang="en" xmltv_id="">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001002" lang="en" xmltv_id="">V+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001008" lang="en" xmltv_id="">R+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001010" lang="en" xmltv_id="">V+ LIVE 2</channel>
@@ -125,4 +27,110 @@
   <channel site="visionplus.id" site_id="00000000000000001012" lang="en" xmltv_id="">V+ LIVE 3</channel>
   <channel site="visionplus.id" site_id="00000000000000001013" lang="en" xmltv_id="">V+ LIVE 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001014" lang="en" xmltv_id="">V+ LIVE 5</channel>
+  <channel site="visionplus.id" site_id="00000000000000001015" lang="en" xmltv_id="">V+ LIVE 6</channel>
+  <channel site="visionplus.id" site_id="00000000000000001016" lang="en" xmltv_id="">V+ LIVE 7</channel>
+  <channel site="visionplus.id" site_id="00000000000000001017" lang="en" xmltv_id="">V+ LIVE 8</channel>
+  <channel site="visionplus.id" site_id="00000000000000001018" lang="en" xmltv_id="">V+ LIVE 9</channel>
+  <channel site="visionplus.id" site_id="00000000000000000165" lang="en" xmltv_id="ABCAustralia.au@SD">ABC</channel>
+  <channel site="visionplus.id" site_id="00000000000000000149" lang="en" xmltv_id="AlJazeera.qa@English">Aljazeera</channel>
+  <channel site="visionplus.id" site_id="00000000000000000153" lang="en" xmltv_id="AlQuranAlKareemTV.sa@SD">Al Quran Al Kareem</channel>
+  <channel site="visionplus.id" site_id="00000000000000000157" lang="en" xmltv_id="AnhuiTV.cn@SD">Anhui</channel>
+  <channel site="visionplus.id" site_id="00000000000000000065" lang="en" xmltv_id="AnimaxAsia.sg@SD">Animax</channel>
+  <channel site="visionplus.id" site_id="00000000000000000010" lang="en" xmltv_id="ANTV.id@SD">ANTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000164" lang="en" xmltv_id="ArirangTV.kr@SD">Arirang</channel>
+  <channel site="visionplus.id" site_id="00000000000000000079" lang="en" xmltv_id="AXNAsia.sg@Indonesia">AXN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000026" lang="en" xmltv_id="BaliTV.id@SD">Bali TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000027" lang="en" xmltv_id="BandungTV.id@SD">Bandung TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000102" lang="en" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
+  <channel site="visionplus.id" site_id="00000000000000000130" lang="en" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
+  <channel site="visionplus.id" site_id="00000000000000000122" lang="en" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000124" lang="en" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000133" lang="en" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
+  <channel site="visionplus.id" site_id="00000000000000000015" lang="en" xmltv_id="BTV.id@SD">BTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000058" lang="en" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000088" lang="en" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000045" lang="en" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
+  <channel site="visionplus.id" site_id="00000000000000000044" lang="en" xmltv_id="CelestialMoviesIndonesia.id@SD">Celestial Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000156" lang="en" xmltv_id="CGTN.cn@SD">CGTN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000155" lang="en" xmltv_id="CGTNDocumentary.cn@SD">CGTN Documentary</channel>
+  <channel site="visionplus.id" site_id="00000000000000000036" lang="en" xmltv_id="Cinemachi.uk@SD">Originals</channel>
+  <channel site="visionplus.id" site_id="00000000000000000040" lang="en" xmltv_id="CinemachiAction.uk@SD">Cineedge</channel>
+  <channel site="visionplus.id" site_id="00000000000000000037" lang="en" xmltv_id="CinemachiKids.uk@SD">Buddy Star</channel>
+  <channel site="visionplus.id" site_id="00000000000000000039" lang="en" xmltv_id="CinemachiMax.uk@SD">Superrix</channel>
+  <channel site="visionplus.id" site_id="00000000000000000038" lang="en" xmltv_id="CinemachiXtra.uk@SD">Uniques</channel>
+  <channel site="visionplus.id" site_id="00000000000000000152" lang="en" xmltv_id="CNA.sg@SD">Channel News Asia</channel>
+  <channel site="visionplus.id" site_id="00000000000000000131" lang="en" xmltv_id="CNBCAsia.sg@SD">CNBC Asia</channel>
+  <channel site="visionplus.id" site_id="00000000000000000095" lang="en" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime Investigation</channel>
+  <channel site="visionplus.id" site_id="00000000000000000018" lang="en" xmltv_id="DAAITV.id@SD">DAAI TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000251" lang="en" xmltv_id="DensFoodChannel.id@SD">DENS Food Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000252" lang="en" xmltv_id="DensPlay.id@SD">DENSPLAY Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000253" lang="en" xmltv_id="DensShowBiz.id@SD">DENS Showbizz Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000029" lang="en" xmltv_id="DMITV.id@SD">DMI TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000159" lang="en" xmltv_id="DragonTV.cn@SD">Shanghai Dragon</channel>
+  <channel site="visionplus.id" site_id="00000000000000000067" lang="en" xmltv_id="DreamWorksChannelAsia.us@SD">Dream Works</channel>
+  <channel site="visionplus.id" site_id="00000000000000000146" lang="en" xmltv_id="DW.de@English">DW</channel>
+  <channel site="visionplus.id" site_id="00000000000000000072" lang="en" xmltv_id="Entertainment.id@SD">Entertainment</channel>
+  <channel site="visionplus.id" site_id="00000000000000000151" lang="en" xmltv_id="EuronewsEnglish.fr@SD">EURONEWS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000154" lang="en" xmltv_id="EWTN.us@AsiaPacific">EWTN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000121" lang="en" xmltv_id="FightSports.us@SD">Fight Sports</channel>
+  <channel site="visionplus.id" site_id="00000000000000000132" lang="en" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
+  <channel site="visionplus.id" site_id="00000000000000000147" lang="en" xmltv_id="France24.fr@English">France 24</channel>
+  <channel site="visionplus.id" site_id="00000000000000000049" lang="en" xmltv_id="Galaxy.id@SD">GALAXY</channel>
+  <channel site="visionplus.id" site_id="00000000000000000048" lang="en" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
+  <channel site="visionplus.id" site_id="00000000000000000103" lang="en" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
+  <channel site="visionplus.id" site_id="00000000000000000003" lang="en" xmltv_id="GTV.id@SD">GTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000104" lang="en" xmltv_id="HistoryAsia.us@SD">History</channel>
+  <channel site="visionplus.id" site_id="00000000000000000077" lang="en" xmltv_id="HITS.sg@SD">Hits</channel>
+  <channel site="visionplus.id" site_id="00000000000000000042" lang="en" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000160" lang="en" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000134" lang="en" xmltv_id="IDXChannel.id@SD">IDX</channel>
+  <channel site="visionplus.id" site_id="00000000000000000050" lang="en" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
+  <channel site="visionplus.id" site_id="00000000000000000004" lang="en" xmltv_id="iNews.id@SD">iNews</channel>
+  <channel site="visionplus.id" site_id="00000000000000000025" lang="en" xmltv_id="JakTV.id@SD">JAK TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000161" lang="en" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000024" lang="en" xmltv_id="JTV.id@SD">JTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000056" lang="en" xmltv_id="KidsTV.id@SD">Kids TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000075" lang="en" xmltv_id="KIX.hk@SD">Kix</channel>
+  <channel site="visionplus.id" site_id="00000000000000000013" lang="en" xmltv_id="KompasTV.id@SD">Kompas TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000138" lang="en" xmltv_id="Life.id@SD">LIFE</channel>
+  <channel site="visionplus.id" site_id="00000000000000000080" lang="en" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
+  <channel site="visionplus.id" site_id="00000000000000000105" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000014" lang="en" xmltv_id="MetroTV.id@SD">Metro TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000002" lang="en" xmltv_id="MNCTV.id@SD">MNCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000142" lang="en" xmltv_id="MusicTV.id@SD">Music TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000137" lang="en" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000023" lang="en" xmltv_id="NET.id@SD">MDTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000162" lang="en" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
+  <channel site="visionplus.id" site_id="00000000000000000076" lang="en" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
+  <channel site="visionplus.id" site_id="00000000000000000064" lang="en" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>
+  <channel site="visionplus.id" site_id="00000000000000000060" lang="en" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
+  <channel site="visionplus.id" site_id="00000000000000000071" lang="en" xmltv_id="OKTV.id@SD">Food Travel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000074" lang="en" xmltv_id="ONE.sg@SD">One</channel>
+  <channel site="visionplus.id" site_id="00000000000000000101" lang="en" xmltv_id="OutdoorChannel.us@SD">Outdoor Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000011" lang="en" xmltv_id="RajawaliTV.id@SD">RTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000001" lang="en" xmltv_id="RCTI.id@SD">RCTI</channel>
+  <channel site="visionplus.id" site_id="00000000000000000139" lang="en" xmltv_id="Reformed21.id@SD">Reformed 21</channel>
+  <channel site="visionplus.id" site_id="00000000000000000092" lang="en" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
+  <channel site="visionplus.id" site_id="00000000000000000093" lang="en" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
+  <channel site="visionplus.id" site_id="00000000000000000150" lang="en" xmltv_id="RT.ru@SD">RT</channel>
+  <channel site="visionplus.id" site_id="00000000000000000005" lang="en" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
+  <channel site="visionplus.id" site_id="00000000000000000115" lang="en" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000113" lang="en" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000112" lang="en" xmltv_id="Sportstars.id@SD">Sportstars</channel>
+  <channel site="visionplus.id" site_id="00000000000000000120" lang="en" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000119" lang="en" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
+  <channel site="visionplus.id" site_id="00000000000000000041" lang="en" xmltv_id="Thrill.hk@SD">Thrill</channel>
+  <channel site="visionplus.id" site_id="00000000000000000007" lang="en" xmltv_id="Trans7.id@SD">Trans 7</channel>
+  <channel site="visionplus.id" site_id="00000000000000000006" lang="en" xmltv_id="TransTV.id@SD">Trans TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000148" lang="en" xmltv_id="TRTWorld.tr@SD">TRT World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000163" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5Monde</channel>
+  <channel site="visionplus.id" site_id="00000000000000000028" lang="en" xmltv_id="TV9Nusantara.id@SD">TV 9</channel>
+  <channel site="visionplus.id" site_id="00000000000000000030" lang="en" xmltv_id="TVMu.id@SD">TV MU</channel>
+  <channel site="visionplus.id" site_id="00000000000000000073" lang="en" xmltv_id="tvNAsia.hk@SD">TVN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000046" lang="en" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000012" lang="en" xmltv_id="tvOne.id@SD">TVOne</channel>
+  <channel site="visionplus.id" site_id="00000000000000000087" lang="en" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
+  <channel site="visionplus.id" site_id="00000000000000000158" lang="en" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000047" lang="en" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>
+  <channel site="visionplus.id" site_id="00000000000000000063" lang="en" xmltv_id="ZooMoo.sg@SD">Zoo Moo</channel>
 </channels>

--- a/sites/visionplus.id/visionplus.id_id.channels.xml
+++ b/sites/visionplus.id/visionplus.id_id.channels.xml
@@ -1,123 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="visionplus.id" site_id="00000000000000000001" lang="id" xmltv_id="RCTI.id@SD">RCTI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000002" lang="id" xmltv_id="MNCTV.id@SD">MNCTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000003" lang="id" xmltv_id="GTV.id@SD">GTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000004" lang="id" xmltv_id="iNews.id@SD">iNews</channel>
-  <channel site="visionplus.id" site_id="00000000000000000005" lang="id" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
-  <channel site="visionplus.id" site_id="00000000000000000006" lang="id" xmltv_id="TransTV.id@SD">Trans TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000007" lang="id" xmltv_id="Trans7.id@SD">Trans 7</channel>
-  <channel site="visionplus.id" site_id="00000000000000000010" lang="id" xmltv_id="ANTV.id@SD">ANTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000011" lang="id" xmltv_id="RajawaliTV.id@SD">RTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000012" lang="id" xmltv_id="tvOne.id@SD">TVOne</channel>
-  <channel site="visionplus.id" site_id="00000000000000000013" lang="id" xmltv_id="KompasTV.id@SD">Kompas TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000014" lang="id" xmltv_id="MetroTV.id@SD">Metro TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000015" lang="id" xmltv_id="BTV.id@SD">BTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000008" lang="id" xmltv_id="">SCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000009" lang="id" xmltv_id="">Indosiar</channel>
   <channel site="visionplus.id" site_id="00000000000000000016" lang="id" xmltv_id="">TVRI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000017" lang="id" xmltv_id="SEAToday.id@SD">SEA Today</channel>
-  <channel site="visionplus.id" site_id="00000000000000000018" lang="id" xmltv_id="DAAITV.id@SD">DAAI TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000023" lang="id" xmltv_id="NET.id@SD">Net TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000024" lang="id" xmltv_id="JTV.id@SD">JTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000025" lang="id" xmltv_id="JakTV.id@SD">JAK TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000026" lang="id" xmltv_id="BaliTV.id@SD">Bali TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000027" lang="id" xmltv_id="BandungTV.id@SD">Bandung TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000028" lang="id" xmltv_id="TV9Nusantara.id@SD">TV 9</channel>
-  <channel site="visionplus.id" site_id="00000000000000000029" lang="id" xmltv_id="TawafTV.id@SD">Tawaf</channel>
-  <channel site="visionplus.id" site_id="00000000000000000030" lang="id" xmltv_id="TVMu.id@SD">TV MU</channel>
-  <channel site="visionplus.id" site_id="00000000000000000036" lang="id" xmltv_id="Cinemachi.uk@SD">Cinemachi</channel>
-  <channel site="visionplus.id" site_id="00000000000000000037" lang="id" xmltv_id="CinemachiKids.uk@SD">Cinemachi Kids</channel>
-  <channel site="visionplus.id" site_id="00000000000000000038" lang="id" xmltv_id="CinemachiXtra.uk@SD">Cinemachi Xtra</channel>
-  <channel site="visionplus.id" site_id="00000000000000000039" lang="id" xmltv_id="CinemachiMax.uk@SD">Cinemachi Max</channel>
-  <channel site="visionplus.id" site_id="00000000000000000040" lang="id" xmltv_id="CinemachiAction.uk@SD">Cinemachi Action</channel>
-  <channel site="visionplus.id" site_id="00000000000000000041" lang="id" xmltv_id="Thrill.hk@SD">Thrill</channel>
-  <channel site="visionplus.id" site_id="00000000000000000042" lang="id" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000044" lang="id" xmltv_id="CelestialMoviesIndonesia.id@SD">Celestial Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000045" lang="id" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000046" lang="id" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000047" lang="id" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>
-  <channel site="visionplus.id" site_id="00000000000000000048" lang="id" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000049" lang="id" xmltv_id="Galaxy.id@SD">GALAXY</channel>
-  <channel site="visionplus.id" site_id="00000000000000000050" lang="id" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
-  <channel site="visionplus.id" site_id="00000000000000000051" lang="id" xmltv_id="MyFamily.id@SD">My Family Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000052" lang="id" xmltv_id="MyCinema.id@SD">My Cinema</channel>
-  <channel site="visionplus.id" site_id="00000000000000000053" lang="id" xmltv_id="MyCinemaAsia.id@SD">My Cinema Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000056" lang="id" xmltv_id="KidsTV.id@SD">Kids TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000019" lang="id" xmltv_id="">Moji</channel>
+  <channel site="visionplus.id" site_id="00000000000000000020" lang="id" xmltv_id="">Mentari TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000054" lang="id" xmltv_id="">Studio Universal</channel>
   <channel site="visionplus.id" site_id="00000000000000000057" lang="id" xmltv_id="">Moonbug</channel>
-  <channel site="visionplus.id" site_id="00000000000000000058" lang="id" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
-  <channel site="visionplus.id" site_id="00000000000000000060" lang="id" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
-  <channel site="visionplus.id" site_id="00000000000000000063" lang="id" xmltv_id="ZooMoo.sg@SD">Zoo Moo</channel>
-  <channel site="visionplus.id" site_id="00000000000000000064" lang="id" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>
-  <channel site="visionplus.id" site_id="00000000000000000065" lang="id" xmltv_id="AnimaxAsia.sg@SD">Animax</channel>
-  <channel site="visionplus.id" site_id="00000000000000000066" lang="id" xmltv_id="MyKidz.id@SD">My Kidz</channel>
-  <channel site="visionplus.id" site_id="00000000000000000067" lang="id" xmltv_id="DreamWorksChannelAsia.us@SD">Dream Works</channel>
-  <channel site="visionplus.id" site_id="00000000000000000071" lang="id" xmltv_id="OKTV.id@SD">Food Travel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000072" lang="id" xmltv_id="Entertainment.id@SD">Entertainment</channel>
-  <channel site="visionplus.id" site_id="00000000000000000073" lang="id" xmltv_id="tvNAsia.hk@SD">TVN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000074" lang="id" xmltv_id="ONE.sg@SD">One</channel>
-  <channel site="visionplus.id" site_id="00000000000000000075" lang="id" xmltv_id="KIX.hk@SD">Kix</channel>
-  <channel site="visionplus.id" site_id="00000000000000000076" lang="id" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
-  <channel site="visionplus.id" site_id="00000000000000000077" lang="id" xmltv_id="HITS.sg@SD">Hits</channel>
-  <channel site="visionplus.id" site_id="00000000000000000079" lang="id" xmltv_id="AXNAsia.sg@Indonesia">AXN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000080" lang="id" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
-  <channel site="visionplus.id" site_id="00000000000000000081" lang="id" xmltv_id="FMN.id@SD">FMN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000087" lang="id" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
-  <channel site="visionplus.id" site_id="00000000000000000088" lang="id" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000068" lang="id" xmltv_id="">HITS Now</channel>
+  <channel site="visionplus.id" site_id="00000000000000000069" lang="id" xmltv_id="">Formosa</channel>
+  <channel site="visionplus.id" site_id="00000000000000000070" lang="id" xmltv_id="">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000089" lang="id" xmltv_id="">Hanacaraka TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000092" lang="id" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
-  <channel site="visionplus.id" site_id="00000000000000000093" lang="id" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
-  <channel site="visionplus.id" site_id="00000000000000000095" lang="id" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime Investigation</channel>
-  <channel site="visionplus.id" site_id="00000000000000000101" lang="id" xmltv_id="OutdoorChannel.us@SD">Outdoor Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000102" lang="id" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
-  <channel site="visionplus.id" site_id="00000000000000000103" lang="id" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
-  <channel site="visionplus.id" site_id="00000000000000000104" lang="id" xmltv_id="HistoryAsia.us@SD">History</channel>
-  <channel site="visionplus.id" site_id="00000000000000000105" lang="id" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
-  <channel site="visionplus.id" site_id="00000000000000000112" lang="id" xmltv_id="Sportstars.id@SD">Sportstars</channel>
-  <channel site="visionplus.id" site_id="00000000000000000113" lang="id" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000115" lang="id" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000119" lang="id" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
-  <channel site="visionplus.id" site_id="00000000000000000120" lang="id" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000121" lang="id" xmltv_id="FightSports.us@SD">Fight Sports</channel>
-  <channel site="visionplus.id" site_id="00000000000000000122" lang="id" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000114" lang="id" xmltv_id="">Sportstars 3</channel>
   <channel site="visionplus.id" site_id="00000000000000000123" lang="id" xmltv_id="">beIN SPORTS 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000124" lang="id" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
   <channel site="visionplus.id" site_id="00000000000000000125" lang="id" xmltv_id="">beIN SPORTS 4</channel>
   <channel site="visionplus.id" site_id="00000000000000000126" lang="id" xmltv_id="">beIN SPORTS 5</channel>
-  <channel site="visionplus.id" site_id="00000000000000000130" lang="id" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
-  <channel site="visionplus.id" site_id="00000000000000000131" lang="id" xmltv_id="CNBCAsia.sg@SD">CNBC Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000132" lang="id" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
-  <channel site="visionplus.id" site_id="00000000000000000133" lang="id" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
-  <channel site="visionplus.id" site_id="00000000000000000134" lang="id" xmltv_id="IDXChannel.id@SD">IDX</channel>
-  <channel site="visionplus.id" site_id="00000000000000000137" lang="id" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000138" lang="id" xmltv_id="Life.id@SD">LIFE</channel>
-  <channel site="visionplus.id" site_id="00000000000000000139" lang="id" xmltv_id="Reformed21.id@SD">Reformed 21</channel>
-  <channel site="visionplus.id" site_id="00000000000000000142" lang="id" xmltv_id="MusicTV.id@SD">Music TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000143" lang="id" xmltv_id="MTVLive.uk@SD">MTV Live</channel>
-  <channel site="visionplus.id" site_id="00000000000000000144" lang="id" xmltv_id="MTV90s.uk@SD">MTV 90s</channel>
-  <channel site="visionplus.id" site_id="00000000000000000146" lang="id" xmltv_id="DW.de@English">DW</channel>
-  <channel site="visionplus.id" site_id="00000000000000000147" lang="id" xmltv_id="France24.fr@English">France 24</channel>
-  <channel site="visionplus.id" site_id="00000000000000000148" lang="id" xmltv_id="TRTWorld.tr@SD">TRT World</channel>
-  <channel site="visionplus.id" site_id="00000000000000000149" lang="id" xmltv_id="AlJazeera.qa@English">Aljazeera</channel>
-  <channel site="visionplus.id" site_id="00000000000000000150" lang="id" xmltv_id="RT.ru@SD">RT</channel>
-  <channel site="visionplus.id" site_id="00000000000000000151" lang="id" xmltv_id="EuronewsEnglish.fr@SD">EURONEWS</channel>
-  <channel site="visionplus.id" site_id="00000000000000000152" lang="id" xmltv_id="CNA.sg@SD">Channel News Asia</channel>
-  <channel site="visionplus.id" site_id="00000000000000000153" lang="id" xmltv_id="AlQuranAlKareemTV.sa@SD">Al Quran Al Kareem</channel>
-  <channel site="visionplus.id" site_id="00000000000000000154" lang="id" xmltv_id="EWTN.us@AsiaPacific">EWTN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000155" lang="id" xmltv_id="CGTNDocumentary.cn@SD">CGTN Documentary</channel>
-  <channel site="visionplus.id" site_id="00000000000000000156" lang="id" xmltv_id="CGTN.cn@SD">CGTN</channel>
-  <channel site="visionplus.id" site_id="00000000000000000157" lang="id" xmltv_id="AnhuiTV.cn@SD">Anhui</channel>
-  <channel site="visionplus.id" site_id="00000000000000000158" lang="id" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000159" lang="id" xmltv_id="DragonTV.cn@SD">Shanghai Dragon</channel>
-  <channel site="visionplus.id" site_id="00000000000000000160" lang="id" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000161" lang="id" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000162" lang="id" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
-  <channel site="visionplus.id" site_id="00000000000000000163" lang="id" xmltv_id="TV5MondeAsia.fr@SD">TV5Monde</channel>
-  <channel site="visionplus.id" site_id="00000000000000000164" lang="id" xmltv_id="ArirangTV.kr@SD">Arirang</channel>
-  <channel site="visionplus.id" site_id="00000000000000000165" lang="id" xmltv_id="ABCAustralia.au@SD">ABC</channel>
-  <channel site="visionplus.id" site_id="00000000000000000206" lang="id" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
-  <channel site="visionplus.id" site_id="00000000000000000207" lang="id" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000251" lang="id" xmltv_id="DensFoodChannel.id@SD">DENS Food Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000252" lang="id" xmltv_id="DensPlay.id@SD">DENSPLAY Channel</channel>
-  <channel site="visionplus.id" site_id="00000000000000000253" lang="id" xmltv_id="DensShowBiz.id@SD">DENS Showbizz Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000201" lang="id" xmltv_id="">RCTI World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000202" lang="id" xmltv_id="">GTV World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000203" lang="id" xmltv_id="">MNCTV World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000204" lang="id" xmltv_id="">Drama World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000205" lang="id" xmltv_id="">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001002" lang="id" xmltv_id="">V+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001008" lang="id" xmltv_id="">R+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001010" lang="id" xmltv_id="">V+ LIVE 2</channel>
@@ -125,4 +27,110 @@
   <channel site="visionplus.id" site_id="00000000000000001012" lang="id" xmltv_id="">V+ LIVE 3</channel>
   <channel site="visionplus.id" site_id="00000000000000001013" lang="id" xmltv_id="">V+ LIVE 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001014" lang="id" xmltv_id="">V+ LIVE 5</channel>
+  <channel site="visionplus.id" site_id="00000000000000001015" lang="id" xmltv_id="">V+ LIVE 6</channel>
+  <channel site="visionplus.id" site_id="00000000000000001016" lang="id" xmltv_id="">V+ LIVE 7</channel>
+  <channel site="visionplus.id" site_id="00000000000000001017" lang="id" xmltv_id="">V+ LIVE 8</channel>
+  <channel site="visionplus.id" site_id="00000000000000001018" lang="id" xmltv_id="">V+ LIVE 9</channel>
+  <channel site="visionplus.id" site_id="00000000000000000165" lang="id" xmltv_id="ABCAustralia.au@SD">ABC</channel>
+  <channel site="visionplus.id" site_id="00000000000000000149" lang="id" xmltv_id="AlJazeera.qa@English">Aljazeera</channel>
+  <channel site="visionplus.id" site_id="00000000000000000153" lang="id" xmltv_id="AlQuranAlKareemTV.sa@SD">Al Quran Al Kareem</channel>
+  <channel site="visionplus.id" site_id="00000000000000000157" lang="id" xmltv_id="AnhuiTV.cn@SD">Anhui</channel>
+  <channel site="visionplus.id" site_id="00000000000000000065" lang="id" xmltv_id="AnimaxAsia.sg@SD">Animax</channel>
+  <channel site="visionplus.id" site_id="00000000000000000010" lang="id" xmltv_id="ANTV.id@SD">ANTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000164" lang="id" xmltv_id="ArirangTV.kr@SD">Arirang</channel>
+  <channel site="visionplus.id" site_id="00000000000000000079" lang="id" xmltv_id="AXNAsia.sg@Indonesia">AXN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000026" lang="id" xmltv_id="BaliTV.id@SD">Bali TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000027" lang="id" xmltv_id="BandungTV.id@SD">Bandung TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000102" lang="id" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
+  <channel site="visionplus.id" site_id="00000000000000000130" lang="id" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
+  <channel site="visionplus.id" site_id="00000000000000000122" lang="id" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000124" lang="id" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000133" lang="id" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
+  <channel site="visionplus.id" site_id="00000000000000000015" lang="id" xmltv_id="BTV.id@SD">BTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000058" lang="id" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000088" lang="id" xmltv_id="CelebritiesTV.id@SD">Celebrities TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000045" lang="id" xmltv_id="CelestialClassicMovies.id@SD">CCM</channel>
+  <channel site="visionplus.id" site_id="00000000000000000044" lang="id" xmltv_id="CelestialMoviesIndonesia.id@SD">Celestial Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000156" lang="id" xmltv_id="CGTN.cn@SD">CGTN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000155" lang="id" xmltv_id="CGTNDocumentary.cn@SD">CGTN Documentary</channel>
+  <channel site="visionplus.id" site_id="00000000000000000036" lang="id" xmltv_id="Cinemachi.uk@SD">Originals</channel>
+  <channel site="visionplus.id" site_id="00000000000000000040" lang="id" xmltv_id="CinemachiAction.uk@SD">Cineedge</channel>
+  <channel site="visionplus.id" site_id="00000000000000000037" lang="id" xmltv_id="CinemachiKids.uk@SD">Buddy Star</channel>
+  <channel site="visionplus.id" site_id="00000000000000000039" lang="id" xmltv_id="CinemachiMax.uk@SD">Superrix</channel>
+  <channel site="visionplus.id" site_id="00000000000000000038" lang="id" xmltv_id="CinemachiXtra.uk@SD">Uniques</channel>
+  <channel site="visionplus.id" site_id="00000000000000000152" lang="id" xmltv_id="CNA.sg@SD">Channel News Asia</channel>
+  <channel site="visionplus.id" site_id="00000000000000000131" lang="id" xmltv_id="CNBCAsia.sg@SD">CNBC Asia</channel>
+  <channel site="visionplus.id" site_id="00000000000000000095" lang="id" xmltv_id="CrimePlusInvestigationAsia.sg@SD">Crime Investigation</channel>
+  <channel site="visionplus.id" site_id="00000000000000000018" lang="id" xmltv_id="DAAITV.id@SD">DAAI TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000251" lang="id" xmltv_id="DensFoodChannel.id@SD">DENS Food Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000252" lang="id" xmltv_id="DensPlay.id@SD">DENSPLAY Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000253" lang="id" xmltv_id="DensShowBiz.id@SD">DENS Showbizz Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000029" lang="id" xmltv_id="DMITV.id@SD">DMI TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000159" lang="id" xmltv_id="DragonTV.cn@SD">Shanghai Dragon</channel>
+  <channel site="visionplus.id" site_id="00000000000000000067" lang="id" xmltv_id="DreamWorksChannelAsia.us@SD">Dream Works</channel>
+  <channel site="visionplus.id" site_id="00000000000000000146" lang="id" xmltv_id="DW.de@English">DW</channel>
+  <channel site="visionplus.id" site_id="00000000000000000072" lang="id" xmltv_id="Entertainment.id@SD">Entertainment</channel>
+  <channel site="visionplus.id" site_id="00000000000000000151" lang="id" xmltv_id="EuronewsEnglish.fr@SD">EURONEWS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000154" lang="id" xmltv_id="EWTN.us@AsiaPacific">EWTN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000121" lang="id" xmltv_id="FightSports.us@SD">Fight Sports</channel>
+  <channel site="visionplus.id" site_id="00000000000000000132" lang="id" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
+  <channel site="visionplus.id" site_id="00000000000000000147" lang="id" xmltv_id="France24.fr@English">France 24</channel>
+  <channel site="visionplus.id" site_id="00000000000000000049" lang="id" xmltv_id="Galaxy.id@SD">GALAXY</channel>
+  <channel site="visionplus.id" site_id="00000000000000000048" lang="id" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
+  <channel site="visionplus.id" site_id="00000000000000000103" lang="id" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
+  <channel site="visionplus.id" site_id="00000000000000000003" lang="id" xmltv_id="GTV.id@SD">GTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000104" lang="id" xmltv_id="HistoryAsia.us@SD">History</channel>
+  <channel site="visionplus.id" site_id="00000000000000000077" lang="id" xmltv_id="HITS.sg@SD">Hits</channel>
+  <channel site="visionplus.id" site_id="00000000000000000042" lang="id" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000160" lang="id" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000134" lang="id" xmltv_id="IDXChannel.id@SD">IDX</channel>
+  <channel site="visionplus.id" site_id="00000000000000000050" lang="id" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
+  <channel site="visionplus.id" site_id="00000000000000000004" lang="id" xmltv_id="iNews.id@SD">iNews</channel>
+  <channel site="visionplus.id" site_id="00000000000000000025" lang="id" xmltv_id="JakTV.id@SD">JAK TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000161" lang="id" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000024" lang="id" xmltv_id="JTV.id@SD">JTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000056" lang="id" xmltv_id="KidsTV.id@SD">Kids TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000075" lang="id" xmltv_id="KIX.hk@SD">Kix</channel>
+  <channel site="visionplus.id" site_id="00000000000000000013" lang="id" xmltv_id="KompasTV.id@SD">Kompas TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000138" lang="id" xmltv_id="Life.id@SD">LIFE</channel>
+  <channel site="visionplus.id" site_id="00000000000000000080" lang="id" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
+  <channel site="visionplus.id" site_id="00000000000000000105" lang="id" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000014" lang="id" xmltv_id="MetroTV.id@SD">Metro TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000002" lang="id" xmltv_id="MNCTV.id@SD">MNCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000142" lang="id" xmltv_id="MusicTV.id@SD">Music TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000137" lang="id" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000023" lang="id" xmltv_id="NET.id@SD">MDTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000162" lang="id" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
+  <channel site="visionplus.id" site_id="00000000000000000076" lang="id" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
+  <channel site="visionplus.id" site_id="00000000000000000064" lang="id" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>
+  <channel site="visionplus.id" site_id="00000000000000000060" lang="id" xmltv_id="NickJrAsia.sg@SD">Nick Jr</channel>
+  <channel site="visionplus.id" site_id="00000000000000000071" lang="id" xmltv_id="OKTV.id@SD">Food Travel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000074" lang="id" xmltv_id="ONE.sg@SD">One</channel>
+  <channel site="visionplus.id" site_id="00000000000000000101" lang="id" xmltv_id="OutdoorChannel.us@SD">Outdoor Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000011" lang="id" xmltv_id="RajawaliTV.id@SD">RTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000001" lang="id" xmltv_id="RCTI.id@SD">RCTI</channel>
+  <channel site="visionplus.id" site_id="00000000000000000139" lang="id" xmltv_id="Reformed21.id@SD">Reformed 21</channel>
+  <channel site="visionplus.id" site_id="00000000000000000092" lang="id" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
+  <channel site="visionplus.id" site_id="00000000000000000093" lang="id" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
+  <channel site="visionplus.id" site_id="00000000000000000150" lang="id" xmltv_id="RT.ru@SD">RT</channel>
+  <channel site="visionplus.id" site_id="00000000000000000005" lang="id" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
+  <channel site="visionplus.id" site_id="00000000000000000115" lang="id" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
+  <channel site="visionplus.id" site_id="00000000000000000113" lang="id" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000112" lang="id" xmltv_id="Sportstars.id@SD">Sportstars</channel>
+  <channel site="visionplus.id" site_id="00000000000000000120" lang="id" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000119" lang="id" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
+  <channel site="visionplus.id" site_id="00000000000000000041" lang="id" xmltv_id="Thrill.hk@SD">Thrill</channel>
+  <channel site="visionplus.id" site_id="00000000000000000007" lang="id" xmltv_id="Trans7.id@SD">Trans 7</channel>
+  <channel site="visionplus.id" site_id="00000000000000000006" lang="id" xmltv_id="TransTV.id@SD">Trans TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000148" lang="id" xmltv_id="TRTWorld.tr@SD">TRT World</channel>
+  <channel site="visionplus.id" site_id="00000000000000000163" lang="id" xmltv_id="TV5MondeAsia.fr@SD">TV5Monde</channel>
+  <channel site="visionplus.id" site_id="00000000000000000028" lang="id" xmltv_id="TV9Nusantara.id@SD">TV 9</channel>
+  <channel site="visionplus.id" site_id="00000000000000000030" lang="id" xmltv_id="TVMu.id@SD">TV MU</channel>
+  <channel site="visionplus.id" site_id="00000000000000000073" lang="id" xmltv_id="tvNAsia.hk@SD">TVN</channel>
+  <channel site="visionplus.id" site_id="00000000000000000046" lang="id" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000012" lang="id" xmltv_id="tvOne.id@SD">TVOne</channel>
+  <channel site="visionplus.id" site_id="00000000000000000087" lang="id" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
+  <channel site="visionplus.id" site_id="00000000000000000158" lang="id" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000047" lang="id" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>
+  <channel site="visionplus.id" site_id="00000000000000000063" lang="id" xmltv_id="ZooMoo.sg@SD">Zoo Moo</channel>
 </channels>

--- a/sites/visionplus.id/visionplus.id_id.channels.xml
+++ b/sites/visionplus.id/visionplus.id_id.channels.xml
@@ -86,6 +86,7 @@
   <channel site="visionplus.id" site_id="00000000000000000138" lang="id" xmltv_id="Life.id@SD">LIFE</channel>
   <channel site="visionplus.id" site_id="00000000000000000080" lang="id" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
   <channel site="visionplus.id" site_id="00000000000000000105" lang="id" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000023" lang="id" xmltv_id="MDTV.id@HD">MDTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000020" lang="id" xmltv_id="MentariTV.id@SD">Mentari TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000014" lang="id" xmltv_id="MetroTV.id@SD">Metro TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000002" lang="id" xmltv_id="MNCTV.id@SD">MNCTV</channel>
@@ -93,7 +94,6 @@
   <channel site="visionplus.id" site_id="00000000000000000057" lang="id" xmltv_id="MoonbugKids.uk@SD">Moonbug</channel>
   <channel site="visionplus.id" site_id="00000000000000000142" lang="id" xmltv_id="MusicTV.id@SD">Music TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000137" lang="id" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000023" lang="id" xmltv_id="NET.id@SD">MDTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000162" lang="id" xmltv_id="NHKWorldJapan.jp@SD">NHK</channel>
   <channel site="visionplus.id" site_id="00000000000000000076" lang="id" xmltv_id="NHKWorldPremium.jp@SD">NHK World Premium</channel>
   <channel site="visionplus.id" site_id="00000000000000000064" lang="id" xmltv_id="NickelodeonAsia.sg@SD">Nick</channel>

--- a/sites/visionplus.id/visionplus.id_id.channels.xml
+++ b/sites/visionplus.id/visionplus.id_id.channels.xml
@@ -1,25 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="visionplus.id" site_id="00000000000000000008" lang="id" xmltv_id="">SCTV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000009" lang="id" xmltv_id="">Indosiar</channel>
-  <channel site="visionplus.id" site_id="00000000000000000016" lang="id" xmltv_id="">TVRI</channel>
-  <channel site="visionplus.id" site_id="00000000000000000019" lang="id" xmltv_id="">Moji</channel>
-  <channel site="visionplus.id" site_id="00000000000000000020" lang="id" xmltv_id="">Mentari TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000054" lang="id" xmltv_id="">Studio Universal</channel>
-  <channel site="visionplus.id" site_id="00000000000000000057" lang="id" xmltv_id="">Moonbug</channel>
-  <channel site="visionplus.id" site_id="00000000000000000068" lang="id" xmltv_id="">HITS Now</channel>
-  <channel site="visionplus.id" site_id="00000000000000000069" lang="id" xmltv_id="">Formosa</channel>
-  <channel site="visionplus.id" site_id="00000000000000000070" lang="id" xmltv_id="">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000089" lang="id" xmltv_id="">Hanacaraka TV</channel>
-  <channel site="visionplus.id" site_id="00000000000000000114" lang="id" xmltv_id="">Sportstars 3</channel>
-  <channel site="visionplus.id" site_id="00000000000000000123" lang="id" xmltv_id="">beIN SPORTS 2</channel>
-  <channel site="visionplus.id" site_id="00000000000000000125" lang="id" xmltv_id="">beIN SPORTS 4</channel>
-  <channel site="visionplus.id" site_id="00000000000000000126" lang="id" xmltv_id="">beIN SPORTS 5</channel>
   <channel site="visionplus.id" site_id="00000000000000000201" lang="id" xmltv_id="">RCTI World</channel>
   <channel site="visionplus.id" site_id="00000000000000000202" lang="id" xmltv_id="">GTV World</channel>
   <channel site="visionplus.id" site_id="00000000000000000203" lang="id" xmltv_id="">MNCTV World</channel>
   <channel site="visionplus.id" site_id="00000000000000000204" lang="id" xmltv_id="">Drama World</channel>
-  <channel site="visionplus.id" site_id="00000000000000000205" lang="id" xmltv_id="">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000001002" lang="id" xmltv_id="">V+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001008" lang="id" xmltv_id="">R+ LIVE</channel>
   <channel site="visionplus.id" site_id="00000000000000001010" lang="id" xmltv_id="">V+ LIVE 2</channel>
@@ -44,7 +29,10 @@
   <channel site="visionplus.id" site_id="00000000000000000102" lang="id" xmltv_id="BBCEarth.uk@Asia">BBC Earth</channel>
   <channel site="visionplus.id" site_id="00000000000000000130" lang="id" xmltv_id="BBCNews.uk@AsiaPacific">BBC World news</channel>
   <channel site="visionplus.id" site_id="00000000000000000122" lang="id" xmltv_id="beINSports1.qa@Indonesia">beIN SPORTS</channel>
+  <channel site="visionplus.id" site_id="00000000000000000123" lang="id" xmltv_id="beINSports2.qa@MENA">beIN SPORTS 2</channel>
   <channel site="visionplus.id" site_id="00000000000000000124" lang="id" xmltv_id="beINSports3.qa@Indonesia">beIN SPORTS 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000125" lang="id" xmltv_id="beINSports4.qa@MENA">beIN SPORTS 4</channel>
+  <channel site="visionplus.id" site_id="00000000000000000126" lang="id" xmltv_id="beINSports5.qa@MENA">beIN SPORTS 5</channel>
   <channel site="visionplus.id" site_id="00000000000000000133" lang="id" xmltv_id="BloombergTV.us@Asia">Bloomberg</channel>
   <channel site="visionplus.id" site_id="00000000000000000015" lang="id" xmltv_id="BTV.id@SD">BTV</channel>
   <channel site="visionplus.id" site_id="00000000000000000058" lang="id" xmltv_id="CBeebies.uk@SD">Cbeebies</channel>
@@ -75,6 +63,7 @@
   <channel site="visionplus.id" site_id="00000000000000000121" lang="id" xmltv_id="FightSports.us@SD">Fight Sports</channel>
   <channel site="visionplus.id" site_id="00000000000000000132" lang="id" xmltv_id="FoxNewsChannel.us@SD">FOX News</channel>
   <channel site="visionplus.id" site_id="00000000000000000147" lang="id" xmltv_id="France24.fr@English">France 24</channel>
+  <channel site="visionplus.id" site_id="00000000000000000069" lang="id" xmltv_id="FTV.tw@SD">Formosa</channel>
   <channel site="visionplus.id" site_id="00000000000000000049" lang="id" xmltv_id="Galaxy.id@SD">GALAXY</channel>
   <channel site="visionplus.id" site_id="00000000000000000048" lang="id" xmltv_id="GalaxyPremium.id@SD">GALAXY PREMIUM</channel>
   <channel site="visionplus.id" site_id="00000000000000000103" lang="id" xmltv_id="GlobalTrekker.sg@SD">Global Trekker</channel>
@@ -82,9 +71,11 @@
   <channel site="visionplus.id" site_id="00000000000000000104" lang="id" xmltv_id="HistoryAsia.us@SD">History</channel>
   <channel site="visionplus.id" site_id="00000000000000000077" lang="id" xmltv_id="HITS.sg@SD">Hits</channel>
   <channel site="visionplus.id" site_id="00000000000000000042" lang="id" xmltv_id="HITSMovies.sg@SD">Hits Movies</channel>
+  <channel site="visionplus.id" site_id="00000000000000000068" lang="id" xmltv_id="HITSNOW.sg@SD">HITS Now</channel>
   <channel site="visionplus.id" site_id="00000000000000000160" lang="id" xmltv_id="HunanTV.cn@SD">Hunan TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000134" lang="id" xmltv_id="IDXChannel.id@SD">IDX</channel>
   <channel site="visionplus.id" site_id="00000000000000000050" lang="id" xmltv_id="IMC.id@SD">IMC (Indonesia Movie Channel)</channel>
+  <channel site="visionplus.id" site_id="00000000000000000009" lang="id" xmltv_id="Indosiar.id@SD">Indosiar</channel>
   <channel site="visionplus.id" site_id="00000000000000000004" lang="id" xmltv_id="iNews.id@SD">iNews</channel>
   <channel site="visionplus.id" site_id="00000000000000000025" lang="id" xmltv_id="JakTV.id@SD">JAK TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000161" lang="id" xmltv_id="JiangsuTV.cn@SD">Jiangsu TV</channel>
@@ -95,8 +86,11 @@
   <channel site="visionplus.id" site_id="00000000000000000138" lang="id" xmltv_id="Life.id@SD">LIFE</channel>
   <channel site="visionplus.id" site_id="00000000000000000080" lang="id" xmltv_id="LifetimeAsia.us@SD">Lifetime</channel>
   <channel site="visionplus.id" site_id="00000000000000000105" lang="id" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="visionplus.id" site_id="00000000000000000020" lang="id" xmltv_id="MentariTV.id@SD">Mentari TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000014" lang="id" xmltv_id="MetroTV.id@SD">Metro TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000002" lang="id" xmltv_id="MNCTV.id@SD">MNCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000019" lang="id" xmltv_id="Moji.id@SD">Moji</channel>
+  <channel site="visionplus.id" site_id="00000000000000000057" lang="id" xmltv_id="MoonbugKids.uk@SD">Moonbug</channel>
   <channel site="visionplus.id" site_id="00000000000000000142" lang="id" xmltv_id="MusicTV.id@SD">Music TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000137" lang="id" xmltv_id="MuslimTV.id@SD">Muslim TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000023" lang="id" xmltv_id="NET.id@SD">MDTV</channel>
@@ -113,12 +107,17 @@
   <channel site="visionplus.id" site_id="00000000000000000092" lang="id" xmltv_id="ROCKEntertainment.sg@SD">Rock Entertainment</channel>
   <channel site="visionplus.id" site_id="00000000000000000093" lang="id" xmltv_id="ROCKExtreme.sg@SD">Rock Action</channel>
   <channel site="visionplus.id" site_id="00000000000000000150" lang="id" xmltv_id="RT.ru@SD">RT</channel>
+  <channel site="visionplus.id" site_id="00000000000000000008" lang="id" xmltv_id="SCTV.id@SD">SCTV</channel>
+  <channel site="visionplus.id" site_id="00000000000000000070" lang="id" xmltv_id="SETTaiwan.tw@SD">Sanlih</channel>
   <channel site="visionplus.id" site_id="00000000000000000005" lang="id" xmltv_id="SindoNewsTV.id@SD">SindoNews</channel>
   <channel site="visionplus.id" site_id="00000000000000000115" lang="id" xmltv_id="SoccerChannel.id@SD">Soccer Channel</channel>
   <channel site="visionplus.id" site_id="00000000000000000113" lang="id" xmltv_id="Sportstars2.id@SD">Sportstars 2</channel>
+  <channel site="visionplus.id" site_id="00000000000000000114" lang="id" xmltv_id="Sportstars3.id@SD">Sportstars 3</channel>
+  <channel site="visionplus.id" site_id="00000000000000000205" lang="id" xmltv_id="Sportstars3.id@SD">Sportstars 4</channel>
   <channel site="visionplus.id" site_id="00000000000000000112" lang="id" xmltv_id="Sportstars.id@SD">Sportstars</channel>
   <channel site="visionplus.id" site_id="00000000000000000120" lang="id" xmltv_id="SPOTV2.id@SD">SpoTV 2</channel>
   <channel site="visionplus.id" site_id="00000000000000000119" lang="id" xmltv_id="SPOTV.id@SD">SpoTV 1</channel>
+  <channel site="visionplus.id" site_id="00000000000000000054" lang="id" xmltv_id="StudioUniversalLatinAmerica.us@Brazil">Studio Universal</channel>
   <channel site="visionplus.id" site_id="00000000000000000041" lang="id" xmltv_id="Thrill.hk@SD">Thrill</channel>
   <channel site="visionplus.id" site_id="00000000000000000007" lang="id" xmltv_id="Trans7.id@SD">Trans 7</channel>
   <channel site="visionplus.id" site_id="00000000000000000006" lang="id" xmltv_id="TransTV.id@SD">Trans TV</channel>
@@ -129,6 +128,7 @@
   <channel site="visionplus.id" site_id="00000000000000000073" lang="id" xmltv_id="tvNAsia.hk@SD">TVN</channel>
   <channel site="visionplus.id" site_id="00000000000000000046" lang="id" xmltv_id="tvNMoviesAsia.hk@SD">TVN Movies</channel>
   <channel site="visionplus.id" site_id="00000000000000000012" lang="id" xmltv_id="tvOne.id@SD">TVOne</channel>
+  <channel site="visionplus.id" site_id="00000000000000000016" lang="id" xmltv_id="TVRI.id@SD">TVRI</channel>
   <channel site="visionplus.id" site_id="00000000000000000087" lang="id" xmltv_id="VisionPrime.id@SD">Vision Prime</channel>
   <channel site="visionplus.id" site_id="00000000000000000158" lang="id" xmltv_id="XingKongChina.cn@SD">Xing kong TV</channel>
   <channel site="visionplus.id" site_id="00000000000000000047" lang="id" xmltv_id="ZeeBioskop.id@SD">Zee Bioskop</channel>


### PR DESCRIPTION
This PR cleans duplicated categories, update test and channels.

```
npm test --- visionplus.id

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand visionplus.id

 PASS  sites/visionplus.id/visionplus.id.test.js
  √ can generate valid url (3 ms)
  √ can parse response (3 ms)                                                                                                                          
  √ can handle empty guide (1 ms)                                                                                                                      
                                                                                                                                                       
Test Suites: 1 passed, 1 total                                                                                                                         
Tests:       3 passed, 3 total                                                                                                                         
Snapshots:   0 total
Time:        0.261 s, estimated 1 s
Ran all test suites matching visionplus.id.
```