### PR TITLE
Fix Sky.com dropping programmes that start between 00:00 and 00:59 BST

### DIFF
--- a/sites/sky.com/__data__/content_bst.json
+++ b/sites/sky.com/__data__/content_bst.json
@@ -1,0 +1,43 @@
+{
+  "date": "20260608",
+  "schedule": [
+    {
+      "sid": "4086",
+      "events": [
+        {
+          "st": 1780873200,
+          "d": 1800,
+          "programmeuuid": "11111111-1111-1111-1111-111111111111",
+          "seasonnumber": 1,
+          "episodenumber": 1,
+          "t": "Midnight Show",
+          "sy": "Starts at 00:00 BST on 8 June (23:00Z on the 7th). Lives entirely before UTC midnight, so a UTC-only start/stop check drops it."
+        },
+        {
+          "st": 1780875900,
+          "d": 3600,
+          "t": "Quarter To One",
+          "sy": "Starts 00:45 BST and straddles UTC midnight (23:45Z -> 00:45Z). tohenk's example from the schedule response."
+        },
+        {
+          "st": 1780916400,
+          "d": 3600,
+          "t": "Midday Movie",
+          "sy": "Noon BST sanity check, well inside the day."
+        },
+        {
+          "st": 1780957800,
+          "d": 1800,
+          "t": "Late Night",
+          "sy": "Last programme of the 8 June local day, starting 23:30 BST."
+        },
+        {
+          "st": 1780961400,
+          "d": 1800,
+          "t": "Next Day Breakfast",
+          "sy": "Starts 00:30 BST on 9 June (23:30Z on the 8th). Belongs to the next local day and must be dropped, even though it falls on UTC day 8."
+        }
+      ]
+    }
+  ]
+}

--- a/sites/sky.com/sky.com.config.js
+++ b/sites/sky.com/sky.com.config.js
@@ -31,7 +31,7 @@ module.exports = {
             if (Array.isArray(schedule.events)) {
               sortBy(schedule.events, p => p.st).forEach(event => {
                 const start = dayjs.utc(event.st * 1000)
-                if (start.isSame(date.tz('Europe/London'), 'd')) {
+                if (start.tz('Europe/London').isSame(date, 'd')) {
                   const image = `https://images.metadata.sky.com/pd-image/${event.programmeuuid}/16-9/640`
                   programs.push({
                     title: event.t,

--- a/sites/sky.com/sky.com.test.js
+++ b/sites/sky.com/sky.com.test.js
@@ -62,6 +62,57 @@ it('can parse response', () => {
   })
 })
 
+it('keeps BST early-morning programmes and drops the next local day', () => {
+  // Sky buckets each schedule by UK *local* day, so a request for 8 June (BST,
+  // UTC+1) returns events from 00:00 BST (23:00Z on the 7th) onwards. Four of the
+  // five events below belong to the 8 June local day; the 00:30 BST 9 June event
+  // sits on UTC day 8 but must NOT leak into the 8 June guide.
+  const date = dayjs.utc('2026-06-08', 'YYYY-MM-DD').startOf('d')
+  const content = fs.readFileSync(path.join(__dirname, '__data__', 'content_bst.json'))
+  const result = parser({ content, channel, date }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(result.length).toBe(4)
+  expect(result.map(p => p.title)).toEqual([
+    'Midnight Show',
+    'Quarter To One',
+    'Midday Movie',
+    'Late Night'
+  ])
+
+  // 00:00 BST: starts 23:00Z on the previous UTC day and never crosses UTC
+  // midnight. A UTC-only start/stop check drops this; the local-day filter keeps it.
+  expect(result[0]).toMatchObject({
+    start: '2026-06-07T23:00:00.000Z',
+    stop: '2026-06-07T23:30:00.000Z',
+    title: 'Midnight Show',
+    season: 1,
+    episode: 1,
+    icon: 'https://images.metadata.sky.com/pd-image/11111111-1111-1111-1111-111111111111/16-9/640',
+    image: 'https://images.metadata.sky.com/pd-image/11111111-1111-1111-1111-111111111111/16-9/640'
+  })
+
+  // 00:45 BST, straddling UTC midnight (23:45Z -> 00:45Z) — the example from the PR thread.
+  expect(result[1]).toMatchObject({
+    start: '2026-06-07T23:45:00.000Z',
+    stop: '2026-06-08T00:45:00.000Z',
+    title: 'Quarter To One'
+  })
+
+  // Last programme of the local day, starting 23:30 BST.
+  expect(result[3]).toMatchObject({
+    start: '2026-06-08T22:30:00.000Z',
+    stop: '2026-06-08T23:00:00.000Z',
+    title: 'Late Night'
+  })
+
+  // 00:30 BST on 9 June (23:30Z on the 8th): on UTC day 8, but the next local day.
+  expect(result.find(p => p.title === 'Next Day Breakfast')).toBeUndefined()
+})
+
 it('can handle empty guide', () => {
   const result = parser({
     date,


### PR DESCRIPTION
dayjs `isSame(x, 'd')` truncates the day window from the left operand's timezone only - the right operand is reduced to a bare instant, and `.tz()` never changes an instant. So the `.tz()` must go on left hand size.

Fixes: https://github.com/iptv-org/epg/issues/2763