### PR TITLE
Update clickthecity.com

### DIFF
--- a/sites/clickthecity.com/clickthecity.com.config.js
+++ b/sites/clickthecity.com/clickthecity.com.config.js
@@ -19,10 +19,7 @@ module.exports = {
     },
     data({ date }) {
       const params = new URLSearchParams()
-      params.append(
-        'optDate',
-        dayjs(date.valueOf()).tz('Asia/Manila').format('YYYY-MM-DD')
-      )
+      params.append('optDate', dayjs(date.valueOf()).tz('Asia/Manila').format('YYYY-MM-DD'))
       params.append('optTime', '00:00:00')
 
       return params
@@ -79,7 +76,7 @@ function parseStart($item, date) {
   const url = $item('td.cPrg > a').attr('href') || ''
   let [, time] = url.match(/starttime=(\d{1,2}%3A\d{2}\+(AM|PM))/) || [null, null]
   if (!time) return null
-  time = `${date.format('YYYY-MM-DD')} ${time.replace('%3A', ':').replace('+', ' ')}`
+  time = `${date.format('YYYY-MM-DD')} ${decodeURIComponent(time).replace(/\+/g, ' ')}`
 
   return dayjs.tz(time, 'YYYY-MM-DD h:mm A', 'Asia/Manila').utc()
 }
@@ -88,7 +85,7 @@ function parseStop($item, date) {
   const url = $item('td.cPrg > a').attr('href') || ''
   let [, time] = url.match(/endtime=(\d{1,2}%3A\d{2}\+(AM|PM))/) || [null, null]
   if (!time) return null
-  time = `${date.format('YYYY-MM-DD')} ${time.replace('%3A', ':').replace('+', ' ')}`
+  time = `${date.format('YYYY-MM-DD')} ${decodeURIComponent(time).replace(/\+/g, ' ')}`
 
   return dayjs.tz(time, 'YYYY-MM-DD h:mm A', 'Asia/Manila').utc()
 }


### PR DESCRIPTION
Fixes "replace() will replace only the first occurrence of '%3A'.".

```sh
npm test --- clickthecity.com

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand clickthecity.com

 PASS  sites/clickthecity.com/clickthecity.com.test.js
  ✓ can generate valid url (5 ms)
  ✓ can generate valid request method (1 ms)
  ✓ can generate valid request headers (2 ms)
  ✓ can generate valid request data (38 ms)
  ✓ can parse response (170 ms)
  ✓ can handle empty guide (2 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.118 s
Ran all test suites matching clickthecity.com.
```