### PR TITLE
Update streamingtvguides.com

### DIFF
--- a/sites/streamingtvguides.com/streamingtvguides.com.config.js
+++ b/sites/streamingtvguides.com/streamingtvguides.com.config.js
@@ -30,7 +30,10 @@ module.exports = {
       })
     })
 
-    programs = sortBy(uniqBy(programs, p => p.start), p => p.start.valueOf())
+    programs = sortBy(
+      uniqBy(programs, p => p.start),
+      p => p.start.valueOf()
+    )
 
     return programs
   },
@@ -45,7 +48,7 @@ module.exports = {
 
     const $ = cheerio.load(data)
     $('#channel-group-all > div > div').each((i, el) => {
-      const site_id = $(el).find('input').attr('value').replace('&', '&amp;')
+      const site_id = $(el).find('input').attr('value').replace(/&/g, '&amp;')
       const label = $(el).text().trim()
       const svgTitle = $(el).find('svg').attr('alt')
       const name = (label || svgTitle || '').replace(site_id, '').trim()


### PR DESCRIPTION
Fixes "replace() will replace only the first occurrence of '&'.".

```sh
npm test --- streamingtvguides.com

> test
> cross-env TZ=Pacific/Nauru npx jest --runInBand streamingtvguides.com

 PASS  sites/streamingtvguides.com/streamingtvguides.com.test.js
  ✓ can generate valid url (4 ms)
  ✓ can parse response (366 ms)
  ✓ can handle empty guide (29 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.313 s
Ran all test suites matching streamingtvguides.com.
```