### PR TITLE
Update channels/`xmltv_id` of various sites

### DIFF
--- a/sites/airtelxstream.in/airtelxstream.in.channels.xml
+++ b/sites/airtelxstream.in/airtelxstream.in.channels.xml
@@ -1,168 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_417" lang="en" xmltv_id="">Sportskool TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_653" lang="en" xmltv_id="">Fireplace Lounge</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_659" lang="en" xmltv_id="">Tranquil Thunderstorms</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1085" lang="en" xmltv_id="">Sword &amp; Shield</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1096" lang="en" xmltv_id="">AWE Plus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1116" lang="en" xmltv_id="">Schwab Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1127" lang="en" xmltv_id="">CJC Television Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1188" lang="en" xmltv_id="">GlewedTV The Vault</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1189" lang="en" xmltv_id="">GlewedTV Spanish</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1190" lang="en" xmltv_id="">GlewedTV Yoga &amp; Fitness</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1192" lang="en" xmltv_id="">Dot Esports</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1220" lang="en" xmltv_id="">TronTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1229" lang="en" xmltv_id="">Screendreams by Invincible</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1236" lang="en" xmltv_id="">fw.tv by Firework</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1249" lang="en" xmltv_id="">Black Enterprise</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1681" lang="en" xmltv_id="">Zoomer TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1688" lang="en" xmltv_id="">Pro Football Focus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1714" lang="en" xmltv_id="">MotorRacing</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1761" lang="en" xmltv_id="">BarkTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1807" lang="en" xmltv_id="">Times Now Navbharat</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2195" lang="en" xmltv_id="">Arré</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2507" lang="en" xmltv_id="">Powersports World</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2531" lang="en" xmltv_id="">Garv Punjab Gurbani</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2532" lang="en" xmltv_id="">Swar Shree</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2535" lang="en" xmltv_id="">Bowery Classics</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2890" lang="en" xmltv_id="">ABP Asmita</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2891" lang="en" xmltv_id="">ABP Majha</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2892" lang="en" xmltv_id="">ABP Ananda</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2893" lang="en" xmltv_id="">ABP Ganga</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2894" lang="en" xmltv_id="">ABP Sanjha</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3074" lang="en" xmltv_id="">NatureStream.tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3080" lang="en" xmltv_id="">Goalcast</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3091" lang="en" xmltv_id="">ROI TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3174" lang="en" xmltv_id="">Autumn Escape</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3175" lang="en" xmltv_id="">Relaxing WinterScapes</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3176" lang="en" xmltv_id="">Spring Escape</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3177" lang="en" xmltv_id="">Study Lounge</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3182" lang="en" xmltv_id="">Life Style by Triptic</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3193" lang="en" xmltv_id="">4K TRAVEL TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3196" lang="en" xmltv_id="">ENCORE+</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3224" lang="en" xmltv_id="">Masala Entertainment Plus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3358" lang="en" xmltv_id="">SoniCentric</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3388" lang="en" xmltv_id="">Bleav Football</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3402" lang="en" xmltv_id="">LifeFit by Triptic</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3449" lang="en" xmltv_id="">Kids TV - Nursery Rhymes and Baby Songs</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3458" lang="en" xmltv_id="">Kids TV Español Latino - Canciones Infantiles</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3489" lang="en" xmltv_id="">MTRSPT1</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3570" lang="en" xmltv_id="">CraftsyTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3612" lang="en" xmltv_id="">9XM</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3613" lang="en" xmltv_id="">9X Jalwa</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3679" lang="en" xmltv_id="">Vikatan TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3687" lang="en" xmltv_id="">Kids TV India - Nursery Rhymes and Baby Songs</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4104" lang="en" xmltv_id="">News9Live</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4105" lang="en" xmltv_id="">TV9 Bangla</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4106" lang="en" xmltv_id="">TV9 Bharatvarsh</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4107" lang="en" xmltv_id="">TV9 Gujarati</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4108" lang="en" xmltv_id="">TV9 Kannada</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4109" lang="en" xmltv_id="">TV9 Marathi</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4110" lang="en" xmltv_id="">TV9 Telugu</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4500" lang="en" xmltv_id="">FloRacing 24/7</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4554" lang="en" xmltv_id="">crema.tv</channel>
   <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4595" lang="en" xmltv_id="">FEVA MUSIC</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4602" lang="en" xmltv_id="">Lakshya TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4603" lang="en" xmltv_id="">Kartavya TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4604" lang="en" xmltv_id="">Kalyan TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4875" lang="en" xmltv_id="">ToonzKids</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4876" lang="en" xmltv_id="">ToonzKids Atfal</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4877" lang="en" xmltv_id="">ToonzKids niños</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4926" lang="en" xmltv_id="">M+</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4928" lang="en" xmltv_id="">Rotana Aflam+</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4958" lang="en" xmltv_id="">Mediacorp Entertainment – English</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4959" lang="en" xmltv_id="">Mediacorp Entertainment – Tamil</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5006" lang="en" xmltv_id="">Bollywood Masala</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5050" lang="en" xmltv_id="">Saga Music</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5061" lang="en" xmltv_id="">Toon Goggles en Español</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5143" lang="en" xmltv_id="">DroneTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5144" lang="en" xmltv_id="">Surf Roots TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5154" lang="en" xmltv_id="">PLL Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5155" lang="en" xmltv_id="">TRACE UK</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5156" lang="en" xmltv_id="">TidPix-Authentically African</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5157" lang="en" xmltv_id="">Green Chillies TV- Zindagi ka Tadka!</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5199" lang="en" xmltv_id="">News Nation</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5206" lang="en" xmltv_id="">Sportstak</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5227" lang="en" xmltv_id="">Watch Wellness</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5228" lang="en" xmltv_id="">Watch Wellness Telugu</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5242" lang="en" xmltv_id="">Comercio TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5245" lang="en" xmltv_id="">Comedy Classics</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5247" lang="en" xmltv_id="">Old West TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5248" lang="en" xmltv_id="">4ACETV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5250" lang="en" xmltv_id="">4ACETV CLASSIC HITS</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5253" lang="en" xmltv_id="">The Holiday TV Channel</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5254" lang="en" xmltv_id="">Haryana Beat</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5255" lang="en" xmltv_id="">Nakshatra Digital Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5257" lang="en" xmltv_id="">Sundrani Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5260" lang="en" xmltv_id="">Colorized.TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5261" lang="en" xmltv_id="">MomCave</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5262" lang="en" xmltv_id="">HIP HOP TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5263" lang="en" xmltv_id="">Fitness Rewind by Collage Video</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5265" lang="en" xmltv_id="">Skull Bound TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5277" lang="en" xmltv_id="">Box Gamers</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5278" lang="en" xmltv_id="">Must See MoviES!</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5281" lang="en" xmltv_id="">HITS MEXICANOS</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5282" lang="en" xmltv_id="">Rockola Television</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5288" lang="en" xmltv_id="">Urban Action Channel</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5290" lang="en" xmltv_id="">a-z Best Classic TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5292" lang="en" xmltv_id="">a-z Classic Flix</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5293" lang="en" xmltv_id="">a-z Western Grit</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5294" lang="en" xmltv_id="">OurVinyl</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5296" lang="en" xmltv_id="">Sports First TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5298" lang="en" xmltv_id="">ACI On The Go</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5301" lang="en" xmltv_id="">NOMADslow tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5303" lang="en" xmltv_id="">Cigar TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5305" lang="en" xmltv_id="">Aaj Ki Khabar</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5306" lang="en" xmltv_id="">Atmadarshan Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5307" lang="en" xmltv_id="">Namma Bangalore</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5308" lang="en" xmltv_id="">Tara Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5309" lang="en" xmltv_id="">The Unmute</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5310" lang="en" xmltv_id="">Bhakthi Siri</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5312" lang="en" xmltv_id="">Wild TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5316" lang="en" xmltv_id="">Vande Bharat News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5317" lang="en" xmltv_id="">KTV Bangla</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5318" lang="en" xmltv_id="">Ann Channel</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5319" lang="en" xmltv_id="">Indian News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5321" lang="en" xmltv_id="">Mahua Play</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5322" lang="en" xmltv_id="">Mahua Khabar</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5324" lang="en" xmltv_id="">Chicas Guapas TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5326" lang="en" xmltv_id="">In Touch+</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5333" lang="en" xmltv_id="">News Marathi 24X7</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5335" lang="en" xmltv_id="">Rozana Spokesman</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5338" lang="en" xmltv_id="">Amplified Voices TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5339" lang="en" xmltv_id="">UnchainedTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5340" lang="en" xmltv_id="">POWERtube TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5343" lang="en" xmltv_id="">Mi Raza Canal</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5344" lang="en" xmltv_id="">Mi Raza Canal Plus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5345" lang="en" xmltv_id="">Mi Miedo Canal</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5346" lang="en" xmltv_id="">India Daily 24x7</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5347" lang="en" xmltv_id="">Elevation Church Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5350" lang="en" xmltv_id="">World Punjabi Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5351" lang="en" xmltv_id="">Top News Marathi</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5357" lang="en" xmltv_id="">Cinema Yoruba</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5358" lang="en" xmltv_id="">Crime &amp; Evidence</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5361" lang="en" xmltv_id="">P18 News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5362" lang="en" xmltv_id="">Big Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5364" lang="en" xmltv_id="">Outdoor Channel</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5365" lang="en" xmltv_id="">WFN: World Fishing Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5368" lang="en" xmltv_id="">Janataa TV Kannada</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5369" lang="en" xmltv_id="">DA News Plus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5372" lang="en" xmltv_id="">35MM</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5374" lang="en" xmltv_id="">Unleashed by DOGTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5381" lang="en" xmltv_id="">Bowling TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5383" lang="en" xmltv_id="">CN News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5389" lang="en" xmltv_id="">Amar Ujala</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5390" lang="en" xmltv_id="">DJ Central TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5391" lang="en" xmltv_id="">GTC Punjabi</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5392" lang="en" xmltv_id="">Punjabi Shorts</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5393" lang="en" xmltv_id="">Rock Solid Wrestling TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5394" lang="en" xmltv_id="">CarbonTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5395" lang="en" xmltv_id="">CG Central</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5396" lang="en" xmltv_id="">spot on news</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5397" lang="en" xmltv_id="">Golf Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5398" lang="en" xmltv_id="">Foosball TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5399" lang="en" xmltv_id="">Bharat Express</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AAJ_KI_KHABAR" lang="en" xmltv_id="">AAJ KI KHABAR</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AASTHA" lang="en" xmltv_id="">AASTHA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ABN_TELUGU_NEWS" lang="en" xmltv_id="">ABN Telugu News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ACTION_CINEMA" lang="en" xmltv_id="">Action Cinema</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_ASTROVAANI" lang="en" xmltv_id="">Airtel Astrovaani</channel>
@@ -202,14 +42,14 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KANNADA_INFO_3" lang="en" xmltv_id="">Airtel Kannada Info 3</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KANNADA_INFO_4" lang="en" xmltv_id="">Airtel Kannada Info 4</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KANNADA_INFO_5" lang="en" xmltv_id="">Airtel Kannada Info 5</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KANNADA_INFO_6" lang="en" xmltv_id="">Airtel Kannada Info 6</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KIDS_JUNIOR" lang="en" xmltv_id="">AIRTEL KIDS JUNIOR</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_KOREAN_TVSYMPLUS" lang="en" xmltv_id="">Airtel Korean TV+</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MAJAMA" lang="en" xmltv_id="">Airtel Majama</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MAKE_YOUR_PACK" lang="en" xmltv_id="">Airtel Make Your Pack</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MAKE_YOUR_PACK_7SYMHYP998" lang="en" xmltv_id="">Airtel Make Your Pack 7-998</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MAKE_YOUR_PACK_11SYMHYP998" lang="en" xmltv_id="">Airtel Make Your Pack 11-998</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MAKE_YOUR_PACK_11SYMHYP998" lang="en" xmltv_id="">Airtel Telugu Info 2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MALAYALAM_INFO_1" lang="en" xmltv_id="">Airtel Home 844</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MARATHI_INFO2" lang="en" xmltv_id="">Airtel Marathi Info2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MARATHI_INFO_1" lang="en" xmltv_id="">Airtel Marathi Info 1</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MARATHI_INFO_3" lang="en" xmltv_id="">Airtel Info 545</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_MARATHI_INFO_4" lang="en" xmltv_id="">Airtel Marathi Info 4</channel>
@@ -246,6 +86,7 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TAMIL_CINEMA" lang="en" xmltv_id="">Airtel Tamil Cinema</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TAMIL_INFO_1" lang="en" xmltv_id="">Airtel Tamil Info 1</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TAMIL_INFO_2" lang="en" xmltv_id="">Airtel Tamil Info 2</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TELUGU_BLOCKBUSTERS" lang="en" xmltv_id="">Airtel Telugu Blockbusters</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TELUGU_CINEMA" lang="en" xmltv_id="">Airtel Telugu Cinema</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TELUGU_INFO_1" lang="en" xmltv_id="">Airtel Telugu Info 1</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AIRTEL_TELUGU_INFO_2" lang="en" xmltv_id="">Airtel Telugu Info 2</channel>
@@ -254,43 +95,52 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ANIMAL_PLANET_WORLD_HD" lang="en" xmltv_id="">Animal Planet HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ANIME_BOOTH_BY_AIRTEL" lang="en" xmltv_id="">Anime Booth by Airtel</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASIAN_NEWS" lang="en" xmltv_id="">ASIAN NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BIG_TV_24X7" lang="en" xmltv_id="">BIG TV 24X7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CUSTOMER_CARE" lang="en" xmltv_id="">Customer Care</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DA_NEWS_PLUS" lang="en" xmltv_id="">DA NEWS PLUS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DAILY_POST" lang="en" xmltv_id="">SKYAMA DAILY POST NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DANGAL_TEST" lang="en" xmltv_id="">RJ PM Evidya 149</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NATIONAL_TEST" lang="en" xmltv_id="">DD One</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DISCOVERY_HD_WORLD" lang="en" xmltv_id="">Discovery HD World</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_EUROSPORT_HD" lang="en" xmltv_id="">Eurosport HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FIRST_INDIA_NEWS_RAJASTHAN" lang="en" xmltv_id="">First India News Rajasthan</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FM_NEWS" lang="en" xmltv_id="FMNews.in@SD">FM NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GANGAUR_TELEVISION" lang="en" xmltv_id="">GANGAUR TELEVISION</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GOLDMINES_BOLLYWOOD" lang="en" xmltv_id="">Goldmines Bollywood</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GTCSYMUNDERSCOREPUNJABI" lang="en" xmltv_id="">GTC PUNJABI</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GUARANTEE_NEWS" lang="en" xmltv_id="">GUARANTEE NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_I_NEWS" lang="en" xmltv_id="">I NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INDIA_NEWS" lang="en" xmltv_id="">INDIA NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INDIA_NEWS_HARYANA" lang="en" xmltv_id="">INDIA NEWS HARYANA</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INDIA_NEWS_UPUK" lang="en" xmltv_id="">INDIA NEWS UPUK</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INVESTIGATION_DISCOVERY_HD" lang="en" xmltv_id="">Investigation Discovery HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JAY_JAGANNATH" lang="en" xmltv_id="">Jay JAGANNATH</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JINVANI_TV" lang="en" xmltv_id="">Jinvani TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_LAKSHYA_TV" lang="en" xmltv_id="">Lakshya TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_LIVE_TIMES" lang="en" xmltv_id="">LIVE TIMES</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NB_NEWS" lang="en" xmltv_id="">ASOM Live 24</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ND24SYMHYPNEWSDAILY24SYMDOTIN" lang="en" xmltv_id="">ND24-Newsdaily24.in</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_HOUR" lang="en" xmltv_id="">NEWS HOUR</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_STATE_PB_HP_HR" lang="en" xmltv_id="">NEWS SPH HARYANA</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_STATE_PB_HP_HR" lang="en" xmltv_id="">NEWS STATE PUNJAB HIMACHAL HARYANA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NTV" lang="en" xmltv_id="">NTV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PEARS_TV" lang="en" xmltv_id="">Pear TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRARTHANA_TV" lang="en" xmltv_id="">Prarthana Life</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PEARS_TV" lang="en" xmltv_id="">PEAR TV</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_POLIMER_NEWS" lang="en" xmltv_id="">POLIMER NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_POLIMER_TV" lang="en" xmltv_id="">POLIMER TV</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRAG_NEWS" lang="en" xmltv_id="">Prag News</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRATHANA_LIFE" lang="en" xmltv_id="">Prarthana Life</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RENGONI_TV" lang="en" xmltv_id="">Rengoni TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ROZANA_SPOKSMAN" lang="en" xmltv_id="">ROZANA SPOKESMAN</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SADHNA_PRIME_NEWS" lang="en" xmltv_id="">Sadhna Prime News</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV" lang="en" xmltv_id="SansadTV1.in@SD">Sansad TV - 1</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_RAJYA_SABHA" lang="en" xmltv_id="SansadTV2.in@SD">Sansad TV - 2</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANDESH_NEWS" lang="en" xmltv_id="">Sandesh News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SIDHARTH_BHAKTI" lang="en" xmltv_id="">SIDHARTH UTSAV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SIDHARTH_GOLD" lang="en" xmltv_id="">SIDHARTH GOLD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SIDHARTH_TV" lang="en" xmltv_id="">SIDHARTH TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_MAX_1" lang="en" xmltv_id="">SONY MAX 1</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SPONDAN" lang="en" xmltv_id="">Spondan</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_SPORTS_TEN_4_KANNADA" lang="en" xmltv_id="">SONY SPORTS TEN 4 KANNADA</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SRI_JAGANNATH_DHAM" lang="en" xmltv_id="">SRI JAGANNATH DHAM</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_SPORTS_4K" lang="en" xmltv_id="">Star 4K</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_T_NEWS" lang="en" xmltv_id="">T NEWS 2</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TLC" lang="en" xmltv_id="TLC.in@SD">TLC</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_T_NEWS" lang="en" xmltv_id="">T NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TLC_HD" lang="en" xmltv_id="">TLC HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TNP_NEWS" lang="en" xmltv_id="">TNP NEWS</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV5_KANNADA" lang="en" xmltv_id="">TV 5 Kannada</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV_24" lang="en" xmltv_id="">TV 24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV_27_NEWS" lang="en" xmltv_id="">TV 27 NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VERTANT_SAMACHAR_PLUS" lang="en" xmltv_id="">VERTANT SAMACHAR PLUS</channel>
@@ -302,12 +152,20 @@
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_7" lang="en" xmltv_id="">Runn Action</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_10" lang="en" xmltv_id="">Runn Short Films</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_11" lang="en" xmltv_id="">Runn Thrillers</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_21" lang="en" xmltv_id="">Runn PrimeTime</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_29" lang="en" xmltv_id="">Superfine Films</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_31" lang="en" xmltv_id="">News Nation</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_36" lang="en" xmltv_id="">News State UP/UK</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_39" lang="en" xmltv_id="">NH BollyGold</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_40" lang="en" xmltv_id="">NH BollyFlix</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_41" lang="en" xmltv_id="">NH BollyRaga</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_94" lang="en" xmltv_id="">Green Gold TV</channel>
   <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_95" lang="en" xmltv_id="">Alright</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_120" lang="en" xmltv_id="">News State Bihar/JH</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_121" lang="en" xmltv_id="">News State MP/CG</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_122" lang="en" xmltv_id="">News State Punjab/HR</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_123" lang="en" xmltv_id="">Eros Universe Bollywood Cinema</channel>
+  <channel site="airtelxstream.in" site_id="RUNNTV_LIVECHANNEL_124" lang="en" xmltv_id="">Eros Universe Entertainment</channel>
   <channel site="airtelxstream.in" site_id="TIMESPLAY_LIVECHANNEL_channel_20" lang="en" xmltv_id="">PICKLEBALL NOW</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_7S_MUSIC" lang="en" xmltv_id="7SMusic.in@SD">7S Music</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_9X_JALWA" lang="en" xmltv_id="9XJalwa.in@SD">9X Jalwa</channel>
@@ -319,32 +177,22 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AAJ_TAK_HD" lang="en" xmltv_id="AajTak.in@SD">Aaj Tak HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AAKASH_AATH" lang="en" xmltv_id="AakaashAath.in@SD">Aakash Aath</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AASEERVATHAM_TV" lang="en" xmltv_id="AaseervathamTV.in@SD">Aaseervatham TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5363" lang="en" xmltv_id="ABNAndhraJyoti.in@SD">ABN Andhra Jyothy</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ABP_ANANDA" lang="en" xmltv_id="ABPAnanda.in@SD">ABP Ananda</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ABP_ASMITA" lang="en" xmltv_id="ABPAsmita.in@SD">ABP Asmita</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ABP_MAJHA" lang="en" xmltv_id="ABPMajha.in@SD">ABP Majha</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ABP_NEWS" lang="en" xmltv_id="ABPNews.in@SD">ABP News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2674" lang="en" xmltv_id="ACLCornholeTV.us@SD">ACL Cornhole TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ADITHYA_TV" lang="en" xmltv_id="AdithyaTV.in@SD">Adithya TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3120" lang="en" xmltv_id="AfricanewsEnglish.fr@SD">Africanews</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2964" lang="en" xmltv_id="AfriwoodBlockbuster.za@SD">Afriwood Blockbuster</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2653" lang="en" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ALANKAR" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4924" lang="en" xmltv_id="Alarabiya.ae@SD">Al Arabiya</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ALL_TIME_MOVIES" lang="en" xmltv_id="AllTimeMovies.in@SD">ALL TIME MOVIES</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5264" lang="en" xmltv_id="AMusicChannel.ng@SD">AMusic Channel</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AMV_NETWORK" lang="en" xmltv_id="AMVNetwork.in@SD">AMV Network</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5327" lang="en" xmltv_id="AnandTV.in@SD">Anand Tv</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_AMV_NETWORK" lang="en" xmltv_id="OnlyBharat.in@SD">ONLY BHARAT</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ANB_NEWS" lang="en" xmltv_id="ANBNews.in@SD">ANB News</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDFLIX_HD" lang="en" xmltv_id="Andflix.in@HD">&amp;flix HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDFLIX" lang="en" xmltv_id="Andflix.in@SD">&amp;flix</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDFLIX_HD" lang="en" xmltv_id="Unite8Sports2.in@HD">Unite8 Sports 2 HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDFLIX" lang="en" xmltv_id="Unite8Sports2.in@SD">Unite8 Sports 2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMAND_PICTURES_HD" lang="en" xmltv_id="Andpictures.in@HD">&amp; Pictures HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDPICTURES" lang="en" xmltv_id="Andpictures.in@SD">&amp;Pictures</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDPRIVE_HD" lang="en" xmltv_id="AndpriveHD.in@SD">&amp;Prive HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMAND_TV_HD" lang="en" xmltv_id="AndTV.in@HD">&amp; TV HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDTV" lang="en" xmltv_id="AndTV.in@SD">&amp;TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SYMANDXPLOR_HD" lang="en" xmltv_id="AndxplorHD.in@HD">&amp;Xplor HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ANGEL_TV" lang="en" xmltv_id="AngelTV.gh@SD">Angel TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ANIMAL_PLANET" lang="en" xmltv_id="AnimalPlanet.in@SD">Animal Planet</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_ANMOL_CINEMA_2" lang="en" xmltv_id="AnmolCinema2.in@SD">Anmol Cinema 2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_ANMOL_CINEMA" lang="en" xmltv_id="AnmolCinema.in@SD">Anmol Cinema</channel>
@@ -358,41 +206,28 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASIANET_MOVIES" lang="en" xmltv_id="AsianetMovies.in@SD">Asianet Movies HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASIANET_NEWS" lang="en" xmltv_id="AsianetNews.in@SD">Asianet News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASIANET_PLUS" lang="en" xmltv_id="AsianetPlus.in">Asianet Plus</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASIANET_SUVARNA_NEWS" lang="en" xmltv_id="AsianetSuvarnaNews.in@SD">Asianet Suvarna News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ASSAM_TALKS" lang="en" xmltv_id="AssamTalks.in@SD">Assam Talks</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_B4U_BHOJPURI" lang="en" xmltv_id="B4UBhojpuri.in@SD">B4U Bhojpuri</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_B4U_KADAK" lang="en" xmltv_id="B4UKadak.in@SD">B4U Kadak</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_B4U_MOVIES" lang="en" xmltv_id="B4UMovies.in@India">B4U Movies</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_B4U_MUSIC" lang="en" xmltv_id="B4UMusic.in@India">B4U Music</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3239" lang="en" xmltv_id="BalleBalle.in@SD">Balle Balle</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BANSAL_NEWS" lang="en" xmltv_id="BansalNews.in@SD">Bansal News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BBC_NEWS" lang="en" xmltv_id="BBCNews.uk@SouthAsia">BBC News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BHAKTI_TV" lang="en" xmltv_id="BhaktiTV.tt@SD">Bhakti TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5328" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BHARAT_24" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BHARAT_EXPRESS" lang="en" xmltv_id="BharatExpress.in@SD">Bharat Express</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR" lang="en" xmltv_id="BharatSamachar.in@SD">Bharat Samachar</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BHOJPURI_CINEMA" lang="en" xmltv_id="BhojpuriCinema.in@SD">BHOJPURI CINEMA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BIG_MAGIC" lang="en" xmltv_id="BigMagic.in@SD">Big Magic</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BIG_TV" lang="en" xmltv_id="BIGTV.in@SD">Big Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2930" lang="en" xmltv_id="BlessTV.jm@SD">Bless TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5276" lang="en" xmltv_id="BoxCinema.in@SD">Box Cinema</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BRIO_TV" lang="en" xmltv_id="BrioTV.in@SD">Brio TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3633" lang="en" xmltv_id="BritAsiaTV.uk@SD">BritAsiaTV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_BRK_NEWS" lang="en" xmltv_id="BRKNews.in@SD">BRK NEWS</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1223" lang="en" xmltv_id="BusinessRockstars.us@SD">Business Rockstars</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CAPTAIN" lang="en" xmltv_id="CaptainTV.in@SD">CAPTAIN</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5244" lang="en" xmltv_id="CartoonClassics.pl@FAST">Cartoon Classics</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CARTOON_NETWORK" lang="en" xmltv_id="CartoonNetwork.in">Cartoon Network</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CARTOON_NETWORK_HDSYMPLUS" lang="en" xmltv_id="CartoonNetworkHDPlus.in@SD">CARTOON NETWORK HD+</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CBEEBIES" lang="en" xmltv_id="CBeebies.uk@SD">CBeebies</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CHANNEL_WIN" lang="en" xmltv_id="ChannelWIN.in@SD">Channel WIN</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CHARDIKLA_TIME_TV" lang="en" xmltv_id="ChardiklaTimeTV.in@SD">Chardikla Time TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CHINTU_TV" lang="en" xmltv_id="ChintuTV.in@SD">Chintu TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1222" lang="en" xmltv_id="Choppertown.us@SD">ChopperTown</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CHUTTI_TV" lang="en" xmltv_id="ChuttiTV.in@SD">Chutti TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2967" lang="en" xmltv_id="CinemaHausa.za@SD">Cinema Hausa</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1224" lang="en" xmltv_id="CinePride.us@SD">Cinepride</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CNBC_AWAAZ" lang="en" xmltv_id="CNBCAwaaz.in@SD">CNBC AWAAZ</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CNBC_BAJAR" lang="en" xmltv_id="CNBCBajar.in@SD">CNBC Bajar</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CNBC_TV18" lang="en" xmltv_id="CNBCTV18.in@SD">CNBC TV18</channel>
@@ -421,9 +256,7 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_COLORS_SUPER" lang="en" xmltv_id="ColorsSuper.in@SD">Colors Super</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_COLORS_TAMIL_HD" lang="en" xmltv_id="ColorsTamil.in@HD">Colors Tamil HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_COLORS_TAMIL" lang="en" xmltv_id="ColorsTamil.in@SD">Colors Tamil</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1210" lang="en" xmltv_id="CookingPanda.us@SD">Cooking Panda</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5382" lang="en" xmltv_id="CTVNAKDPlus.in@SD">CTVN AKD Plus</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CVR_NEWS" lang="en" xmltv_id="CVRNews.in@SD">CVR NEWS1</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CVR_NEWS" lang="en" xmltv_id="CVRNews.in@SD">CVR NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DANGAL_2" lang="en" xmltv_id="Dangal2.in@SD">Dangal 2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DANGAL" lang="en" xmltv_id="DangalTV.in@SD">Dangal</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_ARUNPRABHA" lang="en" xmltv_id="DDArunPrabha.in@SD">DD Arunprabha</channel>
@@ -444,8 +277,8 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_SHILLONG" lang="en" xmltv_id="DDMeghalaya.in@SD">DD Meghalaya</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NATIONAL_HD" lang="en" xmltv_id="DDNational.in@HD">DD National HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NATIONAL" lang="en" xmltv_id="DDNational.in@SD">DD National</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NEWS" lang="en" xmltv_id="DDNews.in@SD">DD News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NEWS_HD" lang="en" xmltv_id="DDNews.in@HD">DD News HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_NEWS" lang="en" xmltv_id="DDNews.in@SD">DD News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_ORIYA" lang="en" xmltv_id="DDOdia.in@SD">DD ODIA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_PUNJABI" lang="en" xmltv_id="DDPunjabi.in@SD">DD Punjabi</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_RAJASTHAN" lang="en" xmltv_id="DDRajasthan.in@SD">DD Rajasthan</channel>
@@ -458,7 +291,6 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_URDU" lang="en" xmltv_id="DDUrdu.in@SD">DD Urdu</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_UP" lang="en" xmltv_id="DDUttarPradesh.in@SD">DD UTTAR PRADESH</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DD_YADAGIRI" lang="en" xmltv_id="DDYadagiri.in@SD">DD Yadagiri</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3426" lang="en" xmltv_id="DeFianceMedia.pr@SD">DeFiance Media</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DHARM_SANDESH" lang="en" xmltv_id="DharmSandesh.in@SD">Dharm Sandesh</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DHOOM_MUSIC" lang="en" xmltv_id="DhoomMusic.in@SD">Dhoom Music</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DISCOVERY_CHANNEL" lang="en" xmltv_id="DiscoveryChannel.in@SD">Discovery Channel</channel>
@@ -471,13 +303,10 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DISNEY_JUNIOR" lang="en" xmltv_id="DisneyJunior.in@SD">Disney Junior</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DISNEY_STORIES" lang="en" xmltv_id="DisneyStories.in@SD">Disney Stories</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DIVYAVANI_TV" lang="en" xmltv_id="DivyavaniTV.in@SD">Divyavani TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1679" lang="en" xmltv_id="DocumentaryPlus.us@International">Documentary+</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_D_TAMIL" lang="en" xmltv_id="DTamil.in@SD">D Tamil</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1225" lang="en" xmltv_id="DungeonTV.us@SD">Dungeon TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_DY365" lang="en" xmltv_id="DY365.in@SD">DY365</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_E24" lang="en" xmltv_id="E24.in@SD">E24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ENTERR10_BANGLA" lang="en" xmltv_id="Enterr10Bangla.in@SD">Enterr10 Bangla</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1081" lang="en" xmltv_id="EntrepreneurTV.us@SD">Entrepreneur</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_EPIC" lang="en" xmltv_id="EpicTV.in@SD">Epic</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ET_NOW" lang="en" xmltv_id="ETNow.in@SD">ET NOW</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ET_NOW_SWADESH" lang="en" xmltv_id="ETNowSwadesh.in@SD">ET SWADESH</channel>
@@ -490,50 +319,36 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ETV_TELANGANA" lang="en" xmltv_id="ETVTelangana.in@SD">ETV Telangana</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ETV_HD" lang="en" xmltv_id="ETVTelugu.in@HD">ETV HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ETV_TELUGU" lang="en" xmltv_id="ETVTelugu.in@SD">ETV Telugu</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1244" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1245" lang="en" xmltv_id="EuronewsSpanish.fr@SD">Euronews Español</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_EUROSPORT" lang="en" xmltv_id="Eurosport.in@SD">Eurosport</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_630" lang="en" xmltv_id="EverydayHeroes.us@SD">Everyday Heroes</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FAKT_MARATHI" lang="en" xmltv_id="FaktMarathi.in@SD">Fakt Marathi</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4581" lang="en" xmltv_id="FEVATV.ca@SD">FEVA TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FILAMCHI_BHOJPURI" lang="en" xmltv_id="FilamchiBhojpuri.in@SD">Filamchi Bhojpuri</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_654" lang="en" xmltv_id="FishTank.us@SD">Fish Tank</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FILAMCHI_BHOJPURI" lang="en" xmltv_id="EpicBhojpuri.in@SD">EPIC BHOJPURI</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FLOWERS_TV" lang="en" xmltv_id="FlowersTV.in@SD">Flowers TV</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FM_NEWS" lang="en" xmltv_id="FMNews.in@SD">FM NEWS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_FRANCE_24" lang="en" xmltv_id="France24.fr@English">France 24</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3166" lang="en" xmltv_id="FUELTV.at@SD">FUEL TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1228" lang="en" xmltv_id="GalxyTV.us@SD">Galxy TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_COMEDY" lang="en" xmltv_id="GeminiComedy.in@SD">Gemini Comedy</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_LIFE" lang="en" xmltv_id="GeminiLife.in@SD">Gemini Life</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MOVIES_HD" lang="en" xmltv_id="GeminiMovies.in@HD">Gemini Movies HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MOVIES" lang="en" xmltv_id="GeminiMovies.in@SD">Gemini Movies</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MUSIC_HD" lang="en" xmltv_id="GeminiMusic.in@HD">Gemini Music HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MUSIC" lang="en" xmltv_id="GeminiMusic.in@SD">Gemini Music</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_TV" lang="en" xmltv_id="GeminiTV.in@HD">Gemini TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_TV_HD" lang="en" xmltv_id="GeminiTV.in@HD">Gemini TV HD</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5238" lang="en" xmltv_id="GhostDimension.us@UK">Ghost Dimension</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_COMEDY" lang="en" xmltv_id="SunGeminiComedy.in@SD">Sun Gemini comedy</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_LIFE" lang="en" xmltv_id="SunGeminiLife.in@SD">Sun Gemini Life</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MOVIES_HD" lang="en" xmltv_id="SunGeminiMovies.in@HD">Sun Gemini Movies HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MOVIES" lang="en" xmltv_id="SunGeminiMovies.in@SD">Sun Gemini Movies</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MUSIC_HD" lang="en" xmltv_id="SunGeminiMusic.in@HD">Sun Gemini Music HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_MUSIC" lang="en" xmltv_id="SunGeminiMusic.in@SD">SUN GEMINI MUSIC</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_TV" lang="en" xmltv_id="SunGemini.in@HD">Sun Gemini</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GEMINI_TV_HD" lang="en" xmltv_id="SunGemini.in@HD">SUN GEMINI HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GOLDMINES" lang="en" xmltv_id="Goldmines.in@SD">Goldmines</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GOODNESS_TV" lang="en" xmltv_id="GoodnessTV.in@SD">Goodness TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY" lang="en" xmltv_id="GoodNewsToday.in@SD">Good News Today</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GOODNEWS_TV" lang="en" xmltv_id="GoodNewsTV.in">Goodnews TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GUBBARE" lang="en" xmltv_id="Gubbare.in@SD">Gubbare</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5371" lang="en" xmltv_id="GujaratFirst.in@SD">Gujarat First</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GUBBARE" lang="en" xmltv_id="EpicKids.in@SD">EPIC KIDS</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GULISTAN_NEWS" lang="en" xmltv_id="GulistanNews.in@SD">Gulistan News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3187" lang="en" xmltv_id="GustoTV.ca@SD">Gusto TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_GYANDARSHAN" lang="en" xmltv_id="Gyandarshan.in@SD">Gyandarshan</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1059" lang="en" xmltv_id="HardKnocks.ca@SD">Hard Knocks</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2787" lang="en" xmltv_id="HareKrsnaTV.in@SD">Hare Krsna</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HARKHABAR" lang="en" xmltv_id="HarKhabar.in@SD">HARKHABAR</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HARVEST_TV_24X7" lang="en" xmltv_id="HarvestTV.in@SD">Harvest TV 24x7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HINDI_KHABAR" lang="en" xmltv_id="HindiKhabar.in@SD">Hindi Khabar</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HISTORY_TV18_HD" lang="en" xmltv_id="HistoryTV18.in@HD">History TV18 HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HISTORY_TV18" lang="en" xmltv_id="HistoryTV18.in@SD">History TV18</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HNN" lang="en" xmltv_id="HNN24x7.in@SD">HNN</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_415" lang="en" xmltv_id="HorizonSports.us@SD">Horizon Sports</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HORNBILL" lang="en" xmltv_id="HornbillTV.in@SD">HORNBILL</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1137" lang="en" xmltv_id="HumorMill.us@SD">Humor Mill</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_HUNGAMA" lang="en" xmltv_id="HungamaTV.in@SD">HUNGAMA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_IBC24" lang="en" xmltv_id="IBC24.in@SD">IBC24</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_629" lang="en" xmltv_id="IDG.us@SD">IDG</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_IND24" lang="en" xmltv_id="Ind24.in@SD">IND24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INDIA_AHEAD" lang="en" xmltv_id="IndiaAhead.in@SD">INDIA AHEAD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INDIA_TODAY" lang="en" xmltv_id="IndiaToday.in@SD">India Today</channel>
@@ -542,9 +357,8 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INH_24X7" lang="en" xmltv_id="INH24x7.in@SD">INH 24X7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_INVESTIGATION_DISCOVERY" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ISAI_ARUVI" lang="en" xmltv_id="IsaiAruvi.in@SD">Isai Aruvi</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ISHARA_TV" lang="en" xmltv_id="IsharaTV.in@SD">Ishara TV</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ISHARA_TV" lang="en" xmltv_id="EpicParivar.in@SD">EPIC PARIVAR</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ISHWAR_TV" lang="en" xmltv_id="IshwarBhaktiTV.in@SD">Ishwar Bhakti</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_656" lang="en" xmltv_id="IslandEscape.us@SD">Island Escape</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JAIHIND_TV" lang="en" xmltv_id="JaihindTV.in@SD">Jaihind TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JAI_MAHARASHTRA" lang="en" xmltv_id="JaiMaharashtra.in@SD">JAI MAHARASHTRA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JALSHA_MOVIES_HD" lang="en" xmltv_id="JalshaMovies.in@HD">Jalsha Movies HD</channel>
@@ -558,7 +372,6 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_J_MOVIES" lang="en" xmltv_id="JMovie.in@SD">J Movies</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JONACK" lang="en" xmltv_id="Jonack.in@SD">Jonack</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_JOTHI_TV" lang="en" xmltv_id="JothiTV.in@SD">JOTHI TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5226" lang="en" xmltv_id="JyotishDuniya.in@SD">Jyotish Duniya</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KAIRALI_NEWS" lang="en" xmltv_id="KairaliNews.in@SD">Kairali News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KAIRALI_TV" lang="en" xmltv_id="KairaliTV.in@SD">Kairali TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KAIRALI_WE" lang="en" xmltv_id="KairaliWe.in@SD">Kairali We</channel>
@@ -571,24 +384,15 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KHABAR_FAST" lang="en" xmltv_id="KhabarFast.in@SD">Khabar Fast</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KHUSHBOO_BANGLA" lang="en" xmltv_id="KhushbooBangla.in@SD">Khushboo Bangla</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KOCHU_TV" lang="en" xmltv_id="KochuTV.in@SD">Kochu TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5360" lang="en" xmltv_id="KolkataTV.in@SD">Kolkata Tv</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KOLKATA_TV" lang="en" xmltv_id="KolkataTV.in@SD">Kolkata TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3197" lang="en" xmltv_id="KozoomTV.fr@SD">KOZOOM TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KTV_HD" lang="en" xmltv_id="KTV.in@HD">KTV HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KTV" lang="en" xmltv_id="KTV.in@SD">KTV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_KUSHI_TV" lang="en" xmltv_id="KushiTV.in@SD">Kushi TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4600" lang="en" xmltv_id="LaBocinaLatina.us@SD">La Bocina Latina</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5287" lang="en" xmltv_id="LivingIndiaNews.in@SD">Living India News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_LIVING_INDIA_NEWS" lang="en" xmltv_id="LivingIndiaNews.in@SD">Living India News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_LOKSHAHI" lang="en" xmltv_id="LokshahiNews.in@SD">Lokshahi</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1055" lang="en" xmltv_id="LoneStar.us@SD">Lone Star</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MADHA_TV" lang="en" xmltv_id="MadhaTV.in@SD">Madha tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5329" lang="en" xmltv_id="MahaaMax.in@SD">Mahaa Max</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MAHAA_MAX" lang="en" xmltv_id="MahaaMax.in@SD">MAHAA MAX</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5330" lang="en" xmltv_id="MahaaNews.in@SD">Mahaa News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MAKKAL_TV" lang="en" xmltv_id="MakkalTV.in@SD">Makkal TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MANORAMA_NEWS" lang="en" xmltv_id="ManoramaNews.in@SD">Manorama News</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MANORANJAN_MOVIES" lang="en" xmltv_id="ManoranjanMovies.in@SD">Manoranjan Movies</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MANORANJAN_TV" lang="en" xmltv_id="ManoranjanTV.in@SD">Manoranjan Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MATHRUBHUMI_NEWS" lang="en" xmltv_id="MathrubhumiNews.in@SD">Mathrubhumi News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MAZHAVIL_MANORAMA_HD" lang="en" xmltv_id="MazhavilManorama.in@HD">Mazhavil Manorama HD</channel>
@@ -602,15 +406,12 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MH_ONE_DIL_SE" lang="en" xmltv_id="MHOneDilSe.in@SD">MH One Dil Se</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MH_ONE_SHRADDHA" lang="en" xmltv_id="MHOneShraddha.in@SD">MH One Shraddha</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MIRROR_NOW" lang="en" xmltv_id="MirrorNow.in@SD">MIRROR NOW</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_661" lang="en" xmltv_id="MMAJunkie.us@SD">MMA Junkie</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MNX_HD" lang="en" xmltv_id="MNX.in@HD">MNX - HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MNX" lang="en" xmltv_id="MNX.in@SD">MNX</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_539" lang="en" xmltv_id="MonarchChannel.us@SD">Monarch</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MOVIES_NOW_HD" lang="en" xmltv_id="MoviesNow.in@HD">MOVIES NOW HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MOVIES_NOW" lang="en" xmltv_id="MoviesNow.in@SD">MOVIES NOW</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MNSYMPLUS" lang="en" xmltv_id="MoviesNowPlus.in@SD">MN+</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MTV" lang="en" xmltv_id="MTV.in@SD">MTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5331" lang="en" xmltv_id="MunsifTV.in@SD">Munsif Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_MUNSIF_TV" lang="en" xmltv_id="MunsifTV.in@SD">MUNSIF TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TAMIL_NAAPTOL" lang="en" xmltv_id="NaaptolTamil.in@SD">Tamil Naaptol</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TELUGU_NAAPTOL" lang="en" xmltv_id="NaaptolTelugu.in@SD">Telugu Naaptol</channel>
@@ -626,65 +427,49 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NDTV_MARATHI" lang="en" xmltv_id="NDTVMarathi.in@SD">NDTV Marathi</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NDTV_PROFIT_PRIME" lang="en" xmltv_id="NDTVProfit.in@SD">NDTV Profit Prime</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NDTV_RAJASTHAN" lang="en" xmltv_id="NDTVRajasthan.in@SD">NDTV Rajasthan</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4557" lang="en" xmltv_id="NegociosTV.es@SD">Negocios TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_1_INDIA" lang="en" xmltv_id="News1India.in@SD">News 1 India</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS7_TAMIL" lang="en" xmltv_id="News7Tamil.in@SD">News7 Tamil</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_7" lang="en" xmltv_id="News7Tamil.in@SD">News 7</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_7" lang="en" xmltv_id="News7Tamil.in@SD">News7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS9" lang="en" xmltv_id="News9Live.in@SD">NEWS9</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_ASSAM_NORTHSYMHYPEAST" lang="en" xmltv_id="News18AssamNorthEast.in@SD">News18 Assam North-East</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_BANGLA" lang="en" xmltv_id="News18Bangla.in@SD">News18 Bangla</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_BIHAR_JHARKHAND" lang="en" xmltv_id="News18BiharJharkhand.in@SD">News18 Bihar Jharkhand</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_GUJARATI" lang="en" xmltv_id="News18Gujarati.in@SD">News18 Gujarati</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_INDIA" lang="en" xmltv_id="News18India.in@SD">News18 India</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_JK_HIMACHAL" lang="en" xmltv_id="News18JKLH.in@SD">News18 JK LA HP</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_JK_HIMACHAL" lang="en" xmltv_id="News18JKLH.in@SD">News18 Delhi NCR JK</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_KANNADA" lang="en" xmltv_id="News18Kannada.in@SD">News18 Kannada</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_KERALA" lang="en" xmltv_id="News18Kerala.in@SD">News18 Kerala</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_LOKMAT" lang="en" xmltv_id="News18Lokmat.in@SD">News 18 Marathi</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_LOKMAT" lang="en" xmltv_id="News18Lokmat.in@SD">News18 Marathi</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_MADHYA_PRADESH_CHHATTISGARH" lang="en" xmltv_id="News18MadhyaPradeshChhattisgarh.in@SD">News18 Madhya Pradesh Chhattisgarh</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_ODIA" lang="en" xmltv_id="News18Odia.in@SD">News18 Odia</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_PUNJAB_HARYANA" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">News18 Punjab Haryana</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_PUNJAB_HARYANA" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">News18 Punjab HR HP</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_RAJASTHAN" lang="en" xmltv_id="News18Rajasthan.in@SD">News18 Rajasthan</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_TAMIL_NADU" lang="en" xmltv_id="News18TamilNadu.in@SD">News18 Tamil Nadu</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS18_UTTAR_PRADESH_UTTARAKHAND" lang="en" xmltv_id="News18UttarPradeshUttarakhand.in@SD">News18 Uttar Pradesh Uttarakhand</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS24" lang="en" xmltv_id="News24.in@SD">News24</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS24_MPCG" lang="en" xmltv_id="News24MPChhattisgarh.in@SD">News24 MPCG</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5332" lang="en" xmltv_id="NewsIndia24x7.in@SD">News India 24X7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_J" lang="en" xmltv_id="NewsJ.in@SD">News J</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_LIVE" lang="en" xmltv_id="NewsLive.in@SD">News Live</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5349" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">News Malayalam 24x7</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_MALAYALAM_24X7" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">News Malayalam 24x7</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_NATION" lang="en" xmltv_id="NewsNation.in@SD">News Nation</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_MALAYALAM_24X7" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">NEWS MALAYALAM 24 X 7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_STATE_MADHYA_PRADESH_CHHATTISGARH" lang="en" xmltv_id="NewsStateMPCHG.in@SD">News State Madhya Pradesh Chhattisgarh</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_STATE_UP_UK" lang="en" xmltv_id="NewsStateUPUK.in@SD">News State UP UK</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5348" lang="en" xmltv_id="NewsTamil24x7.in@SD">News Tamil 24x7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_TAMIL_24X7" lang="en" xmltv_id="NewsTamil24x7.in@SD">News Tamil 24X7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NEWS_TIME_BANGLA" lang="en" xmltv_id="NewsTimeBangla.in@SD">News Time Bangla</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NICK" lang="en" xmltv_id="Nickelodeon.in@SD">Nick</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NICK_HDSYMPLUS" lang="en" xmltv_id="NickHDPlus.in@HD">NICK HD+</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NICK_JUNIOR" lang="en" xmltv_id="NickJr.in@SD">Nick Junior</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5283" lang="en" xmltv_id="Nigbati.ng@SD">Nigbati TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NK_TV_PLUS" lang="en" xmltv_id="NKTV24x7.in@SD">NK TV Plus</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_NORTH_EAST_LIVE" lang="en" xmltv_id="NortheastLive.in@HD">North East Live</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5359" lang="en" xmltv_id="Novocomedy.fr@SD">Novo Comedy</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1095" lang="en" xmltv_id="OANPlus.us@SD">OAN Plus</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_OTV" lang="en" xmltv_id="OdishaTV.in@SD">OTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5386" lang="en" xmltv_id="OnTV4U.us@SD">ONTV4U</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_543" lang="en" xmltv_id="OutsideTV.us@SD">Outside</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PARAS_GOLD_ONE" lang="en" xmltv_id="ParasGold.in@SD">Paras Gold One</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PEACE_OF_MIND" lang="en" xmltv_id="PeaceofMindTV.in@SD">Peace of Mind</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3132" lang="en" xmltv_id="Pitaara.in@SD">Pitaara TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PITAARA" lang="en" xmltv_id="Pitaara.in@SD">Pitaara</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_4927" lang="en" xmltv_id="PNCDrama.eg@SD">PNC Drama</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_POGO" lang="en" xmltv_id="Pogo.in@SD">Pogo</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_POWER_TV" lang="en" xmltv_id="PowerTV.in@SD">Power TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5336" lang="en" xmltv_id="PrameyaNews7.in@SD">Prameya News7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRARTHANA_BHAWAN" lang="en" xmltv_id="PrarthanaBhawanTV.in@SD">Prarthana Bhawan</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5352" lang="en" xmltv_id="PrathamKhabar24x7.in@SD">Pratham Khabar 24x7</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRATIDIN_TIME" lang="en" xmltv_id="PratidinTime.in@SD">Pratidin Time</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRAVAH_PICTURE_HD" lang="en" xmltv_id="PravahPicture.in@HD">Pravah Picture HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PRAVAH_PICTURE" lang="en" xmltv_id="PravahPicture.in@SD">Pravah Picture</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_CHANNEL_36_UP_UK" lang="en" xmltv_id="Prime9News.in@SD">Prime 9 Plus</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5378" lang="en" xmltv_id="PrimeAsiaTV.ca@SD">Prime Asia Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PTC_CHAKDE" lang="en" xmltv_id="PTCChakde.in@SD">PTC Chakde</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PTC_MUSIC" lang="en" xmltv_id="PTCMusic.in@SD">PTC Music</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PTC_NEWS" lang="en" xmltv_id="PTCNews.in@SD">PTC News</channel>
@@ -695,10 +480,8 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PUBLIC_MUSIC" lang="en" xmltv_id="PublicMusic.in@SD">PUBLIC MUSIC</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PUBLIC_TV" lang="en" xmltv_id="PublicTV.in@SD">Public TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PUDHARI_NEWS" lang="en" xmltv_id="PudhariNews.in@SD">Pudhari News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5235" lang="en" xmltv_id="PunjabiHits.in@SD">Punjabi Hits</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PUTHIYA_THALAIMURAI" lang="en" xmltv_id="PuthiyaThalaimurai.in@SD">Puthiya Thalaimurai</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_PUTHU_YUGAM" lang="en" xmltv_id="PuthuyugamTV.in@SD">Puthu Yugam</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5275" lang="en" xmltv_id="PXSports.mx@SD">PXSports</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RAFTAAR_MEDIA" lang="en" xmltv_id="RaftaarMedia.in@SD">RAFTAAR MEDIA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RAJ_NAGAICHUVAI" lang="en" xmltv_id="RajAsia.in@SD">RAJ NAGAICHUVAI</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RAJ_DIGITAL_PLUS" lang="en" xmltv_id="RajDigitalPlus.in@SD">Raj Digital Plus</channel>
@@ -713,37 +496,26 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RAJ_TV" lang="en" xmltv_id="RajTV.in@SD">Raj TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RAMDHENU" lang="en" xmltv_id="Ramdhenu.in@SD">Ramdhenu</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RANG" lang="en" xmltv_id="Rang.in@SD">Rang</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_658" lang="en" xmltv_id="RealVision.us@SD">Real Vision</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_655" lang="en" xmltv_id="RelaxingRain.us@SD">Relaxing Rain</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_REPORTER_TV" lang="en" xmltv_id="ReporterTV.in@SD">REPORTER TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RSYMDOT_BANGLA" lang="en" xmltv_id="RepublicBangla.in@SD">R. Bangla</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_R_BHARAT" lang="en" xmltv_id="RepublicBharat.in@SD">R Bharat</channel>
-  <channel site="airtelxstream.in" site_id="MWTV_LIVETVCHANNEL_RBHARAT" lang="en" xmltv_id="RepublicBharat.in@SD">Republic Bharat</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RSYMDOTKANNADA" lang="en" xmltv_id="RepublicKannada.in@SD">R.Kannada</channel>
-  <channel site="airtelxstream.in" site_id="MWTV_LIVETVCHANNEL_RKANNADA" lang="en" xmltv_id="RepublicKannada.in@SD">RKannada</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_REPUBLIC_TV" lang="en" xmltv_id="RepublicTV.in@SD">Republic TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1240" lang="en" xmltv_id="Revry.us@SD">Revry</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1242" lang="en" xmltv_id="RevryHer.us@SD">Revry Her</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1094" lang="en" xmltv_id="RightNowTV.us@SD">Right Now Tv</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RSYMDOT_BANGLA" lang="en" xmltv_id="RepublicBangla.in@SD">Republic Bangla</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_R_BHARAT" lang="en" xmltv_id="RepublicBharat.in@SD">Republic Bharat</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RSYMDOTKANNADA" lang="en" xmltv_id="RepublicKannada.in@SD">Republic Kannada</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_REPUBLIC_TV" lang="en" xmltv_id="RepublicTV.in@SD">Republic Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ROMEDY_NOW" lang="en" xmltv_id="RomedyNow.in@SD">ROMEDY NOW</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5334" lang="en" xmltv_id="RongeenTV.in@SD">Rongeen Tv</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RONGEEN_TV" lang="en" xmltv_id="RongeenTV.in@SD">Rongeen Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RT" lang="en" xmltv_id="RTIndia.in@HD">RT</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_RUPOSHI_BANGLA_TV" lang="en" xmltv_id="RupasiBangla.in@SD">Ruposhi Bangla TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5384" lang="en" xmltv_id="RVTV.us@HD">RVTV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SAAM_TV" lang="en" xmltv_id="SaamTV.in@SD">Saam TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SADHNA" lang="en" xmltv_id="Sadhna.in@SD">Sadhna</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SADHNA" lang="en" xmltv_id="Sadhna.in@SD">Sadhna Gold</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SAFARI_TV" lang="en" xmltv_id="SafariTV.in@SD">Safari TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SAI_TV" lang="en" xmltv_id="SaiTV.in@SD">SAI TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5373" lang="en" xmltv_id="SakshiTV.in@SD">Sakshi Tv</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SAKSHI_TV" lang="en" xmltv_id="SakshiTV.in@SD">Sakshi TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SALAAM_TV" lang="en" xmltv_id="SalaamTV.in@SD">Salaam TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5367" lang="en" xmltv_id="SanaTV.in@SD">Sana Tv</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5370" lang="en" xmltv_id="SandeshNews.in@SD">Sandesh News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANGEET_BANGLA" lang="en" xmltv_id="SangeetBangla.in@SD">Sangeet Bangla</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANGEET_MARATHI" lang="en" xmltv_id="SangeetMarathi.in@SD">Sangeet Marathi</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD" lang="en" xmltv_id="SansadTV1.in@HD">Sansad TV - 1 HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV" lang="en" xmltv_id="SansadTV1.in@SD">Sansad TV - 1</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV_HD" lang="en" xmltv_id="SansadTV2.in@HD">Sansad TV - 2 HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_RAJYA_SABHA" lang="en" xmltv_id="SansadTV2.in@SD">Sansad TV - 2</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANSKAR" lang="en" xmltv_id="SanskarTV.in@SD">Sanskar</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SANTVANI" lang="en" xmltv_id="SantvaniChannel.in@SD">Santvani</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SARV_DHARAM_SANGAM" lang="en" xmltv_id="SarvDharamSangam.in@SD">Sarv Dharam Sangam</channel>
@@ -755,12 +527,10 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHEMAROO_TV" lang="en" xmltv_id="ShemarooTV.in@SD">Shemaroo TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHEMAROO_UMANG" lang="en" xmltv_id="ShemarooUmang.in@SD">Shemaroo Umang</channel>
   <channel site="airtelxstream.in" site_id="XSTREAMADS_LIVETVCHANNEL_shikshatv" lang="en" xmltv_id="ShikshaTV.in@SD">Shiksha TV</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHOWBOX" lang="en" xmltv_id="ShowBox.in@SD">Showbox</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHOWBOX" lang="en" xmltv_id="EpicMusic.in@SD">EPIC MUSIC</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHUBHSANDESH_TV" lang="en" xmltv_id="ShubhsandeshTV.in@SD">Shubhsandesh TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SHUBH_TV" lang="en" xmltv_id="ShubhTV.in@SD">Shubh TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SIRIPPOLI" lang="en" xmltv_id="SirippoliTV.in@SD">Sirippoli</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1207" lang="en" xmltv_id="SKWAD.us@SD">SKWAD</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1232" lang="en" xmltv_id="SlopesTV.us@SD">Slopes TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONIC" lang="en" xmltv_id="Sonic.in@SD">Sonic</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_8" lang="en" xmltv_id="SonyAath.in@SD">SONY AATH</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_BBC_EARTH_HD" lang="en" xmltv_id="SonyBBCEarth.in@HD">Sony BBC earth HD</channel>
@@ -788,9 +558,6 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_SPORTS_TEN_5" lang="en" xmltv_id="SonySportsTen5.in@SD">SONY SPORTS TEN 5</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_WAH" lang="en" xmltv_id="SonyWah.in@SD">Sony Wah</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SONY_YAY" lang="en" xmltv_id="SonyYay.in@SD">Sony Yay</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3473" lang="en" xmltv_id="SportsConnect.za@SD">Sports Connect</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1239" lang="en" xmltv_id="SportsGrid.us@SD">SportsGrid</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5246" lang="en" xmltv_id="SportsTVPlus.us@SD">SportsTVPlus</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_BHARAT_HD" lang="en" xmltv_id="StarBharat.in@HD">Star Bharat HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_BHARAT" lang="en" xmltv_id="StarBharat.in@SD">Star Bharat</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_GOLD_2_HD" lang="en" xmltv_id="StarGold2.in@HD">Star Gold 2 HD</channel>
@@ -849,9 +616,7 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_UTSAV_MOVIES" lang="en" xmltv_id="StarUtsavMovies.in@SD">STAR UTSAV MOVIES</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VIJAY_HD" lang="en" xmltv_id="StarVijay.in@HD">Star Vijay HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STAR_VIJAY" lang="en" xmltv_id="StarVijay.in@SD">Star Vijay</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_STUDIO_YUVA" lang="en" xmltv_id="StudioYuva.in@SD">Studio Yuva</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUBHAVAARTHA" lang="en" xmltv_id="SubhavaarthaTV.in@SD">Subhavaartha</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5256" lang="en" xmltv_id="SudarshanNews.in@SD">Sudarshan News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS" lang="en" xmltv_id="SudarshanNews.in@SD">Sudarshan News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUN_BANGLA" lang="en" xmltv_id="SunBangla.in@SD">Sun Bangla</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUN_LIFE" lang="en" xmltv_id="SunLife.in@SD">Sun Life</channel>
@@ -864,31 +629,22 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUN_TV_HD" lang="en" xmltv_id="SunTV.in@HD">Sun TV HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUN_TV" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SUPER_HUNGAMA" lang="en" xmltv_id="SuperHungama.in@SD">Super Hungama</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_COMEDY" lang="en" xmltv_id="SuryaComedy.in@SD">Surya Comedy</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_MOVIES" lang="en" xmltv_id="SuryaMovies.in@SD">Surya Movies</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_MUSIC" lang="en" xmltv_id="SuryaMusic.in@SD">Surya Music</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_HD" lang="en" xmltv_id="SuryaTV.in@HD">Surya HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_TV" lang="en" xmltv_id="SuryaTV.in@SD">Surya TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5241" lang="en" xmltv_id="TabbarHits.in@SD">Tabbar Hits</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_COMEDY" lang="en" xmltv_id="SunSuryaComedy.in@SD">Sun Surya Comedy</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_MOVIES" lang="en" xmltv_id="SunSuryaMovies.in@SD">Sun Surya Movies</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_MUSIC" lang="en" xmltv_id="SunSuryaMusic.in@SD">Sun Surya Music</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_HD" lang="en" xmltv_id="SunSurya.in@HD">Sun Surya HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_SURYA_TV" lang="en" xmltv_id="SunSurya.in@SD">Sun Surya</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TABBAR_HITS" lang="en" xmltv_id="TabbarHits.in@SD">Tabbar Hits</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TAMIL_JANAM" lang="en" xmltv_id="TamilJanam.in@SD">TAMIL JANAM</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TARANG_MUSIC" lang="en" xmltv_id="TarangMusic.in@SD">Tarang Music</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TARANG" lang="en" xmltv_id="TarangTV.in@SD">Tarang</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_416" lang="en" xmltv_id="TheBoatShow.us@SD">The Boat Show</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5158" lang="en" xmltv_id="TheCowboyChannel.us@SD">Cowboy Channel</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5325" lang="en" xmltv_id="TheReuters60.pl@FAST">The Reuters 60</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_414" lang="en" xmltv_id="TheTitanicChannel.us@SD">Titanic TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TIMES_NOW" lang="en" xmltv_id="TimesNow.in@SD">TIMES NOW</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT" lang="en" xmltv_id="TimesNowNavbharat.in@SD">NAVBHARAT</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD" lang="en" xmltv_id="TimesNowNavbharat.in@SD">Times Now Navbharat HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TIMES_NOW_WORLD_HD" lang="en" xmltv_id="TimesNowWorld.in@SD">Times Now World HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TLC" lang="en" xmltv_id="TLC.in@SD">TLC</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TOTAL_TV" lang="en" xmltv_id="TotalTVHaryana.in@SD">Total TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3307" lang="en" xmltv_id="TraceBrazuca.fr@SD">TRACE Brazuca</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3242" lang="en" xmltv_id="TraceLatina.uk@SD">TRACE Latina</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_3243" lang="en" xmltv_id="TraceUrban.fr@SD">TRACE Urban</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TRAVELXP" lang="en" xmltv_id="Travelxp.in@HD">Travelxp</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2971" lang="en" xmltv_id="TrueAfrican.za@SD">True African</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2540" lang="en" xmltv_id="TrueHistory.us@SD">True History</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV5_MONDE_ASIA" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5 Monde Asia</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV5_TELUGU" lang="en" xmltv_id="TV5News.in@SD">TV5 Telugu</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV9_BANGLA" lang="en" xmltv_id="TV9Bangla.in@SD">TV9 Bangla</channel>
@@ -897,18 +653,14 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV9_KANNADA" lang="en" xmltv_id="TV9Kannada.in@SD">TV9 Kannada</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV9_MARATHI" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TV9_TELUGU_NEWS" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu News</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_2800" lang="en" xmltv_id="TVPunjab.ca@SD">TV Punjab</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_TWENTY_FOUR" lang="en" xmltv_id="TwentyFourNews.in@SD">Twenty Four</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_COMEDY" lang="en" xmltv_id="UdayaComedy.in@SD">Udaya Comedy</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_MOVIES" lang="en" xmltv_id="UdayaMovies.in@SD">UDAYA MOVIES</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_MUSIC" lang="en" xmltv_id="UdayaMusic.in@SD">Udaya Music</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_HD" lang="en" xmltv_id="UdayaTV.in@HD">Udaya HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_TV" lang="en" xmltv_id="UdayaTV.in@SD">Udaya TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1682" lang="en" xmltv_id="UsWeeklyTV.us@SD">Us Weekly TV</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_COMEDY" lang="en" xmltv_id="SunUdayaComedy.in@SD">Sun Udaya Comedy</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_MOVIES" lang="en" xmltv_id="SunUdayaMovies.in@SD">SUN UDAYA MOVIES</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_MUSIC" lang="en" xmltv_id="SunUdayaMusic.in@SD">SUN UDAYA MUSIC</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_HD" lang="en" xmltv_id="SunUdaya.in@HD">Sun Udaya HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_UDAYA_TV" lang="en" xmltv_id="SunUdaya.in@SD">SUN UDAYA</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_V6_NEWS" lang="en" xmltv_id="V6News.in@SD">V6 NEWS</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VANITHA" lang="en" xmltv_id="VanithaTV.in@SD">Vanitha</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VASANTH_TV" lang="en" xmltv_id="VasanthTV.in@SD">Vasanth TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5274" lang="en" xmltv_id="ViajarTV.ar@SD">Viajar TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VIJAY_SUPER_HD" lang="en" xmltv_id="VijaySuper.in@HD">VIJAY SUPER HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VIJAYSUPER" lang="en" xmltv_id="VijaySuper.in@SD">VIJAYSUPER</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VIJAY_TAKKAR" lang="en" xmltv_id="VijayTakkar.in@SD">Vijay Takkar</channel>
@@ -916,26 +668,20 @@
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VISSA_TV" lang="en" xmltv_id="VissaTV.in@SD">Vissa TV</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VISTAAR_NEWS" lang="en" xmltv_id="VistaarNews.in@SD">Vistaar News</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_VTV_GUJARATI" lang="en" xmltv_id="VTVNews.in@SD">VTV Gujarati</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1733" lang="en" xmltv_id="Wapp.cl@SD">WappTV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5385" lang="en" xmltv_id="WineWatchesWhiskey.us@HD">Wine, Watches &amp; Whiskey</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_WION" lang="en" xmltv_id="WION.in@SD">WION</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1130" lang="en" xmltv_id="WorldPokerTour.us@US">World Poker Tour</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1684" lang="en" xmltv_id="XFCTV.us@SD">XFC TV</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_1032" lang="en" xmltv_id="YoungHollywood.us@SD">Young Hollywood</channel>
-  <channel site="airtelxstream.in" site_id="DISTROTV_LIVETVCHANNEL_5049" lang="en" xmltv_id="YRFMusic.in@SD">YRF Music</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_24_GHANTA" lang="en" xmltv_id="Zee24Ghanta.in@SD">Zee 24 Ghanta</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_24_KALAK" lang="en" xmltv_id="Zee24Kalak.in@SD">Zee 24 Kalak</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_24_TAAS" lang="en" xmltv_id="Zee24Taas.in@SD">Zee 24 Taas</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BANGLA_HD" lang="en" xmltv_id="ZeeBangla.in@HD">Zee Bangla HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BANGLA" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BANGLA_CINEMA" lang="en" xmltv_id="ZeeBanglaSonar.in@SD">Z Bangla Sonar</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BANGLA_CINEMA" lang="en" xmltv_id="ZeeBanglaSonar.in@SD">Zee Bangla Sonar</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BHARAT" lang="en" xmltv_id="ZeeBharat.in@SD">Zee Bharat</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BIHAR_JHARKHAND" lang="en" xmltv_id="ZeeBiharJharkhand.in@SD">Zee Bihar Jharkhand</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BISKOPE" lang="en" xmltv_id="ZeeBiskope.in@SD">Zee Biskope</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BOLLYWOOD" lang="en" xmltv_id="ZeeBollywood.in@SD">Zee Bollywood</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_BUSINESS" lang="en" xmltv_id="ZeeBusiness.in@SD">Zee Business</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CAFE_HD" lang="en" xmltv_id="ZeeCafe.in@HD">Zee Cafe HD</channel>
-  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CAFE" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CAFE_HD" lang="en" xmltv_id="Unite8Sports1.in@HD">Unite8 Sports 1 HD</channel>
+  <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CAFE" lang="en" xmltv_id="Unite8Sports1.in@SD">Unite8 Sports 1</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CINEMA_HD" lang="en" xmltv_id="ZeeCinema.in@HD">Zee Cinema HD</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CINEMA" lang="en" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
   <channel site="airtelxstream.in" site_id="LIVETV_LIVETVCHANNEL_ZEE_CINEMALU_HD" lang="en" xmltv_id="ZeeCinemalu.in@HD">Zee Cinemalu HD</channel>

--- a/sites/dishtv.in/dishtv.in.channels.xml
+++ b/sites/dishtv.in/dishtv.in.channels.xml
@@ -7,7 +7,7 @@
   <channel site="dishtv.in" site_id="100869" lang="en" xmltv_id="DiscoveryChannel.in@SD">Discovery Channel</channel>
   <channel site="dishtv.in" site_id="117852" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
   <channel site="dishtv.in" site_id="117853" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla</channel>
-  <channel site="dishtv.in" site_id="123500" lang="en" xmltv_id="">TLC HD</channel>
+  <channel site="dishtv.in" site_id="123500" lang="en" xmltv_id="TLC.in@HD">TLC HD</channel>
   <channel site="dishtv.in" site_id="135691" lang="en" xmltv_id="MBCTV.in@SD">MBC TV</channel>
   <channel site="dishtv.in" site_id="140063" lang="en" xmltv_id="B4UMovies.in@India">B4U Movies</channel>
   <channel site="dishtv.in" site_id="140066" lang="en" xmltv_id="">Movies Active</channel>
@@ -17,6 +17,7 @@
   <channel site="dishtv.in" site_id="142495" lang="en" xmltv_id="10TV.in@SD">10TV</channel>
   <channel site="dishtv.in" site_id="142504" lang="en" xmltv_id="9XTashan.in@SD">9X Tashan</channel>
   <channel site="dishtv.in" site_id="142505" lang="en" xmltv_id="AadinathTV.in@SD">Aadinath</channel>
+  <channel site="dishtv.in" site_id="142506" lang="en" xmltv_id="">Aaj Ki Khabar</channel>
   <channel site="dishtv.in" site_id="142507" lang="en" xmltv_id="AajTak.in@SD">Aaj Tak</channel>
   <channel site="dishtv.in" site_id="142510" lang="en" xmltv_id="AakaashAath.in@SD">Aakash Aath</channel>
   <channel site="dishtv.in" site_id="142514" lang="en" xmltv_id="AasthaBhajan.in@SD">Aastha Bhajan</channel>
@@ -27,11 +28,10 @@
   <channel site="dishtv.in" site_id="142548" lang="en" xmltv_id="AdithyaTV.in@SD">Adithya TV</channel>
   <channel site="dishtv.in" site_id="142630" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
   <channel site="dishtv.in" site_id="142632" lang="en" xmltv_id="AmritaTV.in@SD">Amrita TV</channel>
-  <channel site="dishtv.in" site_id="142635" lang="en" xmltv_id="Andflix.in@SD">&amp;flix</channel>
-  <channel site="dishtv.in" site_id="142636" lang="en" xmltv_id="Andflix.in@HD">&amp;flix HD</channel>
+  <channel site="dishtv.in" site_id="142635" lang="en" xmltv_id="Unite8Sports2.in@SD">Unite8 Sports 2</channel>
+  <channel site="dishtv.in" site_id="142636" lang="en" xmltv_id="Unite8Sports2.in@HD">Unite8 Sports 2 HD</channel>
   <channel site="dishtv.in" site_id="142637" lang="en" xmltv_id="Andpictures.in@SD">&amp; Pictures</channel>
   <channel site="dishtv.in" site_id="142638" lang="en" xmltv_id="Andpictures.in@HD">&amp; Pictures HD</channel>
-  <channel site="dishtv.in" site_id="142639" lang="en" xmltv_id="AndpriveHD.in@SD">&amp;prive HD</channel>
   <channel site="dishtv.in" site_id="142640" lang="en" xmltv_id="AndTV.in@SD">&amp;TV</channel>
   <channel site="dishtv.in" site_id="142641" lang="en" xmltv_id="AndTV.in@HD">&amp;TV HD</channel>
   <channel site="dishtv.in" site_id="142649" lang="en" xmltv_id="AradanaTV.in@SD">Aradana TV</channel>
@@ -48,7 +48,6 @@
   <channel site="dishtv.in" site_id="142694" lang="en" xmltv_id="B4UBhojpuri.in@SD">B4U Bhojpuri</channel>
   <channel site="dishtv.in" site_id="142695" lang="en" xmltv_id="B4UKadak.in@SD">B4U Kadak</channel>
   <channel site="dishtv.in" site_id="142697" lang="en" xmltv_id="BalleBalle.in@SD">Balle Balle</channel>
-  <channel site="dishtv.in" site_id="142702" lang="en" xmltv_id="BansalNews.in@SD">Bansal News</channel>
   <channel site="dishtv.in" site_id="142709" lang="en" xmltv_id="BhakthiTV.in@SD">Bhakti TV</channel>
   <channel site="dishtv.in" site_id="142710" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
   <channel site="dishtv.in" site_id="142711" lang="en" xmltv_id="BharatExpress.in@SD">Bharat Express</channel>
@@ -80,10 +79,16 @@
   <channel site="dishtv.in" site_id="142780" lang="en" xmltv_id="DDBihar.in@SD">DD Bihar</channel>
   <channel site="dishtv.in" site_id="142781" lang="en" xmltv_id="DDChandana.in@SD">DD Chandana</channel>
   <channel site="dishtv.in" site_id="142782" lang="en" xmltv_id="DDGirnar.in@SD">DD Girnar</channel>
+  <channel site="dishtv.in" site_id="142783" lang="en" xmltv_id="DDGoa.in@SD">DD GOA</channel>
+  <channel site="dishtv.in" site_id="142784" lang="en" xmltv_id="DDHaryana.in@SD">DD Haryana</channel>
   <channel site="dishtv.in" site_id="142788" lang="en" xmltv_id="DDKashir.in@SD">DD Kashir</channel>
   <channel site="dishtv.in" site_id="142789" lang="en" xmltv_id="DDKisan.in@SD">DD Kisan</channel>
   <channel site="dishtv.in" site_id="142790" lang="en" xmltv_id="DDMadhyaPradesh.in@SD">DD Madhya Pradesh</channel>
   <channel site="dishtv.in" site_id="142791" lang="en" xmltv_id="DDMalayalam.in@SD">DD Malayalam</channel>
+  <channel site="dishtv.in" site_id="142792" lang="en" xmltv_id="DDManipur.in@SD">DD Manipur</channel>
+  <channel site="dishtv.in" site_id="142793" lang="en" xmltv_id="DDMeghalaya.in@SD">DD MEGHALAYA</channel>
+  <channel site="dishtv.in" site_id="142794" lang="en" xmltv_id="DDMizoram.in@SD">DD MIZORAM</channel>
+  <channel site="dishtv.in" site_id="142795" lang="en" xmltv_id="DDNagaland.in@SD">DD NAGALAND</channel>
   <channel site="dishtv.in" site_id="142796" lang="en" xmltv_id="DDOdia.in@SD">DD Oriya</channel>
   <channel site="dishtv.in" site_id="142797" lang="en" xmltv_id="DDTamil.in@SD">DD TAMIL</channel>
   <channel site="dishtv.in" site_id="142800" lang="en" xmltv_id="DDPunjabi.in@SD">DD Punjabi</channel>
@@ -92,6 +97,7 @@
   <channel site="dishtv.in" site_id="142804" lang="en" xmltv_id="DDSaptagiri.in@SD">DD Saptagiri</channel>
   <channel site="dishtv.in" site_id="142807" lang="en" xmltv_id="DDUttarPradesh.in@SD">DD UP</channel>
   <channel site="dishtv.in" site_id="142808" lang="en" xmltv_id="DDUrdu.in@SD">DD Urdu</channel>
+  <channel site="dishtv.in" site_id="142809" lang="en" xmltv_id="DDUttarakhand.in@SD">DD Uttrakhand</channel>
   <channel site="dishtv.in" site_id="142810" lang="en" xmltv_id="DDYadagiri.in@SD">DD Yadagiri</channel>
   <channel site="dishtv.in" site_id="142881" lang="en" xmltv_id="GoldminesMovies.in@SD">Goldmines Movies</channel>
   <channel site="dishtv.in" site_id="142882" lang="en" xmltv_id="DhoomMusic.in@SD">Dhoom Music</channel>
@@ -113,7 +119,7 @@
   <channel site="dishtv.in" site_id="142920" lang="en" xmltv_id="SongdewTV.in@SD">Songdew</channel>
   <channel site="dishtv.in" site_id="142921" lang="en" xmltv_id="">TELUGU ACTIVE</channel>
   <channel site="dishtv.in" site_id="142926" lang="en" xmltv_id="">Dish TV Evergreen Classic</channel>
-  <channel site="dishtv.in" site_id="142985" lang="en" xmltv_id="">Watcho One</channel>
+  <channel site="dishtv.in" site_id="142985" lang="en" xmltv_id="">Dish TV Watcho</channel>
   <channel site="dishtv.in" site_id="142986" lang="en" xmltv_id="">Zindagi Active</channel>
   <channel site="dishtv.in" site_id="142989" lang="en" xmltv_id="DisneyInternationalHD.in@SD">Disney International HD</channel>
   <channel site="dishtv.in" site_id="142990" lang="en" xmltv_id="DisneyJunior.in@SD">Disney Junior</channel>
@@ -134,16 +140,16 @@
   <channel site="dishtv.in" site_id="143033" lang="en" xmltv_id="ETVTelugu.in@SD">ETV Telugu</channel>
   <channel site="dishtv.in" site_id="143038" lang="en" xmltv_id="FaktMarathi.in@SD">Fakt Marathi</channel>
   <channel site="dishtv.in" site_id="143065" lang="en" xmltv_id="FlowersTV.in@SD">Flowers TV</channel>
-  <channel site="dishtv.in" site_id="143067" lang="en" xmltv_id="FMNews.in@SD">FM News</channel>
-  <channel site="dishtv.in" site_id="143074" lang="en" xmltv_id="GeminiComedy.in@SD">Gemini Comedy</channel>
-  <channel site="dishtv.in" site_id="143075" lang="en" xmltv_id="GeminiLife.in@SD">Gemini Life</channel>
-  <channel site="dishtv.in" site_id="143076" lang="en" xmltv_id="GeminiMovies.in@SD">Gemini Movies</channel>
-  <channel site="dishtv.in" site_id="143077" lang="en" xmltv_id="GeminiMusic.in@SD">Gemini Music</channel>
-  <channel site="dishtv.in" site_id="143078" lang="en" xmltv_id="GeminiTV.in@SD">Gemini TV</channel>
+  <channel site="dishtv.in" site_id="143074" lang="en" xmltv_id="SunGeminiComedy.in@SD">Sun Gemini Comedy</channel>
+  <channel site="dishtv.in" site_id="143075" lang="en" xmltv_id="SunGeminiLife.in@SD">Sun Gemini Life</channel>
+  <channel site="dishtv.in" site_id="143076" lang="en" xmltv_id="SunGeminiMovies.in@SD">Sun Gemini Movies</channel>
+  <channel site="dishtv.in" site_id="143077" lang="en" xmltv_id="SunGeminiMusic.in@SD">Sun Gemini Music</channel>
+  <channel site="dishtv.in" site_id="143078" lang="en" xmltv_id="SunGemini.in@SD">Sun Gemini</channel>
   <channel site="dishtv.in" site_id="143087" lang="en" xmltv_id="Goldmines.in@SD">Goldmines</channel>
-  <channel site="dishtv.in" site_id="143089" lang="en" xmltv_id="">Goldmines Bollywood</channel>
+  <channel site="dishtv.in" site_id="143089" lang="en" xmltv_id="GoldminesBollywood.in@SD">Goldmines Bollywood</channel>
   <channel site="dishtv.in" site_id="143090" lang="en" xmltv_id="GoodNewsToday.in@SD">Good News Today</channel>
   <channel site="dishtv.in" site_id="143091" lang="en" xmltv_id="GoodnessTV.in@SD">Goodness TV</channel>
+  <channel site="dishtv.in" site_id="143096" lang="en" xmltv_id="GujaratFirst.in@SD">Gujarat First</channel>
   <channel site="dishtv.in" site_id="143097" lang="en" xmltv_id="GulistanNews.in@SD">Gulistan News</channel>
   <channel site="dishtv.in" site_id="143100" lang="en" xmltv_id="Gyandarshan.in@SD">Gyandarshan</channel>
   <channel site="dishtv.in" site_id="143102" lang="en" xmltv_id="HareKrsnaTV.in@SD">Hare Krsna</channel>
@@ -153,14 +159,12 @@
   <channel site="dishtv.in" site_id="143136" lang="en" xmltv_id="HMTV.in@SD">HMTV</channel>
   <channel site="dishtv.in" site_id="143150" lang="en" xmltv_id="HungamaTV.in@SD">Hungama</channel>
   <channel site="dishtv.in" site_id="143156" lang="en" xmltv_id="IBC24.in@SD">IBC24</channel>
-  <channel site="dishtv.in" site_id="143190" lang="en" xmltv_id="IndiaNews.in@SD">India News</channel>
   <channel site="dishtv.in" site_id="143192" lang="en" xmltv_id="IndiaNewsHaryana.in@SD">India News Haryana</channel>
   <channel site="dishtv.in" site_id="143197" lang="en" xmltv_id="IndiaToday.in@SD">INDIA TODAY</channel>
   <channel site="dishtv.in" site_id="143199" lang="en" xmltv_id="IndiaTV.in@SD">India TV</channel>
   <channel site="dishtv.in" site_id="143212" lang="en" xmltv_id="IsaiAruvi.in@SD">Isai Aruvi</channel>
   <channel site="dishtv.in" site_id="143213" lang="en" xmltv_id="IshwarBhaktiTV.in@SD">Ishwar TV</channel>
-  <channel site="dishtv.in" site_id="143215" lang="en" xmltv_id="">J Movies</channel>
-  <channel site="dishtv.in" site_id="143216" lang="en" xmltv_id="JaiMaharashtra.in@SD">Jai Maharashtra</channel>
+  <channel site="dishtv.in" site_id="143215" lang="en" xmltv_id="JMovie.in@SD">J Movies</channel>
   <channel site="dishtv.in" site_id="143217" lang="en" xmltv_id="JaihindTV.in@SD">Jaihind TV</channel>
   <channel site="dishtv.in" site_id="143218" lang="en" xmltv_id="JalshaMovies.in@SD">Jalsha Movies</channel>
   <channel site="dishtv.in" site_id="143219" lang="en" xmltv_id="JalshaMovies.in@HD">Jalsha Movies HD</channel>
@@ -220,6 +224,7 @@
   <channel site="dishtv.in" site_id="143574" lang="en" xmltv_id="NationalGeographic.in@HD">National Geographic Channel HD</channel>
   <channel site="dishtv.in" site_id="143578" lang="en" xmltv_id="News7Tamil.in@SD">News7</channel>
   <channel site="dishtv.in" site_id="143584" lang="en" xmltv_id="Nepal1.in@SD">Nepal 1</channel>
+  <channel site="dishtv.in" site_id="143585" lang="en" xmltv_id="Network10.in@SD">Network 10</channel>
   <channel site="dishtv.in" site_id="143587" lang="en" xmltv_id="News1st.in@SD">News 1st Kannada</channel>
   <channel site="dishtv.in" site_id="143593" lang="en" xmltv_id="NewsIndia24x7.in@SD">News India 24x7</channel>
   <channel site="dishtv.in" site_id="143595" lang="en" xmltv_id="NewsLive.in@SD">News Live</channel>
@@ -231,13 +236,13 @@
   <channel site="dishtv.in" site_id="143608" lang="en" xmltv_id="News18BiharJharkhand.in@SD">News18 Bihar Jharkhand</channel>
   <channel site="dishtv.in" site_id="143609" lang="en" xmltv_id="News18Gujarati.in@SD">News18 Gujarati</channel>
   <channel site="dishtv.in" site_id="143610" lang="en" xmltv_id="News18India.in@SD">News18 India</channel>
-  <channel site="dishtv.in" site_id="143611" lang="en" xmltv_id="News18JKLH.in@SD">News18 Jammu Kashmir Ladakh Himachal Haryana</channel>
+  <channel site="dishtv.in" site_id="143611" lang="en" xmltv_id="News18DelhiNCRJK.in@SD">News18 Delhi NCR Jammu Kashmir</channel>
   <channel site="dishtv.in" site_id="143612" lang="en" xmltv_id="News18Kannada.in@SD">News18 Kannada</channel>
   <channel site="dishtv.in" site_id="143613" lang="en" xmltv_id="News18Kerala.in@SD">News18 Kerala</channel>
-  <channel site="dishtv.in" site_id="143614" lang="en" xmltv_id="News18Lokmat.in@SD">News18 Lokmat</channel>
+  <channel site="dishtv.in" site_id="143614" lang="en" xmltv_id="News18Marathi.in@SD">News18 Marathi</channel>
   <channel site="dishtv.in" site_id="143615" lang="en" xmltv_id="News18MadhyaPradeshChhattisgarh.in@SD">News18 Madhya Pradesh Chhattisgarh</channel>
   <channel site="dishtv.in" site_id="143616" lang="en" xmltv_id="News18Odia.in@SD">News18 Odia</channel>
-  <channel site="dishtv.in" site_id="143617" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">NEWS18 PUNJAB</channel>
+  <channel site="dishtv.in" site_id="143617" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">News18 Punjab Haryana Himachal</channel>
   <channel site="dishtv.in" site_id="143618" lang="en" xmltv_id="News18Rajasthan.in@SD">NEWS18 RAJASTHAN</channel>
   <channel site="dishtv.in" site_id="143619" lang="en" xmltv_id="News18TamilNadu.in@SD">News18 Tamil Nadu</channel>
   <channel site="dishtv.in" site_id="143620" lang="en" xmltv_id="">Prarthana Life</channel>
@@ -269,7 +274,6 @@
   <channel site="dishtv.in" site_id="143686" lang="en" xmltv_id="PublicMovies.in@SD">Public Movies</channel>
   <channel site="dishtv.in" site_id="143687" lang="en" xmltv_id="PublicMusic.in@SD">Public Music</channel>
   <channel site="dishtv.in" site_id="143688" lang="en" xmltv_id="PublicTV.in@SD">Public TV</channel>
-  <channel site="dishtv.in" site_id="143691" lang="en" xmltv_id="PunjabiHits.in@SD">PUNJABI HITS</channel>
   <channel site="dishtv.in" site_id="143692" lang="en" xmltv_id="PuthiyaThalaimurai.in@SD">Puthiya Thalaimurai</channel>
   <channel site="dishtv.in" site_id="143693" lang="en" xmltv_id="PuthuyugamTV.in@SD">Puthu Yugam</channel>
   <channel site="dishtv.in" site_id="143697" lang="en" xmltv_id="RepublicBangla.in@SD">R. Bangla</channel>
@@ -370,10 +374,10 @@
   <channel site="dishtv.in" site_id="143876" lang="en" xmltv_id="SunMusic.in@SD">Sun Music</channel>
   <channel site="dishtv.in" site_id="143877" lang="en" xmltv_id="SunNews.in@SD">Sun News</channel>
   <channel site="dishtv.in" site_id="143883" lang="en" xmltv_id="SuperHungama.in@SD">Super Hungama</channel>
-  <channel site="dishtv.in" site_id="143884" lang="en" xmltv_id="SuryaComedy.in@SD">Surya Comedy</channel>
-  <channel site="dishtv.in" site_id="143885" lang="en" xmltv_id="SuryaMovies.in@SD">Surya Movies</channel>
-  <channel site="dishtv.in" site_id="143886" lang="en" xmltv_id="SuryaMusic.in@SD">Surya Music</channel>
-  <channel site="dishtv.in" site_id="143888" lang="en" xmltv_id="SuryaTV.in@SD">Surya TV</channel>
+  <channel site="dishtv.in" site_id="143884" lang="en" xmltv_id="SunSuryaComedy.in@SD">Sun Surya Comedy</channel>
+  <channel site="dishtv.in" site_id="143885" lang="en" xmltv_id="SunSuryaMovies.in@SD">Sun Surya Movies</channel>
+  <channel site="dishtv.in" site_id="143886" lang="en" xmltv_id="SunSuryaMusic.in@SD">Sun Surya Music</channel>
+  <channel site="dishtv.in" site_id="143888" lang="en" xmltv_id="SunSurya.in@SD">Sun Surya</channel>
   <channel site="dishtv.in" site_id="143889" lang="en" xmltv_id="SVBC.in@SD">SVBC</channel>
   <channel site="dishtv.in" site_id="143890" lang="en" xmltv_id="SVBC2.in@SD">SVBC 2</channel>
   <channel site="dishtv.in" site_id="143919" lang="en" xmltv_id="TNews.in@SD">T News</channel>
@@ -394,10 +398,10 @@
   <channel site="dishtv.in" site_id="144030" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
   <channel site="dishtv.in" site_id="144031" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu</channel>
   <channel site="dishtv.in" site_id="144032" lang="en" xmltv_id="TwentyFourNews.in@SD">Twenty Four</channel>
-  <channel site="dishtv.in" site_id="144039" lang="en" xmltv_id="UdayaComedy.in@SD">Udaya Comedy</channel>
-  <channel site="dishtv.in" site_id="144040" lang="en" xmltv_id="UdayaMovies.in@SD">Udaya Movies</channel>
-  <channel site="dishtv.in" site_id="144041" lang="en" xmltv_id="UdayaMusic.in@SD">Udaya Music</channel>
-  <channel site="dishtv.in" site_id="144042" lang="en" xmltv_id="UdayaTV.in@SD">Udaya TV</channel>
+  <channel site="dishtv.in" site_id="144039" lang="en" xmltv_id="SunUdayaComedy.in@SD">Sun Udaya Comedy</channel>
+  <channel site="dishtv.in" site_id="144040" lang="en" xmltv_id="SunUdayaMovies.in@SD">Sun Udaya Movies</channel>
+  <channel site="dishtv.in" site_id="144041" lang="en" xmltv_id="SunUdayaMusic.in@SD">Sun Udaya Music</channel>
+  <channel site="dishtv.in" site_id="144042" lang="en" xmltv_id="SunUdaya.in@SD">Sun Udaya</channel>
   <channel site="dishtv.in" site_id="144047" lang="en" xmltv_id="V6News.in@SD">V6 News</channel>
   <channel site="dishtv.in" site_id="144068" lang="en" xmltv_id="VasanthTV.in@SD">Vasanth TV</channel>
   <channel site="dishtv.in" site_id="144069" lang="en" xmltv_id="Vedic.in@SD">Vedic</channel>
@@ -420,9 +424,8 @@
   <channel site="dishtv.in" site_id="144437" lang="en" xmltv_id="ZeeBanglaSonar.in@SD">Zee Bangla Sonar</channel>
   <channel site="dishtv.in" site_id="144438" lang="en" xmltv_id="ZeeBollywood.in@SD">Zee Bollywood</channel>
   <channel site="dishtv.in" site_id="144439" lang="en" xmltv_id="ZeeBusiness.in@SD">Zee Business</channel>
-  <channel site="dishtv.in" site_id="144440" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe</channel>
-  <channel site="dishtv.in" site_id="144441" lang="en" xmltv_id="ZeeCafe.in@HD">Zee Cafe HD</channel>
-  <channel site="dishtv.in" site_id="144442" lang="en" xmltv_id="ZeeChitramandir.in@SD">ZEE Chitramandir</channel>
+  <channel site="dishtv.in" site_id="144440" lang="en" xmltv_id="Unite8Sports1.in@SD">Unite8 Sports 1</channel>
+  <channel site="dishtv.in" site_id="144441" lang="en" xmltv_id="Unite8Sports1.in@HD">Unite8 Sports 1 HD</channel>
   <channel site="dishtv.in" site_id="144443" lang="en" xmltv_id="ZeeCinema.in@HD">Zee Cinema HD</channel>
   <channel site="dishtv.in" site_id="144445" lang="en" xmltv_id="ZeeCinemalu.in@SD">Zee Cinemalu</channel>
   <channel site="dishtv.in" site_id="144446" lang="en" xmltv_id="ZeeCinemalu.in@HD">Zee Cinemalu HD</channel>
@@ -459,15 +462,17 @@
   <channel site="dishtv.in" site_id="145322" lang="en" xmltv_id="KTV.in@HD">KTV HD</channel>
   <channel site="dishtv.in" site_id="145426" lang="en" xmltv_id="SansadTV2.in@SD">Sansad TV 2</channel>
   <channel site="dishtv.in" site_id="145427" lang="en" xmltv_id="SunMusic.in@HD">Sun Music HD</channel>
-  <channel site="dishtv.in" site_id="145430" lang="en" xmltv_id="UdayaTV.in@HD">Udaya HD</channel>
+  <channel site="dishtv.in" site_id="145430" lang="en" xmltv_id="SunUdaya.in@HD">Sun Udaya HD</channel>
   <channel site="dishtv.in" site_id="147570" lang="en" xmltv_id="MNX.in@HD">MNX HD</channel>
   <channel site="dishtv.in" site_id="147571" lang="en" xmltv_id="MoviesNow.in@HD">Movies Now HD</channel>
-  <channel site="dishtv.in" site_id="147755" lang="en" xmltv_id="GeminiTV.in@HD">Gemini TV HD</channel>
+  <channel site="dishtv.in" site_id="147755" lang="en" xmltv_id="SunGemini.in@HD">Sun Gemini HD</channel>
   <channel site="dishtv.in" site_id="147769" lang="en" xmltv_id="MazhavilManorama.in@HD">Mazhavil Manorama HD</channel>
   <channel site="dishtv.in" site_id="148763" lang="en" xmltv_id="ZeeKeralam.in@HD">Zee Keralam HD</channel>
   <channel site="dishtv.in" site_id="149166" lang="en" xmltv_id="SonySportsTen4.in@Telugu">Sony Sports Ten 4 Telugu</channel>
-  <channel site="dishtv.in" site_id="149281" lang="en" xmltv_id="SuryaTV.in@HD">Surya HD</channel>
+  <channel site="dishtv.in" site_id="149281" lang="en" xmltv_id="SunSurya.in@HD">Sun Surya HD</channel>
   <channel site="dishtv.in" site_id="153079" lang="en" xmltv_id="SonySportsTen3Hindi.in@SD">Sony Sports Ten 3 Hindi</channel>
+  <channel site="dishtv.in" site_id="154545" lang="en" xmltv_id="DDIndia.in@HD">DD India HD</channel>
+  <channel site="dishtv.in" site_id="154892" lang="en" xmltv_id="ManoranjanPrime.in@SD">Manoranjan Prime</channel>
   <channel site="dishtv.in" site_id="154895" lang="en" xmltv_id="NDTV24x7.in@SD">NDTV 24x7</channel>
   <channel site="dishtv.in" site_id="154897" lang="en" xmltv_id="NTVTelugu.in@SD">NTV</channel>
   <channel site="dishtv.in" site_id="157574" lang="en" xmltv_id="AnimalPlanet.in@SD">Animal Planet</channel>
@@ -485,8 +490,9 @@
   <channel site="dishtv.in" site_id="157600" lang="en" xmltv_id="Zoom.in@SD">Zoom</channel>
   <channel site="dishtv.in" site_id="157679" lang="en" xmltv_id="CNNInternational.us@SouthAsia">CNN International</channel>
   <channel site="dishtv.in" site_id="157682" lang="en" xmltv_id="ColorsTamil.in@SD">Colors Tamil</channel>
+  <channel site="dishtv.in" site_id="157683" lang="en" xmltv_id="DDNews.in@HD">DD News HD</channel>
   <channel site="dishtv.in" site_id="157802" lang="en" xmltv_id="Eurosport.in@SD">EUROSPORT</channel>
-  <channel site="dishtv.in" site_id="157803" lang="en" xmltv_id="FilamchiBhojpuri.in@SD">Filamchi Bhojpuri</channel>
+  <channel site="dishtv.in" site_id="157803" lang="en" xmltv_id="EpicBhojpuri.in@SD">Epic Bhojpuri</channel>
   <channel site="dishtv.in" site_id="157811" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery</channel>
   <channel site="dishtv.in" site_id="157820" lang="en" xmltv_id="NickJr.in@SD">Nick Junior</channel>
   <channel site="dishtv.in" site_id="157960" lang="en" xmltv_id="ShortsTV.uk@SD">Shorts TV</channel>
@@ -499,10 +505,9 @@
   <channel site="dishtv.in" site_id="158049" lang="en" xmltv_id="ZeeBangla.in@HD">Zee Bangla HD</channel>
   <channel site="dishtv.in" site_id="158133" lang="en" xmltv_id="Aastha.in@SD">Aastha</channel>
   <channel site="dishtv.in" site_id="158134" lang="en" xmltv_id="AasthaKannada.in@SD">Aastha Kannada</channel>
-  <channel site="dishtv.in" site_id="158135" lang="en" xmltv_id="AasthaGujarati.in@SD">Aastha Gujarati</channel>
   <channel site="dishtv.in" site_id="158136" lang="en" xmltv_id="AasthaTelugu.in@SD">Aastha Telugu</channel>
   <channel site="dishtv.in" site_id="158138" lang="en" xmltv_id="ABPNews.in@SD">ABP News</channel>
-  <channel site="dishtv.in" site_id="158140" lang="en" xmltv_id="">Animal Planet HD</channel>
+  <channel site="dishtv.in" site_id="158140" lang="en" xmltv_id="AnimalPlanet.in@HD">Animal Planet HD</channel>
   <channel site="dishtv.in" site_id="158141" lang="en" xmltv_id="B4UMusic.in@India">B4U Music</channel>
   <channel site="dishtv.in" site_id="158142" lang="en" xmltv_id="BBCNews.uk@SouthAsia">BBC News</channel>
   <channel site="dishtv.in" site_id="158144" lang="en" xmltv_id="Colors.in@SD">Colors</channel>
@@ -518,7 +523,8 @@
   <channel site="dishtv.in" site_id="158240" lang="en" xmltv_id="ColorsSuper.in@SD">Colors Super</channel>
   <channel site="dishtv.in" site_id="158241" lang="en" xmltv_id="ColorsTamil.in@HD">Colors Tamil HD</channel>
   <channel site="dishtv.in" site_id="158251" lang="en" xmltv_id="DDIndia.in@SD">DD India</channel>
-  <channel site="dishtv.in" site_id="158252" lang="en" xmltv_id="DDNational.in">DD National</channel>
+  <channel site="dishtv.in" site_id="158252" lang="en" xmltv_id="DDNational.in@SD">DD National</channel>
+  <channel site="dishtv.in" site_id="158253" lang="en" xmltv_id="DDNational.in@HD">DD National HD</channel>
   <channel site="dishtv.in" site_id="158254" lang="en" xmltv_id="DDNews.in@SD">DD News</channel>
   <channel site="dishtv.in" site_id="158255" lang="en" xmltv_id="DDSports.in@SD">DD Sports</channel>
   <channel site="dishtv.in" site_id="158297" lang="en" xmltv_id="StarGold2.in@HD">Star Gold 2 HD</channel>
@@ -527,36 +533,36 @@
   <channel site="dishtv.in" site_id="158300" lang="en" xmltv_id="StarSports1Telugu.in@HD">Star Sports 1 Telugu HD</channel>
   <channel site="dishtv.in" site_id="158301" lang="en" xmltv_id="">Hollywood Indie Active</channel>
   <channel site="dishtv.in" site_id="158302" lang="en" xmltv_id="AsianetMovies.in@HD">Asianet Movies HD</channel>
-  <channel site="dishtv.in" site_id="158303" lang="en" xmltv_id="Nazara.in@SD">Nazara</channel>
+  <channel site="dishtv.in" site_id="158303" lang="en" xmltv_id="EpicBharat.in@SD">Epic Bharat</channel>
+  <channel site="dishtv.in" site_id="158312" lang="en" xmltv_id="DDSports.in@HD">DD Sports HD</channel>
   <channel site="dishtv.in" site_id="158319" lang="en" xmltv_id="VijaySuper.in@HD">Star Vijay Super HD</channel>
   <channel site="dishtv.in" site_id="158324" lang="en" xmltv_id="NDTVMadhyaPradeshChhattisgarh.in@SD">NDTV MPCG</channel>
   <channel site="dishtv.in" site_id="158325" lang="en" xmltv_id="NDTVRajasthan.in@SD">NDTV Rajasthan</channel>
   <channel site="dishtv.in" site_id="158328" lang="en" xmltv_id="PudhariNews.in@SD">Pudhari News</channel>
   <channel site="dishtv.in" site_id="158329" lang="en" xmltv_id="ZeeTeluguNews.in@SD">Zee Telugu News</channel>
-  <channel site="dishtv.in" site_id="158336" lang="en" xmltv_id="CaptainTV.in@SD">Captain</channel>
   <channel site="dishtv.in" site_id="158351" lang="en" xmltv_id="StarSports2Telugu.in@SD">Star Sports 2 Telugu</channel>
   <channel site="dishtv.in" site_id="158352" lang="en" xmltv_id="StarSports2Tamil.in@SD">Star Sports 2 Tamil</channel>
+  <channel site="dishtv.in" site_id="158785" lang="en" xmltv_id="">India Daily Live Duplicate</channel>
   <channel site="dishtv.in" site_id="158792" lang="en" xmltv_id="">TNP News HD</channel>
-  <channel site="dishtv.in" site_id="158796" lang="en" xmltv_id="">Asom Live 24</channel>
   <channel site="dishtv.in" site_id="158797" lang="en" xmltv_id="ZingHome.in@SD">Zing Home</channel>
   <channel site="dishtv.in" site_id="158822" lang="en" xmltv_id="StarGoldThrills.in@SD">Star Gold Thrills</channel>
   <channel site="dishtv.in" site_id="158825" lang="en" xmltv_id="">India Daily 24x7</channel>
   <channel site="dishtv.in" site_id="158843" lang="en" xmltv_id="DisneyChannel.in@HD">Disney Channel HD</channel>
   <channel site="dishtv.in" site_id="158844" lang="en" xmltv_id="UniqueTV.in@SD">Unique TV</channel>
+  <channel site="dishtv.in" site_id="158851" lang="en" xmltv_id="NENews.in@SD">Ne News</channel>
   <channel site="dishtv.in" site_id="158861" lang="en" xmltv_id="ShemarooJosh.in@SD">Shemaroo Josh</channel>
   <channel site="dishtv.in" site_id="158863" lang="en" xmltv_id="StarMoviesSelect.in@SD">Star Movies Select</channel>
-  <channel site="dishtv.in" site_id="158864" lang="en" xmltv_id="SachBedhadak.in@SD">SACH BEDHADAK</channel>
-  <channel site="dishtv.in" site_id="158865" lang="en" xmltv_id="">Daily Post- Punjab Haryana Himachal</channel>
-  <channel site="dishtv.in" site_id="159010" lang="en" xmltv_id="">EUROSPORT HD</channel>
+  <channel site="dishtv.in" site_id="158865" lang="en" xmltv_id="">Skyama Daily Post News</channel>
+  <channel site="dishtv.in" site_id="159010" lang="en" xmltv_id="Eurosport.in@HD">EUROSPORT HD</channel>
   <channel site="dishtv.in" site_id="159011" lang="en" xmltv_id="DiscoveryKids.in@SD">Discovery Kids</channel>
   <channel site="dishtv.in" site_id="159012" lang="en" xmltv_id="DisneyChannel.in@SD">Disney Channel</channel>
   <channel site="dishtv.in" site_id="159013" lang="en" xmltv_id="EpicTV.in@SD">Epic TV</channel>
-  <channel site="dishtv.in" site_id="159014" lang="en" xmltv_id="Gubbare.in@SD">Gubbare TV</channel>
-  <channel site="dishtv.in" site_id="159015" lang="en" xmltv_id="IsharaTV.in@SD">ISHARA</channel>
+  <channel site="dishtv.in" site_id="159014" lang="en" xmltv_id="EpicKids.in@SD">Epic Kids</channel>
+  <channel site="dishtv.in" site_id="159015" lang="en" xmltv_id="EpicParivar.in@SD">Epic Parivar</channel>
   <channel site="dishtv.in" site_id="159016" lang="en" xmltv_id="ManoramaNews.in@SD">Manorama News</channel>
   <channel site="dishtv.in" site_id="159093" lang="en" xmltv_id="MTV.in@HD">MTV HD</channel>
-  <channel site="dishtv.in" site_id="159096" lang="en" xmltv_id="SonyEntertainmentTelevision.in@SD">SET HD</channel>
-  <channel site="dishtv.in" site_id="159097" lang="en" xmltv_id="ShowBox.in@SD">Showbox</channel>
+  <channel site="dishtv.in" site_id="159096" lang="en" xmltv_id="SonyEntertainmentTelevision.in@HD">SET HD</channel>
+  <channel site="dishtv.in" site_id="159097" lang="en" xmltv_id="EpicMusic.in@SD">Epic Music</channel>
   <channel site="dishtv.in" site_id="159098" lang="en" xmltv_id="SonyMax.in@HD">SONY MAX HD</channel>
   <channel site="dishtv.in" site_id="159099" lang="en" xmltv_id="SonySAB.in@HD">Sony SAB HD</channel>
   <channel site="dishtv.in" site_id="159100" lang="en" xmltv_id="SonyYay.in@SD">SONY YAY</channel>
@@ -578,6 +584,7 @@
   <channel site="dishtv.in" site_id="159131" lang="en" xmltv_id="StarGold.in@SD">Star Gold</channel>
   <channel site="dishtv.in" site_id="159132" lang="en" xmltv_id="StarUtsav.in@SD">Star Utsav</channel>
   <channel site="dishtv.in" site_id="159135" lang="en" xmltv_id="AlJazeera.qa@English">Al Jazeera English</channel>
+  <channel site="dishtv.in" site_id="159287" lang="en" xmltv_id="KBSWorld.kr@SD">KBS World</channel>
   <channel site="dishtv.in" site_id="159298" lang="en" xmltv_id="ZeeNews.in@SD">Zee News</channel>
   <channel site="dishtv.in" site_id="159339" lang="en" xmltv_id="">DISH BUZZ HD Duplicate</channel>
   <channel site="dishtv.in" site_id="159340" lang="en" xmltv_id="">DISH BUZZ HD Duplicate1</channel>
@@ -589,18 +596,45 @@
   <channel site="dishtv.in" site_id="166276" lang="en" xmltv_id="NDTVMarathi.in@SD">NDTV Marathi</channel>
   <channel site="dishtv.in" site_id="166320" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">News Malayalam 24x7</channel>
   <channel site="dishtv.in" site_id="169160" lang="en" xmltv_id="">Live Times</channel>
-  <channel site="dishtv.in" site_id="169169" lang="en" xmltv_id="">News State Punjab Haryana Himachal</channel>
-  <channel site="dishtv.in" site_id="173277" lang="en" xmltv_id="">Malamaal Reward</channel>
+  <channel site="dishtv.in" site_id="169169" lang="en" xmltv_id="NewsStatePunjabHaryanaHimachal.in@SD">News State Punjab Haryana Himachal</channel>
+  <channel site="dishtv.in" site_id="173164" lang="en" xmltv_id="TV100.in@SD">TV100</channel>
   <channel site="dishtv.in" site_id="177794" lang="en" xmltv_id="">Zing Recharge Reminder</channel>
-  <channel site="dishtv.in" site_id="179406" lang="en" xmltv_id="">Star Sports 2 Telugu HD</channel>
-  <channel site="dishtv.in" site_id="179407" lang="en" xmltv_id="">Star Sports 2 Tamil HD</channel>
-  <channel site="dishtv.in" site_id="179440" lang="en" xmltv_id="">Sony MAX 1</channel>
+  <channel site="dishtv.in" site_id="179406" lang="en" xmltv_id="StarSports2Telugu.in@HD">Star Sports 2 Telugu HD</channel>
+  <channel site="dishtv.in" site_id="179407" lang="en" xmltv_id="StarSports2Tamil.in@HD">Star Sports 2 Tamil HD</channel>
+  <channel site="dishtv.in" site_id="179440" lang="en" xmltv_id="SonyMax1.in@SD">Sony MAX 1</channel>
+  <channel site="dishtv.in" site_id="179441" lang="en" xmltv_id="">NATON 27</channel>
   <channel site="dishtv.in" site_id="179620" lang="en" xmltv_id="StarMaa.in@HD">Star Maa HD</channel>
   <channel site="dishtv.in" site_id="181408" lang="en" xmltv_id="">Live Times</channel>
+  <channel site="dishtv.in" site_id="181409" lang="en" xmltv_id="PragNews.in@SD">Prag News</channel>
+  <channel site="dishtv.in" site_id="181417" lang="en" xmltv_id="Rengoni.in@SD">Rengoni</channel>
   <channel site="dishtv.in" site_id="181723" lang="en" xmltv_id="">Zee News Duplicate</channel>
-  <channel site="dishtv.in" site_id="185336" lang="en" xmltv_id="">NFDC - Cinemas of India</channel>
-  <channel site="dishtv.in" site_id="185737" lang="en" xmltv_id="MKNMarathi.in@SD">MKN News</channel>
   <channel site="dishtv.in" site_id="192071" lang="en" xmltv_id="">Crunchyroll Anime Top Active</channel>
-  <channel site="dishtv.in" site_id="197417" lang="en" xmltv_id="">NFDC MOD</channel>
-  <channel site="dishtv.in" site_id="202704" lang="en" xmltv_id="">GTC Punjabi HD</channel>
+  <channel site="dishtv.in" site_id="202704" lang="en" xmltv_id="GTCPunjabi.in@SD">GTC Punjabi HD</channel>
+  <channel site="dishtv.in" site_id="202705" lang="en" xmltv_id="GTCNews.in@SD">GTC News HD</channel>
+  <channel site="dishtv.in" site_id="206138" lang="en" xmltv_id="">K News India Duplicate</channel>
+  <channel site="dishtv.in" site_id="209012" lang="en" xmltv_id="SonySportsTen4.in@Kannada">Sony Sports Ten 4 Kannada</channel>
+  <channel site="dishtv.in" site_id="209090" lang="en" xmltv_id="">Yaadein Active</channel>
+  <channel site="dishtv.in" site_id="209091" lang="en" xmltv_id="">Tamil Talkies Active</channel>
+  <channel site="dishtv.in" site_id="209124" lang="en" xmltv_id="">Kannada Chitra Active</channel>
+  <channel site="dishtv.in" site_id="209326" lang="en" xmltv_id="DDKisan.in@HD">DD Kisan HD</channel>
+  <channel site="dishtv.in" site_id="209534" lang="en" xmltv_id="DDGirnar.in@HD">DD Girnar HD</channel>
+  <channel site="dishtv.in" site_id="209539" lang="en" xmltv_id="DDOdia.in@HD">DD Oriya HD</channel>
+  <channel site="dishtv.in" site_id="209540" lang="en" xmltv_id="DDTamil.in@HD">DD TAMIL HD</channel>
+  <channel site="dishtv.in" site_id="209541" lang="en" xmltv_id="DDSahyadri.in@HD">DD Sahyadri HD</channel>
+  <channel site="dishtv.in" site_id="209610" lang="en" xmltv_id="">DishTV Delight</channel>
+  <channel site="dishtv.in" site_id="211014" lang="en" xmltv_id="">DishTV Delight Duplicate</channel>
+  <channel site="dishtv.in" site_id="211015" lang="en" xmltv_id="">DishTV Delight Duplicate 1</channel>
+  <channel site="dishtv.in" site_id="211016" lang="en" xmltv_id="">DishTV Delight Duplicate 2</channel>
+  <channel site="dishtv.in" site_id="211017" lang="en" xmltv_id="">DishTV Delight Duplicate 3</channel>
+  <channel site="dishtv.in" site_id="211018" lang="en" xmltv_id="">DishTV Delight Duplicate 4</channel>
+  <channel site="dishtv.in" site_id="211019" lang="en" xmltv_id="">DishTV Delight Duplicate 5</channel>
+  <channel site="dishtv.in" site_id="211052" lang="en" xmltv_id="">DishTV Delight Duplicate 6</channel>
+  <channel site="dishtv.in" site_id="211053" lang="en" xmltv_id="">DishTV Delight Duplicate 7</channel>
+  <channel site="dishtv.in" site_id="211054" lang="en" xmltv_id="">DishTV Delight Duplicate 8</channel>
+  <channel site="dishtv.in" site_id="211888" lang="en" xmltv_id="">Always ON</channel>
+  <channel site="dishtv.in" site_id="211921" lang="en" xmltv_id="">Always ON Duplicate</channel>
+  <channel site="dishtv.in" site_id="213783" lang="en" xmltv_id="">DishTV R.Bangla Duplicate</channel>
+  <channel site="dishtv.in" site_id="213784" lang="en" xmltv_id="">DishTV Living India News Duplicate</channel>
+  <channel site="dishtv.in" site_id="213785" lang="en" xmltv_id="">DishTV R.Kannada Duplicate</channel>
+  <channel site="dishtv.in" site_id="213786" lang="en" xmltv_id="">DishTV Republic TV Duplicate</channel>
 </channels>

--- a/sites/distro.tv/distro.tv.channels.xml
+++ b/sites/distro.tv/distro.tv.channels.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="distro.tv" site_id="8087" lang="en" xmltv_id="FTFSports.us@SD">FTF Sports</channel>
-  <channel site="distro.tv" site_id="11063" lang="en" xmltv_id="HorizonSports.us@SD">Horizon Sports</channel>
-  <channel site="distro.tv" site_id="11064" lang="en" xmltv_id="TheBoatShow.us@SD">The Boat Show</channel>
   <channel site="distro.tv" site_id="15976" lang="en" xmltv_id="OutsideTV.us@SD">Outside</channel>
-  <channel site="distro.tv" site_id="20021" lang="en" xmltv_id="DoveChannel.us@SD">Dove</channel>
-  <channel site="distro.tv" site_id="24375" lang="en" xmltv_id="">The First</channel>
   <channel site="distro.tv" site_id="27440" lang="en" xmltv_id="NewsmaxTV.us@SD">Newsmax TV</channel>
-  <channel site="distro.tv" site_id="28953" lang="en" xmltv_id="LoneStar.us@SD">Lone Star</channel>
-  <channel site="distro.tv" site_id="29218" lang="en" xmltv_id="HardKnocks.ca@SD">Hard Knocks</channel>
-  <channel site="distro.tv" site_id="34007" lang="en" xmltv_id="RightNowTV.us@SD">Right Now Tv</channel>
   <channel site="distro.tv" site_id="34008" lang="en" xmltv_id="OANPlus.us@SD">OAN Plus</channel>
   <channel site="distro.tv" site_id="34009" lang="en" xmltv_id="">AWE Plus</channel>
   <channel site="distro.tv" site_id="35967" lang="en" xmltv_id="QelloConcertsbyStingray.ca@SD">Qello Concerts</channel>
@@ -30,11 +22,7 @@
   <channel site="distro.tv" site_id="36454" lang="en" xmltv_id="SchwabNetwork.us@SD">Schwab Network</channel>
   <channel site="distro.tv" site_id="37560" lang="en" xmltv_id="">CJC Television Network</channel>
   <channel site="distro.tv" site_id="37684" lang="en" xmltv_id="WorldPokerTour.us@US">World Poker Tour</channel>
-  <channel site="distro.tv" site_id="39081" lang="en" xmltv_id="LawCrime.us@SD">Law &amp; Crime</channel>
   <channel site="distro.tv" site_id="39730" lang="en" xmltv_id="24HourFreeMovies.us@SD">24 Hour Free Movies</channel>
-  <channel site="distro.tv" site_id="40431" lang="en" xmltv_id="SKWAD.us@SD">SKWAD</channel>
-  <channel site="distro.tv" site_id="40432" lang="en" xmltv_id="">Channel Fight</channel>
-  <channel site="distro.tv" site_id="40434" lang="en" xmltv_id="CookingPanda.us@SD">Cooking Panda</channel>
   <channel site="distro.tv" site_id="42160" lang="en" xmltv_id="BusinessRockstars.us@SD">Business Rockstars</channel>
   <channel site="distro.tv" site_id="42161" lang="en" xmltv_id="CinePride.us@SD">Cinepride</channel>
   <channel site="distro.tv" site_id="42162" lang="en" xmltv_id="DungeonTV.us@SD">Dungeon TV</channel>
@@ -43,79 +31,29 @@
   <channel site="distro.tv" site_id="42166" lang="en" xmltv_id="">Screendreams by Invincible</channel>
   <channel site="distro.tv" site_id="42167" lang="en" xmltv_id="SlopesTV.us@SD">Slopes TV</channel>
   <channel site="distro.tv" site_id="42168" lang="en" xmltv_id="WatchitScream.us@SD">Watchit Scream!</channel>
-  <channel site="distro.tv" site_id="43797" lang="en" xmltv_id="SportsGrid.us@SD">SportsGrid</channel>
   <channel site="distro.tv" site_id="43912" lang="en" xmltv_id="Revry.us@SD">Revry</channel>
   <channel site="distro.tv" site_id="43914" lang="en" xmltv_id="RevryHer.us@SD">Revry Her</channel>
   <channel site="distro.tv" site_id="45143" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews</channel>
   <channel site="distro.tv" site_id="45144" lang="en" xmltv_id="EuronewsSpanish.fr@SD">Euronews Español</channel>
-  <channel site="distro.tv" site_id="48682" lang="en" xmltv_id="BloombergTV.us@US">Bloomberg Television</channel>
-  <channel site="distro.tv" site_id="49342" lang="en" xmltv_id="CineLife.us@SD">CineLife</channel>
-  <channel site="distro.tv" site_id="50995" lang="en" xmltv_id="BloombergOriginals.us@SD">Bloomberg Originals</channel>
   <channel site="distro.tv" site_id="51671" lang="en" xmltv_id="XFCTV.us@SD">XFC TV</channel>
-  <channel site="distro.tv" site_id="52253" lang="en" xmltv_id="">NOST - The Nostalgia Network</channel>
   <channel site="distro.tv" site_id="52995" lang="en" xmltv_id="ShopLC.us@SD">ShopLC</channel>
-  <channel site="distro.tv" site_id="54754" lang="en" xmltv_id="">MotorRacing</channel>
   <channel site="distro.tv" site_id="55457" lang="en" xmltv_id="Journy.us@SD">Journy</channel>
-  <channel site="distro.tv" site_id="55878" lang="en" xmltv_id="">WION World is One News</channel>
-  <channel site="distro.tv" site_id="56569" lang="en" xmltv_id="">Times Now News</channel>
-  <channel site="distro.tv" site_id="56784" lang="en" xmltv_id="BilliardTV.us@SD">Billiard TV</channel>
-  <channel site="distro.tv" site_id="56785" lang="en" xmltv_id="">BarkTV</channel>
-  <channel site="distro.tv" site_id="58240" lang="en" xmltv_id="">Mirror Now</channel>
-  <channel site="distro.tv" site_id="58724" lang="en" xmltv_id="">Times Now Navbharat</channel>
-  <channel site="distro.tv" site_id="58784" lang="en" xmltv_id="">Zoom</channel>
-  <channel site="distro.tv" site_id="64394" lang="en" xmltv_id="">ACE TV</channel>
   <channel site="distro.tv" site_id="64501" lang="en" xmltv_id="RealAmericasVoice.us@SD">Real America&apos;s Voice</channel>
-  <channel site="distro.tv" site_id="66325" lang="en" xmltv_id="">Powersports World</channel>
-  <channel site="distro.tv" site_id="66501" lang="en" xmltv_id="">Garv Punjab Gurbani</channel>
-  <channel site="distro.tv" site_id="66502" lang="en" xmltv_id="">Swar Shree</channel>
   <channel site="distro.tv" site_id="66893" lang="en" xmltv_id="TrueHistory.us@SD">True History</channel>
-  <channel site="distro.tv" site_id="68556" lang="en" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="distro.tv" site_id="68982" lang="en" xmltv_id="">general HLS test channel</channel>
   <channel site="distro.tv" site_id="68983" lang="en" xmltv_id="">general HLS test channel 2</channel>
-  <channel site="distro.tv" site_id="69140" lang="en" xmltv_id="ACLCornholeTV.us@SD">ACL Cornhole TV</channel>
-  <channel site="distro.tv" site_id="70963" lang="en" xmltv_id="">Hare Krsna</channel>
   <channel site="distro.tv" site_id="71576" lang="en" xmltv_id="">general HLS test channel 3</channel>
-  <channel site="distro.tv" site_id="71637" lang="en" xmltv_id="TVPunjab.ca@SD">TV Punjab</channel>
-  <channel site="distro.tv" site_id="71932" lang="en" xmltv_id="">Swerve Combat</channel>
-  <channel site="distro.tv" site_id="73234" lang="en" xmltv_id="KaloopyTV.us@SD">Kaloopy</channel>
-  <channel site="distro.tv" site_id="73913" lang="en" xmltv_id="">ABP News</channel>
-  <channel site="distro.tv" site_id="73916" lang="en" xmltv_id="">ABP Asmita</channel>
-  <channel site="distro.tv" site_id="73917" lang="en" xmltv_id="">ABP Majha</channel>
-  <channel site="distro.tv" site_id="73918" lang="en" xmltv_id="">ABP Ananda</channel>
-  <channel site="distro.tv" site_id="73919" lang="en" xmltv_id="">ABP Ganga</channel>
-  <channel site="distro.tv" site_id="73920" lang="en" xmltv_id="">ABP Sanjha</channel>
-  <channel site="distro.tv" site_id="75531" lang="en" xmltv_id="">Bless TV</channel>
-  <channel site="distro.tv" site_id="76607" lang="en" xmltv_id="">Journy</channel>
-  <channel site="distro.tv" site_id="76856" lang="en" xmltv_id="">Afriwood Blockbuster</channel>
-  <channel site="distro.tv" site_id="76859" lang="en" xmltv_id="">Cinema Hausa</channel>
-  <channel site="distro.tv" site_id="76863" lang="en" xmltv_id="">True African</channel>
-  <channel site="distro.tv" site_id="77808" lang="en" xmltv_id="">NatureStream.tv</channel>
-  <channel site="distro.tv" site_id="78644" lang="en" xmltv_id="FITE247.us@SD">FITE 24/7</channel>
-  <channel site="distro.tv" site_id="78918" lang="en" xmltv_id="TNAWrestlingChannel.pl@SD">TNA Wrestling Channel</channel>
+  <channel site="distro.tv" site_id="76607" lang="en" xmltv_id="Journy.us@SD">Journy</channel>
   <channel site="distro.tv" site_id="78919" lang="en" xmltv_id="FightNetwork.ca@SD">Fight Network</channel>
   <channel site="distro.tv" site_id="78921" lang="en" xmltv_id="AfricanewsEnglish.fr@SD">Africanews</channel>
-  <channel site="distro.tv" site_id="79275" lang="en" xmltv_id="beINSPORTSXTRA.us@SD">beIN SPORTS Xtra</channel>
-  <channel site="distro.tv" site_id="79276" lang="en" xmltv_id="beINSPORTSXTRAenEspanol.us@SD">beIN SPORTS Xtra en Español</channel>
   <channel site="distro.tv" site_id="79726" lang="en" xmltv_id="">general hls test channel 4</channel>
-  <channel site="distro.tv" site_id="79804" lang="en" xmltv_id="">Pitaara TV</channel>
   <channel site="distro.tv" site_id="80638" lang="en" xmltv_id="">Watchit Kid!</channel>
   <channel site="distro.tv" site_id="81581" lang="en" xmltv_id="FUELTV.pt@US">FUEL TV</channel>
-  <channel site="distro.tv" site_id="81815" lang="en" xmltv_id="NollyAfrica.uk@SD">Nolly Africa HD</channel>
   <channel site="distro.tv" site_id="81997" lang="en" xmltv_id="FUELTV.pt@EMEA">FUEL TV</channel>
   <channel site="distro.tv" site_id="83408" lang="en" xmltv_id="GustoTV.ca@SD">Gusto TV</channel>
   <channel site="distro.tv" site_id="83817" lang="en" xmltv_id="">4K TRAVEL TV</channel>
   <channel site="distro.tv" site_id="83820" lang="en" xmltv_id="">ENCORE+</channel>
   <channel site="distro.tv" site_id="83822" lang="en" xmltv_id="KozoomTV.fr@SD">KOZOOM TV</channel>
-  <channel site="distro.tv" site_id="83823" lang="en" xmltv_id="EstrellaTV.us@SD">EstrellaTV</channel>
-  <channel site="distro.tv" site_id="83824" lang="en" xmltv_id="EstrellaNews.us@SD">Estrella News</channel>
-  <channel site="distro.tv" site_id="83825" lang="en" xmltv_id="EstrellaGames.us@SD">Estrella Games</channel>
-  <channel site="distro.tv" site_id="86482" lang="en" xmltv_id="BalleBalle.in@SD">Balle Balle</channel>
-  <channel site="distro.tv" site_id="86556" lang="en" xmltv_id="">TRACE Latina</channel>
-  <channel site="distro.tv" site_id="86557" lang="en" xmltv_id="TraceUrban.fr@HD">TRACE Urban</channel>
-  <channel site="distro.tv" site_id="87417" lang="en" xmltv_id="BollywoodClassic.ro@HD">Bollywood Classic</channel>
-  <channel site="distro.tv" site_id="87418" lang="en" xmltv_id="BollywoodHD.ro@HD">Bollywood HD</channel>
-  <channel site="distro.tv" site_id="87420" lang="en" xmltv_id="">IndieBox</channel>
-  <channel site="distro.tv" site_id="89324" lang="en" xmltv_id="TraceBrazuca.fr@SD">TRACE Brazuca</channel>
   <channel site="distro.tv" site_id="92944" lang="en" xmltv_id="Motorvision.de@HD">Motorvision TV</channel>
   <channel site="distro.tv" site_id="92945" lang="en" xmltv_id="">Motorvision TV Español</channel>
   <channel site="distro.tv" site_id="95226" lang="en" xmltv_id="CCTV4America.cn@SD">CCTV-4</channel>
@@ -123,139 +61,19 @@
   <channel site="distro.tv" site_id="95228" lang="en" xmltv_id="CGTNDocumentary.cn@SD">CGTN Documentary</channel>
   <channel site="distro.tv" site_id="95229" lang="en" xmltv_id="CGTNSpanish.cn@SD">CGTN Español</channel>
   <channel site="distro.tv" site_id="95621" lang="en" xmltv_id="DeFianceMedia.pr@SD">DeFiance Media</channel>
-  <channel site="distro.tv" site_id="98262" lang="en" xmltv_id="SportsConnect.za@SD">Sports Connect</channel>
-  <channel site="distro.tv" site_id="99076" lang="en" xmltv_id="">MTRSPT1</channel>
   <channel site="distro.tv" site_id="100517" lang="en" xmltv_id="">CraftsyTV</channel>
-  <channel site="distro.tv" site_id="102312" lang="en" xmltv_id="9XM.in@SD">9XM</channel>
-  <channel site="distro.tv" site_id="102313" lang="en" xmltv_id="9XJalwa.in@SD">9X Jalwa</channel>
-  <channel site="distro.tv" site_id="102778" lang="en" xmltv_id="BritAsiaTV.uk@SD">BritAsiaTV</channel>
   <channel site="distro.tv" site_id="103370" lang="en" xmltv_id="JewishLifeTelevision.us@SD">Jewish Life Television JLTV</channel>
-  <channel site="distro.tv" site_id="103416" lang="en" xmltv_id="">Scream TV</channel>
   <channel site="distro.tv" site_id="106818" lang="en" xmltv_id="">general hls test channel 5</channel>
-  <channel site="distro.tv" site_id="109611" lang="en" xmltv_id="">News9Live</channel>
-  <channel site="distro.tv" site_id="109612" lang="en" xmltv_id="TV9Bangla.in@SD">TV9 Bangla</channel>
-  <channel site="distro.tv" site_id="109613" lang="en" xmltv_id="TV9Bharatvarsh.in@SD">TV9 Bharatvarsh</channel>
-  <channel site="distro.tv" site_id="109614" lang="en" xmltv_id="TV9Gujarati.in@SD">TV9 Gujarati</channel>
-  <channel site="distro.tv" site_id="109615" lang="en" xmltv_id="TV9Kannada.in@SD">TV9 Kannada</channel>
-  <channel site="distro.tv" site_id="109616" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
-  <channel site="distro.tv" site_id="109617" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu</channel>
-  <channel site="distro.tv" site_id="112018" lang="en" xmltv_id="FloRacing.us@HD">FloRacing 24/7</channel>
-  <channel site="distro.tv" site_id="112144" lang="en" xmltv_id="">TV9 Telugu USA</channel>
   <channel site="distro.tv" site_id="114214" lang="en" xmltv_id="">crema.tv</channel>
-  <channel site="distro.tv" site_id="114364" lang="en" xmltv_id="NegociosTV.es@SD">Negocios TV</channel>
-  <channel site="distro.tv" site_id="115692" lang="en" xmltv_id="FEVATV.ca@SD">FEVA TV</channel>
-  <channel site="distro.tv" site_id="116082" lang="en" xmltv_id="">FEVA MUSIC</channel>
-  <channel site="distro.tv" site_id="116336" lang="en" xmltv_id="">Lakshya TV</channel>
-  <channel site="distro.tv" site_id="116337" lang="en" xmltv_id="">Kartavya TV</channel>
-  <channel site="distro.tv" site_id="116338" lang="en" xmltv_id="">Kalyan TV</channel>
   <channel site="distro.tv" site_id="119200" lang="en" xmltv_id="">Romance Channel</channel>
   <channel site="distro.tv" site_id="119339" lang="en" xmltv_id="">NTD News</channel>
-  <channel site="distro.tv" site_id="120048" lang="en" xmltv_id="">Al Arabiya</channel>
-  <channel site="distro.tv" site_id="120071" lang="en" xmltv_id="">PNC Drama</channel>
-  <channel site="distro.tv" site_id="120072" lang="en" xmltv_id="">Rotana Aflam+</channel>
-  <channel site="distro.tv" site_id="120073" lang="en" xmltv_id="">M+</channel>
   <channel site="distro.tv" site_id="121809" lang="en" xmltv_id="">Mediacorp Entertainment – Chinese</channel>
   <channel site="distro.tv" site_id="121810" lang="en" xmltv_id="">Mediacorp Entertainment – English</channel>
   <channel site="distro.tv" site_id="121811" lang="en" xmltv_id="">Mediacorp Entertainment – Tamil</channel>
-  <channel site="distro.tv" site_id="123695" lang="en" xmltv_id="">Shemaroo Bollywood</channel>
-  <channel site="distro.tv" site_id="123698" lang="en" xmltv_id="">Shemaroo Filmigaane</channel>
-  <channel site="distro.tv" site_id="124106" lang="en" xmltv_id="">Bollywood Masala</channel>
-  <channel site="distro.tv" site_id="126108" lang="en" xmltv_id="YRFMusic.in@SD">YRF Music</channel>
-  <channel site="distro.tv" site_id="126109" lang="en" xmltv_id="">Saga Music</channel>
-  <channel site="distro.tv" site_id="126119" lang="en" xmltv_id="">Smurf TV</channel>
-  <channel site="distro.tv" site_id="126120" lang="en" xmltv_id="">Pitufo TV</channel>
-  <channel site="distro.tv" site_id="126124" lang="en" xmltv_id="">Toon Goggles en Español</channel>
-  <channel site="distro.tv" site_id="129395" lang="en" xmltv_id="DroneTV.us@SD">DroneTV</channel>
-  <channel site="distro.tv" site_id="129995" lang="en" xmltv_id="">Global Punjab TV</channel>
-  <channel site="distro.tv" site_id="130882" lang="en" xmltv_id="">PLL Network</channel>
-  <channel site="distro.tv" site_id="130883" lang="en" xmltv_id="">PLL Network</channel>
-  <channel site="distro.tv" site_id="130974" lang="en" xmltv_id="TraceUK.uk@HD">TRACE UK</channel>
-  <channel site="distro.tv" site_id="130979" lang="en" xmltv_id="">TidPix-Authentically African</channel>
-  <channel site="distro.tv" site_id="130980" lang="en" xmltv_id="">Green Chillies TV- Zindagi ka Tadka!</channel>
   <channel site="distro.tv" site_id="130981" lang="en" xmltv_id="TheCowboyChannel.us@SD">Cowboy+ Sports</channel>
-  <channel site="distro.tv" site_id="132758" lang="en" xmltv_id="">News Nation</channel>
   <channel site="distro.tv" site_id="133605" lang="en" xmltv_id="FUELTV.pt@AU">FUEL TV</channel>
   <channel site="distro.tv" site_id="133606" lang="en" xmltv_id="FUELTV.pt@BR">FUEL TV</channel>
-  <channel site="distro.tv" site_id="135729" lang="en" xmltv_id="WillowSports.us@SD">Willow Sports</channel>
-  <channel site="distro.tv" site_id="135913" lang="en" xmltv_id="PunjabiHits.in@SD">Punjabi Hits</channel>
-  <channel site="distro.tv" site_id="136206" lang="en" xmltv_id="CNAOriginals.sg@SD">CNA Originals</channel>
-  <channel site="distro.tv" site_id="136208" lang="en" xmltv_id="GhostDimension.us@UK">Ghost Dimension</channel>
-  <channel site="distro.tv" site_id="136255" lang="en" xmltv_id="">Nolly Africa HD</channel>
-  <channel site="distro.tv" site_id="136891" lang="en" xmltv_id="TabbarHits.in@SD">Tabbar Hits</channel>
-  <channel site="distro.tv" site_id="136898" lang="en" xmltv_id="">Comercio TV</channel>
-  <channel site="distro.tv" site_id="136900" lang="en" xmltv_id="CartoonClassics.pl@FAST">Cartoon Classics</channel>
-  <channel site="distro.tv" site_id="136901" lang="en" xmltv_id="">Comedy Classics</channel>
-  <channel site="distro.tv" site_id="136902" lang="en" xmltv_id="SportsTVPlus.us@SD">SportsTVPlus</channel>
-  <channel site="distro.tv" site_id="136903" lang="en" xmltv_id="">Old West TV</channel>
-  <channel site="distro.tv" site_id="137059" lang="en" xmltv_id="">4ACETV</channel>
-  <channel site="distro.tv" site_id="137063" lang="en" xmltv_id="">4ACETV CLASSIC HITS</channel>
-  <channel site="distro.tv" site_id="137114" lang="en" xmltv_id="">The Holiday TV Channel</channel>
-  <channel site="distro.tv" site_id="137117" lang="en" xmltv_id="">Haryana Beat</channel>
-  <channel site="distro.tv" site_id="137118" lang="en" xmltv_id="">Nakshatra Digital Tv</channel>
-  <channel site="distro.tv" site_id="137119" lang="en" xmltv_id="SudarshanNews.in@SD">Sudarshan News</channel>
-  <channel site="distro.tv" site_id="137120" lang="en" xmltv_id="">Sundrani Tv</channel>
-  <channel site="distro.tv" site_id="137453" lang="en" xmltv_id="">Colorized.TV</channel>
-  <channel site="distro.tv" site_id="137454" lang="en" xmltv_id="">MomCave</channel>
-  <channel site="distro.tv" site_id="137455" lang="en" xmltv_id="">HIP HOP TV</channel>
-  <channel site="distro.tv" site_id="137456" lang="en" xmltv_id="">Fitness Rewind by Collage Video</channel>
-  <channel site="distro.tv" site_id="137457" lang="en" xmltv_id="AMusicChannel.ng@SD">AMusic Channel</channel>
-  <channel site="distro.tv" site_id="138019" lang="en" xmltv_id="">Skull Bound TV</channel>
-  <channel site="distro.tv" site_id="138020" lang="en" xmltv_id="">CinePast</channel>
-  <channel site="distro.tv" site_id="138023" lang="en" xmltv_id="">Cowboy Classics</channel>
-  <channel site="distro.tv" site_id="138024" lang="en" xmltv_id="">Hollywood Classic Movies</channel>
-  <channel site="distro.tv" site_id="138025" lang="en" xmltv_id="">Kung Fu Movies</channel>
-  <channel site="distro.tv" site_id="138026" lang="en" xmltv_id="">The Family TV Channel</channel>
-  <channel site="distro.tv" site_id="138027" lang="en" xmltv_id="">The Spanish Family Channel</channel>
-  <channel site="distro.tv" site_id="138028" lang="en" xmltv_id="">ToonOvation</channel>
-  <channel site="distro.tv" site_id="138029" lang="en" xmltv_id="ViajarTV.ar@SD">Viajar TV</channel>
-  <channel site="distro.tv" site_id="138031" lang="en" xmltv_id="BoxCinema.in@SD">Box Cinema</channel>
-  <channel site="distro.tv" site_id="138032" lang="en" xmltv_id="">Box Gamers</channel>
-  <channel site="distro.tv" site_id="138035" lang="en" xmltv_id="">Digo TV</channel>
-  <channel site="distro.tv" site_id="138036" lang="en" xmltv_id="">History Film Channel</channel>
-  <channel site="distro.tv" site_id="138214" lang="en" xmltv_id="">HITS MEXICANOS</channel>
-  <channel site="distro.tv" site_id="138215" lang="en" xmltv_id="">Rockola Television</channel>
-  <channel site="distro.tv" site_id="138216" lang="en" xmltv_id="Nigbati.ng@SD">Nigbati TV</channel>
-  <channel site="distro.tv" site_id="138653" lang="en" xmltv_id="">hi Drama!</channel>
-  <channel site="distro.tv" site_id="138656" lang="en" xmltv_id="">hi Life!</channel>
-  <channel site="distro.tv" site_id="138657" lang="en" xmltv_id="">hi Vida!</channel>
-  <channel site="distro.tv" site_id="138742" lang="en" xmltv_id="">Living India News</channel>
-  <channel site="distro.tv" site_id="138743" lang="en" xmltv_id="">Urban Action Channel</channel>
-  <channel site="distro.tv" site_id="138745" lang="en" xmltv_id="">a-z Best Classic TV</channel>
-  <channel site="distro.tv" site_id="138747" lang="en" xmltv_id="">a-z Classic Flix</channel>
-  <channel site="distro.tv" site_id="138748" lang="en" xmltv_id="">a-z Western Grit</channel>
-  <channel site="distro.tv" site_id="138920" lang="en" xmltv_id="">OurVinyl</channel>
-  <channel site="distro.tv" site_id="138921" lang="en" xmltv_id="">My Money</channel>
-  <channel site="distro.tv" site_id="138922" lang="en" xmltv_id="">Sports First TV</channel>
-  <channel site="distro.tv" site_id="139100" lang="en" xmltv_id="">Cirque du Soleil</channel>
-  <channel site="distro.tv" site_id="139145" lang="en" xmltv_id="">ACI On The Go</channel>
-  <channel site="distro.tv" site_id="139216" lang="en" xmltv_id="">CINDIE TV</channel>
-  <channel site="distro.tv" site_id="139217" lang="en" xmltv_id="">NOMADslow tv</channel>
-  <channel site="distro.tv" site_id="139488" lang="en" xmltv_id="">Cigar TV</channel>
-  <channel site="distro.tv" site_id="139489" lang="en" xmltv_id="">Playing For Change</channel>
-  <channel site="distro.tv" site_id="139658" lang="en" xmltv_id="">Aaj Ki Khabar</channel>
-  <channel site="distro.tv" site_id="139659" lang="en" xmltv_id="">Atmadarshan Tv</channel>
-  <channel site="distro.tv" site_id="139661" lang="en" xmltv_id="">Tara Tv</channel>
-  <channel site="distro.tv" site_id="139662" lang="en" xmltv_id="">The Unmute</channel>
-  <channel site="distro.tv" site_id="139666" lang="en" xmltv_id="">Wild Nature</channel>
-  <channel site="distro.tv" site_id="139667" lang="en" xmltv_id="WildTV.ca@SD">Wild TV</channel>
-  <channel site="distro.tv" site_id="140009" lang="en" xmltv_id="">Vande Bharat News</channel>
-  <channel site="distro.tv" site_id="140010" lang="en" xmltv_id="KTVBangla.in@SD">KTV Bangla</channel>
-  <channel site="distro.tv" site_id="140011" lang="en" xmltv_id="">Ann Channel</channel>
-  <channel site="distro.tv" site_id="140012" lang="en" xmltv_id="">Indian News</channel>
-  <channel site="distro.tv" site_id="140014" lang="en" xmltv_id="">Mahua Play</channel>
-  <channel site="distro.tv" site_id="140015" lang="en" xmltv_id="">Mahua Khabar</channel>
-  <channel site="distro.tv" site_id="140186" lang="en" xmltv_id="">Chicas Guapas TV</channel>
   <channel site="distro.tv" site_id="140290" lang="en" xmltv_id="TheReuters60.pl@FAST">The Reuters 60</channel>
-  <channel site="distro.tv" site_id="140513" lang="en" xmltv_id="">In Touch+</channel>
-  <channel site="distro.tv" site_id="140526" lang="en" xmltv_id="AnandTV.in@SD">Anand Tv</channel>
-  <channel site="distro.tv" site_id="140527" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
-  <channel site="distro.tv" site_id="140528" lang="en" xmltv_id="MahaaMax.in@SD">Mahaa Max</channel>
-  <channel site="distro.tv" site_id="140529" lang="en" xmltv_id="MahaaNews.in@SD">Mahaa News</channel>
-  <channel site="distro.tv" site_id="140530" lang="en" xmltv_id="MunsifTV.in@SD">Munsif Tv</channel>
-  <channel site="distro.tv" site_id="140532" lang="en" xmltv_id="">News Marathi 24X7</channel>
-  <channel site="distro.tv" site_id="140533" lang="en" xmltv_id="RongeenTV.in@SD">Rongeen Tv</channel>
-  <channel site="distro.tv" site_id="140534" lang="en" xmltv_id="">Rozana Spokesman</channel>
-  <channel site="distro.tv" site_id="140563" lang="en" xmltv_id="PrameyaNews7.in@SD">Prameya News7</channel>
   <channel site="distro.tv" site_id="140610" lang="en" xmltv_id="">UnchainedTV</channel>
   <channel site="distro.tv" site_id="140611" lang="en" xmltv_id="">POWERtube TV</channel>
   <channel site="distro.tv" site_id="140612" lang="en" xmltv_id="">Screams TV by Trinian</channel>
@@ -263,56 +81,17 @@
   <channel site="distro.tv" site_id="140614" lang="en" xmltv_id="">Mi Raza Canal</channel>
   <channel site="distro.tv" site_id="140615" lang="en" xmltv_id="">Mi Raza Canal Plus</channel>
   <channel site="distro.tv" site_id="140616" lang="en" xmltv_id="">Mi Miedo Canal</channel>
-  <channel site="distro.tv" site_id="140627" lang="en" xmltv_id="">India Daily 24x7</channel>
   <channel site="distro.tv" site_id="140685" lang="en" xmltv_id="">Elevation Church Network</channel>
-  <channel site="distro.tv" site_id="140886" lang="en" xmltv_id="NewsTamil24x7.in@SD">News Tamil 24x7</channel>
-  <channel site="distro.tv" site_id="140889" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">News Malayalam 24x7</channel>
-  <channel site="distro.tv" site_id="141278" lang="en" xmltv_id="">World Punjabi Tv</channel>
-  <channel site="distro.tv" site_id="141279" lang="en" xmltv_id="">Top News Marathi</channel>
-  <channel site="distro.tv" site_id="141280" lang="en" xmltv_id="PrathamKhabar24x7.in@SD">Pratham Khabar 24x7</channel>
-  <channel site="distro.tv" site_id="141346" lang="en" xmltv_id="Novocomedy.fr@SD">Novo Comedy</channel>
-  <channel site="distro.tv" site_id="141347" lang="en" xmltv_id="">Crime &amp; Evidence</channel>
-  <channel site="distro.tv" site_id="141348" lang="en" xmltv_id="">Cinema Yoruba</channel>
-  <channel site="distro.tv" site_id="141476" lang="en" xmltv_id="KolkataTV.in@SD">Kolkata Tv</channel>
-  <channel site="distro.tv" site_id="141479" lang="en" xmltv_id="">P18 News</channel>
-  <channel site="distro.tv" site_id="142218" lang="en" xmltv_id="BIGTV.in@SD">Big Tv</channel>
-  <channel site="distro.tv" site_id="142219" lang="en" xmltv_id="">ABN Andhra Jyothy</channel>
-  <channel site="distro.tv" site_id="142220" lang="en" xmltv_id="OutdoorChannel.us@SD">Outdoor Channel</channel>
-  <channel site="distro.tv" site_id="142221" lang="en" xmltv_id="">WFN: World Fishing Network</channel>
-  <channel site="distro.tv" site_id="143048" lang="en" xmltv_id="SanaTV.in@SD">Sana Tv</channel>
-  <channel site="distro.tv" site_id="143049" lang="en" xmltv_id="">Janataa TV Kannada</channel>
-  <channel site="distro.tv" site_id="143050" lang="en" xmltv_id="">DA News Plus</channel>
-  <channel site="distro.tv" site_id="143636" lang="en" xmltv_id="SandeshNews.in@SD">Sandesh News</channel>
-  <channel site="distro.tv" site_id="143637" lang="en" xmltv_id="GujaratFirst.in@SD">Gujarat First</channel>
-  <channel site="distro.tv" site_id="143638" lang="en" xmltv_id="">35MM</channel>
-  <channel site="distro.tv" site_id="143644" lang="en" xmltv_id="SakshiTV.in@SD">Sakshi Tv</channel>
-  <channel site="distro.tv" site_id="143663" lang="en" xmltv_id="">Unleashed by DOGTV</channel>
   <channel site="distro.tv" site_id="143731" lang="en" xmltv_id="CGTNGlobalBiz.cn@SD">CGTN Global Biz</channel>
   <channel site="distro.tv" site_id="143732" lang="en" xmltv_id="ChinaTravel.cn@SD">China Travel</channel>
   <channel site="distro.tv" site_id="143733" lang="en" xmltv_id="DiscoveringChina.cn@SD">Discovering China</channel>
-  <channel site="distro.tv" site_id="144082" lang="en" xmltv_id="PrimeAsiaTV.ca@SD">Prime Asia Tv</channel>
   <channel site="distro.tv" site_id="144300" lang="en" xmltv_id="DaystarTV.us@SD">Daystar TV</channel>
   <channel site="distro.tv" site_id="144301" lang="en" xmltv_id="DaystarTVEspanol.us@SD">Daystar Español</channel>
-  <channel site="distro.tv" site_id="144314" lang="en" xmltv_id="">Bowling TV</channel>
-  <channel site="distro.tv" site_id="144339" lang="en" xmltv_id="CTVNAKDPlus.in@SD">CTVN AKD Plus</channel>
-  <channel site="distro.tv" site_id="144340" lang="en" xmltv_id="">CN News</channel>
   <channel site="distro.tv" site_id="144407" lang="en" xmltv_id="RVTV.us@HD">RVTV</channel>
   <channel site="distro.tv" site_id="144408" lang="en" xmltv_id="WineWatchesWhiskey.us@HD">Wine, Watches &amp; Whiskey</channel>
   <channel site="distro.tv" site_id="144409" lang="en" xmltv_id="OnTV4U.us@SD">ONTV4U</channel>
-  <channel site="distro.tv" site_id="144646" lang="en" xmltv_id="">Pickleball Now</channel>
-  <channel site="distro.tv" site_id="144733" lang="en" xmltv_id="PTCPunjabiCanada.ca@SD">PTC Punjabi Canada</channel>
-  <channel site="distro.tv" site_id="144758" lang="en" xmltv_id="AmarUjala.in@SD">Amar Ujala</channel>
-  <channel site="distro.tv" site_id="144819" lang="en" xmltv_id="">DJ Central TV</channel>
-  <channel site="distro.tv" site_id="144844" lang="en" xmltv_id="GTCPunjabi.in@SD">GTC Punjabi</channel>
-  <channel site="distro.tv" site_id="144845" lang="en" xmltv_id="">Punjabi Shorts</channel>
-  <channel site="distro.tv" site_id="144846" lang="en" xmltv_id="">Rock Solid Wrestling TV</channel>
-  <channel site="distro.tv" site_id="144990" lang="en" xmltv_id="">CarbonTV</channel>
-  <channel site="distro.tv" site_id="144991" lang="en" xmltv_id="">CG Central</channel>
-  <channel site="distro.tv" site_id="144992" lang="en" xmltv_id="">spot on news</channel>
   <channel site="distro.tv" site_id="144993" lang="en" xmltv_id="">Golf Network</channel>
   <channel site="distro.tv" site_id="144994" lang="en" xmltv_id="">Foosball TV</channel>
-  <channel site="distro.tv" site_id="144995" lang="en" xmltv_id="BharatExpress.in@SD">Bharat Express</channel>
-  <channel site="distro.tv" site_id="144996" lang="en" xmltv_id="ArgusNews.in@SD">Argus News</channel>
   <channel site="distro.tv" site_id="145126" lang="en" xmltv_id="">CUISINE CULTURE</channel>
   <channel site="distro.tv" site_id="145127" lang="en" xmltv_id="">Trufa</channel>
   <channel site="distro.tv" site_id="145128" lang="en" xmltv_id="">Wai Lana</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
@@ -1411,10 +1411,10 @@
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-603fb593a99efc002dbf90e4" lang="en" xmltv_id="Motorvision.de@SD">Motorvision TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-603fb593a99efc002dbf90e4" lang="en" xmltv_id="Motorvision.de@SD">Motorvision TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-603fb593a99efc002dbf90e4" lang="en" xmltv_id="Motorvision.de@SD">Motorvision TV</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
@@ -1343,11 +1343,11 @@
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-688d3402a6fe30698ab42007" lang="en" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-688d3402a6fe30698ab42007" lang="en" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-688d3402a6fe30698ab42007" lang="en" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-60d4edd6b2fdec002c141123" lang="en" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-60d4edd6b2fdec002c141123" lang="en" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-60d4edd6b2fdec002c141123" lang="en" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
@@ -1406,11 +1406,11 @@
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-63d6fc71a9e88ee909e7ee23" lang="en" xmltv_id="MidsomerMurders.us@SD">Midsomer Murders</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-63d6fc71a9e88ee909e7ee23" lang="en" xmltv_id="MidsomerMurders.us@SD">Midsomer Murders</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-64d79408e5f67b0fab47ff24" lang="en" xmltv_id="Misteriossinresolver.us@SD">Misterios sin Resolver</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
@@ -1463,9 +1463,9 @@
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-5fb81660b7ad2d002dcb7335" lang="en" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-5fb81660b7ad2d002dcb7335" lang="en" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-5fb81660b7ad2d002dcb7335" lang="en" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-61e805952502a7a6fa84d70f" lang="en" xmltv_id="NFLChannel.us@SD">NFL Channel</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-60aeb5cd87f9b1002ce12323" lang="en" xmltv_id="NHRATV.us@SD">NHRA TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-60aeb5cd87f9b1002ce12323" lang="en" xmltv_id="NHRATV.us@SD">NHRA TV</channel>
@@ -1515,11 +1515,11 @@
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-5f0ff263d71dcb00449ec021" lang="en" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-5f0ff263d71dcb00449ec021" lang="en" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-5f0ff263d71dcb00449ec021" lang="en" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-68017ed20268b77d02a5f4bd" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-68017ed20268b77d02a5f4bd" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-68017ed20268b77d02a5f4bd" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
@@ -1734,11 +1734,11 @@
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-62ee72cc271f393d2d9f7098" lang="en" xmltv_id="StingrayY2K.ca@SD">Y2K</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-62ee72cc271f393d2d9f7098" lang="en" xmltv_id="StingrayY2K.ca@SD">Y2K</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-5fc705e2a2236e002d69f3ba" lang="en" xmltv_id="StoriesbyAMC.us@SD">Stories by AMC</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6227c215c9f485cc7afe8c41" lang="en" xmltv_id="SurfNowTV.us@SD">Surfer TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-61f04d2bb01a6e8df3f72902" lang="en" xmltv_id="SwerveSports.us@SD">Swerve Combat</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-61f04d2bb01a6e8df3f72902" lang="en" xmltv_id="SwerveSports.us@SD">Swerve Combat</channel>
@@ -1996,12 +1996,12 @@
   <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-5f170f01b898490041b49dd1" lang="en" xmltv_id="YahooFinance.us@SD">Yahoo Finance</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-5f170f01b898490041b49dd1" lang="en" xmltv_id="YahooFinance.us@SD">Yahoo Finance</channel>
   <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-6617f52f0049fcb8e2b0d5b8" lang="en" xmltv_id="YuGiOh.us@SD">Yu-Gi-Oh!</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
-  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
-  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-682512b03d06c8e426a2941a" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/us#5e20b730f2f8d5003d739db7-682512b03d06c8e426a2941a" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5ef11486d33ab9004048a1cd" lang="es" xmltv_id="">Always Funny</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5f6b8e7900b0950040d0f2b2" lang="es" xmltv_id="">The World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-60afc726623f2f002c5bb49f" lang="es" xmltv_id="">Poker Night TV</channel>
@@ -2355,8 +2355,8 @@
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-66f6b6baac1a1890ef197a4b" lang="es" xmltv_id="Hunter.us@UK">Hunter</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-688d3402a6fe30698ab42007" lang="es" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-688d3402a6fe30698ab42007" lang="es" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6448ba1baf92c31f4a190c27" lang="es" xmltv_id="Jail.pl@Poland">JAIL</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6448ba1baf92c31f4a190c27" lang="es" xmltv_id="Jail.pl@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6448ba1baf92c31f4a190c27" lang="es" xmltv_id="Jail.uk@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6448ba1baf92c31f4a190c27" lang="es" xmltv_id="Jail.uk@Poland">JAIL</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-60d4edd6b2fdec002c141123" lang="es" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-60d4edd6b2fdec002c141123" lang="es" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5f0ff262d71dcb00449ec018" lang="es" xmltv_id="JudgeNosey.us@UK">Judge Nosey</channel>
@@ -2376,8 +2376,8 @@
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-65b16e7b115f5ad5450cfdac" lang="es" xmltv_id="MilenioTelevision.mx@SD">Milenio Television</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-64d79408e5f67b0fab47ff24" lang="es" xmltv_id="Misteriossinresolver.us@SD">Misterios sin Resolver</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-64d79408e5f67b0fab47ff24" lang="es" xmltv_id="Misteriossinresolver.us@SD">Misterios sin Resolver</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6615885e1eabecf2c9d56495" lang="es" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6615885e1eabecf2c9d56495" lang="es" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6615885e1eabecf2c9d56495" lang="es" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6615885e1eabecf2c9d56495" lang="es" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-695d5d279caacd2e64b7a00c" lang="es" xmltv_id="MovieSphere.us@ES">MOVIESPHERE</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6623c8ffed4918437ed56ec4" lang="es" xmltv_id="MovieSphere.us@MX">MOVIESPHERE</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-66a2e90994b6a49cb5054d7d" lang="es" xmltv_id="MrBeanAnimated.uk@ES">Mr. Bean</channel>
@@ -2388,8 +2388,8 @@
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6970fa30bde579fb712623ff" lang="es" xmltv_id="NatureTime.ca@LATAM">Nature Time</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5fb81660b7ad2d002dcb7335" lang="es" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-5fb81660b7ad2d002dcb7335" lang="es" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-66bfb2e6144c201b8b61c10f" lang="es" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-66bfb2e6144c201b8b61c10f" lang="es" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-66bfb2e6144c201b8b61c10f" lang="es" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-66bfb2e6144c201b8b61c10f" lang="es" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-60aeb5cd87f9b1002ce12323" lang="es" xmltv_id="NHRATV.us@SD">NHRA TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-60aeb5cd87f9b1002ce12323" lang="es" xmltv_id="NHRATV.us@SD">NHRA TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-627ec46a92d8e6a705784bd1" lang="es" xmltv_id="NinjaKidzTV.us@SD">Ninja Kidz TV</channel>
@@ -2407,8 +2407,8 @@
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-646c0dfbfb58444e4e1e262d" lang="es" xmltv_id="Pac12Insider.us@SD">Pac-12 Insider</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5f0ff263d71dcb00449ec021" lang="es" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-5f0ff263d71dcb00449ec021" lang="es" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-643f0ecd76de2b4015ae6c01" lang="es" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-643f0ecd76de2b4015ae6c01" lang="es" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-643f0ecd76de2b4015ae6c01" lang="es" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-643f0ecd76de2b4015ae6c01" lang="es" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-68017ed20268b77d02a5f4bd" lang="es" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-666e2178d91d13cb4c8cbb75" lang="es" xmltv_id="PlutoTVNaturaleza.us@SD">Naturaleza</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-666e2178d91d13cb4c8cbb75" lang="es" xmltv_id="PlutoTVNaturaleza.us@SD">Naturaleza</channel>
@@ -2498,8 +2498,8 @@
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-62ee6eae271f393d2d9f7096" lang="es" xmltv_id="StingrayTodaysKPop.ca@SD">Today&apos;s K-Pop</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-62ee72cc271f393d2d9f7098" lang="es" xmltv_id="StingrayY2K.ca@SD">Y2K</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-62ee72cc271f393d2d9f7098" lang="es" xmltv_id="StingrayY2K.ca@SD">Y2K</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-644b13a3a1c0a5b2024c8403" lang="es" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-644b13a3a1c0a5b2024c8403" lang="es" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-644b13a3a1c0a5b2024c8403" lang="es" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-644b13a3a1c0a5b2024c8403" lang="es" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-65cd316a40ab06259e8168a0" lang="es" xmltv_id="TastemadeenEspanol.us@SD">Tastemade en Español</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-65cd2cf397fb4731f54ecae7" lang="es" xmltv_id="TastemadeenEspanol.us@SD">Tastemade en Español</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-62ab5aabbb869dd0df6a3487" lang="es" xmltv_id="TED.us@SD">TED</channel>
@@ -2563,7 +2563,7 @@
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-5f170f01b898490041b49dd1" lang="es" xmltv_id="YahooFinance.us@SD">Yahoo Finance</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-5f170f01b898490041b49dd1" lang="es" xmltv_id="YahooFinance.us@SD">Yahoo Finance</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6750ddfe89fc497ec780f5bd" lang="es" xmltv_id="ZeeMundo.us@SD">Zee Mundo</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-66ce3e009ac0b1441b19ca29" lang="es" xmltv_id="ZNation.pl@SD">Z Nation</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-66ce3e009ac0b1441b19ca29" lang="es" xmltv_id="ZNation.us@SD">Z Nation</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5ef11486d33ab9004048a1cd" lang="fr" xmltv_id="">Always Funny</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5f6b8e7900b0950040d0f2b2" lang="fr" xmltv_id="">The World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-60afc726623f2f002c5bb49f" lang="fr" xmltv_id="">Poker Night TV</channel>
@@ -2708,7 +2708,7 @@
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-66f6b6baac1a1890ef197a4b" lang="fr" xmltv_id="Hunter.us@UK">Hunter</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-67db068f92cb453db28ab017" lang="fr" xmltv_id="IntoCrime.fr@SD">IntoCrime</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-688d3402a6fe30698ab42007" lang="fr" xmltv_id="ITVDeportes.mx@SD">ITV Deportes</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6448ba1baf92c31f4a190c27" lang="fr" xmltv_id="Jail.pl@Poland">JAIL</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6448ba1baf92c31f4a190c27" lang="fr" xmltv_id="Jail.uk@Poland">JAIL</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-60d4edd6b2fdec002c141123" lang="fr" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5f0ff262d71dcb00449ec018" lang="fr" xmltv_id="JudgeNosey.us@UK">Judge Nosey</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-64704954e536e0faaf10be9f" lang="fr" xmltv_id="JustforLaughsGags.us@SD">Just For Laughs Gags</channel>
@@ -2717,12 +2717,12 @@
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-671ff65b29bcfe7b69d4fef7" lang="fr" xmltv_id="LoveCrimeHistory.es@FR">Love Crime &amp;amp; History</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-60db63d29ec966002c9ea6f0" lang="fr" xmltv_id="MadeInHollywood.us@SD">Made In Hollywood</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5ef4e1b40d9ad000423c4430" lang="fr" xmltv_id="MaverickBlackCinema.us@SD">Maverick Black Cinema</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6615885e1eabecf2c9d56495" lang="fr" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6615885e1eabecf2c9d56495" lang="fr" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-675a3b143c1d4ea8298f8f08" lang="fr" xmltv_id="Motorvision.de@SD">Motorvision</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-695d5c1d6e5de3b17595a267" lang="fr" xmltv_id="MovieSphere.us@FR">MOVIESPHERE</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6827c34ca5c6e573c6904444" lang="fr" xmltv_id="NatureTime.ca@France">Nature Time</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5fb81660b7ad2d002dcb7335" lang="fr" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-66bfb2e6144c201b8b61c10f" lang="fr" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-66bfb2e6144c201b8b61c10f" lang="fr" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-60aeb5cd87f9b1002ce12323" lang="fr" xmltv_id="NHRATV.us@SD">NHRA TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-64b1e1217d4037206787f384" lang="fr" xmltv_id="NollyAfrica.uk@SD">Nolly Africa HD</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5f0ff262d71dcb00449ec015" lang="fr" xmltv_id="Nosey.us@US">Nosey</channel>
@@ -2730,7 +2730,7 @@
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-64d4e82ac5d4668c9cb7b5df" lang="fr" xmltv_id="Novelisima.us@SD">Novelisima</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-646c0dfbfb58444e4e1e262d" lang="fr" xmltv_id="Pac12Insider.us@SD">Pac-12 Insider</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5f0ff263d71dcb00449ec021" lang="fr" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-643f0ecd76de2b4015ae6c01" lang="fr" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-643f0ecd76de2b4015ae6c01" lang="fr" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-64ac687b4192b4e1bab96279" lang="fr" xmltv_id="PokerGo.us@UK">PokerGO</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-656fb850cb7e8e6a9bc3f36e" lang="fr" xmltv_id="PopularScience.us@SD">Popular Science</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-69814bbff871095eafc65925" lang="fr" xmltv_id="PowerNationTV.us@SD">Powernation</channel>
@@ -2773,7 +2773,7 @@
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-62f11395586633e88e3a3274" lang="fr" xmltv_id="StingrayTheSpa.ca@SD">The Spa</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-62ee6eae271f393d2d9f7096" lang="fr" xmltv_id="StingrayTodaysKPop.ca@SD">Today&apos;s K-Pop</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-62ee72cc271f393d2d9f7098" lang="fr" xmltv_id="StingrayY2K.ca@SD">Y2K</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-644b13a3a1c0a5b2024c8403" lang="fr" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-644b13a3a1c0a5b2024c8403" lang="fr" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-66311c41707bae70101ec755" lang="fr" xmltv_id="Tastemade.us@UK">Tastemade</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-62ab5aabbb869dd0df6a3487" lang="fr" xmltv_id="TED.us@SD">TED</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-5f123330eca6a20040b328e8" lang="fr" xmltv_id="TGJunior.us@SD">TG Junior</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_plex.channels.xml
@@ -948,9 +948,9 @@
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6533e9b1df3ccc650a965646" lang="en" xmltv_id="AdventureEarth.de@SD">Adventure Earth</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-6533e27abd43e1c8b1865154" lang="en" xmltv_id="AdventureEarth.de@SD">Adventure Earth</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6533e433bd43e1c8b1865156" lang="en" xmltv_id="AdventureEarth.de@SD">Adventure Earth</channel>
-  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6245f06793b402a3d1097787" lang="en" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
-  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6245f06793b402a3d1097787" lang="en" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
-  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6245f06793b402a3d1097787" lang="en" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-6245f06793b402a3d1097787" lang="en" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-6245f06793b402a3d1097787" lang="en" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/nz#5e20b730f2f8d5003d739db7-6245f06793b402a3d1097787" lang="en" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
   <channel site="i.mjh.nz" site_id="Plex/au#697140a85d851f5e69414688-60e737a4ebef9d002c4d0a0c" lang="en" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="i.mjh.nz" site_id="Plex/ca#647f8d22a2fc3fadb4721685-60e737a4ebef9d002c4d0a0c" lang="en" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="i.mjh.nz" site_id="Plex/gb#64305451fc3be5947773c339-60e737a4ebef9d002c4d0a0c" lang="en" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
@@ -2259,8 +2259,8 @@
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-63504925a97bd70eaef54f01" lang="es" xmltv_id="ACLCornholeTV.us@SD">ACL Cornhole TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-63504925a97bd70eaef54f01" lang="es" xmltv_id="ACLCornholeTV.us@SD">ACL Cornhole TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-682510ec0f741b077c360512" lang="es" xmltv_id="Actualidad360.es@SD">Actualidad 360</channel>
-  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6245f06793b402a3d1097787" lang="es" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
-  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6245f06793b402a3d1097787" lang="es" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-6245f06793b402a3d1097787" lang="es" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-6245f06793b402a3d1097787" lang="es" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-60e737a4ebef9d002c4d0a0c" lang="es" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="i.mjh.nz" site_id="Plex/mx#608049aefa2b8ae93c2c3a63-60e737a4ebef9d002c4d0a0c" lang="es" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="i.mjh.nz" site_id="Plex/es#643054b1fc3be59477853717-656236cc5dbccec83a87b647" lang="es" xmltv_id="Andromeda.us@Spain">Andromeda</channel>
@@ -2661,7 +2661,7 @@
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-69333216ac5b3f9f53442374" lang="fr" xmltv_id="">Baby Einstein</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-652875586425fdb1f32d2169" lang="fr" xmltv_id="">World Surf League 24/7</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-63504925a97bd70eaef54f01" lang="fr" xmltv_id="ACLCornholeTV.us@SD">ACL Cornhole TV</channel>
-  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6245f06793b402a3d1097787" lang="fr" xmltv_id="AfricanewsFrench.fr@SD">Euronews Français</channel>
+  <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-6245f06793b402a3d1097787" lang="fr" xmltv_id="EuronewsFrench.fr@SD">Euronews Français</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-60e737a4ebef9d002c4d0a0c" lang="fr" xmltv_id="AfroLandTV.us@SD">AfroLandTV</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-68e03cb418c739b4d91a6a59" lang="fr" xmltv_id="AlerteaMalibu.us@France">Alerte à Malibu TV</channel>
   <channel site="i.mjh.nz" site_id="Plex/fr#6430aa45fc3be5947780904e-674f6a6cf44561420465f9f3" lang="fr" xmltv_id="AnimationPlus.us@SD">Animation+</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
@@ -1072,7 +1072,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#613260e4bdb71c00070d63fa" lang="en" xmltv_id="MoreTVDrama.us@SD">More TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6132619f9ddaa50007e7dd86" lang="en" xmltv_id="MoreTVSitcoms.us@SD">More TV Sitcoms</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@SD">Moviesphere</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#545943f1c9f133a519bbac92" lang="en" xmltv_id="MST3K.us@US">MST3K</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d14fd1a252d35decbc4080c" lang="en" xmltv_id="MTVBiggestPop.us@US">MTV Biggest Pop</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61b86c6ef30f5d0007e4c6d1" lang="da" xmltv_id="">Pluto TV Space</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61b86c6ef30f5d0007e4c6d1" lang="da" xmltv_id="PlutoTVSpace.se@DK">Pluto TV Space</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0b9aab7facb0007913908" lang="da" xmltv_id="">iCarly</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0bbd95df1da0007bed5a0" lang="da" xmltv_id="">Totally Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c1a05ef30f5d0007e562f3" lang="da" xmltv_id="">Til Middag Hos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09a78bd194c0008decc28" lang="da" xmltv_id="">Pluto TV Juniorklubben</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09a78bd194c0008decc28" lang="da" xmltv_id="PlutoTVJuniorklubben.se@DK">Pluto TV Juniorklubben</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09ac98a80a4000703f992" lang="da" xmltv_id="">SvampeBob Firkant</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09b48d6d97900076e91c5" lang="da" xmltv_id="">Avatar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c19af83fae0a00078c8918" lang="da" xmltv_id="">Paradise Hotel</channel>
@@ -15,31 +15,31 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c19dcefbb4b50007d242e1" lang="da" xmltv_id="">Forsidefruer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c19edbf535220007075c4e" lang="da" xmltv_id="">MasterChef Danmarks største madtalenter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c091c39863900007ac9e8f" lang="da" xmltv_id="">Are You The One?</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c097ec8bb1830008e3f962" lang="da" xmltv_id="">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c097ec8bb1830008e3f962" lang="da" xmltv_id="PlutoTVTrueCrime.se@DK">Pluto TV True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c098df897b9d00070375c8" lang="da" xmltv_id="">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c194ff6f23a7000780073a" lang="da" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0909b872c650008ed42e4" lang="da" xmltv_id="">Ex On The Beach</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0925c738ecd000882450a" lang="da" xmltv_id="">Awkward</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c1939b8929e40007ff6382" lang="da" xmltv_id="">BET</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c1979dfa307000070bbe4d" lang="da" xmltv_id="">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c1979dfa307000070bbe4d" lang="da" xmltv_id="PlutoTVStarTrek.se@DK">Pluto TV Star Trek</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09039ebd75200072587f9" lang="da" xmltv_id="">The Hills</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09515fbb4b50007d221f5" lang="da" xmltv_id="">Pluto TV Film</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09938e0d3a700072b68b1" lang="da" xmltv_id="">Pluto TV Tegnefilm</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09515fbb4b50007d221f5" lang="da" xmltv_id="PlutoTVFilm.se@DK">Pluto TV Film</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c09938e0d3a700072b68b1" lang="da" xmltv_id="PlutoTVTegnefilm.se@DK">Pluto TV Tegnefilm</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c091343bf4940007803e03" lang="da" xmltv_id="">Pimp My Ride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c092157e1b8b0007372a35" lang="da" xmltv_id="">MTV Teen Mom</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0974945b45d0007aaa5ac" lang="da" xmltv_id="">Pluto TV Humor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c095861782bd000780e0ba" lang="da" xmltv_id="">Pluto TV Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0974945b45d0007aaa5ac" lang="da" xmltv_id="PlutoTVHumor.se@DK">Pluto TV Humor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c095861782bd000780e0ba" lang="da" xmltv_id="PlutoTVAction.se@DK">Pluto TV Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61c0989431084d0007eab12d" lang="da" xmltv_id="">Comedy Central</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61de991729cd4a00079f812b" lang="da" xmltv_id="">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61de96114757070008d33cae" lang="da" xmltv_id="">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61e82af27027f9000753c6e4" lang="da" xmltv_id="">CBS News 24/7</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61f9598588f86000078ee7d6" lang="da" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#61f9598588f86000078ee7d6" lang="da" xmltv_id="PlutoTVSciFi.se@DK">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61fb988e032c0100077d5252" lang="da" xmltv_id="">Smithsonian Channel Selects</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62a0ae0e4e47a30007fe21bb" lang="da" xmltv_id="">Melrose Place</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62a0aefc7c5f9f00075b4e24" lang="da" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62b9b63d3bbe9000073c0a2d" lang="da" xmltv_id="">Wildfire</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#62b30b0060a9ca0007d628b4" lang="da" xmltv_id="">Pluto TV Dokumentar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#62b30beb81f89900071fc7b9" lang="da" xmltv_id="">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#62b30b0060a9ca0007d628b4" lang="da" xmltv_id="PlutoTVDokumentar.se@DK">Pluto TV Dokumentar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#62b30beb81f89900071fc7b9" lang="da" xmltv_id="PlutoTVParanormal.se@DK">Pluto TV Paranormal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62beb692cda2b10007d5fd76" lang="da" xmltv_id="">Best of The Drew Barrymore Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62bebb3a67307900077a7f9d" lang="da" xmltv_id="">Numbers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62bebc3459624e00078209c3" lang="da" xmltv_id="">Viafree Movies</channel>
@@ -48,23 +48,20 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62cd971cec90c20007081050" lang="da" xmltv_id="">On the Case</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62cd9641393d8400076f34db" lang="da" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62da73c4ec46c000070f4cb1" lang="da" xmltv_id="">Auction Hunters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1c954d3897300079fcb12" lang="da" xmltv_id="">Pluto TV Romantik</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1c9790cc44a0007dc8857" lang="da" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1c954d3897300079fcb12" lang="da" xmltv_id="PlutoTVRomantik.se@DK">Pluto TV Romantik</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1c9790cc44a0007dc8857" lang="da" xmltv_id="PlutoTVHorror.se@DK">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1cab19ab2df0007bf1c8b" lang="da" xmltv_id="">Everybody Hates Chris</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a1caefc8d285000799e8af" lang="da" xmltv_id="">Scorpion</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63a42df60cc44a0007dd47f8" lang="da" xmltv_id="">Robinson Ekspeditionen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63c6a27a4faf1c0007b48f7b" lang="da" xmltv_id="">Boligkøb i blinde</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63c96203636b7e0007d35090" lang="da" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63dbe7ed51f5d000083e9499" lang="da" xmltv_id="">Pluto TV Kultfilm</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#63dbe7ed51f5d000083e9499" lang="da" xmltv_id="PlutoTVKultfilm.se@DK">Pluto TV Kultfilm</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63e3b2cba99571000887a6ce" lang="da" xmltv_id="">Sams Bar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#63e3b33e8795f300087e6a46" lang="da" xmltv_id="">Med kniven for struben</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#64e87c6b28cec700088ceb55" lang="da" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65a93b0607e03a000895abda" lang="da" xmltv_id="">Car Chase</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65b3d7c033ea860008516824" lang="da" xmltv_id="">From South Park with Love</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65b8f959eb87e30008333201" lang="da" xmltv_id="">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65b915b1dc10a40008d53797" lang="da" xmltv_id="">Pluto TV Bud &amp;amp; Terence</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65b915b1dc10a40008d53797" lang="da" xmltv_id="PlutoTVBudTerence.se@DK">Pluto TV Bud &amp;amp; Terence</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65b915780cb1a1000889b837" lang="da" xmltv_id="">3point.dk</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65ba4c9adc10a40008d9fecc" lang="da" xmltv_id="">Explore TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65c33fd4dc10a40008f26af8" lang="da" xmltv_id="">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65c096d23ba51e0008305a75" lang="da" xmltv_id="">The Daily Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65cba715dc10a40008034917" lang="da" xmltv_id="">Key &amp;amp; Peele</channel>
@@ -75,7 +72,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65d879bd0d4561000805d190" lang="da" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65d879e266eec8000887e91b" lang="da" xmltv_id="">South Park: Stan Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65d7239066eec8000881e293" lang="da" xmltv_id="">Come Dine with Me</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#65e9b6498b24c8000806b982" lang="da" xmltv_id="">Glory Kickboxing</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65e976ad0d456100082d9b74" lang="da" xmltv_id="">Chappelle&apos;s Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65e9766eec9fda0008cb418a" lang="da" xmltv_id="">Reno 911</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65e977042873090008b48be9" lang="da" xmltv_id="">Tosh.0</channel>
@@ -85,31 +81,37 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#66c870112630fc0008137ae2" lang="da" xmltv_id="">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#66d712fdabec540008ba66cd" lang="da" xmltv_id="">Escape to the Country</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#66fbf4d3d7de140008d41f5b" lang="da" xmltv_id="">NCIS: Los Angeles</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#66fcedd95049580008d17ddf" lang="da" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#66fd1338ec9d6d00081e0443" lang="da" xmltv_id="">Retake E-sport Live</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#67a09ddc21af380008088dc3" lang="da" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#67a23b4e15d6eb000827a20d" lang="da" xmltv_id="">Dominance FC TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67d2b814fe36d6e7b1d2318a" lang="da" xmltv_id="">Pluto TV Danske klassikere</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f3fb1cdea1c5e0d588ac1b" lang="da" xmltv_id="">Pluto TV Ungdomsserier</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f79fdb3481170e68c0bc38" lang="da" xmltv_id="">PodRadio på Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f508992ebe80e2929b5c98" lang="da" xmltv_id="">Pluto TV Klassiske tegnefilm</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ac51dede4a734954b5a67a" lang="da" xmltv_id="">Pluto TV Motor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ac55bb3efb41cd979a65ec" lang="da" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67d2b814fe36d6e7b1d2318a" lang="da" xmltv_id="PlutoTVDanskeklassikere.se@DK">Pluto TV Danske klassikere</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f3fb1cdea1c5e0d588ac1b" lang="da" xmltv_id="PlutoTVUngdomsserier.se@DK">Pluto TV Ungdomsserier</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f79fdb3481170e68c0bc38" lang="da" xmltv_id="PodRadiopaPlutoTV.se@DK">PodRadio på Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#67f508992ebe80e2929b5c98" lang="da" xmltv_id="PlutoTVKlassisketegnefilm.se@DK">Pluto TV Klassiske tegnefilm</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ac51dede4a734954b5a67a" lang="da" xmltv_id="PlutoTVMotor.se@DK">Pluto TV Motor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ac55bb3efb41cd979a65ec" lang="da" xmltv_id="PlutoTVSnooker900.se@DK">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ac5403de4a734954b5ab75" lang="da" xmltv_id="">FCK Løvinderne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68ad8bececd330dcb0f050b5" lang="da" xmltv_id="">Love Island: All Stars</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68adb066f7d7f0a9b9ff5d32" lang="da" xmltv_id="">Smølferne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68bff9a63efb41cd97562e46" lang="da" xmltv_id="">Highway to Heaven</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68c01afa3efb41cd9759dafb" lang="da" xmltv_id="">Pluto TV Harlequin</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68c01732b3900870ec74766f" lang="da" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68c01afa3efb41cd9759dafb" lang="da" xmltv_id="PlutoTVHarlequin.se@DK">Pluto TV Harlequin</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68c01732b3900870ec74766f" lang="da" xmltv_id="PlutoTVWildWest.se@DK">Pluto TV Wild West</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68d66a37508ba507f075bd8c" lang="da" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68dfa160cc3c6cd90404d798" lang="da" xmltv_id="">Ridiculousness - Nye afsnit</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68dfa431cc3c6cd904053100" lang="da" xmltv_id="">Pluto TV Håndbold Highlights</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#68dfa431cc3c6cd904053100" lang="da" xmltv_id="PlutoTVHandboldHighlights.se@DK">Pluto TV Håndbold Highlights</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68f0f54ca362b63a8df4d5a9" lang="da" xmltv_id="">Medium</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68f0f71bb45f4453e05c0863" lang="da" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#68f0fa98fae18f8db62a920a" lang="da" xmltv_id="">Dollars</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69afec3af59c873b7b874520" lang="da" xmltv_id="">The 4400</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69afeefa0a7f2095e768401c" lang="da" xmltv_id="">The Millers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69b16dc543d0f313203b714c" lang="da" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69c290eeed1b1f1acb446dd8" lang="da" xmltv_id="">Gustav &amp;amp; Linse på udebane</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69c2940612e978ee4920d9b0" lang="da" xmltv_id="">CNN Headlines International</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#69d7a0c04b31808da262933f" lang="da" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#619e1bb3e9af5a0007f235ad" lang="da" xmltv_id="">Ghost Dimension</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#619e1ef4f42ad90007e00a21" lang="da" xmltv_id="">Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#619e21b213ef6b0007d8c17a" lang="da" xmltv_id="">Homicide Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#619e1874e0d3a7000729a036" lang="da" xmltv_id="">Pluto TV Fishing</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#619e1874e0d3a7000729a036" lang="da" xmltv_id="PlutoTVFishing.se@DK">Pluto TV Fishing</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#629e095e511d4b00070c9f44" lang="da" xmltv_id="">Paradise</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#632aff5e44111b00076ad9b1" lang="da" xmltv_id="">Best of MTV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#651e719b575f660008d2e629" lang="da" xmltv_id="">Cheaters</channel>
@@ -119,7 +121,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#654a4cc3f91d250008ac11f6" lang="da" xmltv_id="">Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#654a4e29ab05240008a18625" lang="da" xmltv_id="">Happy Days</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#654a59742c1d33000865a797" lang="da" xmltv_id="">MacGyver</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#655ca7aa635c3c000855d655" lang="da" xmltv_id="">Pluto TV John Wayne</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#655ca7aa635c3c000855d655" lang="da" xmltv_id="PlutoTVJohnWayne.se@DK">Pluto TV John Wayne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#655ca7405812e80008883d4e" lang="da" xmltv_id="">Hot Ones</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#657c0954dfed030008d82ea1" lang="da" xmltv_id="">Kvart i Bold</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660bfc7b2433010008def3e3" lang="da" xmltv_id="">FIFA+</channel>
@@ -128,7 +130,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d6bc10cd4630008f4a25a" lang="da" xmltv_id="">Det sene show med Christian Fuhlendorff</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d6c0094db140008fe2f74" lang="da" xmltv_id="">Breinholts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d66be7bcd8600087cfee5" lang="da" xmltv_id="">Bondi Rescue</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d6360c8311c0008b8a7c6" lang="da" xmltv_id="">Top Gear Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d667519ca71000849a1e1" lang="da" xmltv_id="">Koch&apos;en på toppen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660d714719ca71000849cc1f" lang="da" xmltv_id="">Realmadrid TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#660e7404e8fba8000853abc0" lang="da" xmltv_id="">AWSN</channel>
@@ -137,37 +138,43 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#664f0eaa8ce31100088036bd" lang="da" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#664f132c8ea5560008ce4d86" lang="da" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#668bf7dd74f5ec000817e6d1" lang="da" xmltv_id="">Diagnosis Murder</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#668e5f2bcd0d3100080f6952" lang="da" xmltv_id="">Triton Poker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#671b4dc049c4060008f91d3a" lang="da" xmltv_id="">Horse &amp;amp; Country</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#672e157d7d5da5000812872d" lang="da" xmltv_id="">Becker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#675c0762f433320008707f68" lang="da" xmltv_id="">BET25 Live+</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#677d397b60fbeb00084b0bff" lang="da" xmltv_id="">Pluto TV Verdenskrigene</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#677d397b60fbeb00084b0bff" lang="da" xmltv_id="PlutoTVVerdenskrigene.se@DK">Pluto TV Verdenskrigene</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#678f88bb272ded16b1558c5e" lang="da" xmltv_id="">Man with a Plan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#678f8676ad083171df19ca07" lang="da" xmltv_id="">Ditzel &amp;amp; Turbomodul</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#682b385876963fba9abf0f26" lang="da" xmltv_id="">Iron Chef</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#686d0130ed17cf4c902cbd19" lang="da" xmltv_id="">The Nanny &amp;amp; Mr Sheffield - A Fine Romance</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#688a20c69034bd35f34aaa9e" lang="da" xmltv_id="">Simba Prisen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#689a0ab0f4af1aaca24530ae" lang="da" xmltv_id="">Den gode gerning</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#691ed751bef819002f2c7296" lang="da" xmltv_id="">Inter 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#692ec3a76f84242a60f75f59" lang="da" xmltv_id="">Reality Awards</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#692ec3f475169f09b5c0a8b3" lang="da" xmltv_id="">Robert Prisen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#692edc78d52ea9e4858cf78f" lang="da" xmltv_id="">Dating Naked UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#693add137e308621c051e733" lang="da" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#693ae62a43fe00a023e76e0d" lang="da" xmltv_id="">House of Lies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#693ae5660eedebc8d5db6579" lang="da" xmltv_id="">Crazy Ex-Girlfriend</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#693ae3294258f18a3e117b26" lang="da" xmltv_id="">Teen Wolf</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#693ae48864476d678e9b6235" lang="da" xmltv_id="">The L Word</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#695e2857026be6e9d3ad59d3" lang="da" xmltv_id="">Love Island USA</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#698ddd6ec144dcc29b866133" lang="da" xmltv_id="">Flipper: The New Adventures</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#698ddf5a8c21a5f2d64c14a8" lang="da" xmltv_id="">r8Dio TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#699c1b4c9c3b075ecd513139" lang="da" xmltv_id="">Farscape</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#699c15a9f0b71f2e2eec4393" lang="da" xmltv_id="">21 Jump Street</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#699c18cbf2ad90a4792fd5b8" lang="da" xmltv_id="">Renegade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6177f6bf7693550007531275" lang="da" xmltv_id="">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6177f8fdef21ab0007332b53" lang="da" xmltv_id="">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6177fb39b68ef1000725e59e" lang="da" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6177fd9812fe0c000726f9eb" lang="da" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6177fe76691b2e000702c7fc" lang="da" xmltv_id="">MTV Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6319ec31c62c3f00075c90b1" lang="da" xmltv_id="">NCIS</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6357f3de3643ba0007bc0b50" lang="da" xmltv_id="">Pluto TV Sport</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6357f3de3643ba0007bc0b50" lang="da" xmltv_id="PlutoTVSport.se@DK">Pluto TV Sport</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6380c36389eccc000858c50f" lang="da" xmltv_id="">Judge Judy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6391cef9edb23c0008598cee" lang="da" xmltv_id="">The Nanny</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6400bc50953da40008b94668" lang="da" xmltv_id="">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6400c281dff38e00083f59da" lang="da" xmltv_id="">Star Trek Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6400c095498393000878a634" lang="da" xmltv_id="">Frasier</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6405d444d200410008009419" lang="da" xmltv_id="">BET25 LIVE</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6426a821a3ade7000800031c" lang="da" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6440f8ba939a5900082bddc8" lang="da" xmltv_id="">World of Love Island</channel>
@@ -175,11 +182,10 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6478a9e4f77b61000817034b" lang="da" xmltv_id="">Mission Impossible</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6486e8984cfc2c0008b6844e" lang="da" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6501af923a0d700008b71b53" lang="da" xmltv_id="">Hundehviskeren</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6501c8c76625510008cbe20f" lang="da" xmltv_id="">South Park Halloween</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6512ec7a2ce8e40008bdb433" lang="da" xmltv_id="">Beauty and the Beast</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6512ec9f3a0d700008db4f0c" lang="da" xmltv_id="">The Twilight Zone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6512ecf63a0d700008db506a" lang="da" xmltv_id="">Sabrina the Teenage Witch</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6618f54baec96800081525ec" lang="da" xmltv_id="">Pluto TV Håndbold Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#6618f54baec96800081525ec" lang="da" xmltv_id="PlutoTVHandboldLive.se@DK">Pluto TV Håndbold Live</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6641fd41b18d700008e7e2b8" lang="da" xmltv_id="">Comedy Central Roast</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6720bc6cdaad7f000872a6e2" lang="da" xmltv_id="">2900 Happiness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6728c9c85534bb0008b320a4" lang="da" xmltv_id="">7th Heaven</channel>
@@ -198,7 +204,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6969fc6c3b9ce349c9e41670" lang="da" xmltv_id="">Fristet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61813fbfa19d830007b456c2" lang="da" xmltv_id="">Unsolved Mysteries</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#62790dc1c733e8000733ba4d" lang="da" xmltv_id="">Pixel.tv</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#62792f34f3aa05000728841e" lang="da" xmltv_id="">Bellator MMA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65787e8232c1b300089a8482" lang="da" xmltv_id="">Duck Dynasty</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65787eefcbd0d60008f85b3f" lang="da" xmltv_id="">Dance Moms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65787fb36e4f6a0008740127" lang="da" xmltv_id="">Dog The Bounty Hunter</channel>
@@ -215,12 +220,12 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#627254d6ba35210007e5d4ca" lang="da" xmltv_id="">Project Runway</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#633560bfa693390008b99cf0" lang="da" xmltv_id="">Ice Road Truckers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#643814ef479f6400086ff043" lang="da" xmltv_id="">Mit plastikmareridt</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#650999b86a841400083bd1ab" lang="da" xmltv_id="">Pluto TV Alien Invasion</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#650999b86a841400083bd1ab" lang="da" xmltv_id="PlutoTVAlienInvasion.se@DK">Pluto TV Alien Invasion</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#657880c46e4f6a00087404d0" lang="da" xmltv_id="">Crime 360</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#657881c46e4f6a00087414c2" lang="da" xmltv_id="">I Survived</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#671656a37d5da50008de6514" lang="da" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#685029cda1e091e16ff57fc8" lang="da" xmltv_id="">Brøndby TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/dk#685137f4a1e091e16f2dd471" lang="da" xmltv_id="">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/dk#685137f4a1e091e16f2dd471" lang="da" xmltv_id="">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6181241c1a35d50007874c27" lang="da" xmltv_id="">Forensic Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6272511cb389bb0007b30b09" lang="da" xmltv_id="">For lækker til love</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#6346937a46f9a2000889073d" lang="da" xmltv_id="">48 Hours</channel>
@@ -236,12 +241,10 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#64805922536e0c0008a1a1e6" lang="da" xmltv_id="">DAZN Ringside</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#65649791954b020008d09565" lang="da" xmltv_id="">På Tur</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/dk#61814659533163000748aa04" lang="da" xmltv_id="">FBI Files</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf32c2a5068259a32320fc" lang="de" xmltv_id="MTVTheShores.us@Germany">MTV The Shores</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf330ea5068259a32320fd" lang="de" xmltv_id="MTVDating.us@Germany">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5cb5cfe5caf83414128f209e" lang="de" xmltv_id="">KultKrimi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5cb5d043a461406ffe3fb2de" lang="de" xmltv_id="">Telenovela ZDF</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767b4889bca2ce7b73ef2e" lang="de" xmltv_id="">Pluto TV Science</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5e7cb84a172a0f0007da69e4" lang="de" xmltv_id="RedBullTV.at@SD">Red Bull TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767b4889bca2ce7b73ef2e" lang="de" xmltv_id="PlutoTVScience.de@DACH">Pluto TV Science</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dc287ce3086a20009f5024c" lang="de" xmltv_id="">Pluto TV Romance</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5ede45d077746000072be0fe" lang="de" xmltv_id="">Auction Hunters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5f760c3d41aa2d0007bfde19" lang="de" xmltv_id="">Auto Motor Sport</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#61b33085897b9d000702b72e" lang="de" xmltv_id="">Just.fishing</channel>
@@ -249,70 +252,77 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/de#62bc1784120ba80007935aaa" lang="de" xmltv_id="">Awkward</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#62cebd7302478b00073a6b71" lang="de" xmltv_id="">Der Denver-Clan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#62cebf042ffc6d0007c4e59a" lang="de" xmltv_id="">Frasier</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#62f4f4b88157cf00075c22db" lang="de" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#63c69e6c4207be0007f73c22" lang="de" xmltv_id="">Zoey 101</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#64afe50c5dc16600087f3227" lang="de" xmltv_id="">DAZN Heldinnen x Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#64b67f0424ade50008a3be17" lang="de" xmltv_id="">DAZN Darts x Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#62f4f4b88157cf00075c22db" lang="de" xmltv_id="PlutoTVHorror.de@DACH">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64afe50c5dc16600087f3227" lang="de" xmltv_id="DAZNHeldinnenxPlutoTV.de@DACH">DAZN Heldinnen x Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64b67f0424ade50008a3be17" lang="de" xmltv_id="DAZNDartsxPlutoTV.de@DACH">DAZN Darts x Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#64be635a40962900080aaca5" lang="de" xmltv_id="">Rules of Engagement</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#64be64445dc166000899ce75" lang="de" xmltv_id="">Pluto TV Polizeiserien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64be7398e4391c0008cdedfe" lang="de" xmltv_id="">Pluto TV Bud &amp;amp; Terence</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64be64445dc166000899ce75" lang="de" xmltv_id="PlutoTVPolizeiserien.de@DACH">Pluto TV Polizeiserien</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#64be745340962900080b55e7" lang="de" xmltv_id="">Melrose Place</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#64c109735dc1660008a4a2dc" lang="de" xmltv_id="">Top Gear</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#64eddc3485efec00085b0369" lang="de" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#64eddce19001910008df22b8" lang="de" xmltv_id="">F.B.I. Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65a7d99f4a10d800086083a9" lang="de" xmltv_id="">Assassination Classroom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65a67c494a10d800085cab06" lang="de" xmltv_id="">Drake &amp;amp; Josh</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#65a67d572fac9c000835eb3a" lang="de" xmltv_id="">Moviepilot TV mit Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#65a67d572fac9c000835eb3a" lang="de" xmltv_id="MoviepilotTVmitPlutoTV.de@DACH">Moviepilot TV mit Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65a67dd13af63d0008257f17" lang="de" xmltv_id="">90210</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#65b923f90cb1a100088a03ab" lang="de" xmltv_id="TerraMaterWILD.de@German">Terra Mater WILD</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65b9268fc798e800085add89" lang="de" xmltv_id="">SPIEGEL TV Konflikte</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#65d5fc39a25d5e00082895c4" lang="de" xmltv_id="Naruto.us@Germany">Naruto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65dde5ef28730900089af7cf" lang="de" xmltv_id="">KultKrimi: Der Alte</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65dde626ec9fda0008b3dc89" lang="de" xmltv_id="">KultKrimi: Der Kommissar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65dde5848145cb00083277f6" lang="de" xmltv_id="">KultKrimi: Derrick</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66a244d5cd0d3100083b1e47" lang="de" xmltv_id="">Eine himmlische Familie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#66a10384d5125900089dfd04" lang="de" xmltv_id="">Top Gear Challenge</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66c6fc06489bab0008b6f9da" lang="de" xmltv_id="">Die Nanny</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66c6fcfc6838ee00085beb1a" lang="de" xmltv_id="">McLeods Töchter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#66c45b1803e3b20008d8c200" lang="de" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67a324d221af380008105d6f" lang="de" xmltv_id="">Eine schrecklich nette Familie</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67b481cc1a5ca760801c6c5e" lang="de" xmltv_id="">The Last Flight</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67d983d6a1609bdb523f5f9b" lang="de" xmltv_id="">Pluto TV Sanfte Berührungen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67d983d6a1609bdb523f5f9b" lang="de" xmltv_id="PlutoTVSanfteBeruhrungen.de@DACH">Pluto TV Sanfte Berührungen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67d984c989788ef7f058b084" lang="de" xmltv_id="">Profiling Paris</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67d984408d8dc3d7754dccf2" lang="de" xmltv_id="">Pluto TV Nordic Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67d984408d8dc3d7754dccf2" lang="de" xmltv_id="PlutoTVNordicCrime.de@DACH">Pluto TV Nordic Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67dc21ce5a15c0759a07ee19" lang="de" xmltv_id="">Der Chef</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67ebbdced2832b463faa1e79" lang="de" xmltv_id="">KultKrimi: Küstenwache</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ebc1b6432a0e406f141341" lang="de" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ebc04855de98dc71428538" lang="de" xmltv_id="">Pluto TV Emmanuelle Filme</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ebc1b6432a0e406f141341" lang="de" xmltv_id="PlutoTVReality.de@DACH">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ebc04855de98dc71428538" lang="de" xmltv_id="PlutoTVEmmanuelleFilme.de@DACH">Pluto TV Emmanuelle Filme</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67ed0c86f7c5d70b90889a51" lang="de" xmltv_id="">KultKrimi: Die Rettungsflieger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67f3eb1c443f0671bc03ece8" lang="de" xmltv_id="">Nick Jr. Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67f3eb800a1beb98767ca748" lang="de" xmltv_id="">Nickelodeon Classics</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67f68bd2135aeda9ddf0ef54" lang="de" xmltv_id="">Pluto TV Adult Animation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67fe495d9ebfe4142424b7a7" lang="de" xmltv_id="">Pluto TV Anime: Fantasy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67f68bd2135aeda9ddf0ef54" lang="de" xmltv_id="PlutoTVAdultAnimation.de@DACH">Pluto TV Adult Animation</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67fe498f9ebfe4142424c55d" lang="de" xmltv_id="">Beelzebub</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ff7d9c7fc25e0e72451bc9" lang="de" xmltv_id="">Pluto TV Horror-Serien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#67ff7d9c7fc25e0e72451bc9" lang="de" xmltv_id="PlutoTVHorrorSerien.de@DACH">Pluto TV Horror-Serien</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#67ff7dd84906b1acfad97330" lang="de" xmltv_id="">Blue Mountain State</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ac5543a1ac0c90f2c8943e" lang="de" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ac5543a1ac0c90f2c8943e" lang="de" xmltv_id="PlutoTVSnooker900.de@DACH">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68ad90673efb41cd97c95825" lang="de" xmltv_id="">The Outer Limits</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada3edf84960586ad31c7d" lang="de" xmltv_id="">Pluto TV Reportagen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada46d5190a45dc9c45af1" lang="de" xmltv_id="">Pluto TV Ferne Galaxien</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada3395190a45dc9c445cf" lang="de" xmltv_id="">Pluto TV Historische Serien</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#68b176c2a4841127a8ed1ade" lang="de" xmltv_id="">Pluto TV Europäische Krimis</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada3edf84960586ad31c7d" lang="de" xmltv_id="PlutoTVReportagen.de@DACH">Pluto TV Reportagen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada46d5190a45dc9c45af1" lang="de" xmltv_id="PlutoTVFerneGalaxien.de@DACH">Pluto TV Ferne Galaxien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#68ada3395190a45dc9c445cf" lang="de" xmltv_id="PlutoTVHistorischeSerien.de@DACH">Pluto TV Historische Serien</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68d276ce59fd82da32267d0d" lang="de" xmltv_id="">Liebe Sünde</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68d277fb12bf71eaaed3e9f1" lang="de" xmltv_id="">Flipper</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#68d669f9508ba507f075b5fe" lang="de" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68d2759a59fd82da3226492d" lang="de" xmltv_id="">The L Word – Wenn Frauen lieben</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68d27437e6767bdeb23f0336" lang="de" xmltv_id="">Gigolos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#69a553dc3d27d6da464b17fd" lang="de" xmltv_id="">Pluto TV April, April</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#69a5578b762ae48b4319f113" lang="de" xmltv_id="">Pluto TV Die Rache der Natur</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69a554179a3f3bb488c7d2be" lang="de" xmltv_id="">Pluto TV Laughs in Spanish</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69a554497ed3b3fff0b9ca80" lang="de" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b015c5d29cc97de7da4af8" lang="de" xmltv_id="">Pluto TV Haialarm</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b0160da9b840a456a11b4a" lang="de" xmltv_id="">Vier Frauen und ein Todesfall</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b968a58323ef2714d1aa36" lang="de" xmltv_id="">Schnell ermittelt</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b968ba255fecb01f602257" lang="de" xmltv_id="PlutoTVComedyTherapie.de@DACH">Pluto TV Comedy Therapie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b968ca1c36025fd0a3d92d" lang="de" xmltv_id="PlutoTVWorstofBundy.de@DACH">Pluto TV Worst of Bundy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b968e011fc7b9e27c0d958" lang="de" xmltv_id="PlutoTVFranBesteMamaMomente.de@DACH">Pluto TV Fran: Beste Mama-Momente</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b01641a9b840a456a11c18" lang="de" xmltv_id="">Schlosshotel Orth</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#69b14863dd687227e1e4b6b2" lang="de" xmltv_id="">Seaquest</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69b0167477cdde1f05c8a625" lang="de" xmltv_id="">Der Bergdoktor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69c2ac2b14c0213702da7a29" lang="de" xmltv_id="">Die glorreichen Sieben</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69f209cd0ed14e790bddeb46" lang="de" xmltv_id="">Pluto TV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#622f6e1e2792150007e0b2ff" lang="de" xmltv_id="">Alle hassen Chris</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#622f6faf65be650007f57aab" lang="de" xmltv_id="">Hausmeister Krause</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#622f40c901d4b70007ad7609" lang="de" xmltv_id="">Sabrina - Total verhext!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#622f487722d9d400075f74dd" lang="de" xmltv_id="">Ein Engel auf Erden</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#630dd3b2605f140007e002f5" lang="de" xmltv_id="">Pluto TV Western</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#630dd3b2605f140007e002f5" lang="de" xmltv_id="PlutoTVWestern.de@DACH">Pluto TV Western</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#634fe5afece2e60007c9d8b8" lang="de" xmltv_id="">Mission Impossible</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#638f2bc7bc363100072f02dd" lang="de" xmltv_id="">Rauchende Colts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#638f2983dcd9100008c2374d" lang="de" xmltv_id="">Rawhide - Tausend Meilen Staub</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#642abea1283aa4000805bb5b" lang="de" xmltv_id="">Täterjagd</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#642ad2127ef83900085f8910" lang="de" xmltv_id="">Mork vom Ork</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#642ad072283aa4000806148c" lang="de" xmltv_id="">Pluto TV Weihnachten im Sommer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#642d7e029189ce0008958af5" lang="de" xmltv_id="">X-Factor: Das Unfassbare</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#642d4493aa2d690008f0a03f" lang="de" xmltv_id="">Yu-Gi-Oh!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#645a0ddfe1979c00086d83ff" lang="de" xmltv_id="">Red Shoe Diaries</channel>
@@ -326,15 +336,18 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/de#655ca3d1fbc15b00081f1186" lang="de" xmltv_id="">Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#655ca57e4261ca00080b3a04" lang="de" xmltv_id="">Anger Management</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#660bfc032433010008def35a" lang="de" xmltv_id="">FIFA+</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#660c010ce8fba800084f0697" lang="de" xmltv_id="">South Park Armageddon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#663a15d7cb3ea10008edac88" lang="de" xmltv_id="">Farmland TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#663a163f8ea5560008a3f234" lang="de" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#663e09b341af640008c1b68c" lang="de" xmltv_id="">Stand-up Comedy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#663e09e4b18d700008e48dcf" lang="de" xmltv_id="">BIG BROTHER CLASSIC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#664f10c4f9992200084a2f47" lang="de" xmltv_id="">Pluto TV Heiße Nächte Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#664f0d373d173b0008164948" lang="de" xmltv_id="">South Park: Stars &amp;amp; Sternchen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#664f10c4f9992200084a2f47" lang="de" xmltv_id="PlutoTVHeisseNachteRetro.de@DACH">Pluto TV Heiße Nächte Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#664f12bb3d173b0008168c1f" lang="de" xmltv_id="">South Park Rocks!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#666fe4768768aa0008c31ddf" lang="de" xmltv_id="">Saving Hope</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#667d63d236a2f90008f72269" lang="de" xmltv_id="">Axel!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#667d3534ca74680008696051" lang="de" xmltv_id="">Ladykracher</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#677e5a3d7bffa6000808dbf2" lang="de" xmltv_id="">Pluto TV Britische Serien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#677e5a3d7bffa6000808dbf2" lang="de" xmltv_id="PlutoTVBritischeSerien.de@DACH">Pluto TV Britische Serien</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#677fafd91da79bfe4fb0b4ec" lang="de" xmltv_id="">Quantum Leap</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#677fb078a4af36ad50111032" lang="de" xmltv_id="">Die Sieben-Millionen-Dollar-Frau</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#677fb0231da79bfe4fb0bf4e" lang="de" xmltv_id="">The Real Housewives</channel>
@@ -348,23 +361,21 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/de#686d004094a028da3aac8cb0" lang="de" xmltv_id="">Don Matteo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#691b2b690d121b44ad4a53ef" lang="de" xmltv_id="">Dating hinter Gittern</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#697a0577f9c3aa5a215a4ef8" lang="de" xmltv_id="">Will&amp;amp;Grace</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6152ee71bf99590007893a11" lang="de" xmltv_id="">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6152ee71bf99590007893a11" lang="de" xmltv_id="PlutoTVStarTrek.de@DACH">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6270ea4345f5bc0007823048" lang="de" xmltv_id="">Fury</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6305ca798bd95300072d2f93" lang="de" xmltv_id="">Filmgold</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6447dea7e94c380008dba94c" lang="de" xmltv_id="">Germany Shore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6447df8cd3fdde0008f1f627" lang="de" xmltv_id="">Die Thundermans</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6576c20fb3801200084786c9" lang="de" xmltv_id="CuriosityChannel.de@SD">SPIEGEL TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6628e513cee0d90008639b46" lang="de" xmltv_id="">RoboCop</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6639d7d4b18d700008da5316" lang="de" xmltv_id="EuronewsGerman.fr@SD">Euronews</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6672f49f61a39900089db68e" lang="de" xmltv_id="">Pluto TV Deutsche Comedy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6683f7fe36a2f9000804940c" lang="de" xmltv_id="">DAZN Handball x Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6672f49f61a39900089db68e" lang="de" xmltv_id="PlutoTVDeutscheComedy.de@DACH">Pluto TV Deutsche Comedy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6683f7fe36a2f9000804940c" lang="de" xmltv_id="DAZNHandballxPlutoTV.de@DACH">DAZN Handball x Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6790fa9e1cfc4aa96dfadcef" lang="de" xmltv_id="">Frasier: Berühmte Gäste</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6864e8f264d94c1425fb4563" lang="de" xmltv_id="">Merhaba Türkische Serien</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#6870c9333ffa5e0c914e9205" lang="de" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6989b64839dd847194cadcd7" lang="de" xmltv_id="">The Librarians</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6996f0335452cb4f0a2c4153" lang="de" xmltv_id="">The Nanny &amp;amp; Mr Sheffield - A Fine Romance</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#62441d6ded1827000763dcda" lang="de" xmltv_id="">CBS News 24/7</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#64526a145a0cd50008632bfa" lang="de" xmltv_id="">Pluto TV heiße Nächte</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64526a145a0cd50008632bfa" lang="de" xmltv_id="PlutoTVheisseNachte.de@DACH">Pluto TV heiße Nächte</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#65253d66c52b3600083d8dd2" lang="de" xmltv_id="">Wicked Tuna</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#66337de656fc840008ff7a65" lang="de" xmltv_id="">Pluto TV Kult Comedies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#66337de656fc840008ff7a65" lang="de" xmltv_id="PlutoTVKultComedies.de@DACH">Pluto TV Kult Comedies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66337e6ba0a74e000889563b" lang="de" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66337e365a402e00087eccaf" lang="de" xmltv_id="">CNN Headlines International</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#66337ea1307fa300082c28a0" lang="de" xmltv_id="">BVB-Frauen</channel>
@@ -373,69 +384,76 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/de#69776f2b2c00406316a01945" lang="de" xmltv_id="">Call My Agent!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#630348a54c48ce00077eb6c7" lang="de" xmltv_id="">Becker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#644257fe7cb4b100081ed874" lang="de" xmltv_id="">Hell&apos;s Kitchen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#669526d232e25300084bb47b" lang="de" xmltv_id="">Pluto TV Sharks</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#685136fb33a52de120bbb086" lang="de" xmltv_id="">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#661801e871e8c30008a73f7b" lang="de" xmltv_id="">Pluto TV Camp</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#685136fb33a52de120bbb086" lang="de" xmltv_id="">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#688734b9035d6ef9c34aac16" lang="de" xmltv_id="">Die fliegenden Ärzte</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#691491c6bb69fb3258c3524a" lang="de" xmltv_id="">Swamp People</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6824539e1295f98347e95242" lang="de" xmltv_id="">Missions</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6866525c8a412a0e95c438b4" lang="de" xmltv_id="">Dyn Sport Mix</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#69492467ae33e24d916e56cf" lang="de" xmltv_id="">Pluto TV Star Trek: Animation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#682453215c646751955e1204" lang="de" xmltv_id="">Pluto TV Western Serien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#69492467ae33e24d916e56cf" lang="de" xmltv_id="PlutoTVStarTrekAnimation.de@DACH">Pluto TV Star Trek: Animation</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#682453215c646751955e1204" lang="de" xmltv_id="PlutoTVWesternSerien.de@DACH">Pluto TV Western Serien</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#688735087b2cf33d01a2d411" lang="de" xmltv_id="">Sea Patrol</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#68590366010ddd78ef837d29" lang="de" xmltv_id="">KultKrimi: Ein Fall für zwei</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6914913274601d957ae35565" lang="de" xmltv_id="">Ax Men - Die Holzfäller</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#65004605110545000842035d" lang="de" xmltv_id="">Pluto TV Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#600adbdf8c554e00072125c9" lang="de" xmltv_id="Avatar.us@Germany">Avatar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#65004605110545000842035d" lang="de" xmltv_id="PlutoTVAction.de@DACH">Pluto TV Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#60e4519e6873180007d3cddb" lang="de" xmltv_id="BBCTravel.us@Germany">BBC Travel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#60afb576053df900076fa2f0" lang="de" xmltv_id="BeverlyHills90210.us@Germany">Beverly Hills 90210</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d4947590ba40f75dc29c26b" lang="de" xmltv_id="CCPlutoTV.us@Germany">CC Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d4947590ba40f75dc29c26b" lang="de" xmltv_id="CCPlutoTV.de@DACH">CC Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#60afbad343e3840007164348" lang="de" xmltv_id="ChaosCity.us@Germany">Chaos City</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#611e7f224676bf00076a4d8d" lang="de" xmltv_id="Cheers.us@Germany">Cheers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#66c45b1803e3b20008d8c200" lang="de" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#60c716084d842c00085f6e64" lang="de" xmltv_id="ComedyCentralSouthPark.us@Germany">Comedy Central South Park</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6576c20fb3801200084786c9" lang="de" xmltv_id="CuriosityChannel.de@SD">SPIEGEL TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6639d7d4b18d700008da5316" lang="de" xmltv_id="EuronewsGerman.fr@SD">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5e8b580a233dc90007f0cb9d" lang="de" xmltv_id="iCarly.us@Germany">iCarly</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5ce40f42ba7f7f5ea9518fe1" lang="de" xmltv_id="IcePilots.us@Germany">Ice Pilots</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#615c1e5ce3039400070a0547" lang="de" xmltv_id="Moviedome.us@Germany">MOVIEDOME</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5db6a697d5f34a000934cd13" lang="de" xmltv_id="MTVCatfishTVShow.us@Germany">MTV Catfish TV Show</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf325764025859afdd6c4d" lang="de" xmltv_id="MTVPlutoTV.us@Germany">MTV Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf330ea5068259a32320fd" lang="de" xmltv_id="MTVDating.us@Germany">MTV Dating</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf325764025859afdd6c4d" lang="de" xmltv_id="MTVPlutoTV.de@DACH">MTV Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5f9847fd513250000728a9a5" lang="de" xmltv_id="MTVRidiculousness.us@Germany">MTV Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5cffcf5686dfe15595fb3f56" lang="de" xmltv_id="MTVTeenMom.us@Germany">MTV Teen Mom</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5caf32c2a5068259a32320fc" lang="de" xmltv_id="MTVTheShores.us@Germany">MTV The Shores</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#60080e8a4bf36000076a81b1" lang="de" xmltv_id="N24Doku.de@SD">N24 Doku</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#65d5fc39a25d5e00082895c4" lang="de" xmltv_id="Naruto.us@Germany">Naruto</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5f0d668b872e4400073acc68" lang="de" xmltv_id="NickelodeonTeen.fr">Nickelodeon Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5ede448d3d50590007a4419e" lang="de" xmltv_id="NickPlutoTV.us@Germany">Nickelodeon Toons</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767ae7b456c8cf265ce922" lang="de" xmltv_id="PlutoTVAnimals.us@Germany">Pluto TV Animals</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#608181d420fc8500075f612a" lang="de" xmltv_id="PlutoTVAnime.us@Germany">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5e7b6c60fd20c50007910bf5" lang="de" xmltv_id="PlutoTVCrime.us@Germany">Pluto TV Crime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5ad9b8551b95267e225e59c1" lang="de" xmltv_id="PlutoTVExplore.us@Germany">Pluto TV Explore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dc280c9aa218c0009724b4b" lang="de" xmltv_id="PlutoTVFood.us@Germany">Pluto TV Food</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767b1c126c65d0a307355f" lang="de" xmltv_id="PlutoTVHistory.us@Germany">Pluto TV History</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dde47b63585b500099f74ec" lang="de" xmltv_id="PlutoTVKultfilme.us@Germany">Pluto TV Kultfilme</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5c5c3b948002db3c3e0b262e" lang="de" xmltv_id="PlutoTVMovies.us@Germany">Pluto TV Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#617aad99b68ef100072608cd" lang="de" xmltv_id="PlutoTVMystery.us@Germany">Pluto TV Mystery</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5be1c3f9851dd5632e2c91b2" lang="de" xmltv_id="PlutoTVNature.us@Germany">Pluto TV Nature</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5f98487036af340008da1e37" lang="de" xmltv_id="PlutoTVParanormal.us@Germany">Pluto TV Paranormal</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#60ed498c4248a400077c0b9d" lang="de" xmltv_id="PlutoTVSciFi.us@Germany">Pluto TV Sci-Fi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dc190f7bfed110009d934c3" lang="de" xmltv_id="PlutoTVSerie.us@Germany">Pluto TV Serie</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767ab2b456c8cf265ce921" lang="de" xmltv_id="PlutoTVSitcoms.us@Germany">Pluto TV Sitcoms</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#61409f8d6feb30000766b675" lang="de" xmltv_id="PlutoTVSpace.us@Germany">Pluto TV Space</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#615333098185f00008715a56" lang="de" xmltv_id="PlutoTVTrueCrime.us@Germany">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#64eddc3485efec00085b0369" lang="de" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767ae7b456c8cf265ce922" lang="de" xmltv_id="PlutoTVAnimals.de@DACH">Pluto TV Animals</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#608181d420fc8500075f612a" lang="de" xmltv_id="PlutoTVAnime.de@DACH">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5e7b6c60fd20c50007910bf5" lang="de" xmltv_id="PlutoTVCrime.de@DACH">Pluto TV Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5ad9b8551b95267e225e59c1" lang="de" xmltv_id="PlutoTVExplore.de@DACH">Pluto TV Explore</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dc280c9aa218c0009724b4b" lang="de" xmltv_id="PlutoTVFood.de@DACH">Pluto TV Food</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767b1c126c65d0a307355f" lang="de" xmltv_id="PlutoTVHistory.de@DACH">Pluto TV History</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dde47b63585b500099f74ec" lang="de" xmltv_id="PlutoTVKultfilme.de@DACH">Pluto TV Kultfilme</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5c5c3b948002db3c3e0b262e" lang="de" xmltv_id="PlutoTVMovies.de@DACH">Pluto TV Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#617aad99b68ef100072608cd" lang="de" xmltv_id="PlutoTVMystery.de@DACH">Pluto TV Mystery</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5be1c3f9851dd5632e2c91b2" lang="de" xmltv_id="PlutoTVNature.de@DACH">Pluto TV Nature</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5f98487036af340008da1e37" lang="de" xmltv_id="PlutoTVParanormal.de@DACH">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#60ed498c4248a400077c0b9d" lang="de" xmltv_id="PlutoTVSciFi.de@DACH">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5dc190f7bfed110009d934c3" lang="de" xmltv_id="PlutoTVSerie.de@DACH">Pluto TV Serie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5d767ab2b456c8cf265ce921" lang="de" xmltv_id="PlutoTVSitcoms.de@DACH">Pluto TV Sitcoms</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#61409f8d6feb30000766b675" lang="de" xmltv_id="PlutoTVSpace.de@DACH">Pluto TV Space</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#615333098185f00008715a56" lang="de" xmltv_id="PlutoTVTrueCrime.de@DACH">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#5e7cb84a172a0f0007da69e4" lang="de" xmltv_id="RedBullTV.at@SD">Red Bull TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5d00e8adaab96b5635b2a005" lang="de" xmltv_id="SpongeBobSchwammkopf.us@Germany">SpongeBob Schwammkopf</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#6054a9f4bc8a5f000771504c" lang="de" xmltv_id="TakeshisCastle.us@Germany">Takeshi&apos;s Castle</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5f0d668b872e4400073acc68" lang="de" xmltv_id="NickelodeonTeen.fr">Nickelodeon Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#6870c9333ffa5e0c914e9205" lang="de" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/de#65b923f90cb1a100088a03ab" lang="de" xmltv_id="TerraMaterWILD.de@German">Terra Mater WILD</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5d6792bd6be2998ad0ccce30" lang="de" xmltv_id="TotallyTurtles.us@Germany">Totally Turtles</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/de#5e8b5e43f294f8000793c3d7" lang="de" xmltv_id="Victorious.us@Germany">Victorious</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/de#5ad9b7aae738977e2c312132" lang="de" xmltv_id="WorldPokerTour.us@Germany">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62b97c5f0d8c8e0007cf48b9" lang="en" xmltv_id="">Life &amp;amp; Legend of Wyatt Earp</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62b976b93279cb000772c6f9" lang="en" xmltv_id="">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdaa32a1b2fd00076693e8" lang="en" xmltv_id="">FBI Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdabbc5611f2000761ca30" lang="en" xmltv_id="">The New Detectives</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdacc96a3751000811842d" lang="en" xmltv_id="">Pluto TV Westerns</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdacc96a3751000811842d" lang="en" xmltv_id="PlutoTVWesterns.us@CA">Pluto TV Westerns</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdad934d73d50007a82472" lang="en" xmltv_id="">Doctor Who Classic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdae69a47b6c00076af298" lang="en" xmltv_id="">Baywatch</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdaf9cf1bdc500073a8bcb" lang="en" xmltv_id="">Declassified</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdaf3470f09a000714a2f6" lang="en" xmltv_id="">Degrassi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb0bcd707b9000739d2e5" lang="en" xmltv_id="">Pluto TV Drama Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb0bcd707b9000739d2e5" lang="en" xmltv_id="PlutoTVDramaMovies.us@CA">Pluto TV Drama Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb1c5e25122000798ac79" lang="en" xmltv_id="">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb7f0db2eb30007376d4d" lang="en" xmltv_id="">Cheers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb75c3afd1200079146a6" lang="en" xmltv_id="">Nick Jr. Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb75c3afd1200079146a6" lang="en" xmltv_id="NickJrPlutoTV.us@CA">Nick Jr. Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb919d36cbd0007e6ab8a" lang="en" xmltv_id="">South Park En Français</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62bdb5500c21270007218ce1" lang="en" xmltv_id="">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62cbef9ebb857100072fc187" lang="en" xmltv_id="">Global News National</channel>
@@ -454,13 +472,12 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62cc00359cb58900088dc840" lang="en" xmltv_id="">Global News Saskatoon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62cc0120880c890007191016" lang="en" xmltv_id="">Global News Winnipeg</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e90e8cb05d2b0007f10a61" lang="en" xmltv_id="">Game Show Central</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91af00c43540007f2bb43" lang="en" xmltv_id="">Pluto TV Classic TV Families</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91af00c43540007f2bb43" lang="en" xmltv_id="ClassicTVFamilies.us@CA">Pluto TV Classic TV Families</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91b5ca909cb0008114ae4" lang="en" xmltv_id="">Leave it to Bryan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91c3add66e00007eeb24c" lang="en" xmltv_id="">More Pluto TV Comedy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92a58f3e4290007290c96" lang="en" xmltv_id="">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92a58f3e4290007290c96" lang="en" xmltv_id="PlutoTVParanormal.us@CA">Pluto TV Paranormal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92b5fca869f00078f0162" lang="en" xmltv_id="">The Pet Collective</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92e536f28870007fa9b3a" lang="en" xmltv_id="">The Judge Judy Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e93b8eb8e02600071f8b1d" lang="en" xmltv_id="">Total Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e93d0a80d8d10008a0181e" lang="en" xmltv_id="">Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e94ec74823db0007277a8f" lang="en" xmltv_id="">One Piece</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e916affb29c60007211c8a" lang="en" xmltv_id="">Gunsmoke</channel>
@@ -471,26 +488,25 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e925bc68d18a00077bb990" lang="en" xmltv_id="">48 Hours</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e9145ec07f2a00070e68dc" lang="en" xmltv_id="">The Andy Griffith Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e9186f8b685d000773cf58" lang="en" xmltv_id="">Taxi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e9289f8d467f0007fbc701" lang="en" xmltv_id="">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e9289f8d467f0007fbc701" lang="en" xmltv_id="PlutoTVTrueCrime.us@CA">Pluto TV True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e9566e27ce19000732ec85" lang="en" xmltv_id="">Tortues Ninja TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91563ce7ce300076f917e" lang="en" xmltv_id="">The Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92392a3e6270007f562e8" lang="en" xmltv_id="">Forensic Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92447ea1e2a000735ed33" lang="en" xmltv_id="">Midsomer Murders</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92708a7ce600007b2676a" lang="en" xmltv_id="">Pluto TV Crime Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92708a7ce600007b2676a" lang="en" xmltv_id="PlutoTVCrimeDrama.us@CA">Pluto TV Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92951c2db99000787c00d" lang="en" xmltv_id="">Deal or no Deal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92967cd663f0007e604fd" lang="en" xmltv_id="">Homeful</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e95265c9fd030007268fb9" lang="en" xmltv_id="">Totally Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e926429cb58900088f951f" lang="en" xmltv_id="">Income Property</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e951258a26d40007b3034c" lang="en" xmltv_id="">Dora TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e91384210bec0007ba714c" lang="en" xmltv_id="">The Dick Van Dyke Show</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92178946c8000079a3160" lang="en" xmltv_id="">Pluto TV Comedy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3c2e4823db00072788ed" lang="en" xmltv_id="">Pluto TV Action Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3d24b8e02600071fa296" lang="en" xmltv_id="">Pluto TV Comedy Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3f8a38acc80007072d26" lang="en" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62e92178946c8000079a3160" lang="en" xmltv_id="PlutoTVComedy.us@CA">Pluto TV Comedy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3c2e4823db00072788ed" lang="en" xmltv_id="PlutoTVActionMovies.us@CA">Pluto TV Action Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3d24b8e02600071fa296" lang="en" xmltv_id="PlutoTVComedyMovies.us@CA">Pluto TV Comedy Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea3f8a38acc80007072d26" lang="en" xmltv_id="PlutoTVHorror.us@CA">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea4b755e8e770007387b79" lang="en" xmltv_id="">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea4dadce395f0007086df2" lang="en" xmltv_id="">TNA Wrestling</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea43aa0c43540007f2db96" lang="en" xmltv_id="">Mission Impossible</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea459c8d467f0007fbec86" lang="en" xmltv_id="">The Emeril Lagasse Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62ea45010d0611000839868c" lang="en" xmltv_id="">Gordon Ramsay&apos;s Hell&apos;s Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62f4f5de1c100100075665ef" lang="en" xmltv_id="">NCIS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#62f4f90e39183b000769f12b" lang="en" xmltv_id="">Frasier</channel>
@@ -520,7 +536,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64c2214c2a7f2200089a0c4b" lang="en" xmltv_id="">The Price is Right</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64c2222fb0cf5c0008288c4f" lang="en" xmltv_id="">Family Feud Classic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64ca723a2bc49300081a8966" lang="en" xmltv_id="">Three&apos;s Company</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#64e89cfc9c1e3900084ca663" lang="en" xmltv_id="">Real Disaster Channel</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#64e89cfc9c1e3900084ca663" lang="en" xmltv_id="">Mayday: Air Disaster</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64f8a0c230ab3300084369b8" lang="en" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64f8a2a23a0d700008a6ed7b" lang="en" xmltv_id="">Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64f8a22a3efb510008245df0" lang="en" xmltv_id="">The Challenge</channel>
@@ -543,8 +559,8 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66a105f4a79dea0008aa5e0f" lang="en" xmltv_id="">JAG</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66a106c8a79dea0008aa5ef3" lang="en" xmltv_id="">NCIS: Los Angeles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66bb3212fe11e5000883ea6b" lang="en" xmltv_id="">Married... with Children</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66c45c274f25dd00092739ee" lang="en" xmltv_id="">CNN Headlines International</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66d717c6abec540008ba7eb5" lang="en" xmltv_id="">Pluto TV 80&apos;s Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66c45c274f25dd00092739ee" lang="en" xmltv_id="">CNN Headlines</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66d717c6abec540008ba7eb5" lang="en" xmltv_id="PlutoTV80sAction.us@CA">Pluto TV 80&apos;s Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66dad50215d2c60008d7afbd" lang="en" xmltv_id="">Pluto Classic Movie Westerns</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66e2a94d167a8b000813485d" lang="en" xmltv_id="">The Conners</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66ebf4a88131f10008b74739" lang="en" xmltv_id="">Pokémon</channel>
@@ -553,19 +569,23 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#67b4b8b47d8025b1610a0a57" lang="en" xmltv_id="">The Martha Stewart Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#68b9afd66985e192657a2b7f" lang="en" xmltv_id="">APTN Beyond</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#68b9b0dbf9cf3d7cb9f56d88" lang="en" xmltv_id="">MTV Jersey Shore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#68d25b620a0f3829b116bb6f" lang="en" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#68d25c623175a2780d051d3a" lang="en" xmltv_id="">Pluto TV Classic TV Variety</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69a9ae4d3bd16a4ed04240d7" lang="en" xmltv_id="">Pluto TV Retro Action Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69aafc7fdbb42217471e9eb8" lang="en" xmltv_id="">Farmer Wants a Wife</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69aee8a1acb7eb0bb68df641" lang="en" xmltv_id="">Pluto TV Retro Crime Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#630f1e6073bd1800082107f0" lang="en" xmltv_id="">Pluto TV Retro Crime Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#68d25b620a0f3829b116bb6f" lang="en" xmltv_id="PlutoTVAnime.us@CA">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#68d25c623175a2780d051d3a" lang="en" xmltv_id="PlutoTVClassicTVVariety.us@CA">Pluto TV Classic TV Variety</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69a9ae4d3bd16a4ed04240d7" lang="en" xmltv_id="PlutoTVRetroActionMovies.us@CA">Pluto TV Retro Action Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69aee8a1acb7eb0bb68df641" lang="en" xmltv_id="PlutoTVRetroCrimeAction.us@CA">Pluto TV Retro Crime Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69b83e4169056557a9252f61" lang="en" xmltv_id="">Hit Sitcoms</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69b03041cafd86d9dc5763c3" lang="en" xmltv_id="">All My Children</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69c592dff0f1a7d732dc6e36" lang="en" xmltv_id="PlutoTVCars.us@CA">Pluto TV Cars</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69dd5d7bfcb9bf5e3063cb16" lang="en" xmltv_id="">History &amp;amp; Warfare</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#69dd5d9dceddf13a1a7e39c2" lang="en" xmltv_id="">True Crime Now</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#630f1e6073bd1800082107f0" lang="en" xmltv_id="PlutoTVRetroCrimeDrama.us@CA">Pluto TV Retro Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#638e0f4832494900074481e7" lang="en" xmltv_id="">Confess by Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#638e10de75c3a30007092693" lang="en" xmltv_id="">Antiques Road Show UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#638e10220aa6a6000726979f" lang="en" xmltv_id="">Top Gear</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#638e11951177840007fdd6b2" lang="en" xmltv_id="">Pluto TV British Comedy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#639b4f75d3d35c0007d37b30" lang="en" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#638e11951177840007fdd6b2" lang="en" xmltv_id="BritishComedy.us@CA">Pluto TV British Comedy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#639b4f75d3d35c0007d37b30" lang="en" xmltv_id="PlutoTVSnooker900.us@CA">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#647f07e74cfc2c0008a2e557" lang="en" xmltv_id="">DAZN TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#653bdb0fbdf3cf00089cc395" lang="en" xmltv_id="">Pluto TV Adventure</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#653bdb0fbdf3cf00089cc395" lang="en" xmltv_id="PlutoTVAdventure.us@CA">Pluto TV Adventure</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#654ca7f92c1d3300086b608c" lang="en" xmltv_id="">NickToons</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#655f2d713944b60008bc7e90" lang="en" xmltv_id="">Ink Master</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#655f2ee6c0fc88000877d26c" lang="en" xmltv_id="">Bar Rescue</channel>
@@ -576,17 +596,18 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#681b196b896dcc617f8558fe" lang="en" xmltv_id="">RigTV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#681b16158f97d58ff194a3a9" lang="en" xmltv_id="">Project Runway</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#688a44cf5d73ec0a3f49718b" lang="en" xmltv_id="">Weeds / Nurse Jackie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#691b012d1148fa1cd8a75d5c" lang="en" xmltv_id="">Hardcore Pawn</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#691b023a7613e09a8b209539" lang="en" xmltv_id="">The X-Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#691e0561e32eb094b835c418" lang="en" xmltv_id="">Fresh Movies by VVS Films</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#693adae77f21340ef9746f56" lang="en" xmltv_id="">Pluto TV FBI</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#693adae77f21340ef9746f56" lang="en" xmltv_id="PlutoTVFBI.us@CA">Pluto TV FBI</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#693bf37b75432d022c85ef01" lang="en" xmltv_id="">Stargate</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#696e647b07ea70192d49f6a5" lang="en" xmltv_id="">Bonanza</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#696e61287d2afdec4ff2cb75" lang="en" xmltv_id="">Puto TV Classic TV Crime Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#696e61287d2afdec4ff2cb75" lang="en" xmltv_id="">Pluto TV Classic TV Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6310cbee5a8ad300070fdb7c" lang="en" xmltv_id="">Best of The Drew Barrymore Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6350fdd266e9ea0007bedec5" lang="en" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6368e15a51e9560007c592ed" lang="en" xmltv_id="">OUTflix Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6408ae8f9b39550008caf94f" lang="en" xmltv_id="">American Pickers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#6408b41b83f58900081d91ad" lang="en" xmltv_id="">Pluto TV Retro Kid</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#6408b41b83f58900081d91ad" lang="en" xmltv_id="PlutoTVRetroKid.us@CA">Pluto TV Retro Kid</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6482f27c17f5e10008c10ff0" lang="en" xmltv_id="">Arthur</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6540fe4bbdf3cf0008aa2cdd" lang="en" xmltv_id="">Ax Men</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6540fe6fbfbaec0008a583ae" lang="en" xmltv_id="">Duck Dynasty</channel>
@@ -597,6 +618,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6565fefdc917a50008485cc6" lang="en" xmltv_id="">The Beverly Hillbillies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6582f7d612d5ee00089a663d" lang="en" xmltv_id="">Cheaters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6582f8dadfed030008e5a93d" lang="en" xmltv_id="">Iron Chef</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#6654adb1f99922000854388c" lang="en" xmltv_id="">Summer of Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6703a96763292d000836b4fa" lang="en" xmltv_id="">Crime Up Close</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6728c561daad7f000881ac83" lang="en" xmltv_id="">Wicked Tuna</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6729d651c7626f0008b5dacf" lang="en" xmltv_id="">Super Channel Hearties</channel>
@@ -607,7 +629,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#64240d3d466225000827412b" lang="en" xmltv_id="">Qello Concerts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#65367e724f123d000877cfe5" lang="en" xmltv_id="">Come Dine with Me</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#65367e914f123d000877d021" lang="en" xmltv_id="">River Monsters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66166cb1307fa30008f275e7" lang="en" xmltv_id="">Pluto TV Sci-fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#66166cb1307fa30008f275e7" lang="en" xmltv_id="PlutoTVSciFi.us@CA">Pluto TV Sci-fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66166ce7aec96800080f6bd3" lang="en" xmltv_id="">The Graham Norton Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#68679fc6bb46d0bdd38ac9a4" lang="en" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#69172f1699758a0f03459c5b" lang="en" xmltv_id="">America&apos;s Funniest Home Videos</channel>
@@ -622,9 +644,8 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6541010f770cf1000866be98" lang="en" xmltv_id="">MTV Spankin’ New</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6850335b5965a2fd49f7e36d" lang="en" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6972546cc62833833a187f50" lang="en" xmltv_id="">Willow Sports</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#63920159db0dea0007dd9932" lang="en" xmltv_id="">Shades of Black</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66588931a3865300085ca800" lang="en" xmltv_id="">Bob l&apos;éponge</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ca#67922858b83355184c699699" lang="en" xmltv_id="">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ca#67922858b83355184c699699" lang="en" xmltv_id="PlutoTVReality.us@CA">Pluto TV Reality</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#635659445b4c4700076d2ad1" lang="en" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6536725167bd1a00084481bc" lang="en" xmltv_id="">CBC News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#6601948129adfd0008a1c0ba" lang="en" xmltv_id="">Crime &amp;amp; Justice</channel>
@@ -632,25 +653,15 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#65660223635c3c00086c2578" lang="en" xmltv_id="">Rawhide</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66166989635c7500084105a2" lang="en" xmltv_id="">Bondi Rescue</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ca#66289716039f940008cf20a2" lang="en" xmltv_id="">The Dog Whisperer with Caesar Millan</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c5c2b9d8002db3c3e0b1c6d" lang="en" xmltv_id="PlutoTVRetroToons.us@UK">Pluto TV Retro Toons</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ca1da6c593a5d78f0e7edce" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc3fc6b9133f500099c7d98" lang="en" xmltv_id="">Pluto TV Family Movie Club</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc3fc6b9133f500099c7d98" lang="en" xmltv_id="PlutoTVFamilyMovieClub.de@UK">Pluto TV Family Movie Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf901280e3550009139c86" lang="en" xmltv_id="">5 Exploring Britain</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf91149880d60009d35d27" lang="en" xmltv_id="PlutoTVDrama.us@UK">Pluto TV Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ea18cd42ee5410007e349dc" lang="en" xmltv_id="">Crime Investigation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62ab579258cb950007811aad" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62ac50e92c48f900071444c9" lang="en" xmltv_id="AuctionHunters.us@SD">Auction Hunters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#62ac405b3874370007419b7f" lang="en" xmltv_id="">Barney &amp;amp; Friends</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62d550d81054990007db7798" lang="en" xmltv_id="TeenMom.us@SD">Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#62e9184439d80c00076e166d" lang="en" xmltv_id="">Aftershock</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62f53dc6ee9a0400071dc22b" lang="en" xmltv_id="PlutoTVSitcoms.us@Germany">Pluto TV Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63c1384e829c850007922ca4" lang="en" xmltv_id="">5 Emergency Rescue</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d000ef4e83e700086e0d6c" lang="en" xmltv_id="">Scorpion</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d8ed19a9957100086f4d33" lang="en" xmltv_id="">Transformers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d91c9c8795f30008678e62" lang="en" xmltv_id="">Nature Time</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d91cc58795f30008678e9d" lang="en" xmltv_id="">Bloodline Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d91d624e83e7000881ca8c" lang="en" xmltv_id="">Escape to the Country</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d91d2560bc8f0008a225e4" lang="en" xmltv_id="FIFAPlus.uk@English">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63fe2ec4dff38e000835f786" lang="en" xmltv_id="">Rookie Blue</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64c0d6b424ade50008bc8883" lang="en" xmltv_id="">U&amp;amp;Real Heroes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64c0d6f34096290008132d6b" lang="en" xmltv_id="">U&amp;amp;Laughs</channel>
@@ -658,33 +669,21 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64c0d6765dc1660008a3e033" lang="en" xmltv_id="">U&amp;amp;Transport</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64c37e47dac71b000809abab" lang="en" xmltv_id="">Evidence of Evil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64c37e710e086a0009e824ab" lang="en" xmltv_id="">That&apos;s 70s</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#64edf6eaa7ec0d000812f58c" lang="en" xmltv_id="SouthPark.us@France">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#64ff1d92d545e9000877fba4" lang="en" xmltv_id="">A Haunting</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a6a5e90c7ff50008cb9815" lang="en" xmltv_id="FunnyAF.us@SD">Funny AF</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a6a7a00c7ff50008cba07b" lang="en" xmltv_id="PlutoTVCrimeDrama.us@SD">Pluto TV Crime Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7ab137bdc8d0008487dfb" lang="en" xmltv_id="">Pluto TV Erotica</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7ab137bdc8d0008487dfb" lang="en" xmltv_id="PlutoTVErotica.de@UK">Pluto TV Erotica</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7af553af63d000828acca" lang="en" xmltv_id="">Cash In The Attic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7b04e7bdc8d0008488307" lang="en" xmltv_id="">True Crime Now</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7b0814a10d800085ff2df" lang="en" xmltv_id="">Pluto TV PetrolHeads</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7b0814a10d800085ff2df" lang="en" xmltv_id="PlutoTVPetrolHeads.de@UK">Pluto TV PetrolHeads</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a7b01907e03a0008913e8f" lang="en" xmltv_id="">Best of Dr. Phil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65b14aae0cb1a100087a216e" lang="en" xmltv_id="">DAZN Ringside</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65b3895660eb8700089e7f53" lang="en" xmltv_id="">Car Chase</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65c4960d11ced7000812c433" lang="en" xmltv_id="GeordieShore.us@Italy">Geordie Shore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65f0166566eec80008b96f7e" lang="en" xmltv_id="">Pluto TV Wildest Adventures</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66a10eacfe11e500084c6925" lang="en" xmltv_id="">Flashpoint</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66a10eeb46762a0008201e85" lang="en" xmltv_id="Teletubbies.uk@SD">Teletubbies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66ba1e23d2d50d00084a1e57" lang="en" xmltv_id="">Crimes That Shook Britain</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66ba1e4446762a000855cd87" lang="en" xmltv_id="GirlfriendsFilms.us@SD">Girlfriends</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66c45afaa72e7b0008a2b153" lang="en" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d717d2abec540008ba7ec4" lang="en" xmltv_id="">Pluto TV 80&apos;s Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d885aef0f17500084b6750" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d717d2abec540008ba7ec4" lang="en" xmltv_id="PlutoTV80sAction.de@UK">Pluto TV 80&apos;s Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d82143abec540008bd2b1c" lang="en" xmltv_id="">Project Runway</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66dff9d46ad04d0008fda4de" lang="en" xmltv_id="">CNN Headlines International</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66e06576abec540008cc17a9" lang="en" xmltv_id="">The Graham Norton Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66ebf9bc55567d0008de3b29" lang="en" xmltv_id="">The Hotel Inspector</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66ed3e9d5e4a6e0008b346e0" lang="en" xmltv_id="">UFC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66f135b45e4a6e0008b80606" lang="en" xmltv_id="AntiquesRoadTrip.us@SD">Antiques Road Trip</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66f137cb483d460008ece053" lang="en" xmltv_id="RugbyPassTV.uk@SD">Rugby Pass TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66f1331f9409630008077623" lang="en" xmltv_id="">Earth: Final Conflict</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66fd37885049580008d295b6" lang="en" xmltv_id="">AWSN</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68b5a7b69ac85c428f54c441" lang="en" xmltv_id="">Curzon</channel>
@@ -695,6 +694,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68c82005be767928b4a8ef0c" lang="en" xmltv_id="">I Survived...</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68c820525ec82769fdfcd104" lang="en" xmltv_id="">Wrestling Legends TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68d113f9184f1a0620c8101c" lang="en" xmltv_id="">Medical Detectives</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#68d67005bdb33359705bbed3" lang="en" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e3b6112baff9f069d02540" lang="en" xmltv_id="">Relic Hunter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e3bffe1cfcd7541d59090f" lang="en" xmltv_id="">Most Haunted: Unseen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e3c37c19f32ffa27bae948" lang="en" xmltv_id="">Unsolved Mysteries with Dennis Farina</channel>
@@ -703,24 +703,21 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e38aaf8082ad3760def7bc" lang="en" xmltv_id="">Hercules: The Legendary Journeys</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e38b005c876cf730fcbf0f" lang="en" xmltv_id="">Six Million Dollar Man</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68e38b6e20115bbaf9c91083" lang="en" xmltv_id="">The Incredible Hulk</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#620f6c60b994540007ddd74b" lang="en" xmltv_id="">Moesha</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#620f6f9e36a49b000761f0d5" lang="en" xmltv_id="">Location, location, location</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#69b917d632eb9227dd6b427e" lang="en" xmltv_id="">The Therapy Crouch</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#69b422590306b277746f48cb" lang="en" xmltv_id="">The Raccoons</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#69c6a93486431735d974bc2a" lang="en" xmltv_id="">Deal Masters</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#69d51f98fcb9bf5e303ca0c1" lang="en" xmltv_id="">Dinner Date</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#600acaff5f2d6e000745effb" lang="en" xmltv_id="PlutoTVToughJobs.de@UK">Pluto TV Tough Jobs</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#622f48de713e510007f85808" lang="en" xmltv_id="">Dynasty</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#622f498d119b4c000719c0b7" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">Judge Judy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#625e8cb585ef320007806caf" lang="en" xmltv_id="">Pluto TV Britain at War</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#625e8cb585ef320007806caf" lang="en" xmltv_id="PlutoTVBritainatWar.de@UK">Pluto TV Britain at War</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#625eaebc2a73a00007d3f855" lang="en" xmltv_id="">Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#639b558c73423d00071ce624" lang="en" xmltv_id="">More TV Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#645e00d5d3fdde000829463a" lang="en" xmltv_id="">More TV Sci-fi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#655b7cbb2c46f300086f0afa" lang="en" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#656df599c0fc8800089c75ab" lang="en" xmltv_id="Avatar.us@UK">Avatar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#655b7cbb2c46f300086f0afa" lang="en" xmltv_id="PlutoTVSnooker900.de@UK">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#656df2849d5ac400083be647" lang="en" xmltv_id="">5 Trucking Hell</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#656ef4af4261ca00083c8f37" lang="en" xmltv_id="TotallyTurtles.us@US">Totally Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#660be37e7bcd860008793a6a" lang="en" xmltv_id="">Bondi Rescue</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#660c209e19ca71000846cf38" lang="en" xmltv_id="Now90s00s.uk@Poland">That&apos;s 90s00s</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#660e5dc60cd4630008f6198a" lang="en" xmltv_id="">JAG</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#661cf62d24e1d000087dae0d" lang="en" xmltv_id="Cops.us@SD">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#664c94e80120f40008b860f0" lang="en" xmltv_id="">POP</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#667ac79c15f35c00088a2409" lang="en" xmltv_id="">Outback Truckers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#667d664815f35c00089489bf" lang="en" xmltv_id="">Corner Gas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#672cb91149c40600081cbee5" lang="en" xmltv_id="">Whose Line Is It Anyway?</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#677fb0b33a225c2d0d8a17be" lang="en" xmltv_id="">Xena: Warrior Princess</channel>
@@ -729,90 +726,62 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#677fb115a4af36ad50113e56" lang="en" xmltv_id="">The Real Housewives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#677fb137a5d8215f99b9cc06" lang="en" xmltv_id="">Top Chef</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#677fb3432952c1163bf1a539" lang="en" xmltv_id="">Million Dollar Listing</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#680bb31c56ff83bcd685d64e" lang="en" xmltv_id="Farscape.us@SD">Farscape</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#685aa802fb6023de7cc56357" lang="en" xmltv_id="">Dominance FC TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#686cd713e48af72bc250efb8" lang="en" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#686fc8fe1889b4ad04604704" lang="en" xmltv_id="">Icons Unearthed+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#690dc8ed1ee9b6ac66607ce2" lang="en" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#691b453846ca5e6d1665f03b" lang="en" xmltv_id="">Meet, Marry, Murder</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#692ebafce72f03e07e7df985" lang="en" xmltv_id="">Pluto TV American True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#692ebafce72f03e07e7df985" lang="en" xmltv_id="PlutoTVAmericanTrueCrime.de@UK">Pluto TV American True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#696e024a7e92438c27a425a8" lang="en" xmltv_id="">Rally TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#697a2f8b3991484f03064614" lang="en" xmltv_id="">Super Mario Bros.</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#698a040b48d98175cb870fc5" lang="en" xmltv_id="">Hoarders</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6231eb3865be650007f59595" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6299e5afdd5833000727e795" lang="en" xmltv_id="48Hours.us@SD">48 Hours</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6304f8d5ffb61000071ab478" lang="en" xmltv_id="">CSI: Crime Scene Investigation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6304fb268bd95300072d2198" lang="en" xmltv_id="TrueCrime.uk@SD">True Crime UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6319ee0cf78bb10007ee5e6b" lang="en" xmltv_id="">World War TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6319f06067a3ee000708af95" lang="en" xmltv_id="HauntTV.ca@SD">Haunt TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@UK">Moviesphere</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6568a78d635c3c0008765f41" lang="en" xmltv_id="NOWRock.uk@SD">That&apos;s Rock</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6683cd71a1d7ad000866ec6a" lang="en" xmltv_id="PlutoTVPokemon.us@UK">Pokémon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6960c5a906d76f50db2816dc" lang="en" xmltv_id="">Cagney &amp;amp; Lacey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6981cc6a644861a57c3bd8ad" lang="en" xmltv_id="">Shockwave</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#62556bfa3261a300076b0baa" lang="en" xmltv_id="">Arthur</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#63693fa2bfa0690007ebc880" lang="en" xmltv_id="">Wicked Tuna</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#63808dc806aa4700075f319a" lang="en" xmltv_id="PlutoTVInvestigation.us@France">Pluto TV Investigation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#64634eb42858cb0008fd92d6" lang="en" xmltv_id="">How To Use Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#64634eb42858cb0008fd92d6" lang="en" xmltv_id="HowToUsePlutoTV.de@UK">How To Use Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65819f83a620e300080f692a" lang="en" xmltv_id="">Weird or What? With William Shatner</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66275e41cee0d900085fde6e" lang="en" xmltv_id="TheLoveBoat.us@SD">The Love Boat</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65819fc1b9adc4000813f37d" lang="en" xmltv_id="">History Hunters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#67063e78b2ffb10008195d08" lang="en" xmltv_id="">MODUS Super Series Darts</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#68503cfda1e091e16f000625" lang="en" xmltv_id="">7th Heaven</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68503d3bc692373f0158c43f" lang="en" xmltv_id="">Hawaii Five-O</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#68503d1736c9361b191e7d89" lang="en" xmltv_id="Gunsmoke.us@SD">Gunsmoke</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68503d585965a2fd49fc2f0b" lang="en" xmltv_id="">MacGyver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#69038c2ee0e0c5f8208c033a" lang="en" xmltv_id="">Murdertown</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#69987f939c3b075ecd3b8255" lang="en" xmltv_id="">Dog Vs Duck</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#685041d936c9361b1921c26c" lang="en" xmltv_id="">Pluto TV Fantasy &amp;amp; Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#685041d936c9361b1921c26c" lang="en" xmltv_id="PlutoTVFantasyHorror.de@UK">Pluto TV Fantasy &amp;amp; Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#694178a8026be6e9d3ea7d7a" lang="en" xmltv_id="">Mona The Vampire</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6462190b7cb4b1000862dd60" lang="en" xmltv_id="">Pluto TV Alien Invasion</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6462190b7cb4b1000862dd60" lang="en" xmltv_id="PlutoTVAlienInvasion.de@UK">Pluto TV Alien Invasion</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6490254fd2c47c00083a5743" lang="en" xmltv_id="">That&apos;s 80s</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6514346fa76507000887d441" lang="en" xmltv_id="">Confess by Nosey</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6627621d56fc840008e47c90" lang="en" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6850426e53d981d1fdb0d966" lang="en" xmltv_id="Matlock.us@SD">Matlock</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6852854bce36f0644f37d765" lang="en" xmltv_id="">A New Life in the Sun</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6882521ac258734a42a60ed0" lang="en" xmltv_id="WorldPokerTour.us">DP World Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6900997e043e3df1897d017f" lang="en" xmltv_id="">Ironside</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#61559552dd585f0007321eca" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#65031534d545e9000881ed10" lang="en" xmltv_id="">British Screen Classics</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66276091cee0d900085fe053" lang="en" xmltv_id="SabrinaTeenageWitch.us@UK">Sabrina The Teenage Witch</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#68504098f212bedacf63a7e1" lang="en" xmltv_id="">Touched by an Angel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#650315163a0d700008bb07f8" lang="en" xmltv_id="">Criminal Confessions</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6695294632e25300084bb61b" lang="en" xmltv_id="">Sister, Sister</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6850408053d981d1fdb01696" lang="en" xmltv_id="">Taxi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6852811933a52de120f8b89d" lang="en" xmltv_id="">Mayday Air Disaster</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#682453731295f98347e92da8" lang="en" xmltv_id="">River Monsters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5a6b92f6e22a617379789618" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5a74b8e1e22a61737979c6bf" lang="en" xmltv_id="">FOX Sports</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5bdcdf1e851dd5632e2c11d1" lang="en" xmltv_id="">QVC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96c0222df39f1a338d163" lang="en" xmltv_id="PlutoTVNovelas.us@SD">Pluto TV Novelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5ef3958c66ac540007d6e6a7" lang="en" xmltv_id="">Dark Shadows</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5db0ad56edc89300090d2ebb" lang="en" xmltv_id="">Kids Movie Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60fb053712f22a0007ff14d2" lang="en" xmltv_id="">Transformers TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#61b3b8c645b45d0007a9bb8d" lang="en" xmltv_id="BlueBloods.us@SD">Blue Bloods</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#61e9af6bfbbcc6000700119b" lang="en" xmltv_id="">WeatherNation Los Angeles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#61f33318210549000806a530" lang="en" xmltv_id="">Classic Movie Westerns</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#62ba60f059624e000781c436" lang="en" xmltv_id="">00s Replay</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#62cdc813f5def500070361eb" lang="en" xmltv_id="">CBS News Texas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#62f54c11b3af68000702c304" lang="en" xmltv_id="">CSI: Miami</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#62f54c6439183b000769fb8f" lang="en" xmltv_id="">CSI: NY</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#63a0e33a45264d000850ed7e" lang="en" xmltv_id="CBSSportsGolazoNetwork.us@SD">Golazo Network</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#63d025db4e83e700086eaa96" lang="en" xmltv_id="LiveNOWfromFOX.us@SD">LiveNOW from FOX</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#63d0269d60bc8f000890facc" lang="en" xmltv_id="FoxDeportes.us@SD">FOX Deportes</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#64b585f84ea480000838e446" lang="en" xmltv_id="">Pluto TV Icons</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#64b9671cdac71b0008f371df" lang="en" xmltv_id="PlutoTVCineClasico.us@US">Cine Clásico</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#64d2b6bf9b414d0008187d83" lang="en" xmltv_id="">Real Disaster Channel</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#64b585f84ea480000838e446" lang="en" xmltv_id="PlutoTVIcons.us@SD">Pluto TV Icons</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#64d2b6bf9b414d0008187d83" lang="en" xmltv_id="">Mayday: Air Disaster</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#64d160f53c785e0008df525e" lang="en" xmltv_id="">Top Rank Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#64d161c93c785e0008df575e" lang="en" xmltv_id="">Vevo Íconos Latinos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#64d1606b4c5ed80008e3b8b9" lang="en" xmltv_id="">Dynasty</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#64dab1f835425100080e1e7b" lang="en" xmltv_id="AcapulcoShore.us@SD">Acapulco Shore</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#64dab5fe35425100080e2991" lang="en" xmltv_id="">Vevo Regional Mexicano</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#64e561a4354251000823a0e0" lang="en" xmltv_id="GhostHunters.us@UK">Ghost Hunters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65a6dafb7bdc8d0008473c85" lang="en" xmltv_id="">The Lone Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65a9b20f0c7ff50008d3a3b6" lang="en" xmltv_id="">Universal Monsters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69bbfd77d450008c7ffee" lang="en" xmltv_id="">Star Trek: Deep Space Nine</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69bf23ef47d0008583967" lang="en" xmltv_id="">Tough Jobs</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69ee3d77d450008c80438" lang="en" xmltv_id="">F1 Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#65d92a8c8b24c80008e285c0" lang="en" xmltv_id="BBCNews.uk@Africa">BBC News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65e23f340d4561000821540d" lang="en" xmltv_id="">Mister Rogers&apos; Neighborhood</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65ea8b928145cb0008509426" lang="en" xmltv_id="">UEFA Champions League</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66a7f0a78561260008c177f2" lang="en" xmltv_id="">Salem News Channel</channel>
@@ -821,17 +790,12 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66ba53cda4ee2700083fac09" lang="en" xmltv_id="">Sala de Emergencias: Historias Inéditas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66ba495ffe11e5000881f049" lang="en" xmltv_id="">Cheers + Frasier</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66c638726838ee00085ac20d" lang="en" xmltv_id="">Andromeda</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#66df8a29b25d2b0008fc5fe0" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66df8aa7abec540008ca8cb6" lang="en" xmltv_id="">Homeful</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66e0b4a3f0f17500085cc268" lang="en" xmltv_id="">Hit Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66e0b4536ad04d0008fff4b2" lang="en" xmltv_id="">CNN Originals</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#66e0b4866ad04d0008fff4d8" lang="en" xmltv_id="Mythbusters.us@UK">MythBusters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#66fedd65d7de140008dccd66" lang="en" xmltv_id="PlutoTVElReinoInfantil.us@SD">El Reino Infantil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#66ff0cf663292d0008320cf8" lang="en" xmltv_id="">No Reservations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#67c62ac2095aea2ec805eb34" lang="en" xmltv_id="">The Martha Stewart Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#67c63b90a20c0399a381b816" lang="en" xmltv_id="">Inuyasha</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#67d07b7b798df95b8e9484b5" lang="en" xmltv_id="">The Emeril Lagasse Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#67ed8f7e443f0671bc2b2368" lang="en" xmltv_id="PlutoTVAnimeMovies.us@SD">Pluto TV Anime Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68bb16a500a2f063fdf89f8c" lang="en" xmltv_id="">Chef vs Chef by Food Network</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68bb16ba3efb41cd971f3ce6" lang="en" xmltv_id="">Delicious Eats by Food Network</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68bb16e7f89c82a68bcc4397" lang="en" xmltv_id="">Chip &amp;amp; Jo: Feels Like Home by Magnolia Network</channel>
@@ -842,12 +806,18 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68c32d88f56983aba40052bd" lang="en" xmltv_id="">BET Comedy Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68e9913c4a666b9054849832" lang="en" xmltv_id="">Bonanza</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68ee9a999938143525bfc385" lang="en" xmltv_id="">Shop LC</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#68fbf8101d26140175db8b58" lang="en" xmltv_id="">Pluto TV Franchise Favorites</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69d6c7befde57cd5ba0160c3" lang="en" xmltv_id="PlutoTVHometownDrama.us@SD">Pluto TV Hometown Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69d7ebb726eeec84158e28cb" lang="en" xmltv_id="PlutoTVAdventure.us@US">Pluto TV Adventure</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69d7ebff029c431826bd328e" lang="en" xmltv_id="">Battlestar Galactica</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69e6be40fde57cd5ba562b29" lang="en" xmltv_id="">Pokémon en español</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69eaa34817801c84fca05d94" lang="en" xmltv_id="">Always Funny</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#69fa3faab9c0f0d444e64de3" lang="en" xmltv_id="">Pluto TV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#620bfa7df72827000703ddb1" lang="en" xmltv_id="">Stargate</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#623a1b5188ecdc0007c9ef5a" lang="en" xmltv_id="">XITE Rock x Metal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#623b92a2ccefed0007b1db48" lang="en" xmltv_id="">XITE Classic Country</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#623b93628e6ded0007337d4d" lang="en" xmltv_id="">XITE Gospel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#627d355aa95efd00077afcc7" lang="en" xmltv_id="">Cheaters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#628e685ba3811100070551a8" lang="en" xmltv_id="HallmarkMoviesMore.us@SD">Hallmark Movies &amp;amp; More</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#632b606e12a67b0007c9e371" lang="en" xmltv_id="">CSI: NY en español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#632b619c8d2a6c0007ff534e" lang="en" xmltv_id="">KIRO Seattle</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#632b5950b515b000079e6b81" lang="en" xmltv_id="">CSI: Miami en español</channel>
@@ -855,11 +825,8 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#634ee8f95aa9870007248333" lang="en" xmltv_id="">Confess by Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#634f307c7a068e00072c9982" lang="en" xmltv_id="">Rawhide</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#634f3011f4fff20007431641" lang="en" xmltv_id="">I Love Lucy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#636adc255bcf470007d6e0e2" lang="en" xmltv_id="TopGear.uk@SD">Top Gear</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#637e55347427a40007fac703" lang="en" xmltv_id="">Sailor Moon</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#640a68880e884c0009979cc2" lang="en" xmltv_id="FoxWeather.us@SD">FOX Weather</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#643f03b9d8436e0008edf021" lang="en" xmltv_id="">Family Feud Classic</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#643f035d5a0cd50008361534" lang="en" xmltv_id="ThePriceIsRight.us@HD">The Price Is Right</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#645e7828e1979c00087b75b4" lang="en" xmltv_id="">MovieSphere by Lionsgate</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#649b6898f2ec0000081a9460" lang="en" xmltv_id="">DAZN Ringside</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#649ddbfb6f29ec000874ca9e" lang="en" xmltv_id="">Supermarket Sweep</channel>
@@ -873,40 +840,28 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#667f3852efa2a10008e1e514" lang="en" xmltv_id="">Go Go Gadget!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#667f393836a2f90008fd17c0" lang="en" xmltv_id="">Strawberry Shortcake and Friends</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#668c5cb4f01dbe0008dd4082" lang="en" xmltv_id="">CBS en español</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#668c5d3bfd9eb2000882bb50" lang="en" xmltv_id="">ONE Championship TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#668c566d08d5490008075948" lang="en" xmltv_id="">La Familia del Barrio</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#672e4d915534bb0008c50168" lang="en" xmltv_id="">Family Feud</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#673bf05ddaad7f0008ac7a5c" lang="en" xmltv_id="">Dinos 24/7</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#674f735a2fb8a100087bf253" lang="en" xmltv_id="Revry.us@SD">Revry</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#677d9adfa9a51b0008497fa0" lang="en" xmltv_id="">UFC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#677d672ef090ab00085b8e9b" lang="en" xmltv_id="">Robot Wars by MECH+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#682e43b21295f98347710917" lang="en" xmltv_id="">AWSN</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#683df56f5195c2a60a3f5559" lang="en" xmltv_id="SwerveSports.us@SD">Swerve Sports</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#686c1c873ffa5e0c91a85938" lang="en" xmltv_id="">Cine Crimen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#686c2677ed17cf4c900a496d" lang="en" xmltv_id="">Wicked Tuna</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#686d8dd294a028da3ac59566" lang="en" xmltv_id="WomensSportsNetwork.us@SD">Women&apos;s Sports Network</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#686d61503484d6073283059d" lang="en" xmltv_id="">Black Family Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#687fea9a4fa995eff284a1c8" lang="en" xmltv_id="">Más adrenalina</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#687ff00ff6bc08130f16ab81" lang="en" xmltv_id="">Beyond the Gates</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#691cf0410a78a9ce61ad2121" lang="en" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#691d1200c2185a44642f5e7c" lang="en" xmltv_id="">El Rey Rebel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#695c32e61ca20bb8ca802eb9" lang="en" xmltv_id="">Star Trek: The Next Generation</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6283d51144ad8f0007fa382d" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">The Judge Judy Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6400f731d200410008f9b339" lang="en" xmltv_id="FastTV.us@SD">Discovery Turbo TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6452c77ed3fdde00080eb3a8" lang="en" xmltv_id="">90s Kids TV 2</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6452c814939a590008567a3b" lang="en" xmltv_id="">90&apos;s Kids</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6532e6a9bdf3cf000887ab29" lang="en" xmltv_id="">More True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6532e7fa045c3d0008514ca7" lang="en" xmltv_id="">Warner Bros. TV Sweet Escapes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6532e8342cf13100083b404c" lang="en" xmltv_id="">Warner Bros. TV Say Yes to the Dress</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6661f11a41af6400080e90d8" lang="en" xmltv_id="">Big Brother</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6675c88da1d7ad00084762cb" lang="en" xmltv_id="">Star Trek: The Motion Pictures</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6675c713fc3a46000863dde7" lang="en" xmltv_id="">Ebony TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6675c742ca74680008566b88" lang="en" xmltv_id="">Nash Bridges</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6675c7868768aa0008d7f1c7" lang="en" xmltv_id="PlutoTVPokemon.us@US">Pokémon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6792c30abc03978b9b8bb832" lang="en" xmltv_id="">The NBA Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6793ea255225b515b4ba91a7" lang="en" xmltv_id="ALLBLKGems.us@SD">ALLBLK Gems</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6793eaa4bc03978b9bc63db1" lang="en" xmltv_id="">ANIME x HIDIVE</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6793eaa4bc03978b9bc63db1" lang="en" xmltv_id="AnimexHIDIVE.us@SD">ANIME x HIDIVE</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6887a4e01067b66fa16966ec" lang="en" xmltv_id="">Live PD Presents</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6887a8fd8e92b5e0a7244e88" lang="en" xmltv_id="">Ancient Aliens</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6887a86be3703b7d42b3eca3" lang="en" xmltv_id="">Matched Married Meet by Lifetime</channel>
@@ -915,6 +870,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6913e381b6bf26bb6e798c13" lang="en" xmltv_id="">The X-Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#61325c4f982acd000723287e" lang="en" xmltv_id="">Classic TV Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#63335b193583440007c859fb" lang="en" xmltv_id="">Lifetime Movie Favorites</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#65033c4b98020f0008547124" lang="en" xmltv_id="">S.W.A.T.</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65244c403fd33c0008ffff31" lang="en" xmltv_id="">Car Chase</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65453f30085df200085883d8" lang="en" xmltv_id="">ION</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65492fc7056b9700088560b5" lang="en" xmltv_id="">American Crimes</channel>
@@ -923,7 +879,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65775d29dfed030008cb3db2" lang="en" xmltv_id="">Modern Marvels by HISTORY</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65790cda6e4f6a0008768764" lang="en" xmltv_id="">NBC Los Angeles News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65790feacbd0d60008fac87a" lang="en" xmltv_id="">Telemundo Noticias California</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#67352ed93a61d4000881f9fa" lang="en" xmltv_id="PlutoTVTheTwilightZone.us@SD">The Twilight Zone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#67882c1c7b11714b795c2008" lang="en" xmltv_id="">Sketchy AF</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68487fb3f212bedacf5a53e3" lang="en" xmltv_id="">50 Cent Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68509fe882d704acfc5bacd1" lang="en" xmltv_id="">Tastemade Smokehouse</channel>
@@ -939,20 +894,15 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#654932fa4d6d8f00084c4723" lang="en" xmltv_id="">Bad Girls Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#654933ac986ad20008a1f406" lang="en" xmltv_id="">Little House on the Prairie</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#654933e253fc970008390114" lang="en" xmltv_id="">Universal Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#656535fc2c46f30008870fae" lang="en" xmltv_id="BBCEarth.uk@US">BBC Earth</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#656538f8954b020008d389db" lang="en" xmltv_id="">UnXplained Zone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#656542ae4261ca00082154a8" lang="en" xmltv_id="">Ultimate Builds</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#661827ffe8fba800086b217d" lang="en" xmltv_id="">Triton Poker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#663946c1b18d700008d9c168" lang="en" xmltv_id="">BET Visionaries</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#673248f9030a2c0008033af8" lang="en" xmltv_id="">CNN XPRESS</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#673248f9030a2c0008033af8" lang="en" xmltv_id="">CNN Noticias</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#673249afc7626f0008c7205d" lang="en" xmltv_id="">Vidas Extremas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#681109b688b9d85d0938c6ba" lang="en" xmltv_id="TennisChannel.us@Plus2">TennisChannel 2</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#696689d13b9ce349c9be3a18" lang="en" xmltv_id="">Stingray DJAZZ</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#696998dfa2b623e8b20125a3" lang="en" xmltv_id="">ZenLIFE by Stingray</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#698384cb7230043f21f4a3f4" lang="en" xmltv_id="">Property Brothers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6049295e7dcef800073c2499" lang="en" xmltv_id="">Star Trek en español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6267352efcf21c0007c76642" lang="en" xmltv_id="">Let&apos;s Make A Deal</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6450209d939a5900084dba1d" lang="en" xmltv_id="iCarly.us@East">iCarly TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6549306c83595c000815a696" lang="en" xmltv_id="">NBC Sports NOW</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6549310a53fc97000838fcc9" lang="en" xmltv_id="">Bravo Vault</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6549316d2c1d330008631496" lang="en" xmltv_id="">Real Housewives Vault</channel>
@@ -963,50 +913,59 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65493029ab052400089e9d2f" lang="en" xmltv_id="">GolfPass</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#65653817c917a5000844bc30" lang="en" xmltv_id="">Criminal Minds</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#67817323dd7846fe546940dd" lang="en" xmltv_id="">QVC2</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#673247127d5da5000817b4d6" lang="en" xmltv_id="">Pluto TV Trending Now</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#673247127d5da5000817b4d6" lang="en" xmltv_id="PlutoTVTrendingNow.us@SD">Pluto TV Trending Now</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#673249433a61d400087a51ed" lang="en" xmltv_id="">Construcciones Asombrosas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#696998915a0ae9e1b563f0c6" lang="en" xmltv_id="">Qello Concerts</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6549341853fc9700083901ac" lang="en" xmltv_id="UniversalCrime.us@East">Universal Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#696997049889f8db34c936c2" lang="en" xmltv_id="">Boruto: Naruto Next Generations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6549337183595c000815ad05" lang="en" xmltv_id="">Murder, She Wrote</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#68758038552299d2b08162e3" lang="en" xmltv_id="">Law &amp;amp; Order</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6996296087742204bff43147" lang="en" xmltv_id="">Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d2c571faeb3e2738ae27933" lang="en" xmltv_id="5Cops.us@UK">5 Cops</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6299e5afdd5833000727e795" lang="en" xmltv_id="48Hours.us@SD">48 Hours</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6176f39e709f160007ec61c3" lang="en" xmltv_id="48Hours.us@SD">48 Hours</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d878d3d19b30007d2e782" lang="en" xmltv_id="70sCinema.us@SD">70s Cinema</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca525b650be2571e3943c63" lang="en" xmltv_id="80sRewind.us@SD">80s Rewind</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d86f519358a00072b978e" lang="en" xmltv_id="90sThrowback.us@SD">90s Throwback</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d83e0a382c00007bc02e7" lang="en" xmltv_id="BeverlyHills90210.us@Germany">Beverly Hills 90210</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6508be683a0d700008c534e4" lang="en" xmltv_id="ABCNewsLive.us@SD">ABC News Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#64dab1f835425100080e1e7b" lang="en" xmltv_id="AcapulcoShore.us@US">Acapulco Shore</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6793ea255225b515b4ba91a7" lang="en" xmltv_id="ALLBLKGems.us@SD">ALLBLK Gems</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e82530945600e0007ca076c" lang="en" xmltv_id="AllRealitybyWEtv.us@SD">All Reality WE tv</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e84f54a82f05300080e6746" lang="en" xmltv_id="AmericasTestKitchen.us@SD">America&apos;s Test Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e1f7da4bc7d740009831259" lang="en" xmltv_id="AmericasVoiceNews.us@SD">America&apos;s Voice News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5e8db96bccae160007c71eec" lang="en" xmltv_id="Andromeda.us@UK">Andromeda</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5812b7d3249444e05d09cc49" lang="en" xmltv_id="PlutoTVAnime.us@US">Pluto TV Anime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ce44810b421747ae467b7cd" lang="en" xmltv_id="AntiquesRoadshowUK.us@SD">Antiques Roadshow UK</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66f135b45e4a6e0008b80606" lang="en" xmltv_id="AntiquesRoadTrip.us@SD">Antiques Road Trip</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#615b8ec39e878900073f419a" lang="en" xmltv_id="AntiquesRoadTrip.us@SD">Antiques Road Trip</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62ac50e92c48f900071444c9" lang="en" xmltv_id="AuctionHunters.us@SD">Auction Hunters</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#656df599c0fc8800089c75ab" lang="en" xmltv_id="Avatar.us@UK">Avatar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60faffc3fbbc120007fc4376" lang="en" xmltv_id="BabySharkTV.us@SD">Baby Shark TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60a3d889a5b3690008dc7fe8" lang="en" xmltv_id="BarRescue.us@SD">Bar Rescue</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#656535fc2c46f30008870fae" lang="en" xmltv_id="BBCEarth.uk@US">BBC Earth</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#65d92a8c8b24c80008e285c0" lang="en" xmltv_id="BBCNews.uk@Africa">BBC News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ebc8688f3697d00072f7cf8" lang="en" xmltv_id="BellatorMMA.us@SD">Bellator MMA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f760bbdf090700075d7bfe" lang="en" xmltv_id="BestofDrPhil.us@SD">Best of Dr. Phil</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#604f8f8622166000071a929f" lang="en" xmltv_id="BETPlutoTV.us@UK">BET Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#60f85644a9493e0007a1f035" lang="en" xmltv_id="BETClassicsPlutoTV.us@France">BET Classics</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#604f8f8622166000071a929f" lang="en" xmltv_id="BETPlutoTV.de@UK">BET Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca670f6593a5d78f0e85aed" lang="en" xmltv_id="BETPlutoTV.us@US">BET Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f7796e470510900070d4e3d" lang="en" xmltv_id="BeverlyHillbillies.us@US">Beverly Hillbillies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d83e0a382c00007bc02e7" lang="en" xmltv_id="BeverlyHills90210.us@Germany">Beverly Hills 90210</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#611f85396abc84000738417b" lang="en" xmltv_id="BeyondBeliefFactorFiction.us@UK">Beyond Belief: Fact or Fiction</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#58af4c093a41ca9d4ecabe96" lang="en" xmltv_id="BlackCinema.us@SD">BET Cinema</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#60f85644a9493e0007a1f035" lang="en" xmltv_id="BETClassicsPlutoTV.us@France">BET Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d51e2bceca5b4b2c0e06c50" lang="en" xmltv_id="BlackInkCrew.us@SD">Black Ink Crew</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#61326275b3c86a00078e4833" lang="en" xmltv_id="BlackThrowbacks.us@SD">BET Throwbacks</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e46fba0c43b0d00096e5ac1" lang="en" xmltv_id="BlazeLive.us@SD">Blaze Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#61559552dd585f0007321eca" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#54ff7ba69222cb1c2624c584" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg TV+</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#61b3b8c645b45d0007a9bb8d" lang="en" xmltv_id="BlueBloods.us@SD">Blue Bloods</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6176fd25e83a5f0007a464c9" lang="en" xmltv_id="BounceXL.us@SD">Bounce XL</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f5d389985a0c0007357304" lang="en" xmltv_id="BritBoxMysteries.us@SD">BritBox Mysteries</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5812bfbe4ced4f7b601b12e6" lang="en" xmltv_id="Buzzr.us@SD">BUZZR</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6231eb3865be650007f59595" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5a6b92f6e22a617379789618" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f75919718aed0007250d7a" lang="en" xmltv_id="CBSNewsBaltimore.us@SD">CBS News Baltimore</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1afb21486df0007abc57c" lang="en" xmltv_id="CBSNewsBayArea.us@SD">CBS News Bay Area</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1af2ad345340008fccd1e" lang="en" xmltv_id="CBSNewsBoston.us@SD">CBS News Boston</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1aeb2fd4b8a00076c2047" lang="en" xmltv_id="CBSNewsChicago.us@SD">CBS News Chicago</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#62cdc75b1a1cbd0007ed45dc" lang="en" xmltv_id="CBSNewsChicago.us@SD">CBS News Chicago</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1b12146cba40007aa7e5d" lang="en" xmltv_id="CBSNewsColorado.us@SD">CBS News Colorado</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#634f2610d5023700078f7dee" lang="en" xmltv_id="CBSNewsDetroit.us@SD">CBS News Detroit</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eceb0d4065c240007688ec6" lang="en" xmltv_id="CBSNewsDFW.us@SD">CBS News Texas</channel>
@@ -1019,22 +978,24 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1b05ea168cc000767ba67" lang="en" xmltv_id="CBSNewsPhilly.us@SD">CBS News Philadelphia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5eb1b17aa5277e00083f6521" lang="en" xmltv_id="CBSNewsPittsburgh.us@SD">CBS News Pittsburgh</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60cb6df2b2ad610008cd5bea" lang="en" xmltv_id="CBSNewsSacramento.us@SD">CBS News Sacramento</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#63a0e33a45264d000850ed7e" lang="en" xmltv_id="CBSSportsGolazoNetwork.us@SD">Golazo Network</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e9f2c05172a0f0007db4786" lang="en" xmltv_id="CBSSportsHQ.us@SD">CBS Sports HQ</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8d164d92e97a5e107638d2" lang="en" xmltv_id="CineAdrenalina.us@SD">Cine adrenalina</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5f513564e4622a0007c578c0" lang="en" xmltv_id="PlutoTVCineComedia.us@Spain">Cine comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf968040ab7d8f181e6a68b" lang="en" xmltv_id="CinePremiere.us@SD">Cine Premiere</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8d180092e97a5e107638d3" lang="en" xmltv_id="CineTerror.us@SD">Cine terror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f5136317aedfb0007016f93" lang="en" xmltv_id="CineAmor.us@SD">Cine Amor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf968040ab7d8f181e6a68b" lang="en" xmltv_id="CinePremiere.us@SD">Cine Premiere</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8d180092e97a5e107638d3" lang="en" xmltv_id="CineTerror.us@US">Cine terror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f779951372da90007fd45e8" lang="en" xmltv_id="Classica.us@SD">Classica</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#561c5b0dada51f8004c4d855" lang="en" xmltv_id="ClassicMoviesChannel.us@SD">Classic Movies Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f15e32b297f96000768f928" lang="en" xmltv_id="ClassicTVComedy.us@SD">Classic TV Comedy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f15e3cccf49290007053c67" lang="en" xmltv_id="ClassicTVDrama.us@SD">Classic TV Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#61325d18f5166c00081b84e0" lang="en" xmltv_id="ClassicTVFamilies.us@SD">Classic TV: Families</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#61325d18f5166c00081b84e0" lang="en" xmltv_id="ClassicTVFamilies.us@US">Classic TV: Families</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f68f53eb1e5800007390bf8" lang="en" xmltv_id="CMTEqualPlay.us@SD">CMT Equal Play</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66c45afaa72e7b0008a2b153" lang="en" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5421f71da6af422839419cb3" lang="en" xmltv_id="CNNRePlay.us@SD">CNN HEADLINES</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5c37d6712de254456f7ec340" lang="en" xmltv_id="ColdCaseFiles.us@SD">Cold Case Files by A&amp;amp;E</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96dad1652631e36d43320" lang="en" xmltv_id="ComedyCentralenEspanol.us@SD">Comedy Central en español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca671f215a62078d2ec0abf" lang="en" xmltv_id="ComedyCentralPlutoTV.us@US">Comedy Central Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#661cf62d24e1d000087dae0d" lang="en" xmltv_id="Cops.us@SD">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e1f7e089f23700009d66303" lang="en" xmltv_id="Cops.us@SD">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5dae0b4841a7d0000938ddbd" lang="en" xmltv_id="CourtTV.us@SD">Court TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6000a5a9e767980007b497ca" lang="en" xmltv_id="Crime360.us@SD">A&amp;amp;E Crime 360</channel>
@@ -1049,38 +1010,45 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ce4475cd43850831ca91ce7" lang="en" xmltv_id="DoctorWhoClassic.us@US">Doctor Who Classic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5f6b535a278bfe000799484a" lang="en" xmltv_id="DogtheBountyHunter.us@UK">Dog The Bounty Hunter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5bee1a7359ee03633e780238" lang="en" xmltv_id="DogtheBountyHunter.us@US">Dog the Bounty Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#60e453641239a700071f53a1" lang="en" xmltv_id="DogWhisperer.us@UK">Dog Whisperer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d14fb6c84dd37df3b4290c5" lang="en" xmltv_id="DoraTV.us@US">Peppa Pig</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5f6b54b9e67cf60007d4cef1" lang="en" xmltv_id="DuckDynasty.us@UK">Duck Dynasty</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5dc0c78281eddb0009a02d5e" lang="en" xmltv_id="EntertainmentTonight.us@SD">ET</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60492e6d7f3f560007ab0f62" lang="en" xmltv_id="EstrellaNews.us@SD">Estrella News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf0622da00ca1e2f6fac712" lang="en" xmltv_id="EstrellaTV.us@SD">EstrellaTV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5dc0c78281eddb0009a02d5e" lang="en" xmltv_id="EntertainmentTonight.us@SD">ET</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ca1da6c593a5d78f0e7edce" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#554158e864526b29254ff105" lang="en" xmltv_id="FailArmy.us@US">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f77939a630f530007dde654" lang="en" xmltv_id="FamilyTies.us@SD">Family Ties</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#680bb31c56ff83bcd685d64e" lang="en" xmltv_id="Farscape.us@SD">Farscape</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6400f731d200410008f9b339" lang="en" xmltv_id="FastTV.us@SD">Discovery Turbo TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5cb6f6f9a461406ffe4022cf" lang="en" xmltv_id="FBIFiles.us@UK">FBI Files</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#63d91d2560bc8f0008a225e4" lang="en" xmltv_id="FIFAPlus.uk@English">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#58e55b14ad8e9c364d55f717" lang="en" xmltv_id="FlicksofFury.us@SD">Flicks of Fury</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5bb1af6a268cae539bcedb0a" lang="en" xmltv_id="ForensicFiles.us@SD">Forensic Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#56171fafada51f8004c4b40f" lang="en" xmltv_id="ForeverKids.us@SD">Forever Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5e78faa05a0e200007a6f487" lang="en" xmltv_id="FullCustomGarage.us@UK">Full Custom Garage</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#640a68880e884c0009979cc2" lang="en" xmltv_id="FoxWeather.us@SD">FOX Weather</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a6a5e90c7ff50008cb9815" lang="en" xmltv_id="FunnyAF.us@SD">Funny AF</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#580e87ff497c73ba2f321dd3" lang="en" xmltv_id="FunnyAF.us@SD">Funny AF</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e54187aae660e00093561d6" lang="en" xmltv_id="GameShowCentral.us@SD">Game Show Central</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60faf9ddfcc1f200070a5932" lang="en" xmltv_id="GarfieldandFriends.us@US">Garfield and Friends</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c45f5a9d40d58066869fa60" lang="en" xmltv_id="GhostDimension.us@UK">Ghost Dimension</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65c4960d11ced7000812c433" lang="en" xmltv_id="GeordieShore.us@Italy">Geordie Shore</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5f27bbe4779de70007a6d1c1" lang="en" xmltv_id="GhostHunters.us@UK">Ghost Hunters</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5417a212ff9fba68282fbf5e" lang="en" xmltv_id="GloryKickboxing.us@US">GLORY Kickboxing</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#64e561a4354251000823a0e0" lang="en" xmltv_id="GhostHunters.us@UK">Ghost Hunters</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66ba1e4446762a000855cd87" lang="en" xmltv_id="GirlfriendsFilms.us@SD">Girlfriends</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4e99f4423e067bd6df6903" lang="en" xmltv_id="GordonRamsaysHellsKitchen.us@SD">Gordon Ramsay&apos;s Hell&apos;s Kitchen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#68503d1736c9361b191e7d89" lang="en" xmltv_id="Gunsmoke.us@SD">Gunsmoke</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f75771dfc72a00071fd0e0" lang="en" xmltv_id="Gunsmoke.us@SD">Gunsmoke</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#628e685ba3811100070551a8" lang="en" xmltv_id="HallmarkMoviesMore.us@SD">Hallmark Movies &amp;amp; More</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f7794162a4559000781fc12" lang="en" xmltv_id="HappyDays.us@SD">Happy Days</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6319f06067a3ee000708af95" lang="en" xmltv_id="HauntTV.us@SD">Haunt TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#61f07513227feb00073ee6bc" lang="en" xmltv_id="Heartland.us@Web">Heartland</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5e6f38792075160007d85823" lang="en" xmltv_id="HellsKitchen.us@UK">Hell&apos;s Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6081738748d3200007afb24b" lang="en" xmltv_id="HighwaytoHeaven.us@UK">Highway to Heaven</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c5c2e9d8002db3c3e0b1c72" lang="en" xmltv_id="HomesUnderHammer.us@UK">Homes Under Hammer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#60e452730e76f20007598de8" lang="en" xmltv_id="HomicideHunter.us@UK">Homicide Hunter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f8a02476b72230007e62b7d" lang="en" xmltv_id="HSN.us@East">HSN</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#59b722526996084038c01e1b" lang="en" xmltv_id="TNAWrestlingChannel.pl@SD">TNA Wrestling</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6450209d939a5900084dba1d" lang="en" xmltv_id="iCarly.us@East">iCarly TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60807fd5db701400078219c2" lang="en" xmltv_id="InkMaster.us@SD">Ink Master</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#61c49f1495f417000731cef0" lang="en" xmltv_id="InsideCrime.us@UK">Inside Crime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d765786aad587cf4d0e2bf6" lang="en" xmltv_id="InspectorGadget.us@UK">Inspector Gadget</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96b8f4f1ca3f0629f4bf1" lang="en" xmltv_id="Investiga.us@SD">Investiga</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#609bfa51fbecc1000733152e" lang="en" xmltv_id="JerseyShore.us@SD">Jersey Shore</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e9decb953e157000752321c" lang="en" xmltv_id="JudgeNosey.us@US">Judge Nosey</channel>
@@ -1090,17 +1058,22 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#51c75f7bb6f26ba1cd00002f" lang="en" xmltv_id="LittleStarsUniverse.us@SD">Little Stars Universe</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5dc1cb279c91420009db261d" lang="en" xmltv_id="LivelyPlace.us@SD">Home.Made.Nation</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5873fc21cad696fb37aa9054" lang="en" xmltv_id="LiveMusicReplay.us@SD">Live Music</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#63d025db4e83e700086eaa96" lang="en" xmltv_id="LiveNOWfromFOX.us@SD">LiveNOW from FOX</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ce5a8954311f992edbe1da2" lang="en" xmltv_id="LogoPlutoTV.us@SD">Logo Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d51ddf0369acdb278dfb05e" lang="en" xmltv_id="LoveHipHop.us@SD">Love &amp;amp; Hip Hop</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5c01df1759ee03633e7b272c" lang="en" xmltv_id="LuchaLibreAAA.us@SD">Lucha Libre AAA</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#66df8a29b25d2b0008fc5fe0" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6850426e53d981d1fdb0d966" lang="en" xmltv_id="Matlock.us@SD">Matlock</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f754f98185580007eb0754" lang="en" xmltv_id="Matlock.us@SD">Matlock</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cbf6a868a1bce4a3d52a5e9" lang="en" xmltv_id="MidsomerMurders.us@SD">Midsomer Murders</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62ab579258cb950007811aad" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f77977bd924d80007eee60c" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d882d5233170007ee880e" lang="en" xmltv_id="Misteriossinresolver.us@SD">Misterios sin resolver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e66968a70f34c0007d050be" lang="en" xmltv_id="MLB.us@SD">MLB</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#613260e4bdb71c00070d63fa" lang="en" xmltv_id="MoreTVDrama.us@SD">More TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6132619f9ddaa50007e7dd86" lang="en" xmltv_id="MoreTVSitcoms.us@SD">More TV Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@SD">Moviesphere</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#545943f1c9f133a519bbac92" lang="en" xmltv_id="MST3K.us@US">MST3K</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d14fd1a252d35decbc4080c" lang="en" xmltv_id="MTVBiggestPop.us@US">MTV Biggest Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d3609cd6a6c78d7672f2a81" lang="en" xmltv_id="MTVBlockParty.us@SD">MTV Flow Latino</channel>
@@ -1109,17 +1082,19 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d14fdb8ca91eedee1633117" lang="en" xmltv_id="MTVSpankinNew.us@US">MTV Spankin&apos; New</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#61c4a09d6c959f0007189c93" lang="en" xmltv_id="MysteryTV.us@UK">Mystery TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5bd833b41843b56328bac189" lang="en" xmltv_id="Mythbusters.us@UK">Mythbusters</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#66e0b4866ad04d0008fff4d8" lang="en" xmltv_id="Mythbusters.us@UK">MythBusters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5da0c85bd2c9c10009370984" lang="en" xmltv_id="Naruto.us@US">Naruto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5df97894467dfa00091c873c" lang="en" xmltv_id="NBCNewsNOW.us@SD">NBC News NOW</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5fff49cfb5cd4f0007c2b0dc" lang="en" xmltv_id="News12NewYork.us@SD">News 12 New York</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#55b179af994403942f3061d6" lang="en" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5459795fc9f133a519bc0bef" lang="en" xmltv_id="ScrippsNews.us@SD">Scripps News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ced7d5df64be98e07ed47b6" lang="en" xmltv_id="NFLChannel.us@SD">NFL Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8d08395f39465da6fb3ec4" lang="en" xmltv_id="NickenEspanol.us@SD">Nickelodeon en español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca6748a37b88b269472dad9" lang="en" xmltv_id="NickJrPlutoTV.us@US">Nick Jr. Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca673e0d0bd6c2689c94ce3" lang="en" xmltv_id="NickPlutoTV.us@US">Nickelodeon Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5ca673e0d0bd6c2689c94ce3" lang="en" xmltv_id="NickelodeonPlutoTV.us@SD">Nickelodeon Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc2ba1a9c91420009db4858" lang="en" xmltv_id="Nosey.us@UK">Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5aec96ec5126c2157123c657" lang="en" xmltv_id="Nosey.us@US">Nosey</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#660c209e19ca71000846cf38" lang="en" xmltv_id="Now90s00s.uk@Poland">That&apos;s 90s00s</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6568a78d635c3c0008765f41" lang="en" xmltv_id="NOWRock.uk@SD">That&apos;s Rock</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e7cf6c7b156d500078c5f44" lang="en" xmltv_id="OANPlus.us@SD">OAN Plus</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f7790b3ed0c88000720b241" lang="en" xmltv_id="OnePiece.us@SD">One Piece</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#615af74dfe3d8e0007524511" lang="en" xmltv_id="OnTheCase.us@UK">On The Case</channel>
@@ -1131,77 +1106,101 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#640a64bd73e013000893d4e0" lang="en" xmltv_id="PBSNature.us@SD">PBS Nature</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60fb2f47c133270007327375" lang="en" xmltv_id="PelisyPopcorn.us@SD">Cine aventura</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6197086891ddd4000739941a" lang="en" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d885aef0f17500084b6750" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5de94dacb394a300099fa22a" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbfeb961b411c00090b52b3" lang="en" xmltv_id="PlutoTVAction.us@UK">Pluto TV Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbfeb961b411c00090b52b3" lang="en" xmltv_id="PlutoTVAction.de@UK">Pluto TV Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#561d7d484dc7c8770484914a" lang="en" xmltv_id="PlutoTVAction.us@US">Pluto TV Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf8ea0d000120009bcad83" lang="en" xmltv_id="PlutoTVAnimals.us@UK">Pluto TV Animals</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#612f761008a9e50007984ba0" lang="en" xmltv_id="PlutoTVAnimation.us@UK">Pluto TV Animation</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf8ea0d000120009bcad83" lang="en" xmltv_id="PlutoTVAnimals.de@UK">Pluto TV Animals</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#612f761008a9e50007984ba0" lang="en" xmltv_id="PlutoTVAnimation.de@UK">Pluto TV Animation</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5812b7d3249444e05d09cc49" lang="en" xmltv_id="PlutoTVAnime.us@US">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#67ed8f7e443f0671bc2b2368" lang="en" xmltv_id="PlutoTVAnimeMovies.us@SD">Pluto TV Anime Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cabdf1437b88b26947346b2" lang="en" xmltv_id="PlutoTVBackcountry.us@SD">Pluto TV Backcountry</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5812b3a4249444e05d09cc46" lang="en" xmltv_id="PlutoTVCars.us@SD">Pluto TV Cars</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d134a74ca91eedee1630faa" lang="en" xmltv_id="PlutoTVClassicTV.us@UK">Pluto TV Classic TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c363c2411c5ca053f198f97" lang="en" xmltv_id="PlutoTVComedy.us@UK">Pluto TV Comedy Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5f513564e4622a0007c578c0" lang="en" xmltv_id="PlutoTVCineComedia.us@US">Cine comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d134a74ca91eedee1630faa" lang="en" xmltv_id="PlutoTVClassicTV.de@UK">Pluto TV Classic TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c363c2411c5ca053f198f97" lang="en" xmltv_id="PlutoTVComedyMovies.de@UK">Pluto TV Comedy Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5a4d3a00ad95e4718ae8d8db" lang="en" xmltv_id="PlutoTVComedy.us@US">Pluto TV Comedy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4ae94ef1a1bbb350ca41bb" lang="en" xmltv_id="PlutoTVConspiracy.us@UK">Pluto TV Conspiracy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4ae94ef1a1bbb350ca41bb" lang="en" xmltv_id="PlutoTVConspiracy.de@UK">Pluto TV Conspiracy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6036e6e7ac69c400072afca2" lang="en" xmltv_id="PlutoTVCourtroom.us@SD">Hot Bench</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d767790d0438aceb41d03ae" lang="en" xmltv_id="PlutoTVCrime.us@UK">Pluto TV Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d767790d0438aceb41d03ae" lang="en" xmltv_id="PlutoTVCrime.de@UK">Pluto TV Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#65a6a7a00c7ff50008cba07b" lang="en" xmltv_id="PlutoTVCrimeDrama.de@UK">Pluto TV Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f31fd1b4c510e00071c3103" lang="en" xmltv_id="PlutoTVCrimeDrama.us@SD">Pluto TV Crime Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d8594eb979c0007706de7" lang="en" xmltv_id="PlutoTVCrimeMovies.us@SD">Pluto TV Crime Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c5c31f2f21b553c1f673fb0" lang="en" xmltv_id="PlutoTVCultFilms.us@UK">Pluto TV Cult Films</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c5c31f2f21b553c1f673fb0" lang="en" xmltv_id="PlutoTVCultFilms.de@UK">Pluto TV Cult Films</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5c665db3e6c01b72c4977bc2" lang="en" xmltv_id="PlutoTVCultFilms.us@US">Pluto TV Cult Films</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf91149880d60009d35d27" lang="en" xmltv_id="PlutoTVDrama.de@UK">Pluto TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4e92e4694c027be6ecece1" lang="en" xmltv_id="PlutoTVDrama.us@US">Pluto TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f24662bebe0f0000767de32" lang="en" xmltv_id="PlutoTVDramaLife.us@SD">Supernatural Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#66fedd65d7de140008dccd66" lang="en" xmltv_id="PlutoTVElReinoInfantil.us@SD">El Reino Infantil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b64a245a202b3337f09e51d" lang="en" xmltv_id="PlutoTVFantastic.us@SD">Pluto TV Fantastic</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf930548ff9b00090d5686" lang="en" xmltv_id="PlutoTVFood.us@UK">Pluto TV Food</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ddf930548ff9b00090d5686" lang="en" xmltv_id="PlutoTVFood.de@UK">Pluto TV Food</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6036e7c385749f00075dbd3b" lang="en" xmltv_id="PlutoTVGameShows.us@SD">Pluto TV Game Shows</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4af1803e7983b391d73b13" lang="en" xmltv_id="PlutoTVHistory.us@UK">Pluto TV History</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4af1803e7983b391d73b13" lang="en" xmltv_id="PlutoTVHistory.de@UK">Pluto TV History</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5a4d35dfa5c02e717a234f86" lang="en" xmltv_id="PlutoTVHistory.us@US">Pluto TV History</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#612cda102f5f18000705e0bf" lang="en" xmltv_id="PlutoTVHorror.us@UK">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#612cda102f5f18000705e0bf" lang="en" xmltv_id="PlutoTVHorror.de@UK">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#569546031a619b8f07ce6e25" lang="en" xmltv_id="PlutoTVHorror.us@US">Pluto TV Horror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ad8d54be738977e2c310940" lang="en" xmltv_id="PlutoTVKids.us@UK">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#63808dc806aa4700075f319a" lang="en" xmltv_id="PlutoTVInvestigation.de@UK">Pluto TV Investigation</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ad8d54be738977e2c310940" lang="en" xmltv_id="PlutoTVKids.de@UK">Pluto TV Kids</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8beeb39b5d5d5f8c672530" lang="en" xmltv_id="PlutoTVLives.us@US">Pluto TV Lives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5bb3fea0f711fd76340eebff" lang="en" xmltv_id="PlutoTVMilitary.us@SD">Pluto TV Military</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ad8d3a31b95267e225e4e09" lang="en" xmltv_id="PlutoTVMovies.us@UK">Pluto TV Movies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4af2ffa9506ab29cf38c38" lang="en" xmltv_id="PlutoTVParanormal.us@UK">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ad8d3a31b95267e225e4e09" lang="en" xmltv_id="PlutoTVMovies.de@UK">Pluto TV Movies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96c0222df39f1a338d163" lang="en" xmltv_id="PlutoTVNovelas.us@US">Pluto TV Novelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4af2ffa9506ab29cf38c38" lang="en" xmltv_id="PlutoTVParanormal.de@UK">Pluto TV Paranormal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5adf96e3e738977e2c31cb04" lang="en" xmltv_id="PlutoTVParanormal.us@US">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6683cd71a1d7ad000866ec6a" lang="en" xmltv_id="PlutoTVPokemon.us@UK">Pokémon</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6675c7868768aa0008d7f1c7" lang="en" xmltv_id="PlutoTVPokemon.us@US">Pokémon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#617b37b361e0fd0008cfd8c5" lang="en" xmltv_id="PlutoTVReaction.us@SD">Pluto TV Reaction</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5bd8186d53ed2c6334ea0855" lang="en" xmltv_id="PlutoTVReality.us@UK">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5bd8186d53ed2c6334ea0855" lang="en" xmltv_id="PlutoTVReality.de@UK">Pluto TV Reality</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d8bf0b06d2d855ee15115e3" lang="en" xmltv_id="PlutoTVReality.us@US">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5c5c2b9d8002db3c3e0b1c6d" lang="en" xmltv_id="PlutoTVRetroToons.de@UK">Pluto TV Retro Toons</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5a66795ef91fef2c7031c599" lang="en" xmltv_id="PlutoTVRomance.us@US">Pluto TV Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d9492c77ea6f99188738ff1" lang="en" xmltv_id="PlutoTVScience.us@UK">Pluto TV Science</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d9492c77ea6f99188738ff1" lang="en" xmltv_id="PlutoTVScience.de@UK">Pluto TV Science</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#563a970aa1a1f7fe7c9daad7" lang="en" xmltv_id="PlutoTVScience.us@US">Pluto TV Science</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc02a44a9518600094273ac" lang="en" xmltv_id="PlutoTVSciFi.us@UK">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc02a44a9518600094273ac" lang="en" xmltv_id="PlutoTVSciFi.de@UK">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4fc274694c027be6ed3eea" lang="en" xmltv_id="PlutoTVSciFi.us@US">Pluto TV Sci-Fi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#619247c34a270700077c8415" lang="en" xmltv_id="PlutoTVScifiSeries.us@UK">Pluto TV Sci-fi Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc2c00abfed110009d97243" lang="en" xmltv_id="PlutoTVSherlock.us@UK">Pluto TV Sherlock</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbc2f98777f2e0009934ae7" lang="en" xmltv_id="PlutoTVSpace.us@UK">Pluto TV Space</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#619247c34a270700077c8415" lang="en" xmltv_id="PlutoTVScifiSeries.de@UK">Pluto TV Sci-fi Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dc2c00abfed110009d97243" lang="en" xmltv_id="PlutoTVSherlock.de@UK">Pluto TV Sherlock</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62f53dc6ee9a0400071dc22b" lang="en" xmltv_id="PlutoTVSitcoms.de@UK">Pluto TV Sitcoms</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbc2f98777f2e0009934ae7" lang="en" xmltv_id="PlutoTVSpace.de@UK">Pluto TV Space</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ba3fb9c4b078e0f37ad34e8" lang="en" xmltv_id="PlutoTVSpotlight.us@SD">Pluto TV Spotlight</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d863b98b41000076cd061" lang="en" xmltv_id="PlutoTVStaffPicks.us@SD">Pluto TV Staff Picks</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5c6dc88fcd232425a6e0f06e" lang="en" xmltv_id="PlutoTVTerror.us@SD">Pluto TV Terror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbfedccc563080009b60f4a" lang="en" xmltv_id="PlutoTVThrillers.us@UK">Pluto TV Thrillers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#67352ed93a61d4000881f9fa" lang="en" xmltv_id="PlutoTVTheTwilightZone.us@SD">The Twilight Zone</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbfedccc563080009b60f4a" lang="en" xmltv_id="PlutoTVThrillers.de@UK">Pluto TV Thrillers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4e69e08291147bd04a9fd7" lang="en" xmltv_id="PlutoTVThrillers.us@US">Pluto TV Thrillers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5812be1c249444e05d09cc50" lang="en" xmltv_id="PlutoTVTrueCrime.us@US">Pluto TV True Crime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#603fde9026ecbf0007752c2c" lang="en" xmltv_id="PlutoTVVs.us@SD">Pluto TV Competition</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4bdb635ce813b38639e6a3" lang="en" xmltv_id="PlutoTVWesterns.us@UK">Pluto TV Westerns</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#603fde9026ecbf0007752c2c" lang="en" xmltv_id="PlutoTVCompetition.us@SD">Pluto TV Competition</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#5d4bdb635ce813b38639e6a3" lang="en" xmltv_id="PlutoTVWesterns.de@UK">Pluto TV Westerns</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4e94282d4ec87bdcbb87cd" lang="en" xmltv_id="PlutoTVWesterns.us@US">Pluto TV Westerns</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5fc54366b04b2300072e31af" lang="en" xmltv_id="PokerGo.us@US">PokerGO</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#63b48016d9dd51000828fa37" lang="en" xmltv_id="PowerNationTV.us@SD">POWERNATION</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#674f735a2fb8a100087bf253" lang="en" xmltv_id="Revry.us@SD">Revry</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#58d947b9e420d8656ee101ab" lang="en" xmltv_id="RiffTrax.us@US">RiffTrax</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66f137cb483d460008ece053" lang="en" xmltv_id="RugbyPassTV.uk@SD">Rugby Pass TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5fb584b7613a31000789de5a" lang="en" xmltv_id="RyanandFriends.us@SD">Ryan and Friends</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66276091cee0d900085fe053" lang="en" xmltv_id="SabrinaTeenageWitch.us@UK">Sabrina The Teenage Witch</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60d393e5579a420007ee553c" lang="en" xmltv_id="Saladeparejas.us@SD">Casos de la Dra. Polo</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5459795fc9f133a519bc0bef" lang="en" xmltv_id="ScrippsNews.us@SD">Scripps News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5e9ed47c26ebb000074af566" lang="en" xmltv_id="SensingMurder.us@UK">Sensing Murder</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96b1c4f1ca3f0629f4bf0" lang="en" xmltv_id="Septimoarte.us@SD">Cine en español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6000a6f4c3f8550008fc9b91" lang="en" xmltv_id="SkillsPlusThrills.us@SD">Xtreme Outdoor by HISTORY</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#55b285cd2665de274553d66f" lang="en" xmltv_id="SkyNews.uk@SD">Sky News</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f21ea08007a49000762d349" lang="en" xmltv_id="SmithsonianChannelSelects.us@SD">Smithsonian Channel Selects</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#605e479d5b8229000763e697" lang="en" xmltv_id="SonyCanalEscapePerfecto.us@SD">Sony Canal Escape Perfecto</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#64edf6eaa7ec0d000812f58c" lang="en" xmltv_id="SouthPark.us@France">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5c393cad2de254456f7ef8c2" lang="en" xmltv_id="SpikeOutdoors.us@SD">Spike Outdoors</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5812bcc8237a6ff45d16c407" lang="en" xmltv_id="SpikePlutoTV.us@SD">Spike Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#5efbd39f8c4ce900075d7698" lang="en" xmltv_id="StarTrek.us@SD">Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#5efbd39f8c4ce900075d7698" lang="en" xmltv_id="StarTrek.us@US">Star Trek</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5812bd9f249444e05d09cc4e" lang="en" xmltv_id="StingrayNaturescape.ca@SD">Naturescape</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#62f2ce24f328e00007e7f55a" lang="en" xmltv_id="StoriesbyAMC.us@SD">Stories by AMC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f21e7b24744c60007c1f6fc" lang="en" xmltv_id="Survivor.us@SD">Survivor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#683df56f5195c2a60a3f5559" lang="en" xmltv_id="SwerveSports.us@SD">Swerve Women’s Sports</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#62d550d81054990007db7798" lang="en" xmltv_id="TeenMom.us@SD">Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6127e12ed140e900077e7b6f" lang="en" xmltv_id="TeenMom.us@SD">Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5cf96cc422df39f1a338d165" lang="en" xmltv_id="TelemundoTelenovelasClasicas.us@SD">Telemundo telenovelas clásicas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#66a10eeb46762a0008201e85" lang="en" xmltv_id="Teletubbies.uk@SD">Teletubbies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#681109b688b9d85d0938c6ba" lang="en" xmltv_id="TennisChannel.us@Plus2">TennisChannel 2</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6627621d56fc840008e47c90" lang="en" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d81607ab737153ea3c1c80e" lang="en" xmltv_id="TheAddamsFamily.us@SD">The Addams Family</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f21e8a6e2f12b000755afdb" lang="en" xmltv_id="TheAmazingRace.us@SD">The Amazing Race</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60f75178e7f8aa0007e9c259" lang="en" xmltv_id="TheAndyGriffithShow.us@SD">The Andy Griffith Show</channel>
@@ -1209,10 +1208,13 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d48685da7e9f476aa8a1888" lang="en" xmltv_id="TheChallenge.us@SD">The Challenge</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d486acc34ceb37d3c458a64" lang="en" xmltv_id="TheFirstTV.us@SD">The First</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#64dab9df3d48f40008868091" lang="en" xmltv_id="TheJamieOliverChannel.us@SD">The Jamie Oliver Channel</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#622f498d119b4c000719c0b7" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">Judge Judy</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6283d51144ad8f0007fa382d" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">The Judge Judy Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f7794a788d29000079d2f07" lang="en" xmltv_id="TheLoveBoat.us@SD">The Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5e393d5c696b3b0009775c8b" lang="en" xmltv_id="TheNewDetectives.us@UK">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5aea40b35126c2157123aa64" lang="en" xmltv_id="TheNewDetectives.us@US">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5bb1ad55268cae539bcedb08" lang="en" xmltv_id="ThePetCollective.us@US">The Pet Collective</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#643f035d5a0cd50008361534" lang="en" xmltv_id="ThePriceIsRight.us@HD">The Price Is Right</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f7791b8372da90007fd45e6" lang="en" xmltv_id="ThePriceIsRightTheBarkerEra.us@SD">The Price Is Right: The Barker Era</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e825550e758c700077b0aef" lang="en" xmltv_id="TheRifleman.us@SD">The Rifleman</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e82bb378601b80007b4bd78" lang="en" xmltv_id="TheWalkingDeadenEspanol.us@SD">The Walking Dead en español</channel>
@@ -1220,11 +1222,16 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d51e791b7dba3b2ae990ab2" lang="en" xmltv_id="ThisOldHouse.us@SD">This Old House</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5ef3977e5d773400077de284" lang="en" xmltv_id="ThreesCompany.us@SD">Three&apos;s Company</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#601a0342dcf4370007566891" lang="en" xmltv_id="TinyHouseNation.us@SD">Tiny House Nation</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#59b722526996084038c01e1b" lang="en" xmltv_id="TNAWrestlingChannel.pl@SD">TNA Wrestling</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d695f7db53adf96b78e7ce3" lang="en" xmltv_id="TODAYAllDay.us@SD">TODAY All Day</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#636adc255bcf470007d6e0e2" lang="en" xmltv_id="TopGear.uk@SD">Top Gear</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5dae084727c8af0009fe40a4" lang="en" xmltv_id="Tosh0.us@SD">Tosh.0</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#656ef4af4261ca00083c8f37" lang="en" xmltv_id="TotallyTurtles.us@US">Totally Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d0c16d686454ead733d08f8" lang="en" xmltv_id="TotallyTurtles.us@US">TOTALLY TURTLES</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/gb#6304fb268bd95300072d2198" lang="en" xmltv_id="TrueCrime.uk@SD">True Crime UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d40bebc5e3d2750a2239d7e" lang="en" xmltv_id="TVLandDrama.us@SD">TV Land Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5c2d64ffbdf11b71587184b8" lang="en" xmltv_id="TVLandSitcoms.us@SD">TV Land Sitcoms</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6549341853fc9700083901ac" lang="en" xmltv_id="UniversalCrime.us@East">Universal Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5bd05b4694d45d266bc951f2" lang="en" xmltv_id="UnsolvedMysteries.us@UK">Unsolved Mysteries</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5b4e96a0423e067bd6df6901" lang="en" xmltv_id="UnsolvedMysteries.us@US">Unsolved Mysteries</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5fd7bca3e0a4ee0007a38e8c" lang="en" xmltv_id="Vevo2K.us@SD">Vevo 2K</channel>
@@ -1239,54 +1246,55 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e8df4bc16e34700077e77d3" lang="en" xmltv_id="WesternTV.us@SD">Western TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#60817936fd2d70000763d2b2" lang="en" xmltv_id="WildatHeart.us@UK">Wild at Heart</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d48678d34ceb37d3c458a55" lang="en" xmltv_id="WildNOut.us@SD">Wild &apos;N Out</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#686d8dd294a028da3ac59566" lang="en" xmltv_id="WomensSportsNetwork.us@SD">Women&apos;s Sports Network</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5ad8d796e738977e2c31094a" lang="en" xmltv_id="WorldPokerTour.us@UK">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5616f9c0ada51f8004c4b091" lang="en" xmltv_id="WorldPokerTour.us@US">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5d14fc31252d35decbc4080b" lang="en" xmltv_id="YoMTV.us@SD">Yo! MTV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4ec10ed9636f00089b8c89" lang="en" xmltv_id="YuGiOh.us@SD">Yu-Gi-Oh!</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcdde78f080d900098550e4" lang="es" xmltv_id="">Pluto TV Cine Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="">Pluto TV Cine Terror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="">Pluto TV Cine Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="">Pluto TV Novelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="">Pluto TV Misterios</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde07af1c85b0009b18651" lang="es" xmltv_id="">Pluto TV Deportes</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde17bf6591d0009839e02" lang="es" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="">Pluto TV Investiga</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde197f6591d0009839e04" lang="es" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde437229eff00091b6c30" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde0657444a40009cd2422" lang="es" xmltv_id="">Pluto TV Estilo de Vida</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde1317578340009b751d0" lang="es" xmltv_id="">Pluto TV Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6d935d000120009bc1132" lang="es" xmltv_id="">Pluto TV Competencias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="">Pluto TV Velocidad</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="">Pluto TV Cine Familia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd7ea2aeab5230009986735" lang="es" xmltv_id="">Pluto TV Cine Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="">Pluto TV Naturaleza</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd837642c6e9300098ad484" lang="es" xmltv_id="">Pluto TV Series Latinas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="">Pluto TV Cine Suspenso</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc266f80e3550009136843" lang="es" xmltv_id="">Pluto TV Aventura</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="">Pluto TV Documentales</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="PlutoTVCineAccion.us@LatAm">Pluto TV Cine Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcdde78f080d900098550e4" lang="es" xmltv_id="PlutoTVCineComedia.us@LatAm">Pluto TV Cine Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="CineTerror.us@LatAm">Pluto TV Cine Terror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="PlutoTVCineDrama.us@LatAm">Pluto TV Cine Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="PlutoTVNovelas.us@LatAm">Pluto TV Novelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="PlutoTVJunior.us@LatAm">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="PlutoTVMisterios.us@LatAm">Pluto TV Misterios</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde07af1c85b0009b18651" lang="es" xmltv_id="PlutoTVDeportes.us@LatAm">Pluto TV Deportes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde17bf6591d0009839e02" lang="es" xmltv_id="PlutoTVAnime.us@LatAm">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="Investiga.us@LatAm">Pluto TV Investiga</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde197f6591d0009839e04" lang="es" xmltv_id="PlutoTVReality.us@LatAm">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde437229eff00091b6c30" lang="es" xmltv_id="PlutoTVCineEstelar.us@LatAm">Pluto TV Cine Estelar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde0657444a40009cd2422" lang="es" xmltv_id="PlutoTVEstilodeVida.us@LatAm">Pluto TV Estilo de Vida</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dcde1317578340009b751d0" lang="es" xmltv_id="PlutoTVSeries.us@LatAm">Pluto TV Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6d935d000120009bc1132" lang="es" xmltv_id="PlutoTVCompetencias.us@LatAm">Pluto TV Competencias</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="PlutoTVKids.us@LatAm">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="PlutoTVVelocidad.us@LatAm">Pluto TV Velocidad</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="PlutoTVCineFamilia.us@LatAm">Pluto TV Cine Familia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd7ea2aeab5230009986735" lang="es" xmltv_id="PlutoTVCineRomance.us@LatAm">Pluto TV Cine Romance</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="PlutoTVNaturaleza.us@LatAm">Pluto TV Naturaleza</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dd837642c6e9300098ad484" lang="es" xmltv_id="PlutoTVSeriesLatinas.us@LatAm">Pluto TV Series Latinas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="PlutoTVCineSuspenso.us@LatAm">Pluto TV Cine Suspenso</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc266f80e3550009136843" lang="es" xmltv_id="PlutoTVAventura.us@LatAm">Pluto TV Aventura</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="PlutoTVDocumentales.us@LatAm">Pluto TV Documentales</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ddd7cb2cbb9010009b4fe32" lang="es" xmltv_id="">Nick Jr. Club</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="">Pluto TV Historia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de802659167b10009e7deba" lang="es" xmltv_id="">Pluto TV Series Retro</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5defde6d6c07b50009cf0757" lang="es" xmltv_id="">Pluto TV Nuestro Cine</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5df265697ec3510009df1ef0" lang="es" xmltv_id="">Pluto TV Vida Real</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="">Pluto TV A La Mexicana</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Pride</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="PlutoTVHistoria.us@LatAm">Pluto TV Historia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5de802659167b10009e7deba" lang="es" xmltv_id="PlutoTVSeriesRetro.us@LatAm">Pluto TV Series Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5defde6d6c07b50009cf0757" lang="es" xmltv_id="PlutoTVNuestroCine.us@LatAm">Pluto TV Nuestro Cine</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5df265697ec3510009df1ef0" lang="es" xmltv_id="PlutoTVVidaReal.us@LatAm">Pluto TV Vida Real</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="PlutoTVALaMexicana.us@LatAm">Pluto TV A La Mexicana</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef México</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e46e64dc73db400094b5f0b" lang="es" xmltv_id="">Minuto Para Ganar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e67d41b93312100076f3fca" lang="es" xmltv_id="">Los archivos del FBI</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e98a911c881310007d7aae2" lang="es" xmltv_id="">MTV Ridiculousness</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e98b0447665f200078caded" lang="es" xmltv_id="">Pluto TV Peleas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e98b0447665f200078caded" lang="es" xmltv_id="PlutoTVPeleas.us@LatAm">Pluto TV Peleas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e972a21ad709d00074195ba" lang="es" xmltv_id="">Estrellas de Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e8397936791b30007ebb5a7" lang="es" xmltv_id="">Pluto TV Humor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5e8397936791b30007ebb5a7" lang="es" xmltv_id="PlutoTVHumor.us@LatAm">Pluto TV Humor</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ea71d48af1d0b0007d837f4" lang="es" xmltv_id="">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ea7215005d66d0007e8128a" lang="es" xmltv_id="">Rugrats</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ebac49ce4dc8b00078b23bc" lang="es" xmltv_id="">Babyfirst</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ebacbcae43a6d000787b88e" lang="es" xmltv_id="">The Pet Collective</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ebaccf1734aaf0007142c86" lang="es" xmltv_id="">FailArmy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ec5761aabe4690007f6e047" lang="es" xmltv_id="">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ec5761aabe4690007f6e047" lang="es" xmltv_id="StarTrek.us@LatAm">Pluto TV Star Trek</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ed6828192e8b3000743ef61" lang="es" xmltv_id="">Wipe Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ee92e72fb286e0007285fec" lang="es" xmltv_id="">Naruto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5efb8c19b2678b000780d032" lang="es" xmltv_id="">Archivos Forenses</channel>
@@ -1298,26 +1306,27 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f99a772c54853000797bf18" lang="es" xmltv_id="">Lucha Libre AAA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f230e416b68ff00075b0139" lang="es" xmltv_id="">Misterios Medicos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f998c1fc54853000797bacd" lang="es" xmltv_id="">Tastemade</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f2817d3d7573a00080f9175" lang="es" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f2817d3d7573a00080f9175" lang="es" xmltv_id="PlutoTVSciFi.us@LatAm">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f9992c685a2a80007fa414a" lang="es" xmltv_id="">Dog el cazarrecompensas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f23102d5e239d00074b092a" lang="es" xmltv_id="">Empeños a lo bestia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5f610042272f68000867685b" lang="es" xmltv_id="">Misterios sin Resolver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5fab09a8749b1a00077d35d2" lang="es" xmltv_id="">Nickelodeon Teen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5fab088b3279760007d4e4fd" lang="es" xmltv_id="">MTV Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5fab088b3279760007d4e4fd" lang="es" xmltv_id="MTVPlutoTV.us@LatAm">MTV Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5fcea93ffcf94500071c4b2f" lang="es" xmltv_id="">Kenan y Kel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5fceaab478f2af00080ff51f" lang="es" xmltv_id="">Yu-Gi-Oh</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ff4b9ccf938f8000779eb99" lang="es" xmltv_id="">One Piece</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ff608e60e2996000768c366" lang="es" xmltv_id="">Tokusato</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ff3934600d4c7000733ff49" lang="es" xmltv_id="">Pluto TV E-Sports</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ffcc21a432945000762d06b" lang="es" xmltv_id="">Comedy Central Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ff3934600d4c7000733ff49" lang="es" xmltv_id="PlutoTVESports.us@LatAm">Pluto TV E-Sports</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#5ffcc21a432945000762d06b" lang="es" xmltv_id="ComedyCentralPlutoTV.us@LatAm">Comedy Central Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#60e5ea9a9bb4200008376f76" lang="es" xmltv_id="">Motorvision TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#61a52615cbef2500072876e2" lang="es" xmltv_id="">Acapulco Shore Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#61a52615cbef2500072876e2" lang="es" xmltv_id="AcapulcoShore.us@LatAm">Acapulco Shore Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#61b793ccf571b80007b7a610" lang="es" xmltv_id="">Adrenalina Pura TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#62b218fc511d4b00070ddc0c" lang="es" xmltv_id="">MTV Flow Latino</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#62c5d80dc6de440007e033eb" lang="es" xmltv_id="">Runtime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#62d08af527ce19000731eaa0" lang="es" xmltv_id="">La Familia del Barrio</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#62d0895ebe7a970008785244" lang="es" xmltv_id="">Daria</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#63a084934734f30007457b2c" lang="es" xmltv_id="">Smithsonian Channel Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#63a084934734f30007457b2c" lang="es" xmltv_id="SmithsonianChannelPlutoTV.us@LatAm">Smithsonian Channel Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#63c6e37e636b7e0007ccb635" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#63d2c140c111bc0008cb890b" lang="es" xmltv_id="">TeleFórmula</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#63dac1b78795f300086d5ca6" lang="es" xmltv_id="">TikTok Radio en Español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#63dd5d7a4e83e700088fbca8" lang="es" xmltv_id="">Las Tortugas Ninja</channel>
@@ -1346,9 +1355,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67a52c8397782f00081879aa" lang="es" xmltv_id="">Top Barça</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67a52cd4ec91870008a62164" lang="es" xmltv_id="">UFC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67d9b0ebc290c9499046e88f" lang="es" xmltv_id="">RCN Noticias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#67e598e28b99330f75b4c629" lang="es" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67e5941f0812459cb682d9c6" lang="es" xmltv_id="">Relic Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#67e5987eef24f48ffca08fd7" lang="es" xmltv_id="">Doc Martin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67f95fa76b11614ab0caaef3" lang="es" xmltv_id="">Hechiceras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67f960680072d6b187a0682e" lang="es" xmltv_id="">Números</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#68a3a97fd8f7693ae3f8575f" lang="es" xmltv_id="">Los Pitufos</channel>
@@ -1357,13 +1364,20 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#68b88712e777774982269ce9" lang="es" xmltv_id="">Tastemade Viajes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#68ba0910e1d03fec7d5c084f" lang="es" xmltv_id="">Al Ritmo del Jaripeo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#68ffc086a530e036bc8f0305" lang="es" xmltv_id="">Mi Bella Genio</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69de4ad924a6d521f8b0a348" lang="es" xmltv_id="">RCN Más</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fca9dd14a5dfae8875a3be" lang="es" xmltv_id="">Survivor México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fca9f9b9c0f0d444f631ca" lang="es" xmltv_id="">Mr. Bean Animated</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fcaa71ea95ffff0987f555" lang="es" xmltv_id="">MasterChef Colombia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fcaa88e022927e1c94c533" lang="es" xmltv_id="">MasterChef Argentina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fcaaa1853a01a827bcd056" lang="es" xmltv_id="">I Shouldn&apos;t Be Alive</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#69fcdc73488e575cff213adc" lang="es" xmltv_id="">Hermanos a la Obra</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#604bdf4e6d0abc0007ba77ad" lang="es" xmltv_id="">Sin Tetas No Hay Paraíso</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#609ae5cd48d3200007b0a98e" lang="es" xmltv_id="">Comedy Central South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#619d5e6a093e7c0007489211" lang="es" xmltv_id="">Baby Shark TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#619d59b7cbef25000728221c" lang="es" xmltv_id="">Euronews Español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#620fd9f4afb9a80007a9c6d5" lang="es" xmltv_id="">MTV Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#620ff0a01f9e8700076c6f9d" lang="es" xmltv_id="">Nickelodeon iCarly</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#624af40c004f8000079b784d" lang="es" xmltv_id="">Pluto TV Cine Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#624af40c004f8000079b784d" lang="es" xmltv_id="PlutoTVCineCrimen.us@LatAm">Pluto TV Cine Crimen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#626c2ed933a2890007e91422" lang="es" xmltv_id="">Death Note</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#631fb6be21b7440007b9f606" lang="es" xmltv_id="">Hechizada</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#645d1abbe1979c0008779d5a" lang="es" xmltv_id="">Archivos Extraterrestres</channel>
@@ -1371,9 +1385,9 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#646cce4d1593940008a33f09" lang="es" xmltv_id="">Azteca Internacional</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#652e91fd6208700008dcaf7b" lang="es" xmltv_id="">Canal 6 CdMX</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#652e922db4b047000825f975" lang="es" xmltv_id="">Milenio Televisión</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f62ff954b020008c91ec6" lang="es" xmltv_id="">Pluto TV Series de Crimen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="">Pluto TV Series de Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f636d954b020008c93299" lang="es" xmltv_id="">Pluto TV Series de Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f62ff954b020008c91ec6" lang="es" xmltv_id="PlutoTVSeriesdeCrimen.us@LatAm">Pluto TV Series de Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="PlutoTVSeriesdeComedia.us@LatAm">Pluto TV Series de Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#655f636d954b020008c93299" lang="es" xmltv_id="PlutoTVSeriesdeDrama.us@LatAm">Pluto TV Series de Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#656e2536fbc15b00084ae29d" lang="es" xmltv_id="">Mi Coche Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#656f37f257fe4a000884dfee" lang="es" xmltv_id="">Boruto: Naruto Next Generations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#673f7446030a2c0008231bc3" lang="es" xmltv_id="">C4 en Alerta</channel>
@@ -1381,38 +1395,38 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#678aa0b3680721c77c5035dd" lang="es" xmltv_id="">The Walking Dead by AMC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#680bdaf54d7cf165c705f91e" lang="es" xmltv_id="">Zona Investigación TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#681ba2729624e6275efe0044" lang="es" xmltv_id="">NatureTime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="">Pluto TV Novelas de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="PlutoTVNovelasdeOtrosContinentes.us@LatAm">Pluto TV Novelas de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#697c9bc2a7ce9d5a3d83504a" lang="es" xmltv_id="">Dr. G</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="">Pluto TV Amor y Mentiras</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="PlutoTVAmoryMentiras.us@LatAm">Pluto TV Amor y Mentiras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6047fabfce6e8e00070bcc9f" lang="es" xmltv_id="">MTV Biggest Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6095ad97351eb0000754c1e6" lang="es" xmltv_id="">Hells Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6109a9f5531b840007a4a187" lang="es" xmltv_id="">Cazador de Homicidas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6109ab25b84d6a0007504886" lang="es" xmltv_id="">Pluto TV Mi Obsesión Favorita</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6185a9a88b2ce30007de5128" lang="es" xmltv_id="">Pluto TV Dramas Coreanos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6109ab25b84d6a0007504886" lang="es" xmltv_id="PlutoTVMiObsesionFavorita.us@LatAm">Pluto TV Mi Obsesión Favorita</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6185a9a88b2ce30007de5128" lang="es" xmltv_id="PlutoTVDramasCoreanos.us@LatAm">Pluto TV Dramas Coreanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6320d80a66666000086712d7" lang="es" xmltv_id="">Claro Sports</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6320ddef274b1b0007b2ee88" lang="es" xmltv_id="">Revive Gran Hermano</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6419ab7c9189ce000865a469" lang="es" xmltv_id="">COPS</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="">Pluto TV Novelas de México</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6474a86917f5e100089a0c1c" lang="es" xmltv_id="">Pluto TV Novelas de Venezuela</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="">Pluto TV Series de Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="PlutoTVNovelasdeMexico.us@LatAm">Pluto TV Novelas de México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6474a86917f5e100089a0c1c" lang="es" xmltv_id="PlutoTVNovelasdeVenezuela.us@LatAm">Pluto TV Novelas de Venezuela</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="PlutoTVSeriesdeAccion.us@LatAm">Pluto TV Series de Acción</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6495af324c014a000842e923" lang="es" xmltv_id="">Desafío Super Humanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6582f002a620e3000813b329" lang="es" xmltv_id="">Azteca Deportes Network</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6661d5424b10960008599fa3" lang="es" xmltv_id="">Pluto TV Dramas Coreanos Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6661d5424b10960008599fa3" lang="es" xmltv_id="PlutoTVDramasCoreanosTeen.us@LatAm">Pluto TV Dramas Coreanos Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6759ee82bd523200083b4f0f" lang="es" xmltv_id="">Avatar: La Leyenda de Aang</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6806d519fea7414f33f57016" lang="es" xmltv_id="">Pluto TV Cine Inspirador</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6806d570c178637410ae4962" lang="es" xmltv_id="">Pluto TV Series de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6806d519fea7414f33f57016" lang="es" xmltv_id="PlutoTVCineInspirador.us@LatAm">Pluto TV Cine Inspirador</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#6806d570c178637410ae4962" lang="es" xmltv_id="PlutoTVSeriesdeOtrosContinentes.us@LatAm">Pluto TV Series de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6824cda00101510f9eeaa011" lang="es" xmltv_id="">Nickelodeon Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6851b909954170e0128bc71d" lang="es" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6894fc3f66f164e402f4fd14" lang="es" xmltv_id="">Dulce by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6894febddbd49c964f3b66c8" lang="es" xmltv_id="">Plato del Dia by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#61099f2b40d0640007fc5aa2" lang="es" xmltv_id="">El Encantador de Perros</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#63211ba9cad976000794f988" lang="es" xmltv_id="">La Selección</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#64510d3ad3fdde00080951f2" lang="es" xmltv_id="">MTV Drag</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#65662f8a2c46f300088a84cc" lang="es" xmltv_id="">Pluto TV Series de Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#65662f8a2c46f300088a84cc" lang="es" xmltv_id="PlutoTVSeriesdeSciFi.us@LatAm">Pluto TV Series de Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#66997d18a1b69e00082ee85f" lang="es" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#67813f893886aa863497733d" lang="es" xmltv_id="">Red Bull TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/ar#609059dc63be6e0007b4eca6" lang="es" xmltv_id="">Pluto TV Cine Clásico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/ar#609059dc63be6e0007b4eca6" lang="es" xmltv_id="PlutoTVCineClasico.us@LatAm">Pluto TV Cine Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#625461ef01f27a0007976ad1" lang="es" xmltv_id="">MTV Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#638693db857364000781b471" lang="es" xmltv_id="">MTV Con Mi Ex</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#639751f81a36b400072b8f5a" lang="es" xmltv_id="">Vive Kanal D Drama</channel>
@@ -1432,49 +1446,49 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#699763787cfe0ffadadd106f" lang="es" xmltv_id="">Mi Gorda Bella</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#64025592953da40008bf9238" lang="es" xmltv_id="">Obsesión por los Autos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/ar#6868152657543d1f8be4ece3" lang="es" xmltv_id="">Concert Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcdde78f080d900098550e4" lang="es" xmltv_id="">Pluto TV Cine Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="">Pluto TV Cine Terror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="">Pluto TV Cine Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="">Pluto TV Novelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="">Pluto TV Misterios</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde17bf6591d0009839e02" lang="es" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="">Pluto TV Investiga</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde197f6591d0009839e04" lang="es" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde437229eff00091b6c30" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde0657444a40009cd2422" lang="es" xmltv_id="">Pluto TV Estilo de Vida</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde1317578340009b751d0" lang="es" xmltv_id="">Pluto TV Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6d935d000120009bc1132" lang="es" xmltv_id="">Pluto TV Competencias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="">Pluto TV Velocidad</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="">Pluto TV Cine Familia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd7ea2aeab5230009986735" lang="es" xmltv_id="">Pluto TV Cine Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="">Pluto TV Naturaleza</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd837642c6e9300098ad484" lang="es" xmltv_id="">Pluto TV Series Latinas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="">Pluto TV Cine Suspenso</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc266f80e3550009136843" lang="es" xmltv_id="">Pluto TV Aventura</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="">Pluto TV Documentales</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="PlutoTVCineAccion.us@LatAm">Pluto TV Cine Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcdde78f080d900098550e4" lang="es" xmltv_id="PlutoTVCineComedia.us@LatAm">Pluto TV Cine Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="CineTerror.us@LatAm">Pluto TV Cine Terror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="PlutoTVCineDrama.us@LatAm">Pluto TV Cine Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="PlutoTVNovelas.us@LatAm">Pluto TV Novelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="PlutoTVJunior.us@LatAm">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="PlutoTVMisterios.us@LatAm">Pluto TV Misterios</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde17bf6591d0009839e02" lang="es" xmltv_id="PlutoTVAnime.us@LatAm">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="Investiga.us@LatAm">Pluto TV Investiga</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde197f6591d0009839e04" lang="es" xmltv_id="PlutoTVReality.us@LatAm">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde437229eff00091b6c30" lang="es" xmltv_id="PlutoTVCineEstelar.us@LatAm">Pluto TV Cine Estelar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde0657444a40009cd2422" lang="es" xmltv_id="PlutoTVEstilodeVida.us@LatAm">Pluto TV Estilo de Vida</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dcde1317578340009b751d0" lang="es" xmltv_id="PlutoTVSeries.us@LatAm">Pluto TV Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6d935d000120009bc1132" lang="es" xmltv_id="PlutoTVCompetencias.us@LatAm">Pluto TV Competencias</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="PlutoTVKids.us@LatAm">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="PlutoTVVelocidad.us@LatAm">Pluto TV Velocidad</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="PlutoTVCineFamilia.us@LatAm">Pluto TV Cine Familia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd7ea2aeab5230009986735" lang="es" xmltv_id="PlutoTVCineRomance.us@LatAm">Pluto TV Cine Romance</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="PlutoTVNaturaleza.us@LatAm">Pluto TV Naturaleza</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dd837642c6e9300098ad484" lang="es" xmltv_id="PlutoTVSeriesLatinas.us@LatAm">Pluto TV Series Latinas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="PlutoTVCineSuspenso.us@LatAm">Pluto TV Cine Suspenso</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc266f80e3550009136843" lang="es" xmltv_id="PlutoTVAventura.us@LatAm">Pluto TV Aventura</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="PlutoTVDocumentales.us@LatAm">Pluto TV Documentales</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ddd7cb2cbb9010009b4fe32" lang="es" xmltv_id="">Nick Jr. Club</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="">Pluto TV Historia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de802659167b10009e7deba" lang="es" xmltv_id="">Pluto TV Series Retro</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5defde6d6c07b50009cf0757" lang="es" xmltv_id="">Pluto TV Nuestro Cine</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5df265697ec3510009df1ef0" lang="es" xmltv_id="">Pluto TV Vida Real</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="">Pluto TV A La Mexicana</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Pride</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="PlutoTVHistoria.us@LatAm">Pluto TV Historia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5de802659167b10009e7deba" lang="es" xmltv_id="PlutoTVSeriesRetro.us@LatAm">Pluto TV Series Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5defde6d6c07b50009cf0757" lang="es" xmltv_id="PlutoTVNuestroCine.us@LatAm">Pluto TV Nuestro Cine</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5df265697ec3510009df1ef0" lang="es" xmltv_id="PlutoTVVidaReal.us@LatAm">Pluto TV Vida Real</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="PlutoTVALaMexicana.us@LatAm">Pluto TV A La Mexicana</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef México</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e46e64dc73db400094b5f0b" lang="es" xmltv_id="">Minuto Para Ganar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e67d41b93312100076f3fca" lang="es" xmltv_id="">Los archivos del FBI</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e98a911c881310007d7aae2" lang="es" xmltv_id="">MTV Ridiculousness</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e98b0447665f200078caded" lang="es" xmltv_id="">Pluto TV Peleas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e98b0447665f200078caded" lang="es" xmltv_id="PlutoTVPeleas.us@LatAm">Pluto TV Peleas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e972a21ad709d00074195ba" lang="es" xmltv_id="">Estrellas de Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e8397936791b30007ebb5a7" lang="es" xmltv_id="">Pluto TV Humor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5e8397936791b30007ebb5a7" lang="es" xmltv_id="PlutoTVHumor.us@LatAm">Pluto TV Humor</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ea71d48af1d0b0007d837f4" lang="es" xmltv_id="">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ea7215005d66d0007e8128a" lang="es" xmltv_id="">Rugrats</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ebac49ce4dc8b00078b23bc" lang="es" xmltv_id="">Babyfirst</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ebacbcae43a6d000787b88e" lang="es" xmltv_id="">The Pet Collective</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ebaccf1734aaf0007142c86" lang="es" xmltv_id="">FailArmy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ec5761aabe4690007f6e047" lang="es" xmltv_id="">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ec5761aabe4690007f6e047" lang="es" xmltv_id="StarTrek.us@LatAm">Pluto TV Star Trek</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ed6828192e8b3000743ef61" lang="es" xmltv_id="">Wipe Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ee92e72fb286e0007285fec" lang="es" xmltv_id="">Naruto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5efb8c19b2678b000780d032" lang="es" xmltv_id="">Archivos Forenses</channel>
@@ -1486,26 +1500,26 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f99a772c54853000797bf18" lang="es" xmltv_id="">Lucha Libre AAA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f230e416b68ff00075b0139" lang="es" xmltv_id="">Misterios Medicos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f998c1fc54853000797bacd" lang="es" xmltv_id="">Tastemade</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f2817d3d7573a00080f9175" lang="es" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f2817d3d7573a00080f9175" lang="es" xmltv_id="PlutoTVSciFi.us@LatAm">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f9992c685a2a80007fa414a" lang="es" xmltv_id="">Dog el cazarrecompensas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f23102d5e239d00074b092a" lang="es" xmltv_id="">Empeños a lo bestia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5f610042272f68000867685b" lang="es" xmltv_id="">Misterios sin Resolver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5fab09a8749b1a00077d35d2" lang="es" xmltv_id="">Nickelodeon Teen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5fab088b3279760007d4e4fd" lang="es" xmltv_id="">MTV Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5fab088b3279760007d4e4fd" lang="es" xmltv_id="MTVPlutoTV.us@LatAm">MTV Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5fcea93ffcf94500071c4b2f" lang="es" xmltv_id="">Kenan y Kel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5fceaab478f2af00080ff51f" lang="es" xmltv_id="">Yu-Gi-Oh</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ff4b9ccf938f8000779eb99" lang="es" xmltv_id="">One Piece</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ff608e60e2996000768c366" lang="es" xmltv_id="">Tokusato</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ff3934600d4c7000733ff49" lang="es" xmltv_id="">Pluto TV E-Sports</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ffcc21a432945000762d06b" lang="es" xmltv_id="">Comedy Central Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ff3934600d4c7000733ff49" lang="es" xmltv_id="PlutoTVESports.us@LatAm">Pluto TV E-Sports</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#5ffcc21a432945000762d06b" lang="es" xmltv_id="ComedyCentralPlutoTV.us@LatAm">Comedy Central Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#60e5ea9a9bb4200008376f76" lang="es" xmltv_id="">Motorvision TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#61a52615cbef2500072876e2" lang="es" xmltv_id="">Acapulco Shore Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#61a52615cbef2500072876e2" lang="es" xmltv_id="AcapulcoShore.us@LatAm">Acapulco Shore Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#61b793ccf571b80007b7a610" lang="es" xmltv_id="">Adrenalina Pura TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#62b218fc511d4b00070ddc0c" lang="es" xmltv_id="">MTV Flow Latino</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#62c5d80dc6de440007e033eb" lang="es" xmltv_id="">Runtime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#62d08af527ce19000731eaa0" lang="es" xmltv_id="">La Familia del Barrio</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#62d0895ebe7a970008785244" lang="es" xmltv_id="">Daria</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#63a084934734f30007457b2c" lang="es" xmltv_id="">Smithsonian Channel Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#63a084934734f30007457b2c" lang="es" xmltv_id="SmithsonianChannelPlutoTV.us@LatAm">Smithsonian Channel Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#63c6e37e636b7e0007ccb635" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#63d2c140c111bc0008cb890b" lang="es" xmltv_id="">TeleFórmula</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#63dac1b78795f300086d5ca6" lang="es" xmltv_id="">TikTok Radio en Español</channel>
@@ -1535,9 +1549,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67a52c8397782f00081879aa" lang="es" xmltv_id="">Top Barça</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67a52cd4ec91870008a62164" lang="es" xmltv_id="">UFC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67d9b0ebc290c9499046e88f" lang="es" xmltv_id="">RCN Noticias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#67e598e28b99330f75b4c629" lang="es" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67e5941f0812459cb682d9c6" lang="es" xmltv_id="">Relic Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#67e5987eef24f48ffca08fd7" lang="es" xmltv_id="">Doc Martin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67f95fa76b11614ab0caaef3" lang="es" xmltv_id="">Hechiceras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67f960680072d6b187a0682e" lang="es" xmltv_id="">Números</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#68a3a97fd8f7693ae3f8575f" lang="es" xmltv_id="">Los Pitufos</channel>
@@ -1546,13 +1558,20 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#68b88712e777774982269ce9" lang="es" xmltv_id="">Tastemade Viajes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#68ba0910e1d03fec7d5c084f" lang="es" xmltv_id="">Al Ritmo del Jaripeo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#68ffc086a530e036bc8f0305" lang="es" xmltv_id="">Mi Bella Genio</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69de4ad924a6d521f8b0a348" lang="es" xmltv_id="">RCN Más</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fca9dd14a5dfae8875a3be" lang="es" xmltv_id="">Survivor México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fca9f9b9c0f0d444f631ca" lang="es" xmltv_id="">Mr. Bean Animated</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fcaa71ea95ffff0987f555" lang="es" xmltv_id="">MasterChef Colombia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fcaa88e022927e1c94c533" lang="es" xmltv_id="">MasterChef Argentina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fcaaa1853a01a827bcd056" lang="es" xmltv_id="">I Shouldn&apos;t Be Alive</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#69fcdc73488e575cff213adc" lang="es" xmltv_id="">Hermanos a la Obra</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#604bdf4e6d0abc0007ba77ad" lang="es" xmltv_id="">Sin Tetas No Hay Paraíso</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#609ae5cd48d3200007b0a98e" lang="es" xmltv_id="">Comedy Central South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#619d5e6a093e7c0007489211" lang="es" xmltv_id="">Baby Shark TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#619d59b7cbef25000728221c" lang="es" xmltv_id="">Euronews Español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#620fd9f4afb9a80007a9c6d5" lang="es" xmltv_id="">MTV Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#620ff0a01f9e8700076c6f9d" lang="es" xmltv_id="">Nickelodeon iCarly</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#624af40c004f8000079b784d" lang="es" xmltv_id="">Pluto TV Cine Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#624af40c004f8000079b784d" lang="es" xmltv_id="PlutoTVCineCrimen.us@LatAm">Pluto TV Cine Crimen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#626c2ed933a2890007e91422" lang="es" xmltv_id="">Death Note</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#631fb6be21b7440007b9f606" lang="es" xmltv_id="">Hechizada</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#645d1abbe1979c0008779d5a" lang="es" xmltv_id="">Archivos Extraterrestres</channel>
@@ -1560,9 +1579,9 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#646cce4d1593940008a33f09" lang="es" xmltv_id="">Azteca Internacional</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#652e91fd6208700008dcaf7b" lang="es" xmltv_id="">Canal 6 CdMX</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#652e922db4b047000825f975" lang="es" xmltv_id="">Milenio Televisión</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f62ff954b020008c91ec6" lang="es" xmltv_id="">Pluto TV Series de Crimen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="">Pluto TV Series de Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f636d954b020008c93299" lang="es" xmltv_id="">Pluto TV Series de Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f62ff954b020008c91ec6" lang="es" xmltv_id="PlutoTVSeriesdeCrimen.us@LatAm">Pluto TV Series de Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="PlutoTVSeriesdeComedia.us@LatAm">Pluto TV Series de Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#655f636d954b020008c93299" lang="es" xmltv_id="PlutoTVSeriesdeDrama.us@LatAm">Pluto TV Series de Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#656e2536fbc15b00084ae29d" lang="es" xmltv_id="">Mi Coche Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#656f37f257fe4a000884dfee" lang="es" xmltv_id="">Boruto: Naruto Next Generations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#673f7446030a2c0008231bc3" lang="es" xmltv_id="">C4 en Alerta</channel>
@@ -1570,38 +1589,38 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#678aa0b3680721c77c5035dd" lang="es" xmltv_id="">The Walking Dead by AMC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#680bdaf54d7cf165c705f91e" lang="es" xmltv_id="">Zona Investigación TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#681ba2729624e6275efe0044" lang="es" xmltv_id="">NatureTime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="">Pluto TV Novelas de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="PlutoTVNovelasdeOtrosContinentes.us@LatAm">Pluto TV Novelas de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#697c9bc2a7ce9d5a3d83504a" lang="es" xmltv_id="">Dr. G</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="">Pluto TV Amor y Mentiras</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="PlutoTVAmoryMentiras.us@LatAm">Pluto TV Amor y Mentiras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6047fabfce6e8e00070bcc9f" lang="es" xmltv_id="">MTV Biggest Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6095ad97351eb0000754c1e6" lang="es" xmltv_id="">Hells Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6109a9f5531b840007a4a187" lang="es" xmltv_id="">Cazador de Homicidas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6109ab25b84d6a0007504886" lang="es" xmltv_id="">Pluto TV Mi Obsesión Favorita</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6185a9a88b2ce30007de5128" lang="es" xmltv_id="">Pluto TV Dramas Coreanos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6109ab25b84d6a0007504886" lang="es" xmltv_id="PlutoTVMiObsesionFavorita.us@LatAm">Pluto TV Mi Obsesión Favorita</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6185a9a88b2ce30007de5128" lang="es" xmltv_id="PlutoTVDramasCoreanos.us@LatAm">Pluto TV Dramas Coreanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6320d80a66666000086712d7" lang="es" xmltv_id="">Claro Sports</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6320ddef274b1b0007b2ee88" lang="es" xmltv_id="">Revive Gran Hermano</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6419ab7c9189ce000865a469" lang="es" xmltv_id="">COPS</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="">Pluto TV Novelas de México</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6474a86917f5e100089a0c1c" lang="es" xmltv_id="">Pluto TV Novelas de Venezuela</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="">Pluto TV Series de Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="PlutoTVNovelasdeMexico.us@LatAm">Pluto TV Novelas de México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6474a86917f5e100089a0c1c" lang="es" xmltv_id="PlutoTVNovelasdeVenezuela.us@LatAm">Pluto TV Novelas de Venezuela</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="PlutoTVSeriesdeAccion.us@LatAm">Pluto TV Series de Acción</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6495af324c014a000842e923" lang="es" xmltv_id="">Desafío Super Humanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6582f002a620e3000813b329" lang="es" xmltv_id="">Azteca Deportes Network</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6661d5424b10960008599fa3" lang="es" xmltv_id="">Pluto TV Dramas Coreanos Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6661d5424b10960008599fa3" lang="es" xmltv_id="PlutoTVDramasCoreanosTeen.us@LatAm">Pluto TV Dramas Coreanos Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6759ee82bd523200083b4f0f" lang="es" xmltv_id="">Avatar: La Leyenda de Aang</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6806d519fea7414f33f57016" lang="es" xmltv_id="">Pluto TV Cine Inspirador</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6806d570c178637410ae4962" lang="es" xmltv_id="">Pluto TV Series de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6806d519fea7414f33f57016" lang="es" xmltv_id="PlutoTVCineInspirador.us@LatAm">Pluto TV Cine Inspirador</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#6806d570c178637410ae4962" lang="es" xmltv_id="PlutoTVSeriesdeOtrosContinentes.us@LatAm">Pluto TV Series de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6824cda00101510f9eeaa011" lang="es" xmltv_id="">Nickelodeon Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6851b909954170e0128bc71d" lang="es" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6894fc3f66f164e402f4fd14" lang="es" xmltv_id="">Dulce by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6894febddbd49c964f3b66c8" lang="es" xmltv_id="">Plato del Dia by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#61099f2b40d0640007fc5aa2" lang="es" xmltv_id="">El Encantador de Perros</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#63211ba9cad976000794f988" lang="es" xmltv_id="">La Selección</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#64510d3ad3fdde00080951f2" lang="es" xmltv_id="">MTV Drag</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#65662f8a2c46f300088a84cc" lang="es" xmltv_id="">Pluto TV Series de Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#65662f8a2c46f300088a84cc" lang="es" xmltv_id="PlutoTVSeriesdeSciFi.us@LatAm">Pluto TV Series de Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#66997d18a1b69e00082ee85f" lang="es" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#67813f893886aa863497733d" lang="es" xmltv_id="">Red Bull TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/cl#609059dc63be6e0007b4eca6" lang="es" xmltv_id="">Pluto TV Cine Clásico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/cl#609059dc63be6e0007b4eca6" lang="es" xmltv_id="PlutoTVCineClasico.us@LatAm">Pluto TV Cine Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#625461ef01f27a0007976ad1" lang="es" xmltv_id="">MTV Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#638693db857364000781b471" lang="es" xmltv_id="">MTV Con Mi Ex</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#639751f81a36b400072b8f5a" lang="es" xmltv_id="">Vive Kanal D Drama</channel>
@@ -1621,52 +1640,58 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#699763787cfe0ffadadd106f" lang="es" xmltv_id="">Mi Gorda Bella</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#64025592953da40008bf9238" lang="es" xmltv_id="">Obsesión por los Autos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/cl#6868152657543d1f8be4ece3" lang="es" xmltv_id="">Concert Channel</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1abce155a03d0007718834" lang="es" xmltv_id="">Pluto TV Comedia made in Spain</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1abce155a03d0007718834" lang="es" xmltv_id="PlutoTVComediamadeinSpain.de@ES">Pluto TV Comedia made in Spain</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aca8310a30e00074fab92" lang="es" xmltv_id="">Los Asesinatos de Midsomer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1acba0d1f6340007db8843" lang="es" xmltv_id="">Los nuevos detectives</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#60cc807324d60a0007708dc8" lang="es" xmltv_id="">Pluto TV Cine de autor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#60cc807324d60a0007708dc8" lang="es" xmltv_id="PlutoTVCinedeautor.de@ES">Pluto TV Cine de autor</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#60d356a534f63f000850cdd7" lang="es" xmltv_id="">Top Gear</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#60d3583ef310610007fb02b1" lang="es" xmltv_id="">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#61bb2814ac085a00074309a6" lang="es" xmltv_id="">Unidad de investigación</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#61cd7b49543066000713b620" lang="es" xmltv_id="">Pluto TV Historia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#61cd7b49543066000713b620" lang="es" xmltv_id="PlutoTVHistoria.de@ES">Pluto TV Historia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#62ac3d7dc23b400008ae5b5a" lang="es" xmltv_id="">MTV Jerseys</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#63c69c87808b740007599fe1" lang="es" xmltv_id="">Érase una vez...</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#63d7a8e5a9957100086bfc23" lang="es" xmltv_id="">South Park Versión Original</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#63eb944dc111bc0008fe7021" lang="es" xmltv_id="">Pluto TV Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#63eb944dc111bc0008fe7021" lang="es" xmltv_id="PlutoTVTeen.de@ES">Pluto TV Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#63eb9495a8b227000841bf64" lang="es" xmltv_id="">MTV Vergüenza ajena</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#63eb96754e83e70008ab8941" lang="es" xmltv_id="">Yu-Gi-Oh!</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#64a3f200f238ce0008d47247" lang="es" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#64db2e0835425100080f2f5a" lang="es" xmltv_id="">Pluto TV Diseño</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#63fe0111dff38e00083510f9" lang="es" xmltv_id="">Pluto TV Orgullo</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#64a3f200f238ce0008d47247" lang="es" xmltv_id="PlutoTVTrueCrime.de@ES">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#64db2e0835425100080f2f5a" lang="es" xmltv_id="PlutoTVDiseno.de@ES">Pluto TV Diseño</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#64ddcbb14c5ed80008fad416" lang="es" xmltv_id="">Crimen &amp;amp; Historia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65b91e530d9ab40008340d8d" lang="es" xmltv_id="">Al salir de clase</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#65bd0f53dc10a40008e68b96" lang="es" xmltv_id="">Pluto TV Gasolina</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#65ce480a78df2200131c597b" lang="es" xmltv_id="">Pluto TV Psycho</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#65cf6ab58145cb0008129ca8" lang="es" xmltv_id="">Pluto TV Series criminales</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#65ddec1ef7f0af0008be4b65" lang="es" xmltv_id="">Pluto TV Series Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#65bd0f53dc10a40008e68b96" lang="es" xmltv_id="PlutoTVGasolina.de@ES">Pluto TV Gasolina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#65ce480a78df2200131c597b" lang="es" xmltv_id="PlutoTVPsycho.de@ES">Pluto TV Psycho</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#65cf6ab58145cb0008129ca8" lang="es" xmltv_id="PlutoTVSeriescriminales.de@ES">Pluto TV Series criminales</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#65ddec1ef7f0af0008be4b65" lang="es" xmltv_id="PlutoTVSeriesSciFi.de@ES">Pluto TV Series Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65dded9a0d456100081417ae" lang="es" xmltv_id="">Primeval</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65dded6966eec80008947157" lang="es" xmltv_id="">¡Llama a la Comadrona!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65f96cd34e01740008ef1c97" lang="es" xmltv_id="">Realmadrid TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#66b0dfa1d512590008bfa7fd" lang="es" xmltv_id="">Pluto TV Gore &amp;amp; Slasher</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#66b0dfa1d512590008bfa7fd" lang="es" xmltv_id="PlutoTVGoreSlasher.de@ES">Pluto TV Gore &amp;amp; Slasher</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#66c45c0de7f5e80008b82005" lang="es" xmltv_id="">CNN Headlines International</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#66d71c656b63480008cf0427" lang="es" xmltv_id="">Cherif</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#66d71f8ee5de930008016f83" lang="es" xmltv_id="">Alice Nevers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#67c7249be979b84e78ca43ff" lang="es" xmltv_id="">Los Mosqueteros</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#68adc3fdd8f7693ae347a63a" lang="es" xmltv_id="">Los Gipsy Kings</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#68adc697116b783a33f99e6c" lang="es" xmltv_id="">Pluto TV Impacto</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#68d566603d3a9580eb461251" lang="es" xmltv_id="">Paramount Network de Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#68adc697116b783a33f99e6c" lang="es" xmltv_id="PlutoTVImpacto.de@ES">Pluto TV Impacto</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#68d566603d3a9580eb461251" lang="es" xmltv_id="ParamountNetworkdePlutoTV.de@ES">Paramount Network de Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#68d27949793c71d988ca624c" lang="es" xmltv_id="">Los Pitufos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#68de3db35fc0afe85de0b843" lang="es" xmltv_id="">Comedia a lo bestia de Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#68de3db35fc0afe85de0b843" lang="es" xmltv_id="ComediaalobestiadePlutoTV.de@ES">Comedia a lo bestia de Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#68e8fd7c3ede4398bc69af93" lang="es" xmltv_id="">Dragon Ball Z</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#68e8fe3bcba140ddfe903677" lang="es" xmltv_id="">Monster High</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69b3db5d61e8e298254c7108" lang="es" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69c5100c3d2597380f0f6422" lang="es" xmltv_id="">Gata salvaje</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69c51060ed1b1f1acb5092dc" lang="es" xmltv_id="">Alaska y Mario</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69f0bb1a00ad62de02a6b716" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69f9c50202b6c1c00a213519" lang="es" xmltv_id="">Dominance FC TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#619b9f16b8fee4000832d447" lang="es" xmltv_id="">El Detective Endeavour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#622f42b831233300078658cc" lang="es" xmltv_id="">Ciudadanos por el mundo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#627d3176d7dfa500077042f1" lang="es" xmltv_id="">MTV Geordies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#629a066860ef810008267b70" lang="es" xmltv_id="">Detective Conan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#632c6df43d2bc5000751f621" lang="es" xmltv_id="">Inazuma Eleven</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#645a309c5a0cd5000873f609" lang="es" xmltv_id="">Pluto TV Catástrofes</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#654a35ce346f420008d5c36e" lang="es" xmltv_id="">Pluto TV Invasión Alien</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#655b5d865812e80008843bd1" lang="es" xmltv_id="">Pluto TV Comedias Románticas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#645a309c5a0cd5000873f609" lang="es" xmltv_id="PlutoTVCatastrofes.de@ES">Pluto TV Catástrofes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#654a35ce346f420008d5c36e" lang="es" xmltv_id="PlutoTVInvasionAlien.de@ES">Pluto TV Invasión Alien</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#655b5d865812e80008843bd1" lang="es" xmltv_id="PlutoTVComediasRomanticas.de@ES">Pluto TV Comedias Románticas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#660c29f80cd4630008f1547c" lang="es" xmltv_id="">FIFA+</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#662a69daa0a74e00087a1c72" lang="es" xmltv_id="">Pluto TV Telenovelas Clásicas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#662a69daa0a74e00087a1c72" lang="es" xmltv_id="PlutoTVTelenovelasClasicas.de@ES">Pluto TV Telenovelas Clásicas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#664c76d68ea5560008c6c7a4" lang="es" xmltv_id="">Alerta Cobra</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#676e7b4a4bd636000819c6a7" lang="es" xmltv_id="">SensaCine TV x Pluto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#680ba8c3a48b3ead0db701cc" lang="es" xmltv_id="">Los caballeros del Zodiaco</channel>
@@ -1676,23 +1701,23 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/es#686cd8bb9d079f48dbbdfecb" lang="es" xmltv_id="">Metal Rocks</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#686cd84603ad75cfd132d672" lang="es" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#690dd10a37b131228d76d5b1" lang="es" xmltv_id="">El Mueble</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#691ddf2a3ae32cf55263476d" lang="es" xmltv_id="">Pluto TV Forever Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#691ddf2a3ae32cf55263476d" lang="es" xmltv_id="PlutoTVForeverKids.de@ES">Pluto TV Forever Kids</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#696e02423b9ce349c90edef9" lang="es" xmltv_id="">Rally TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6086d3f420fc8500075f8dbf" lang="es" xmltv_id="">Runtime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6231ede1be5b460007f91bc1" lang="es" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6245c03922d9d4000760d205" lang="es" xmltv_id="">Melrose Place</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6267d4d1fb694f0007a6af0e" lang="es" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6267d4d1fb694f0007a6af0e" lang="es" xmltv_id="PlutoTVHorror.de@ES">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6304f530440dc90007f514d3" lang="es" xmltv_id="">Poirot &amp;amp; Miss Marple</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6335a6b6e6f7a600076e589e" lang="es" xmltv_id="">Cazasubastas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6385e82900ab2e000768a058" lang="es" xmltv_id="">Pluto TV Western</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6475bfec536e0c0008858e9f" lang="es" xmltv_id="">Pluto TV K-Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6385e82900ab2e000768a058" lang="es" xmltv_id="PlutoTVWestern.de@ES">Pluto TV Western</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6475bfec536e0c0008858e9f" lang="es" xmltv_id="PlutoTVKDrama.de@ES">Pluto TV K-Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6523f672a6c38300088cb807" lang="es" xmltv_id="">El Reino Infantil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6554bd45aa9ffb00088e5589" lang="es" xmltv_id="">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6682bd9b8768aa0008f25be5" lang="es" xmltv_id="">Los misterios de Murdoch</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6745f0643a61d40008a61510" lang="es" xmltv_id="">Rookie Blue</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6880aa28164eb4890282e803" lang="es" xmltv_id="">Pluto TV Toons</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6793ac47f5c74bff95d18a99" lang="es" xmltv_id="">TOP BARÇA</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6880aa28164eb4890282e803" lang="es" xmltv_id="PlutoTVToons.de@ES">Pluto TV Toons</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6964d2179ba4ac18051a18ce" lang="es" xmltv_id="">Léo Mattéï: Brigada de protección</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6995daa579545c21a10e84de" lang="es" xmltv_id="">Pluto TV Basadas en libros</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#62568a94ed1f380007b0211f" lang="es" xmltv_id="">Winx Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65254e8d81f9420008342cee" lang="es" xmltv_id="">La fiebre del Jade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#65786abdb3801200084c593a" lang="es" xmltv_id="">Homeful</channel>
@@ -1701,9 +1726,8 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/es#67517f923a61d40008c451f0" lang="es" xmltv_id="">Historia y Vida</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#67517fae5534bb0008187997" lang="es" xmltv_id="">Actualidad 360</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#67921b873de7c8cf94233f52" lang="es" xmltv_id="">UFC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#68751a3bfd6704e9d3cc7b3d" lang="es" xmltv_id="">Pequeños aventureros de Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#68779a09c691b3f0964127c6" lang="es" xmltv_id="">Heidi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#69148c470155f9b136b5d856" lang="es" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#69148c470155f9b136b5d856" lang="es" xmltv_id="PlutoTVSnooker900.de@ES">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#600169ec77e6f70008fa9cf0" lang="es" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#628751bb7154a40007168843" lang="es" xmltv_id="">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#657868a7a620e30008fdbfeb" lang="es" xmltv_id="">Embrujadas</channel>
@@ -1712,54 +1736,54 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6578836cdfed030008ce5bdb" lang="es" xmltv_id="">Sí quiero ese vestido</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6812206e1b3e3be031a5c363" lang="es" xmltv_id="">Águila Roja</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6888928eb52fb742416673d2" lang="es" xmltv_id="">Mattel Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#65786888b228b7000843ad9a" lang="es" xmltv_id="">Pluto TV Zombies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#65786888b228b7000843ad9a" lang="es" xmltv_id="PlutoTVZombies.de@ES">Pluto TV Zombies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#67164414e40c4a00087f450d" lang="es" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#6578808014fbe400086e21bc" lang="es" xmltv_id="">Medium</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#688892172928933015abe479" lang="es" xmltv_id="">Barbie &amp;amp; Friends</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcdde78f080d900098550e4" lang="es" xmltv_id="">Pluto TV Cine Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="">Pluto TV Cine Terror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="">Pluto TV Cine Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="">Pluto TV Novelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="">Pluto TV Misterios</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde07af1c85b0009b18651" lang="es" xmltv_id="">Pluto TV Deportes</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde17bf6591d0009839e02" lang="es" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="">Pluto TV Investiga</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde197f6591d0009839e04" lang="es" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde437229eff00091b6c30" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde0657444a40009cd2422" lang="es" xmltv_id="">Pluto TV Estilo de Vida</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde1317578340009b751d0" lang="es" xmltv_id="">Pluto TV Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6d935d000120009bc1132" lang="es" xmltv_id="">Pluto TV Competencias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="">Pluto TV Velocidad</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="">Pluto TV Cine Familia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd7ea2aeab5230009986735" lang="es" xmltv_id="">Pluto TV Cine Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="">Pluto TV Naturaleza</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd837642c6e9300098ad484" lang="es" xmltv_id="">Pluto TV Series Latinas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="">Pluto TV Cine Suspenso</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc266f80e3550009136843" lang="es" xmltv_id="">Pluto TV Aventura</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="">Pluto TV Documentales</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="PlutoTVCineAccion.us@LatAm">Pluto TV Cine Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcdde78f080d900098550e4" lang="es" xmltv_id="PlutoTVCineComedia.us@LatAm">Pluto TV Cine Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="CineTerror.us@LatAm">Pluto TV Cine Terror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="PlutoTVCineDrama.us@LatAm">Pluto TV Cine Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="PlutoTVNovelas.us@LatAm">Pluto TV Novelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="PlutoTVJunior.us@LatAm">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="PlutoTVMisterios.us@LatAm">Pluto TV Misterios</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde07af1c85b0009b18651" lang="es" xmltv_id="PlutoTVDeportes.us@LatAm">Pluto TV Deportes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde17bf6591d0009839e02" lang="es" xmltv_id="PlutoTVAnime.us@LatAm">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde27ffae9520009c0c75a" lang="es" xmltv_id="Investiga.us@LatAm">Pluto TV Investiga</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde197f6591d0009839e04" lang="es" xmltv_id="PlutoTVReality.us@LatAm">Pluto TV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde437229eff00091b6c30" lang="es" xmltv_id="PlutoTVCineEstelar.us@LatAm">Pluto TV Cine Estelar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde0657444a40009cd2422" lang="es" xmltv_id="PlutoTVEstilodeVida.us@LatAm">Pluto TV Estilo de Vida</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dcde1317578340009b751d0" lang="es" xmltv_id="PlutoTVSeries.us@LatAm">Pluto TV Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6d935d000120009bc1132" lang="es" xmltv_id="PlutoTVCompetencias.us@LatAm">Pluto TV Competencias</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="PlutoTVKids.us@LatAm">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6dc7480e3550009133d4a" lang="es" xmltv_id="PlutoTVVelocidad.us@LatAm">Pluto TV Velocidad</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="PlutoTVCineFamilia.us@LatAm">Pluto TV Cine Familia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd7ea2aeab5230009986735" lang="es" xmltv_id="PlutoTVCineRomance.us@LatAm">Pluto TV Cine Romance</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd85eac039bba0009e86d1d" lang="es" xmltv_id="PlutoTVNaturaleza.us@LatAm">Pluto TV Naturaleza</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dd837642c6e9300098ad484" lang="es" xmltv_id="PlutoTVSeriesLatinas.us@LatAm">Pluto TV Series Latinas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="PlutoTVCineSuspenso.us@LatAm">Pluto TV Cine Suspenso</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc266f80e3550009136843" lang="es" xmltv_id="PlutoTVAventura.us@LatAm">Pluto TV Aventura</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddc503ac7ef120009b101a2" lang="es" xmltv_id="PlutoTVDocumentales.us@LatAm">Pluto TV Documentales</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ddd7cb2cbb9010009b4fe32" lang="es" xmltv_id="">Nick Jr. Club</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="">Pluto TV Historia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de802659167b10009e7deba" lang="es" xmltv_id="">Pluto TV Series Retro</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5defde6d6c07b50009cf0757" lang="es" xmltv_id="">Pluto TV Nuestro Cine</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5df265697ec3510009df1ef0" lang="es" xmltv_id="">Pluto TV Vida Real</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="">Pluto TV A La Mexicana</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Pride</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="PlutoTVHistoria.us@LatAm">Pluto TV Historia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5de802659167b10009e7deba" lang="es" xmltv_id="PlutoTVSeriesRetro.us@LatAm">Pluto TV Series Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5defde6d6c07b50009cf0757" lang="es" xmltv_id="PlutoTVNuestroCine.us@LatAm">Pluto TV Nuestro Cine</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5df265697ec3510009df1ef0" lang="es" xmltv_id="PlutoTVVidaReal.us@LatAm">Pluto TV Vida Real</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="PlutoTVALaMexicana.us@LatAm">Pluto TV A La Mexicana</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef México</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e46e64dc73db400094b5f0b" lang="es" xmltv_id="">Minuto Para Ganar</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e67d41b93312100076f3fca" lang="es" xmltv_id="">Los archivos del FBI</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e98a911c881310007d7aae2" lang="es" xmltv_id="">MTV Ridiculousness</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e98b0447665f200078caded" lang="es" xmltv_id="">Pluto TV Peleas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e98b0447665f200078caded" lang="es" xmltv_id="PlutoTVPeleas.us@LatAm">Pluto TV Peleas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e972a21ad709d00074195ba" lang="es" xmltv_id="">Estrellas de Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e8397936791b30007ebb5a7" lang="es" xmltv_id="">Pluto TV Humor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5e8397936791b30007ebb5a7" lang="es" xmltv_id="PlutoTVHumor.us@LatAm">Pluto TV Humor</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ea71d48af1d0b0007d837f4" lang="es" xmltv_id="">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ea7215005d66d0007e8128a" lang="es" xmltv_id="">Rugrats</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ebac49ce4dc8b00078b23bc" lang="es" xmltv_id="">Babyfirst</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ebacbcae43a6d000787b88e" lang="es" xmltv_id="">The Pet Collective</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ebaccf1734aaf0007142c86" lang="es" xmltv_id="">FailArmy</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ec5761aabe4690007f6e047" lang="es" xmltv_id="">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ec5761aabe4690007f6e047" lang="es" xmltv_id="StarTrek.us@LatAm">Pluto TV Star Trek</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ed6828192e8b3000743ef61" lang="es" xmltv_id="">Wipe Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ee92e72fb286e0007285fec" lang="es" xmltv_id="">Naruto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5efb8c19b2678b000780d032" lang="es" xmltv_id="">Archivos Forenses</channel>
@@ -1771,26 +1795,27 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f99a772c54853000797bf18" lang="es" xmltv_id="">Lucha Libre AAA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f230e416b68ff00075b0139" lang="es" xmltv_id="">Misterios Medicos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f998c1fc54853000797bacd" lang="es" xmltv_id="">Tastemade</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f2817d3d7573a00080f9175" lang="es" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f2817d3d7573a00080f9175" lang="es" xmltv_id="PlutoTVSciFi.us@LatAm">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f9992c685a2a80007fa414a" lang="es" xmltv_id="">Dog el cazarrecompensas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f23102d5e239d00074b092a" lang="es" xmltv_id="">Empeños a lo bestia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5f610042272f68000867685b" lang="es" xmltv_id="">Misterios sin Resolver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5fab09a8749b1a00077d35d2" lang="es" xmltv_id="">Nickelodeon Teen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5fab088b3279760007d4e4fd" lang="es" xmltv_id="">MTV Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5fab088b3279760007d4e4fd" lang="es" xmltv_id="MTVPlutoTV.us@LatAm">MTV Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5fcea93ffcf94500071c4b2f" lang="es" xmltv_id="">Kenan y Kel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5fceaab478f2af00080ff51f" lang="es" xmltv_id="">Yu-Gi-Oh</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ff4b9ccf938f8000779eb99" lang="es" xmltv_id="">One Piece</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ff608e60e2996000768c366" lang="es" xmltv_id="">Tokusato</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ff3934600d4c7000733ff49" lang="es" xmltv_id="">Pluto TV E-Sports</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ffcc21a432945000762d06b" lang="es" xmltv_id="">Comedy Central Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ff3934600d4c7000733ff49" lang="es" xmltv_id="PlutoTVESports.us@LatAm">Pluto TV E-Sports</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#5ffcc21a432945000762d06b" lang="es" xmltv_id="ComedyCentralPlutoTV.us@LatAm">Comedy Central Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#60e5ea9a9bb4200008376f76" lang="es" xmltv_id="">Motorvision TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#61a52615cbef2500072876e2" lang="es" xmltv_id="">Acapulco Shore Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#61a52615cbef2500072876e2" lang="es" xmltv_id="AcapulcoShore.us@LatAm">Acapulco Shore Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#61b793ccf571b80007b7a610" lang="es" xmltv_id="">Adrenalina Pura TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#62b218fc511d4b00070ddc0c" lang="es" xmltv_id="">MTV Flow Latino</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#62c5d80dc6de440007e033eb" lang="es" xmltv_id="">Runtime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#62d08af527ce19000731eaa0" lang="es" xmltv_id="">La Familia del Barrio</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#62d0895ebe7a970008785244" lang="es" xmltv_id="">Daria</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#63a084934734f30007457b2c" lang="es" xmltv_id="">Smithsonian Channel Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#63a084934734f30007457b2c" lang="es" xmltv_id="SmithsonianChannelPlutoTV.us@LatAm">Smithsonian Channel Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#63c6e37e636b7e0007ccb635" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#63d2c140c111bc0008cb890b" lang="es" xmltv_id="">TeleFórmula</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#63dac1b78795f300086d5ca6" lang="es" xmltv_id="">TikTok Radio en Español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#63dd5d7a4e83e700088fbca8" lang="es" xmltv_id="">Las Tortugas Ninja</channel>
@@ -1820,9 +1845,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67a52c8397782f00081879aa" lang="es" xmltv_id="">Top Barça</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67a52cd4ec91870008a62164" lang="es" xmltv_id="">UFC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67d9b0ebc290c9499046e88f" lang="es" xmltv_id="">RCN Noticias</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#67e598e28b99330f75b4c629" lang="es" xmltv_id="">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67e5941f0812459cb682d9c6" lang="es" xmltv_id="">Relic Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#67e5987eef24f48ffca08fd7" lang="es" xmltv_id="">Doc Martin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67f95fa76b11614ab0caaef3" lang="es" xmltv_id="">Hechiceras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67f960680072d6b187a0682e" lang="es" xmltv_id="">Números</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#68a3a97fd8f7693ae3f8575f" lang="es" xmltv_id="">Los Pitufos</channel>
@@ -1831,13 +1854,21 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#68b88712e777774982269ce9" lang="es" xmltv_id="">Tastemade Viajes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#68ba0910e1d03fec7d5c084f" lang="es" xmltv_id="">Al Ritmo del Jaripeo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#68ffc086a530e036bc8f0305" lang="es" xmltv_id="">Mi Bella Genio</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69b32974814d27f4aed90fdd" lang="es" xmltv_id="">Madre</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69de4ad924a6d521f8b0a348" lang="es" xmltv_id="">RCN Más</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fca9dd14a5dfae8875a3be" lang="es" xmltv_id="">Survivor México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fca9f9b9c0f0d444f631ca" lang="es" xmltv_id="">Mr. Bean Animated</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fcaa71ea95ffff0987f555" lang="es" xmltv_id="">MasterChef Colombia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fcaa88e022927e1c94c533" lang="es" xmltv_id="">MasterChef Argentina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fcaaa1853a01a827bcd056" lang="es" xmltv_id="">I Shouldn&apos;t Be Alive</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#69fcdc73488e575cff213adc" lang="es" xmltv_id="">Hermanos a la Obra</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#604bdf4e6d0abc0007ba77ad" lang="es" xmltv_id="">Sin Tetas No Hay Paraíso</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#609ae5cd48d3200007b0a98e" lang="es" xmltv_id="">Comedy Central South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#619d5e6a093e7c0007489211" lang="es" xmltv_id="">Baby Shark TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#619d59b7cbef25000728221c" lang="es" xmltv_id="">Euronews Español</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#620fd9f4afb9a80007a9c6d5" lang="es" xmltv_id="">MTV Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#620ff0a01f9e8700076c6f9d" lang="es" xmltv_id="">Nickelodeon iCarly</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#624af40c004f8000079b784d" lang="es" xmltv_id="">Pluto TV Cine Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#624af40c004f8000079b784d" lang="es" xmltv_id="PlutoTVCineCrimen.us@LatAm">Pluto TV Cine Crimen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#626c2ed933a2890007e91422" lang="es" xmltv_id="">Death Note</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#631fb6be21b7440007b9f606" lang="es" xmltv_id="">Hechizada</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#645d1abbe1979c0008779d5a" lang="es" xmltv_id="">Archivos Extraterrestres</channel>
@@ -1847,9 +1878,9 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#646cce4d1593940008a33f09" lang="es" xmltv_id="">Azteca Internacional</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#652e91fd6208700008dcaf7b" lang="es" xmltv_id="">Canal 6 CdMX</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#652e922db4b047000825f975" lang="es" xmltv_id="">Milenio Televisión</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f62ff954b020008c91ec6" lang="es" xmltv_id="">Pluto TV Series de Crimen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="">Pluto TV Series de Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f636d954b020008c93299" lang="es" xmltv_id="">Pluto TV Series de Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f62ff954b020008c91ec6" lang="es" xmltv_id="PlutoTVSeriesdeCrimen.us@LatAm">Pluto TV Series de Crimen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f626d57fe4a00085c7c3e" lang="es" xmltv_id="PlutoTVSeriesdeComedia.us@LatAm">Pluto TV Series de Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#655f636d954b020008c93299" lang="es" xmltv_id="PlutoTVSeriesdeDrama.us@LatAm">Pluto TV Series de Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#656e2536fbc15b00084ae29d" lang="es" xmltv_id="">Mi Coche Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#656f37f257fe4a000884dfee" lang="es" xmltv_id="">Boruto: Naruto Next Generations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#662bf39756fc840008f25cb9" lang="es" xmltv_id="">Sony One Escape Perfecto</channel>
@@ -1858,38 +1889,38 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#678aa0b3680721c77c5035dd" lang="es" xmltv_id="">The Walking Dead by AMC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#680bdaf54d7cf165c705f91e" lang="es" xmltv_id="">Zona Investigación TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#681ba2729624e6275efe0044" lang="es" xmltv_id="">NatureTime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="">Pluto TV Novelas de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="PlutoTVNovelasdeOtrosContinentes.us@LatAm">Pluto TV Novelas de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#697c9bc2a7ce9d5a3d83504a" lang="es" xmltv_id="">Dr. G</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="">Pluto TV Amor y Mentiras</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#698a45156dc3c71eb1ba6599" lang="es" xmltv_id="PlutoTVAmoryMentiras.us@LatAm">Pluto TV Amor y Mentiras</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6047fabfce6e8e00070bcc9f" lang="es" xmltv_id="">MTV Biggest Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6095ad97351eb0000754c1e6" lang="es" xmltv_id="">Hells Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6109a9f5531b840007a4a187" lang="es" xmltv_id="">Cazador de Homicidas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6109ab25b84d6a0007504886" lang="es" xmltv_id="">Pluto TV Mi Obsesión Favorita</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6185a9a88b2ce30007de5128" lang="es" xmltv_id="">Pluto TV Dramas Coreanos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6109ab25b84d6a0007504886" lang="es" xmltv_id="PlutoTVMiObsesionFavorita.us@LatAm">Pluto TV Mi Obsesión Favorita</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6185a9a88b2ce30007de5128" lang="es" xmltv_id="PlutoTVDramasCoreanos.us@LatAm">Pluto TV Dramas Coreanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6320d2755e54db000783fd87" lang="es" xmltv_id="">Claro Sports Mexico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6320ddef274b1b0007b2ee88" lang="es" xmltv_id="">Revive Gran Hermano</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6419ab7c9189ce000865a469" lang="es" xmltv_id="">COPS</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="">Pluto TV Novelas de México</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6474a86917f5e100089a0c1c" lang="es" xmltv_id="">Pluto TV Novelas de Venezuela</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="">Pluto TV Series de Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6474a7958e3c0a0008b97cae" lang="es" xmltv_id="PlutoTVNovelasdeMexico.us@LatAm">Pluto TV Novelas de México</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6474a86917f5e100089a0c1c" lang="es" xmltv_id="PlutoTVNovelasdeVenezuela.us@LatAm">Pluto TV Novelas de Venezuela</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6479ff1c17f5e10008ad2797" lang="es" xmltv_id="PlutoTVSeriesdeAccion.us@LatAm">Pluto TV Series de Acción</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6495af324c014a000842e923" lang="es" xmltv_id="">Desafío Super Humanos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6647c02422494d000804b13a" lang="es" xmltv_id="">Sony One Shark Tank México</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6661d5424b10960008599fa3" lang="es" xmltv_id="">Pluto TV Dramas Coreanos Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6661d5424b10960008599fa3" lang="es" xmltv_id="PlutoTVDramasCoreanosTeen.us@LatAm">Pluto TV Dramas Coreanos Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6759ee82bd523200083b4f0f" lang="es" xmltv_id="">Avatar: La Leyenda de Aang</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6806d519fea7414f33f57016" lang="es" xmltv_id="">Pluto TV Cine Inspirador</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6806d570c178637410ae4962" lang="es" xmltv_id="">Pluto TV Series de Otros Continentes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6806d519fea7414f33f57016" lang="es" xmltv_id="PlutoTVCineInspirador.us@LatAm">Pluto TV Cine Inspirador</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#6806d570c178637410ae4962" lang="es" xmltv_id="PlutoTVSeriesdeOtrosContinentes.us@LatAm">Pluto TV Series de Otros Continentes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6824cda00101510f9eeaa011" lang="es" xmltv_id="">Nickelodeon Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6851b909954170e0128bc71d" lang="es" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6894fc3f66f164e402f4fd14" lang="es" xmltv_id="">Dulce by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#6894febddbd49c964f3b66c8" lang="es" xmltv_id="">Plato del Dia by elGourmet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#61099f2b40d0640007fc5aa2" lang="es" xmltv_id="">El Encantador de Perros</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#63211ba9cad976000794f988" lang="es" xmltv_id="">La Selección</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#64510d3ad3fdde00080951f2" lang="es" xmltv_id="">MTV Drag</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#65662f8a2c46f300088a84cc" lang="es" xmltv_id="">Pluto TV Series de Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#65662f8a2c46f300088a84cc" lang="es" xmltv_id="PlutoTVSeriesdeSciFi.us@LatAm">Pluto TV Series de Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#66997d18a1b69e00082ee85f" lang="es" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#67813f893886aa863497733d" lang="es" xmltv_id="">Red Bull TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/mx#609059dc63be6e0007b4eca6" lang="es" xmltv_id="">Pluto TV Cine Clásico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/mx#609059dc63be6e0007b4eca6" lang="es" xmltv_id="PlutoTVCineClasico.us@LatAm">Pluto TV Cine Clásico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#625461ef01f27a0007976ad1" lang="es" xmltv_id="">MTV Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#638693db857364000781b471" lang="es" xmltv_id="">MTV Con Mi Ex</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/mx#639751f81a36b400072b8f5a" lang="es" xmltv_id="">Vive Kanal D Drama</channel>
@@ -1927,29 +1958,28 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ab3c7778230000735cf41" lang="es" xmltv_id="MTVCatfishTVShow.us@Spain">MTV Catfish TV Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#5f98537a5a4341000733aefe" lang="es" xmltv_id="MTVEmbarazadaalos16.us@Spain">MTV Embarazada a los 16</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aadf373bed3000794d1d7" lang="es" xmltv_id="MTVOriginals.us@Spain">MTV Originals</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6130d8dc943001000708548d" lang="es" xmltv_id="MTVRealities.us@Spain">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6130d8dc943001000708548d" lang="es" xmltv_id="MTVRealities.us@Spain">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#611b87946b7f420007c22361" lang="es" xmltv_id="MTVTattooados.us@Spain">MTV Tattoo a dos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#604f81a49ef73300070e554f" lang="es" xmltv_id="MTVTeenMom.us@Spain">MTV Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#60dd6b1da79e4d0007309455" lang="es" xmltv_id="NatureTime.ca@ES">Nature Time</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aa9bcd8160700076d45d1" lang="es" xmltv_id="PlanetaJuniorTV.us@Spain">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#600ae6a78d801e0007117d21" lang="es" xmltv_id="PlutoTVAnimales.us@Spain">Pluto TV Animales</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#608035b8d8705f0007260287" lang="es" xmltv_id="PlutoTVAnime.us@Spain">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac2591dd8880007bb7d6d" lang="es" xmltv_id="PlutoTVCineAccion.us@Spain">Pluto TV Cine Acción</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#61373bb45168fe000773eecd" lang="es" xmltv_id="PlutoTVCineClasico.us@Spain">Pluto TV Cine Clásico</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8099c49f600076579b2" lang="es" xmltv_id="PlutoTVCineComedia.us@Spain">Pluto TV Cine Comedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac947dcd00d0007937c08" lang="es" xmltv_id="PlutoTVCineDrama.us@Spain">Pluto TV Cine Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac1f1b66c76000790ef27" lang="es" xmltv_id="PlutoTVCineEstelar.us@Spain">Pluto TV Cine Estelar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac9a2d3611d0007a844bb" lang="es" xmltv_id="PlutoTVCineRomantico.us@Spain">Pluto TV Cine Romántico</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1acdaa8ba90f0007d5e760" lang="es" xmltv_id="PlutoTVCocina.us@Spain">Pluto TV Cocina</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aab1d29b39600073e243f" lang="es" xmltv_id="PlutoTVKids.us@Spain">Pluto TV Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#6080345ebb49b90007ce0baf" lang="es" xmltv_id="PlutoTVMotor.us@Spain">Pluto TV Motor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#612ce5214bb5790007ad3016" lang="es" xmltv_id="PlutoTVParanormal.us@Spain">Pluto TV Paranormal</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#61b87bc867b03a0007864e0d" lang="es" xmltv_id="PlutoTVReality.us@Spain">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f6a38eaa5b68b0007a00e7a" lang="es" xmltv_id="PlutoTVSciFi.us@Spain">Pluto TV Sci-Fi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8f49205650007bc15f1" lang="es" xmltv_id="PlutoTVSeries.us@Spain">Pluto TV Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#60b4c06717da110007ee1af6" lang="es" xmltv_id="PlutoTVTelenovelas.us@Spain">Pluto TV Telenovelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8a87cd38d000745d7cf" lang="es" xmltv_id="PlutoTVThrillers.us@Spain">Pluto TV Thrillers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/es#609e7e423e9173000706a681" lang="es" xmltv_id="PlutoTVToonsClasico.us@Spain">Pluto TV Kids Classics</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aa9bcd8160700076d45d1" lang="es" xmltv_id="PlutoTVJunior.de@ES">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#600ae6a78d801e0007117d21" lang="es" xmltv_id="PlutoTVAnimales.de@ES">Pluto TV Animales</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#608035b8d8705f0007260287" lang="es" xmltv_id="PlutoTVAnime.de@ES">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac2591dd8880007bb7d6d" lang="es" xmltv_id="PlutoTVCineAccion.de@ES">Pluto TV Cine Acción</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#61373bb45168fe000773eecd" lang="es" xmltv_id="PlutoTVCineClasico.de@ES">Pluto TV Cine Clásico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8099c49f600076579b2" lang="es" xmltv_id="PlutoTVCineComedia.de@ES">Pluto TV Cine Comedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac947dcd00d0007937c08" lang="es" xmltv_id="PlutoTVCineDrama.de@ES">Pluto TV Cine Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac1f1b66c76000790ef27" lang="es" xmltv_id="PlutoTVCineEstelar.de@ES">Pluto TV Cine Estelar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac9a2d3611d0007a844bb" lang="es" xmltv_id="PlutoTVCineRomantico.de@ES">Pluto TV Cine Romántico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1acdaa8ba90f0007d5e760" lang="es" xmltv_id="PlutoTVCocina.de@ES">Pluto TV Cocina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1aab1d29b39600073e243f" lang="es" xmltv_id="PlutoTVKids.de@ES">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#6080345ebb49b90007ce0baf" lang="es" xmltv_id="PlutoTVMotor.de@ES">Pluto TV Motor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#612ce5214bb5790007ad3016" lang="es" xmltv_id="PlutoTVParanormal.de@ES">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f6a38eaa5b68b0007a00e7a" lang="es" xmltv_id="PlutoTVSciFi.de@ES">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8f49205650007bc15f1" lang="es" xmltv_id="PlutoTVSeries.de@ES">Pluto TV Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#60b4c06717da110007ee1af6" lang="es" xmltv_id="PlutoTVTelenovelas.de@ES">Pluto TV Telenovelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#5f1ac8a87cd38d000745d7cf" lang="es" xmltv_id="PlutoTVThrillers.de@ES">Pluto TV Thrillers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/es#609e7e423e9173000706a681" lang="es" xmltv_id="PlutoTVKidsClassics.de@ES">Pluto TV Kids Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#610c09219fc0430007a3fce6" lang="es" xmltv_id="Rugrats.us@Spain">Rugrats</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#5f28009b150b2500077766b8" lang="es" xmltv_id="Vayasemanita.us@Spain">Vaya semanita</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/es#604f8125c6669b00077f7699" lang="es" xmltv_id="Wipeout.us@Spain">Wipeout</channel>
@@ -1957,69 +1987,75 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb8a8b2619a000710605c" lang="fr" xmltv_id="">Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb66537867f0007146953" lang="fr" xmltv_id="">CATFISH TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ecfb9db6c180007a6d1b0" lang="fr" xmltv_id="">WPT</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6a1ecc3d7120a26f0dcf89e7" lang="fr" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60afaa535580be0007ac9ee4" lang="fr" xmltv_id="">Alerte à Malibu</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60afb203ec391c00070ea1bf" lang="fr" xmltv_id="">Génération Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60d35bcaf1ff4a00078af0a6" lang="fr" xmltv_id="">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60dc6937b450ad0007377e48" lang="fr" xmltv_id="">Charlotte aux Fraises</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#61fc0df14159c40007250432" lang="fr" xmltv_id="">Nature Time</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e2d000418d00070f7dbc" lang="fr" xmltv_id="">Ciné d&apos;Asie by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e2d000418d00070f7dbc" lang="fr" xmltv_id="CinedAsiebyPlutoTV.de@FR">Ciné d&apos;Asie by Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e4bc08f5ec000744f552" lang="fr" xmltv_id="">Alerte Cobra</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e8ad2a8e8000077b013d" lang="fr" xmltv_id="">Detective Conan</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e0522443200008c567d7" lang="fr" xmltv_id="">Pluto TV French Collection</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3e0522443200008c567d7" lang="fr" xmltv_id="PlutoTVFrenchCollection.de@FR">Pluto TV French Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3ece7b09fd6000783bfb9" lang="fr" xmltv_id="">Un gars, une fille</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#62f3f05505e621000783df2f" lang="fr" xmltv_id="">Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#63b578b524f0cf00072f2a52" lang="fr" xmltv_id="">Echappées Belles &amp;amp; Co</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#63b579961bdba100071214cb" lang="fr" xmltv_id="">C&apos;est pas sorcier</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#64bab8ba5dc1660008969b5a" lang="fr" xmltv_id="">Adjugé, vendu !</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#64c9260ac0222700089ee62b" lang="fr" xmltv_id="">Family Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#64c1093824ade50008bd117f" lang="fr" xmltv_id="">Top Gear</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#64d626ac9b414d000820e2fc" lang="fr" xmltv_id="">DAZN Ringside</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#65a69ef53af63d000825e0ee" lang="fr" xmltv_id="">Ciné Catastrophe by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#65cca3e2ec452d0008af3a65" lang="fr" xmltv_id="">Ciné Western by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#65a69ef53af63d000825e0ee" lang="fr" xmltv_id="CineCatastrophebyPlutoTV.de@FR">Ciné Catastrophe by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#65cca3e2ec452d0008af3a65" lang="fr" xmltv_id="CineWesternbyPlutoTV.de@FR">Ciné Western by Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#65ccd26060eb870008db95fc" lang="fr" xmltv_id="">JAG</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#65cce23bdc10a400080645ad" lang="fr" xmltv_id="">Les Routes du Paradis</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#65cce14060eb870008dbd003" lang="fr" xmltv_id="">Cheers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b227b446762a000846c208" lang="fr" xmltv_id="">Z Nation</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b228d4cd0d3100085d27b7" lang="fr" xmltv_id="">Les Anges</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b498bc14a2bb00086965bc" lang="fr" xmltv_id="">Pluto TV 2010&apos;s Classics</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b4990746762a00084c2f78" lang="fr" xmltv_id="">Pluto TV 90&apos;s Classics</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b498bc14a2bb00086965bc" lang="fr" xmltv_id="PlutoTV2010sClassics.de@FR">Pluto TV 2010&apos;s Classics</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66b4990746762a00084c2f78" lang="fr" xmltv_id="PlutoTV90sClassics.de@FR">Pluto TV 90&apos;s Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66c45b36a72e7b0008a2b291" lang="fr" xmltv_id="">CNN Headlines International</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66d71ff86b63480008cf15c5" lang="fr" xmltv_id="">Flashpoint</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66d722d31878f200081c2c64" lang="fr" xmltv_id="">Most Haunted</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66e1978babec540008ce41ac" lang="fr" xmltv_id="">Ciné Horreur by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66e1978babec540008ce41ac" lang="fr" xmltv_id="CineHorreurbyPlutoTV.de@FR">Ciné Horreur by Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55a9a747bfa0008521859" lang="fr" xmltv_id="">Blue Bloods</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55c3955567d0008ef9b68" lang="fr" xmltv_id="">Turbo</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55c55940963000810bb14" lang="fr" xmltv_id="">Les Reines du Shopping</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55cf2483d460008f68746" lang="fr" xmltv_id="">Zone Interdite</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55d0b5e4a6e0008c2b920" lang="fr" xmltv_id="">Enquêtes Criminelles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55d205e4a6e0008c2b92b" lang="fr" xmltv_id="">Incroyables Transformations</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#66f55d565e4a6e0008c2b9d2" lang="fr" xmltv_id="">Les Marseillais</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66fd35e44ca31f0008060b77" lang="fr" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#67b4b2d976a934282e92d71c" lang="fr" xmltv_id="">Pluto TV Comédies Cultes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#66fd35e44ca31f0008060b77" lang="fr" xmltv_id="PlutoTVSnooker900.de@FR">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#67b4b2d976a934282e92d71c" lang="fr" xmltv_id="PlutoTVComediesCultes.de@FR">Pluto TV Comédies Cultes</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#67b4b3c51a5ca760802cc1c7" lang="fr" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#67b4b4a21a5ca760802d25fd" lang="fr" xmltv_id="">Tout le monde déteste Chris</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#68b16d2282862c1f067dc763" lang="fr" xmltv_id="">Les Schtroumpfs</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#68b17414c23bb80b3c1d5bb5" lang="fr" xmltv_id="">Doraemon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#68d292d554c61bfff220a635" lang="fr" xmltv_id="">Flynn Carson et The Outpost</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#69aadc5551df9542f2521e1a" lang="fr" xmltv_id="">Dawson</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#69aadcdb6c0414a7ecb56ede" lang="fr" xmltv_id="">Pluto TV Anime Retro</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#69b3db536c0414a7ecf564fb" lang="fr" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#69c2ae0d1f1accd54916c825" lang="fr" xmltv_id="">Pluto TV Footanim&apos;</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#617bae1d69bca3000729561e" lang="fr" xmltv_id="">Digimon Adventure</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#625ec7a1c853fd00073b38fd" lang="fr" xmltv_id="">Pluto TV Séries Fantastiques</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#625ec7a1c853fd00073b38fd" lang="fr" xmltv_id="PlutoTVSeriesFantastiques.de@FR">Pluto TV Séries Fantastiques</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#639b54404cfdf7000729b3c1" lang="fr" xmltv_id="">INA 70</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#652d0b9ceb72580008a4ea5b" lang="fr" xmltv_id="">Qui veut gagner des millions?</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#652d0b756208700008d758ad" lang="fr" xmltv_id="">Les Z&apos;amours</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#654a58dbf9cc82000868f0fb" lang="fr" xmltv_id="">Pluto TV Kids Classics</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#654a58dbf9cc82000868f0fb" lang="fr" xmltv_id="PlutoTVKidsClassics.de@FR">Pluto TV Kids Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#660c2a2d2433010008df7e92" lang="fr" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#662a622b5e2370000800f392" lang="fr" xmltv_id="">Faites entrer l&apos;accusé</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#662a63275a402e00086bc8a5" lang="fr" xmltv_id="">Olive &amp;amp; Tom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#662a6309307fa30008196b4e" lang="fr" xmltv_id="">Plus Belle la Vie 2</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#664c8ba33d173b00080ef0c8" lang="fr" xmltv_id="">Beyblade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#678f894ef5c74bff95c20a7f" lang="fr" xmltv_id="">Pêche à haut risque</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#684bf01df7d8b74b625b7dd1" lang="fr" xmltv_id="">Pluto TV Brigade Criminelle</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#684bf01df7d8b74b625b7dd1" lang="fr" xmltv_id="PlutoTVBrigadeCriminelle.de@FR">Pluto TV Brigade Criminelle</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#685a999bd33909bdd7d2fb1e" lang="fr" xmltv_id="">La maison France 5</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#686e74b0e48af72bc266e798" lang="fr" xmltv_id="">Mattel Junior</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#686e74c777ed3360cb6908bf" lang="fr" xmltv_id="">Mayday: Catastrophe Aérienne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#686e7499e0ecf0e0cc25dbe3" lang="fr" xmltv_id="">Barbie &amp;amp; Friends</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#691b332aa4385c191ee44b57" lang="fr" xmltv_id="">Rex, chien flic</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#691b3669c48674840c3b832a" lang="fr" xmltv_id="PlutoTVANIMEGO.de@FR">Pluto TV ANIME GO!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#692ec6d82329c10c5166f436" lang="fr" xmltv_id="">Nina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#692ec71425eaa17b6daf2a11" lang="fr" xmltv_id="">PJ</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#697a34496f47f39d31ff8bde" lang="fr" xmltv_id="">Si près de chez vous</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6130d9c712c2b000070abb50" lang="fr" xmltv_id="">Yu-Gi-Oh!</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6231ec93779a9d00079ba8e2" lang="fr" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6245ccd0c6cdb800074632e4" lang="fr" xmltv_id="">MacGyver</channel>
@@ -2031,16 +2067,17 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6671b26836a2f90008d9333c" lang="fr" xmltv_id="">Diane, femme flic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6683b680efa2a10008e8a393" lang="fr" xmltv_id="">Daria</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#6683cd0f63a5f20008fb84a3" lang="fr" xmltv_id="">Un Si Grand Soleil</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6683cd2fca74680008772545" lang="fr" xmltv_id="">Investigation by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6683cd2fca74680008772545" lang="fr" xmltv_id="InvestigationbyPlutoTV.de@FR">Investigation by Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#63921a1bf76e7d0007c998a6" lang="fr" xmltv_id="">Enquêtes de Choc</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#63921a3d00c96100082a3cb4" lang="fr" xmltv_id="">Homicide</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#67921b78b83355184c667770" lang="fr" xmltv_id="">UFC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#652557d93fd33c000802f995" lang="fr" xmltv_id="">Pluto TV Super Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#652557d93fd33c000802f995" lang="fr" xmltv_id="PlutoTVSuperKids.de@FR">Pluto TV Super Kids</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#671643fc5534bb00089187ad" lang="fr" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#680291e38e1ff89c2427aefd" lang="fr" xmltv_id="">Voyages &amp;amp; Saveurs</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6092544e7639460007d4835e" lang="fr" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#682318568e6c0f2f6c6e0038" lang="fr" xmltv_id="">Pluto TV Dating</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6823648580b2665220d9e69a" lang="fr" xmltv_id="">Ciné 666 by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#699865ccac36b147e74619fe" lang="fr" xmltv_id="">Pluto TV Téléréalité France</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6092544e7639460007d4835e" lang="fr" xmltv_id="PlutoTVReality.de@FR">Pluto TV Pride</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#682318568e6c0f2f6c6e0038" lang="fr" xmltv_id="PlutoTVDating.de@FR">Pluto TV Dating</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#6823648580b2665220d9e69a" lang="fr" xmltv_id="Cine666byPlutoTV.de@FR">Ciné 666 by Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60d35a74c63c3c0008df6a90" lang="fr" xmltv_id="BBCDrama.uk@France">BBC Series</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5ffc8c345822750007e167de" lang="fr" xmltv_id="Bobleponge.us@France">Bob l&apos;éponge</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e71322f5f180007001dde" lang="fr" xmltv_id="Degrassi.us@France">Degrassi</channel>
@@ -2057,49 +2094,48 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8edb6df1ebb800072edf10" lang="fr" xmltv_id="LesNouveauxDetectives.us@France">Les Nouveaux Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed6d569d2d4000864a976" lang="fr" xmltv_id="LouisLaBrocante.us@France">Louis La Brocante</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f92b56a367e170007cd43f4" lang="fr" xmltv_id="MTVClassic.us@France">MTV CLASSICS</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed1ff5c39700007e2204a" lang="fr" xmltv_id="PlutoTVAction.us@France">Ciné Action by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60925a44f0350600075a1fdc" lang="fr" xmltv_id="PlutoTVAnimaux.us@France">Pluto TV Animaux</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed0f17564a300082b676a" lang="fr" xmltv_id="PlutoTVCine.us@France">Ciné by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed168f72fcd0007e56269" lang="fr" xmltv_id="PlutoTVCineRetro.us@France">Ciné Rétro by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb91bb9b9e7000817e67f" lang="fr" xmltv_id="PlutoTVComedie.us@France">Pluto TV Comédie</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed48146ba9e00078424b6" lang="fr" xmltv_id="PlutoTVCuisine.us@France">Pluto TV Cuisine</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e771e2f5f180007002224" lang="fr" xmltv_id="PlutoTVHistoire.us@France">Pluto TV Histoire</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed3892ed7bb000741a1d2" lang="fr" xmltv_id="PlutoTVInside.us@France">Pluto TV Inside</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f914f4b36d67d0007a91a04" lang="fr" xmltv_id="PlutoTVInvestigation.us@France">True Crime by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ecb336537e8000764a17f" lang="fr" xmltv_id="PlutoTVJunior.us@France">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eba14a4ffb8000764e950" lang="fr" xmltv_id="PlutoTVKidsAnimation.us@France">Pluto TV Toons</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e6ddc7fcd580007d1eb5f" lang="fr" xmltv_id="PlutoTVKidsGaming.us@France">Pluto TV Kids Club</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb99ff17815000784a3b0" lang="fr" xmltv_id="PlutoTVKidsSeries.us@France">Pluto TV Teen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed9461b35690007a0bc3a" lang="fr" xmltv_id="PlutoTVParanormal.us@France">Pluto TV Paranormal</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed4dbf6bb0800071ffbcb" lang="fr" xmltv_id="PlutoTVPolar.us@France">Pluto TV Polar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e6a9b4bb5790007a6f0f8" lang="fr" xmltv_id="PlutoTVRetroToons.us@France">Pluto TV Retro Toons</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60812fc8539963000707d1e1" lang="fr" xmltv_id="PlutoTVRomance.us@France">Ciné Romance by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60c34592c911890007f29a73" lang="fr" xmltv_id="PlutoTVSciFi.us@France">Ciné Sci-Fi by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed2d1c34c2300073bf02c" lang="fr" xmltv_id="PlutoTVSeries.us@France">Series by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60c3472a51a2050008dad272" lang="fr" xmltv_id="PlutoTVThrillers.us@France">Ciné Thrillers by Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e7811eb9daf000764cbfd" lang="fr" xmltv_id="PlutoTVVoyage.us@France">Pluto TV Aventure</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed1ff5c39700007e2204a" lang="fr" xmltv_id="CineActionbyPlutoTV.de@FR">Ciné Action by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60925a44f0350600075a1fdc" lang="fr" xmltv_id="PlutoTVAnimaux.de@FR">Pluto TV Animaux</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed0f17564a300082b676a" lang="fr" xmltv_id="CinebyPlutoTV.de@FR">Ciné by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed168f72fcd0007e56269" lang="fr" xmltv_id="CineRetrobyPlutoTV.de@FR">Ciné Rétro by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb91bb9b9e7000817e67f" lang="fr" xmltv_id="PlutoTVComedie.de@FR">Pluto TV Comédie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed48146ba9e00078424b6" lang="fr" xmltv_id="PlutoTVCuisine.de@FR">Pluto TV Cuisine</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e771e2f5f180007002224" lang="fr" xmltv_id="PlutoTVHistoire.de@FR">Pluto TV Histoire</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed3892ed7bb000741a1d2" lang="fr" xmltv_id="PlutoTVInside.de@FR">Pluto TV Inside</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f914f4b36d67d0007a91a04" lang="fr" xmltv_id="TrueCrimebyPlutoTV.de@FR">True Crime by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ecb336537e8000764a17f" lang="fr" xmltv_id="PlutoTVJunior.de@FR">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eba14a4ffb8000764e950" lang="fr" xmltv_id="PlutoTVToons.de@FR">Pluto TV Toons</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e6ddc7fcd580007d1eb5f" lang="fr" xmltv_id="PlutoTVKidsClub.de@FR">Pluto TV Kids Club</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8eb99ff17815000784a3b0" lang="fr" xmltv_id="PlutoTVTeen.de@FR">Pluto TV Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed9461b35690007a0bc3a" lang="fr" xmltv_id="PlutoTVParanormal.de@FR">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed4dbf6bb0800071ffbcb" lang="fr" xmltv_id="PlutoTVPolar.de@FR">Pluto TV Polar</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e6a9b4bb5790007a6f0f8" lang="fr" xmltv_id="PlutoTVRetroToons.de@FR">Pluto TV Retro Toons</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60812fc8539963000707d1e1" lang="fr" xmltv_id="CineRomancebyPlutoTV.de@FR">Ciné Romance by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60c34592c911890007f29a73" lang="fr" xmltv_id="CineSciFibyPlutoTV.de@FR">Ciné Sci-Fi by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ed2d1c34c2300073bf02c" lang="fr" xmltv_id="SeriesbyPlutoTV.de@FR">Series by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#60c3472a51a2050008dad272" lang="fr" xmltv_id="CineThrillersbyPlutoTV.de@FR">Ciné Thrillers by Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/fr#611e7811eb9daf000764cbfd" lang="fr" xmltv_id="PlutoTVAventure.de@FR">Pluto TV Aventure</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ece1a89d79800072510e6" lang="fr" xmltv_id="TheAsylum.us@France">The Asylum</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#5f8ecc1b37867f00071469e9" lang="fr" xmltv_id="TortuesNinjaTV.us@France">Tortues Ninja TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60afa749ac7f3200078adb40" lang="fr" xmltv_id="WalkerTexasRanger.us@France">Walker Texas Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#60b4d6c806ad2a00073b3108" lang="fr" xmltv_id="WildSideTV.fr@SD">Wild Side TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/fr#612e044c970e6f00083bcf3b" lang="fr" xmltv_id="Yaquelaveritequicompte.us@France">Y&apos;a que la vérité qui compte</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#61b86ea479a4390007c6d5fc" lang="it" xmltv_id="">Euronews</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#61c09e3ac210ed0007606620" lang="it" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#61c09e3ac210ed0007606620" lang="it" xmltv_id="PlutoTVHorror.de@IT">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#61fbd3f0733df400076c9a2d" lang="it" xmltv_id="">Il Testimone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62bc1f502b70e3000706298e" lang="it" xmltv_id="">South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62e7fa5ab5062e0007dcf97d" lang="it" xmltv_id="">BBC Series</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#62e7fb67478a5b0007e6c50c" lang="it" xmltv_id="">Pluto TV Western</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#62e7fb67478a5b0007e6c50c" lang="it" xmltv_id="PlutoTVWestern.de@IT">Pluto TV Western</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62e7fc8c0d061100083946a9" lang="it" xmltv_id="">Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62e8d5369e48940007fc1dc1" lang="it" xmltv_id="">The Asylum</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#63c923944207be0007fd0887" lang="it" xmltv_id="">Pluto TV Viaggi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#63c923944207be0007fd0887" lang="it" xmltv_id="PlutoTVViaggi.de@IT">Pluto TV Viaggi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#63eb57d6c111bc0008fe2658" lang="it" xmltv_id="">Sanctuary</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#63eb82e24e83e70008ab735f" lang="it" xmltv_id="">Yu-Gi-Oh!</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#63eb573ba99571000897135b" lang="it" xmltv_id="">Pluto TV Teen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#63eb573ba99571000897135b" lang="it" xmltv_id="PlutoTVTeen.de@IT">Pluto TV Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#64c109a4798def0008a6e03e" lang="it" xmltv_id="">Top Gear</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#64ec5c6644fe100009d114ae" lang="it" xmltv_id="">Affare Fatto</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#64ec5cf50f73a800081310a5" lang="it" xmltv_id="">Forensic Files</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#64fee60130ab3300084d9157" lang="it" xmltv_id="">The Musketeers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#65b90daed77d450008a43345" lang="it" xmltv_id="">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#65b90daed77d450008a43345" lang="it" xmltv_id="PlutoTVAnime.de@IT">Pluto TV Anime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#65cb73d33ba51e00084cabad" lang="it" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#65cb76ea11ced70008206b66" lang="it" xmltv_id="">Dynasty</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#65cb78b83a116800079e2e35" lang="it" xmltv_id="">Cin Cin</channel>
@@ -2113,44 +2149,53 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66a8c64814a2bb00084d09d6" lang="it" xmltv_id="">Gormiti</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66c35c0c92b1af0008c8e83a" lang="it" xmltv_id="">Horror Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66c45ba803e3b20008d8c294" lang="it" xmltv_id="">CNN Headlines International</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#66c70033b1a34600087bb09a" lang="it" xmltv_id="">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#66c70033b1a34600087bb09a" lang="it" xmltv_id="PlutoTVParanormal.de@IT">Pluto TV Paranormal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66d9a98961dbf00008efb5fc" lang="it" xmltv_id="">Sulle tracce del crimine</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66d9aa4315d2c60008d4ac40" lang="it" xmltv_id="">Alice Nevers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#66d9ab4bf0f17500084e9b7e" lang="it" xmltv_id="">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#66d9ab4bf0f17500084e9b7e" lang="it" xmltv_id="PlutoTVTrueCrime.de@IT">Pluto TV True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66d7120815d2c60008cec006" lang="it" xmltv_id="">Flashpoint</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#67c832cc9b53325ee16fb899" lang="it" xmltv_id="">Wicked Tuna</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#67d9836ba1609bdb523f0c9d" lang="it" xmltv_id="">Relic Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#67e3b0d2443f0671bc8a1297" lang="it" xmltv_id="">Pluto TV Shore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#67ed14aaf7c5d70b9089c3bf" lang="it" xmltv_id="">Pluto TV Serie Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#67e3b0d2443f0671bc8a1297" lang="it" xmltv_id="PlutoTVShore.de@IT">Pluto TV Shore</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#67ed14aaf7c5d70b9089c3bf" lang="it" xmltv_id="PlutoTVSerieSciFi.de@IT">Pluto TV Serie Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#67f4f99729b03f18cb36647e" lang="it" xmltv_id="">Super! Kids Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#68adb5853efb41cd97ce413d" lang="it" xmltv_id="">I Puffi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69affcad8940750a23a7231a" lang="it" xmltv_id="">One Piece</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69b1489b5828e7c242d83064" lang="it" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69ef53e12f4d2b4f9c582e76" lang="it" xmltv_id="">That&apos;s 70s</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69ef54f3c700cf0140272def" lang="it" xmltv_id="">That&apos;s 80s</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69ef55c3b80e144b55d74e36" lang="it" xmltv_id="">That&apos;s 90s/00s</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69ef5682980899a9edf1a884" lang="it" xmltv_id="">That&apos;s Rock</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#610a9ebe8c2ac2000734776e" lang="it" xmltv_id="">Naturescape</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#612e05b885183d0007958101" lang="it" xmltv_id="">Pluto TV Christmas tutto l&apos;anno</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#612e05b885183d0007958101" lang="it" xmltv_id="PlutoTVChristmastuttolanno.de@IT">Pluto TV Christmas tutto l&apos;anno</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#625e6cc905e09f00073addee" lang="it" xmltv_id="">Squadra Speciale Cobra 11</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#638f286445264d00084ec6dc" lang="it" xmltv_id="">Autostop per il cielo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#660bfc4424e1d000085b5f93" lang="it" xmltv_id="">FIFA+</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#661f8f01801af800083d9d81" lang="it" xmltv_id="">Pluto TV Alberto Sordi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#661f8f01801af800083d9d81" lang="it" xmltv_id="PlutoTVAlbertoSordi.de@IT">Pluto TV Alberto Sordi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#664f0ddbf78a8500092dcffa" lang="it" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#686cfdf894a028da3aac4252" lang="it" xmltv_id="">Barbie &amp;amp; Friends</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#686cfe983ffa5e0c91cdb5df" lang="it" xmltv_id="">Mattel Junior</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#690cb9140d121b44ad925ac9" lang="it" xmltv_id="">Mayday: Disastro Aereo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#691c5b2e74baa89ef7230baf" lang="it" xmltv_id="">Nina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#691c5bef3a369d8f40192e71" lang="it" xmltv_id="">Inter 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#696e0fe49ba4ac18057433ac" lang="it" xmltv_id="">Rally TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#699d87093d5dba980705cca8" lang="it" xmltv_id="PlutoTVFilmAncoraPiuRomantici.de@IT">Pluto TV Film Ancora Più Romantici</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6093f9ed2c75660007322bb7" lang="it" xmltv_id="">Catfish</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6231ec4b62cd1f0007093c7b" lang="it" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6245d3792792150007e20634" lang="it" xmltv_id="">Settimo Cielo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6602acadb2abe500081cf28a" lang="it" xmltv_id="">I soliti idioti</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6616a51124e1d00008761a7e" lang="it" xmltv_id="">Triton Poker</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c8dd8caba6f046c5c5d5" lang="it" xmltv_id="">Pluto TV Notti di Terrore</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c9b88caba6f046c5ca8f" lang="it" xmltv_id="">Pluto TV Notti di Crimine</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c92b4316999535eb1e08" lang="it" xmltv_id="">Pluto TV Notti di Sangue</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c9704316999535eb21cf" lang="it" xmltv_id="">Pluto TV Notti di Passione</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c8dd8caba6f046c5c5d5" lang="it" xmltv_id="PlutoTVNottidiTerrore.de@IT">Pluto TV Notti di Terrore</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c92b4316999535eb1e08" lang="it" xmltv_id="PlutoTVNottidiSangue.de@IT">Pluto TV Notti di Sangue</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6911c9704316999535eb21cf" lang="it" xmltv_id="PlutoTVNottidiPassione.de@IT">Pluto TV Notti di Passione</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6971fc6dca441014e4600f2c" lang="it" xmltv_id="">Automoto</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6971fc07c945e6e4e5bc46bf" lang="it" xmltv_id="">Gambero Rosso</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6971fc932c004063166ac8fd" lang="it" xmltv_id="">Il Sole24Ore TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62442f28afe626000747f195" lang="it" xmltv_id="">I Jefferson</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#64808a8c536e0c0008a276d1" lang="it" xmltv_id="">Pluto TV Legami Letali</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#65253f9881f942000833ccd5" lang="it" xmltv_id="">Pluto TV Totò</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#65253fdf3fd33c00080214a3" lang="it" xmltv_id="">Pluto TV Storia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#64808a8c536e0c0008a276d1" lang="it" xmltv_id="PlutoTVLegamiLetali.de@IT">Pluto TV Legami Letali</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#65253f9881f942000833ccd5" lang="it" xmltv_id="PlutoTVToto.de@IT">Pluto TV Totò</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#65253fdf3fd33c00080214a3" lang="it" xmltv_id="PlutoTVStoria.de@IT">Pluto TV Storia</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#66177d18c8311c0008d077d0" lang="it" xmltv_id="">Storie Criminali</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#69148c76e9dec35c9269a16c" lang="it" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#69148c76e9dec35c9269a16c" lang="it" xmltv_id="PlutoTVSnooker900.de@IT">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#69664afedcbf5c784492e422" lang="it" xmltv_id="">The Intern</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#634926e4b51d2d00077819a2" lang="it" xmltv_id="">Renegade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#653660b4295b840008a70ba3" lang="it" xmltv_id="">CineThriller</channel>
@@ -2158,14 +2203,16 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/it#671754d8e482950008962aaf" lang="it" xmltv_id="">Cinema Poliziottesco</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#679203d4bc03978b9b4b79a6" lang="it" xmltv_id="">UFC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6349279ed5023700078f2bc2" lang="it" xmltv_id="">Mai dire sì</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6500457d3efb510008315e59" lang="it" xmltv_id="">New Tricks</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6536608b4f123d000876b78b" lang="it" xmltv_id="">Gli Immortali | Van Damme vs Lundgren</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6786235bd648bf0008c2780a" lang="it" xmltv_id="">Pluto TV Cinema Orientale</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#6875080e3484d607323641f8" lang="it" xmltv_id="">Pluto TV Dive Italiane</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6786235bd648bf0008c2780a" lang="it" xmltv_id="PlutoTVCinemaOrientale.de@IT">Pluto TV Cinema Orientale</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6875080e3484d607323641f8" lang="it" xmltv_id="PlutoTVDiveItaliane.de@IT">Pluto TV Dive Italiane</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#6994800c470389f33df8e090" lang="it" xmltv_id="PlutoTVAzioneCult.de@IT">Pluto TV Azione Cult</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#62619405c733e8000732d1fe" lang="it" xmltv_id="">Teenage Mutant Ninja Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#612375086abc84000738fc03" lang="it" xmltv_id="">Inazuma Eleven</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6661739641af6400080cd8f1" lang="it" xmltv_id="">Extreme Makeover Home Edition</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#66335489307fa300082bd6e4" lang="it" xmltv_id="">Pluto TV Eros</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#68750875759366af05a151ce" lang="it" xmltv_id="">Pluto TV Film Storici</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#66335489307fa300082bd6e4" lang="it" xmltv_id="PlutoTVEros.de@IT">Pluto TV Eros</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#68750875759366af05a151ce" lang="it" xmltv_id="PlutoTVFilmStorici.de@IT">Pluto TV Film Storici</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#60940a07d88ba90007b9cb71" lang="it" xmltv_id="16AnnieIncinta.us@Italy">16 Anni e Incinta</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#60802d37ee238e0007c94e64" lang="it" xmltv_id="Andromeda.us@Italy">Andromeda</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#608014d19a26320007c92ab6" lang="it" xmltv_id="FailArmy.us@Italy">FailArmy</channel>
@@ -2173,21 +2220,21 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/it#60e4507a06171800072339a3" lang="it" xmltv_id="IlBancodeiPugni.us@Italy">Il Banco dei Pugni</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6093f48c95132a00075fd859" lang="it" xmltv_id="JustforLaughs.us@Italy">Just for Laughs GAGS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#60a2837f8154ab0007c4dcdf" lang="it" xmltv_id="LesorelleMcLeod.us@Italy">Le sorelle McLeod</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa7d8359b270007861489" lang="it" xmltv_id="PlutoTVCinemaItaliano.us@Italy">Pluto TV Cinema Italiano</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa777b907770007e5d05d" lang="it" xmltv_id="PlutoTVCrime.us@Italy">Pluto TV Serie Crime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa718a8ec810007d87fee" lang="it" xmltv_id="PlutoTVCucina.us@Italy">Pluto TV Cucina</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa8a5709d6b0007b132fe" lang="it" xmltv_id="PlutoTVDocumentari.us@Italy">Pluto TV Documentari</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa17fb9f4490007e6419a" lang="it" xmltv_id="PlutoTVFilm.us@Italy">Pluto TV Film</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa20a2e7f270007c4878d" lang="it" xmltv_id="PlutoTVFilmAzione.us@Italy">Pluto TV Film Azione</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa512d67fd900072323db" lang="it" xmltv_id="PlutoTVFilmCommedia.us@Italy">Pluto TV Film Commedia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa4a4cc92820007b663af" lang="it" xmltv_id="PlutoTVFilmRomantici.us@Italy">Pluto TV Film Romantici</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa5e995132a00075f7005" lang="it" xmltv_id="PlutoTVFilmThriller.us@Italy">Pluto TV Film Thriller</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#60802b37709d6b0007b0c549" lang="it" xmltv_id="PlutoTVNatura.us@Italy">Pluto TV Natura</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#60801976f92a750007a0699c" lang="it" xmltv_id="PlutoTVRealLife.us@Italy">Pluto TV Real Life</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#61728bb9ee3773000840c1fa" lang="it" xmltv_id="PlutoTVSciFi.us@Italy">Pluto TV Sci-Fi</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#60b9ff2722bfa400072676ef" lang="it" xmltv_id="PlutoTVSerie.us@Italy">Pluto TV Serie</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#608030eff4b6f70007e1684c" lang="it" xmltv_id="PlutoTVSport.us@Italy">Pluto TV Sport</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/it#609404b0a8ec810007d8de9d" lang="it" xmltv_id="Scherzierisate.us@Italy">Pluto TV Scherzi e risate</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa7d8359b270007861489" lang="it" xmltv_id="PlutoTVCinemaItaliano.de@IT">Pluto TV Cinema Italiano</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa777b907770007e5d05d" lang="it" xmltv_id="PlutoTVSerieCrime.de@IT">Pluto TV Serie Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa718a8ec810007d87fee" lang="it" xmltv_id="PlutoTVCucina.de@IT">Pluto TV Cucina</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa8a5709d6b0007b132fe" lang="it" xmltv_id="PlutoTVDocumentari.de@IT">Pluto TV Documentari</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa17fb9f4490007e6419a" lang="it" xmltv_id="PlutoTVFilm.de@IT">Pluto TV Film</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa20a2e7f270007c4878d" lang="it" xmltv_id="PlutoTVFilmAzione.de@IT">Pluto TV Film Azione</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa512d67fd900072323db" lang="it" xmltv_id="PlutoTVFilmCommedia.de@IT">Pluto TV Film Commedia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa4a4cc92820007b663af" lang="it" xmltv_id="PlutoTVFilmRomantici.de@IT">Pluto TV Film Romantici</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608aa5e995132a00075f7005" lang="it" xmltv_id="PlutoTVFilmThriller.de@IT">Pluto TV Film Thriller</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#60802b37709d6b0007b0c549" lang="it" xmltv_id="PlutoTVNatura.de@IT">Pluto TV Natura</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#60801976f92a750007a0699c" lang="it" xmltv_id="PlutoTVRealLife.de@IT">Pluto TV Real Life</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#61728bb9ee3773000840c1fa" lang="it" xmltv_id="PlutoTVSciFi.de@IT">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#60b9ff2722bfa400072676ef" lang="it" xmltv_id="PlutoTVSerie.de@IT">Pluto TV Serie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#608030eff4b6f70007e1684c" lang="it" xmltv_id="PlutoTVSport.de@IT">Pluto TV Sport</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/it#609404b0a8ec810007d8de9d" lang="it" xmltv_id="PlutoTVScherzierisate.de@IT">Pluto TV Scherzi e risate</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#609401db8cf51c00084b592e" lang="it" xmltv_id="SuperiCarly.us@Italy">Super! iCarly</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6093f7b5bb49b90007cecaad" lang="it" xmltv_id="SuperPop.us@Italy">Super! Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/it#6093f9281db477000759fce0" lang="it" xmltv_id="SuperSpongeBob.us@Italy">Super! SpongeBob</channel>
@@ -2197,7 +2244,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d9b31a9c310008f8ee57" lang="no" xmltv_id="">iCarly</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d56f28e94c0007827bdb" lang="no" xmltv_id="">The Hills</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d59a244e500007581861" lang="no" xmltv_id="">SvampeBob Firkant</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d459fbb4b50007d24647" lang="no" xmltv_id="">Pluto TV Juniorklubben</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d459fbb4b50007d24647" lang="no" xmltv_id="PlutoTVJuniorklubben.se@NO">Pluto TV Juniorklubben</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1d66518447e000717e4c2" lang="no" xmltv_id="">Ex On The Beach</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1da718a80a4000704013e" lang="no" xmltv_id="">Totally Turtles</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1db8ed6d97900076ea15c" lang="no" xmltv_id="">Are You The One?</channel>
@@ -2209,18 +2256,18 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1df62b7672a0007b6c9ba" lang="no" xmltv_id="">MTV Teen Mom</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e0f1d6d97900076ea16f" lang="no" xmltv_id="">Luksusfellen Sverige</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e1c445b45d0007aad03e" lang="no" xmltv_id="">Unga Mammor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e1e55deef000075aed0c" lang="no" xmltv_id="">Pluto TV Film</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e3a679a4390007c78136" lang="no" xmltv_id="">Pluto TV Komedie</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e1e55deef000075aed0c" lang="no" xmltv_id="PlutoTVFilm.se@NO">Pluto TV Film</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e3a679a4390007c78136" lang="no" xmltv_id="PlutoTVKomedie.se@NO">Pluto TV Komedie</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e88cd168ea0007068133" lang="no" xmltv_id="">South Park</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e914bf8c520007a93ff1" lang="no" xmltv_id="">Pluto TV Tegnefilm</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e51354d923000731bf78" lang="no" xmltv_id="">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e914bf8c520007a93ff1" lang="no" xmltv_id="PlutoTVTegnefilm.se@NO">Pluto TV Tegnefilm</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e51354d923000731bf78" lang="no" xmltv_id="PlutoTVTrueCrime.se@NO">Pluto TV True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e060197fe600073c1ffb" lang="no" xmltv_id="">Luksusfellen</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e74354d923000731bf7c" lang="no" xmltv_id="">Pluto TV Overnaturlig</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e270489a9c000874d209" lang="no" xmltv_id="">Pluto TV Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e74354d923000731bf7c" lang="no" xmltv_id="PlutoTVOvernaturlig.se@NO">Pluto TV Overnaturlig</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61c1e270489a9c000874d209" lang="no" xmltv_id="PlutoTVAction.se@NO">Pluto TV Action</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61dd5bf8db0b8e00080804ff" lang="no" xmltv_id="">BET</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61de8d4b8acf6c0007f1c2f3" lang="no" xmltv_id="">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61de8e502c8e9400077e5de7" lang="no" xmltv_id="">Euronews</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#61f957e051cca800076f2358" lang="no" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#61f957e051cca800076f2358" lang="no" xmltv_id="PlutoTVSciFi.se@NO">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62a0ada2f1bdc5000738e020" lang="no" xmltv_id="">Melrose Place</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62a0ae8b2241f500073e0925" lang="no" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62beb7d7fbf54600076abc7b" lang="no" xmltv_id="">Wildfire</channel>
@@ -2231,19 +2278,17 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62da7159ca8f220008032730" lang="no" xmltv_id="">Auction Hunters</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62e7ba25be69bc0007b77fdc" lang="no" xmltv_id="">Jakt är Jakt</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63a1c959d9dd51000825d659" lang="no" xmltv_id="">Scorpion</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#63a19bb5e6914b000721b5c0" lang="no" xmltv_id="">Pluto TV Romantikk</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#63a19cb7847a090007f230d7" lang="no" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#63a19bb5e6914b000721b5c0" lang="no" xmltv_id="PlutoTVRomantikk.se@NO">Pluto TV Romantikk</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#63a19cb7847a090007f230d7" lang="no" xmltv_id="PlutoTVHorror.se@NO">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63c6a1c46d126a000760b91c" lang="no" xmltv_id="">Boligkjøp i blinde</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63c95451d3485c0007734f55" lang="no" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#63dbe80f60bc8f0008aa7c78" lang="no" xmltv_id="">Pluto TV Kultfilmer</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#63dbe80f60bc8f0008aa7c78" lang="no" xmltv_id="PlutoTVKultfilmer.se@NO">Pluto TV Kultfilmer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63dbe78051f5d000083e9249" lang="no" xmltv_id="">Numb3rs</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63e389dcc111bc0008ee5b8c" lang="no" xmltv_id="">Cheers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#64e77016324d190008291c13" lang="no" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#64eca23c9c1e390008524ae6" lang="no" xmltv_id="">Nordisk krim fra Viaplay</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65a93b870c7ff50008d1ca47" lang="no" xmltv_id="">Car Chase</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#65b3d7c80cb1a10008822e85" lang="no" xmltv_id="">From South Park with Love</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#65b8f87ac798e800085a123f" lang="no" xmltv_id="">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#65b916ec3af63d00084c5841" lang="no" xmltv_id="">Pluto TV Bud &amp;amp; Terence</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#65b916ec3af63d00084c5841" lang="no" xmltv_id="PlutoTVBudTerence.se@NO">Pluto TV Bud &amp;amp; Terence</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65ba4db63ef47d000837b535" lang="no" xmltv_id="">McLeods døtre &amp;amp; Grantchester</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65c340383a116800078c8454" lang="no" xmltv_id="">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65c0973311ced7000808d255" lang="no" xmltv_id="">The Daily Show</channel>
@@ -2256,7 +2301,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65d87fcb66eec8000887f4aa" lang="no" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65d7243c4e017400089e14a8" lang="no" xmltv_id="">Come Dine with Me</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65d88004ec9fda0008a5b8b3" lang="no" xmltv_id="">South Park: Kyle Collection</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#65e9b676332fec00085b300e" lang="no" xmltv_id="">Glory Kickboxing</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65e977a618036500082ec972" lang="no" xmltv_id="">Chappelle&apos;s Show</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65e977c48b24c8000805b9ef" lang="no" xmltv_id="">Tosh.0</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65e977874e01740008c9fb4c" lang="no" xmltv_id="">Reno 911</channel>
@@ -2265,22 +2309,27 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#66bb374ba4ee27000841a62c" lang="no" xmltv_id="">Pixel.tv</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#66c86fff9ba9e800080d8ebe" lang="no" xmltv_id="">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#66d71485167a8b0008fd3345" lang="no" xmltv_id="">Escape to the Country</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#66fcee104ca31f00080492e0" lang="no" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#67a09e25c070cf00083c40fa" lang="no" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#67a23b899a300a00086f3371" lang="no" xmltv_id="">Dominance FC TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#67f3fb7d07d2ba4121bd0c8b" lang="no" xmltv_id="">Pluto TV Ungdomsserier</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#67f508f68ddd60c57dc44766" lang="no" xmltv_id="">Pluto TV Klassiske tegnefilmer</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#68ac52b05190a45dc990ee39" lang="no" xmltv_id="">Pluto TV Motor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#68ac55fe3efb41cd979a6877" lang="no" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#67f3fb7d07d2ba4121bd0c8b" lang="no" xmltv_id="PlutoTVUngdomsserier.se@NO">Pluto TV Ungdomsserier</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#67f508f68ddd60c57dc44766" lang="no" xmltv_id="PlutoTVKlassisketegnefilmer.se@NO">Pluto TV Klassiske tegnefilmer</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68ac52b05190a45dc990ee39" lang="no" xmltv_id="PlutoTVMotor.se@NO">Pluto TV Motor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68ac55fe3efb41cd979a6877" lang="no" xmltv_id="PlutoTVSnooker900.se@NO">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68adb0a9f84960586ad4a334" lang="no" xmltv_id="">Smurfene</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#68c01b9a6bdcf3b9a64febcc" lang="no" xmltv_id="">Pluto TV Harlequin</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68c01b9a6bdcf3b9a64febcc" lang="no" xmltv_id="PlutoTVHarlequin.se@NO">Pluto TV Harlequin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68c014ee337652ee75dab43b" lang="no" xmltv_id="">Highway to Heaven</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#68c01785b3900870ec7480e4" lang="no" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68c01785b3900870ec7480e4" lang="no" xmltv_id="PlutoTVWildWest.se@NO">Pluto TV Wild West</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68d66a69508ba507f075c185" lang="no" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68dfa1a7fae18f8db6218222" lang="no" xmltv_id="">Ridiculousness - Nye episoder</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68f0f602a362b63a8df4efb4" lang="no" xmltv_id="">Medium</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68f0f7571d26140175255e43" lang="no" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#68f0fad2fae18f8db62a9f37" lang="no" xmltv_id="">Dynastiet</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#69a162eb762ae48b4302fb7c" lang="no" xmltv_id="">Retake E-sport Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#69afeca6ac36b147e7ef33a7" lang="no" xmltv_id="">The 4400</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#69afef233bd16a4ed07108e9" lang="no" xmltv_id="">The Millers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#69b16df6ed2a2444365e7ff1" lang="no" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#69c2946724a6d521f82a8595" lang="no" xmltv_id="">CNN Headlines International</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#69d7a0d0f57dc59a5f928fb2" lang="no" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#619e259fd8b672000729b1d7" lang="no" xmltv_id="">Ghost Dimension</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#619e279d45b45d0007a8d839" lang="no" xmltv_id="">Nosey</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#619e286e093e7c0007489e6a" lang="no" xmltv_id="">Homicide Hunter</channel>
@@ -2293,12 +2342,11 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#654a4fe9056b9700088804a0" lang="no" xmltv_id="">Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#654a59d483595c0008187514" lang="no" xmltv_id="">MacGyver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#654a508d986ad20008a456a5" lang="no" xmltv_id="">Happy Days</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#655ca99dfbc15b00081f209c" lang="no" xmltv_id="">Pluto TV John Wayne</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#655ca99dfbc15b00081f209c" lang="no" xmltv_id="PlutoTVJohnWayne.se@NO">Pluto TV John Wayne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#655ca968c917a5000830f8f5" lang="no" xmltv_id="">Hot Ones</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660bfca524e1d000085b6007" lang="no" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660bff5724e1d000085b7c07" lang="no" xmltv_id="">South Park Armageddon</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660d6b00635c75000828aa27" lang="no" xmltv_id="">Jade Fever</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#660d64a7aec9680008f8ba77" lang="no" xmltv_id="">Top Gear Classics</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660d67c419ca71000849a4e9" lang="no" xmltv_id="">Bondi Rescue</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660d71e2aec9680008f8f18a" lang="no" xmltv_id="">Realmadrid TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#660e746024e1d00008610ea1" lang="no" xmltv_id="">AWSN</channel>
@@ -2306,19 +2354,24 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#664f0ecc41af640008e37b43" lang="no" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#664f1370f78a8500092df452" lang="no" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#668bf91208d5490008065ffd" lang="no" xmltv_id="">Diagnosis Murder</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#668e60013a4ad20008c878f4" lang="no" xmltv_id="">Triton Poker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#671b4e47daad7f000868b840" lang="no" xmltv_id="">Horse &amp;amp; Country</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#672e1634e482950008c759a5" lang="no" xmltv_id="">Becker</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#677d3a424bd63600082f7baf" lang="no" xmltv_id="">Pluto TV Verdenskrigene</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#677d3a424bd63600082f7baf" lang="no" xmltv_id="PlutoTVVerdenskrigene.se@NO">Pluto TV Verdenskrigene</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#682b3932faaa60cd7dbf87b4" lang="no" xmltv_id="">Iron Chef</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#691ed76a9c828fb484f7c2e5" lang="no" xmltv_id="">Inter 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#692edcff77f0147d69f19498" lang="no" xmltv_id="">Dating Naked UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#693addd62bf6cf7414c4b2fc" lang="no" xmltv_id="">Star Trek: The Original Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#693ae4b616c2bba998852c21" lang="no" xmltv_id="">The L Word</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#693ae58fc2d0f38be38df821" lang="no" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#693ae65fab5959c036fa6c1e" lang="no" xmltv_id="">House of Lies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#693ae3624258f18a3e117b8b" lang="no" xmltv_id="">Teen Wolf</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#697b5a6c9567bf7b5f71a350" lang="no" xmltv_id="">Everybody Hates Chris</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#698dde17c7f3f49e64e3414a" lang="no" xmltv_id="">Flipper: The New Adventures</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#699c1bd39a3f3bb4887e045e" lang="no" xmltv_id="">Farscape</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#699c162a684d0f308795258f" lang="no" xmltv_id="">21 Jump Street</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#699c192688133556bd253602" lang="no" xmltv_id="">Renegade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6231e909bc960f00075d8e7c" lang="no" xmltv_id="">CBS News 24/7</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#6357f33cb51d2d00077927c6" lang="no" xmltv_id="">Pluto TV Sport</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#6357f33cb51d2d00077927c6" lang="no" xmltv_id="PlutoTVSport.se@NO">Pluto TV Sport</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6380c428dd0f47000799907c" lang="no" xmltv_id="">Judge Judy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6400bdb1219c4c00081751aa" lang="no" xmltv_id="">COPS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6400c228498393000878a9b7" lang="no" xmltv_id="">Star Trek Movies</channel>
@@ -2326,7 +2379,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6464cd7c7cb4b100086c71c9" lang="no" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6486e8328e3c0a0008e5686c" lang="no" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6501ad3a98020f0008503dba" lang="no" xmltv_id="">Hundehviskeren</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#6501c7ea9201e80008bb17b9" lang="no" xmltv_id="">South Park Halloween</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6512d3a0bdcb19000799cc82" lang="no" xmltv_id="">The Twilight Zone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6512d3c96a84140008513ff5" lang="no" xmltv_id="">Sabrina the Teenage Witch</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6512d36ca765070008836eac" lang="no" xmltv_id="">Beauty and the Beast</channel>
@@ -2346,7 +2398,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61814ff322e67b00074a5c43" lang="no" xmltv_id="">Project Runway</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62022f7b9fcc3800076f8c26" lang="no" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#62724ae034f5190007b63424" lang="no" xmltv_id="">Doc Martin</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#62792d003b8ddc000714f43a" lang="no" xmltv_id="">Bellator MMA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#63047bd6b0726b000795341d" lang="no" xmltv_id="">Merry Christmas from Viafree</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#64424a1d5a0cd500083ed27c" lang="no" xmltv_id="">Geordie Shore</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#64424b21e1979c0008379681" lang="no" xmltv_id="">Jersey Shore</channel>
@@ -2372,39 +2423,35 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61781878a3580d0008967df8" lang="no" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61815067b9802500076e16e0" lang="no" xmltv_id="">FBI Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#65788362cbd0d60008f8729a" lang="no" xmltv_id="">Dog The Bounty Hunter</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/no#68513950f212bedacf8ec48f" lang="no" xmltv_id="">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/no#68513950f212bedacf8ec48f" lang="no" xmltv_id="">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#634690323ce5fa0007c621f2" lang="no" xmltv_id="">48 Hours</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#6578843432c1b300089a9a98" lang="no" xmltv_id="">Celeb Reality</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61781077929e930007c194ee" lang="no" xmltv_id="">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/no#61781254560f2e00071b78ce" lang="no" xmltv_id="">World Poker Tour</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1ef1a8cec6be00072a7ac9" lang="pt" xmltv_id="">Pluto TV História</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1ef23020a5ac0007e5e8ea" lang="pt" xmltv_id="">Pluto TV Cozinha</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d2db0af67400077f29c4" lang="pt" xmltv_id="">Pluto TV Esportes</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d432d612e50007e56133" lang="pt" xmltv_id="">Pluto TV Viagens</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f99ac4fded33000078f29ab" lang="pt" xmltv_id="">Pluto TV Star Trek</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12111c9e6c2c00078ef3bb" lang="pt" xmltv_id="CineTerror.us@Brazil">Pluto TV Cine Terror</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f512365abe1f50007d3ff56" lang="pt" xmltv_id="PlutoTVNovelas.us@SD">Pluto TV Novelas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa991b1f09e020007e78626" lang="pt" xmltv_id="">Pluto TV Cine Inspiração</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5ffcc5130fd98c0007f2e216" lang="pt" xmltv_id="KenanKel.us@Brazil">Kenan &amp;amp; Kel</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1ef1a8cec6be00072a7ac9" lang="pt" xmltv_id="PlutoTVHistoria.us@BR">Pluto TV História</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1ef23020a5ac0007e5e8ea" lang="pt" xmltv_id="PlutoTVCozinha.us@BR">Pluto TV Cozinha</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d2db0af67400077f29c4" lang="pt" xmltv_id="PlutoTVEsportes.us@BR">Pluto TV Esportes</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d432d612e50007e56133" lang="pt" xmltv_id="PlutoTVViagens.us@BR">Pluto TV Viagens</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f99ac4fded33000078f29ab" lang="pt" xmltv_id="StarTrek.us@BR">Pluto TV Star Trek</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa991b1f09e020007e78626" lang="pt" xmltv_id="PlutoTVCineInspiracao.us@BR">Pluto TV Cine Inspiração</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#61f1d27a189ed10007b7393e" lang="pt" xmltv_id="">Diff’rent Strokes Arnold</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62b5c5a064163d0007b2efe6" lang="pt" xmltv_id="">Mistérios sem Solução</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62c5d32e2c48f9000715b6e9" lang="pt" xmltv_id="">Runtime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62d969fd8451a30007f0fd94" lang="pt" xmltv_id="">Cocoricó</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62e010e6cd663f0007e57dc8" lang="pt" xmltv_id="">TV Cultura</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#63d2ba2f60bc8f0008981a0e" lang="pt" xmltv_id="">Pluto TV Séries Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#63d2ba2f60bc8f0008981a0e" lang="pt" xmltv_id="PlutoTVSeriesSciFi.us@BR">Pluto TV Séries Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63da6bcd60bc8f0008a5d364" lang="pt" xmltv_id="">Baby Shark TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63dac32bda711800088a2ba3" lang="pt" xmltv_id="">TikTok Radio Brasil</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#63dac28760bc8f0008a7654b" lang="pt" xmltv_id="RealMadridTV.es@SD">Realmadrid TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63dd5c904e83e700088fb68a" lang="pt" xmltv_id="">As Tartarugas Ninja</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63eb9c5351f5d000085e8d7e" lang="pt" xmltv_id="">CSI: Miami</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63eb9dc84e83e70008abea92" lang="pt" xmltv_id="">MacGyver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63eb9fdda995710008991c54" lang="pt" xmltv_id="">NCIS</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63eba66da8b2270008436b10" lang="pt" xmltv_id="">World Poker Tour</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63eba189c111bc0008ff59c5" lang="pt" xmltv_id="">Moranguinho</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#64ad7394798def00087b2bfe" lang="pt" xmltv_id="">Pluto TV Negócio Fechado</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#64b9370b409629000802d32b" lang="pt" xmltv_id="">Pluto TV Canal UOL</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#64ad7394798def00087b2bfe" lang="pt" xmltv_id="PlutoTVNegocioFechado.us@BR">Pluto TV Negócio Fechado</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#64b9370b409629000802d32b" lang="pt" xmltv_id="PlutoTVCanalUOL.us@BR">Pluto TV Canal UOL</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#64c92f965580090008084968" lang="pt" xmltv_id="">Naruto Shippuden</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#64c815e8a1c6130008fef928" lang="pt" xmltv_id="">Pluto TV Gaming por Ubisoft</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#64c815e8a1c6130008fef928" lang="pt" xmltv_id="PlutoTVGamingporUbisoft.us@BR">Pluto TV Gaming por Ubisoft</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#64df7ab4dfa32400083c517b" lang="pt" xmltv_id="">DAZN Combat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#64e501eec630a900088ed0f8" lang="pt" xmltv_id="">Clube do Terror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#64e50055286f6b000838c067" lang="pt" xmltv_id="">Teletubbies</channel>
@@ -2416,15 +2463,15 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/br#65df713dec9fda0008b7a81d" lang="pt" xmltv_id="">South Park: Coleção Kyle</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#65df71008b24c80008f04281" lang="pt" xmltv_id="">South Park: Coleção Cartman</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#65df704366eec8000898e32f" lang="pt" xmltv_id="">South Park: Coleção Kenny</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#65f060d84e01740008d7421f" lang="pt" xmltv_id="">Pluto TV Séries Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#65f060d84e01740008d7421f" lang="pt" xmltv_id="PlutoTVSeriesDrama.us@BR">Pluto TV Séries Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66a01dcb8561260008b0a41d" lang="pt" xmltv_id="">MTV Classic</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66a01e07d2d50d0008100d6a" lang="pt" xmltv_id="">MTV Rocks</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66a7d0e0cd0d310008448610" lang="pt" xmltv_id="">Salon Line</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#66aa67493a4ad2000806d91b" lang="pt" xmltv_id="">Pluto TV Terror Trash</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#66aa67493a4ad2000806d91b" lang="pt" xmltv_id="PlutoTVTerrorTrash.us@BR">Pluto TV Terror Trash</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66b3af48d2d50d00083d6936" lang="pt" xmltv_id="">Z Nation</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66b26681d2d50d00083abe8b" lang="pt" xmltv_id="">Inuyasha</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#66c8cae7fed35b0008580ec0" lang="pt" xmltv_id="">Pluto TV Kids Club</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#66c79a4262e5510008ff68a5" lang="pt" xmltv_id="">Pluto TV Filmes Aventura</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#66c8cae7fed35b0008580ec0" lang="pt" xmltv_id="PlutoTVKidsClub.us@BR">Pluto TV Kids Club</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#66c79a4262e5510008ff68a5" lang="pt" xmltv_id="PlutoTVFilmesAventura.us@BR">Pluto TV Filmes Aventura</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66c7982f6838ee00085f0d24" lang="pt" xmltv_id="">JoJo’s Bizarre Adventure</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#67e59a6557487a8b7fe73e23" lang="pt" xmltv_id="">A Caçadora de Relíquias</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#67f960c5441853fe50e7afc1" lang="pt" xmltv_id="">Numbers</channel>
@@ -2432,6 +2479,10 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/br#68b88ae1943f6fb1fb2ad749" lang="pt" xmltv_id="">Os Smurfs</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#68b88821e542386ab0bf5bef" lang="pt" xmltv_id="">Tastemade Casa</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#68b8875777201ec428d9eaa5" lang="pt" xmltv_id="">Tastemade Viagem</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#69a20556814d27f4ae630a92" lang="pt" xmltv_id="">UFC</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#69fca7dd2387729708faa32c" lang="pt" xmltv_id="">Mr. Bean</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#69fca7fadf0b6d462c0a0ac3" lang="pt" xmltv_id="">Sobrevivi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#69fca82395df3283d2b60ef9" lang="pt" xmltv_id="">Topa ou Não Topa EUA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#619e6614c9d9650007a2b171" lang="pt" xmltv_id="">Euronews Português</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#620d12a82e8ac50007c269c3" lang="pt" xmltv_id="">Os Arquivos do FBI</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#620d1512c7986a0007220213" lang="pt" xmltv_id="">Assombrações</channel>
@@ -2442,43 +2493,40 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/br#631fa8dd7f25240007099a40" lang="pt" xmltv_id="">A Feiticeira</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#633dc392e0282400071b0d39" lang="pt" xmltv_id="">Beyblade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#633dcebd80386500074a2461" lang="pt" xmltv_id="">Filmelier TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#633ee9ba83c08f00076b60a6" lang="pt" xmltv_id="">Pluto TV KFOOD</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#633ee9ba83c08f00076b60a6" lang="pt" xmltv_id="PlutoTVKFOOD.us@BR">Pluto TV KFOOD</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#638df93ae2f2a3000737c168" lang="pt" xmltv_id="">Detetives Médicos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#655e5bc94261ca000810cb17" lang="pt" xmltv_id="">Pluto TV Séries Comédia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#655e5c4d2c46f3000877a54b" lang="pt" xmltv_id="">Pluto TV Desenhos Clássicos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#655e5bc94261ca000810cb17" lang="pt" xmltv_id="PlutoTVSeriesComedia.us@BR">Pluto TV Séries Comédia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#655e5c4d2c46f3000877a54b" lang="pt" xmltv_id="PlutoTVDesenhosClassicos.us@BR">Pluto TV Desenhos Clássicos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#656e2a4b4261ca00083aa99e" lang="pt" xmltv_id="">Acumuladores Obsessivos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#656e2a10954b020008ed167c" lang="pt" xmltv_id="">Caçadores de Óvnis</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#656e2a81954b020008ed17a4" lang="pt" xmltv_id="">Estado Paranormal</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#656f389c3944b60008e5bdab" lang="pt" xmltv_id="">Boruto: Naruto Next Generations</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#663b9dc7cb3ea10008f1a0ce" lang="pt" xmltv_id="">Pluto TV Bang Bang</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#663b9de4f999220008230fa8" lang="pt" xmltv_id="">Pluto TV Netmovies</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#666c9c60a7efd40008f552f0" lang="pt" xmltv_id="BMCNews.br@SD">BM&amp;amp;C News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#663b9dc7cb3ea10008f1a0ce" lang="pt" xmltv_id="PlutoTVBangBang.us@BR">Pluto TV Bang Bang</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#663b9de4f999220008230fa8" lang="pt" xmltv_id="PlutoTVNetmovies.us@BR">Pluto TV Netmovies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#677d93f37bffa600080795e7" lang="pt" xmltv_id="">Popeye</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#678aa104680721c77c506746" lang="pt" xmltv_id="">The Walking Dead by AMC</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#678fdf9e3de7c8cf948e8824" lang="pt" xmltv_id="">Pluto TV Policial</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#678fdf9e3de7c8cf948e8824" lang="pt" xmltv_id="PlutoTVPolicial.us@BR">Pluto TV Policial</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#679a973a97782f0008ff4bb6" lang="pt" xmltv_id="">Times Brasil | CNBC</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#681ba2ad93d3d19bcab47433" lang="pt" xmltv_id="">NatureTime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6102e04e9ab1db0007a980a1" lang="pt" xmltv_id="">Pluto TV Record News</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6298bd10d88ef000073f16b7" lang="pt" xmltv_id="SmithsonianChannelSelects.us@SD">Smithsonian Channel Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474aa984cfc2c0008883a92" lang="pt" xmltv_id="">Pluto TV Animais</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474aadc8e3c0a0008b98493" lang="pt" xmltv_id="">Pluto TV Curiosidade</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474ab1da51cb80008bfb5f4" lang="pt" xmltv_id="">Pluto TV Séries Ação</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474ab5cdc7a760008745008" lang="pt" xmltv_id="">Pluto TV Séries Criminais</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6479ff764f5ba5000878dfe2" lang="pt" xmltv_id="">Pluto TV Cine Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6102e04e9ab1db0007a980a1" lang="pt" xmltv_id="PlutoTVRecordNews.us@BR">Pluto TV Record News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474aa984cfc2c0008883a92" lang="pt" xmltv_id="PlutoTVAnimais.us@BR">Pluto TV Animais</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474aadc8e3c0a0008b98493" lang="pt" xmltv_id="PlutoTVCuriosidade.us@BR">Pluto TV Curiosidade</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474ab1da51cb80008bfb5f4" lang="pt" xmltv_id="PlutoTVSeriesAcao.us@BR">Pluto TV Séries Ação</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6474ab5cdc7a760008745008" lang="pt" xmltv_id="PlutoTVSeriesCriminais.us@BR">Pluto TV Séries Criminais</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6479ff764f5ba5000878dfe2" lang="pt" xmltv_id="PlutoTVCineCrime.us@BR">Pluto TV Cine Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6647c0b91050b60008390de4" lang="pt" xmltv_id="">Sony One Shark Tank Brasil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6660b636cb3ea10008429c6a" lang="pt" xmltv_id="">SFT Combat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6759eeb1bd523200083b4f29" lang="pt" xmltv_id="">Avatar: A lenda de Aang</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6806d65e84f24b70109485fa" lang="pt" xmltv_id="">Pluto TV Aliens</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6806d62369aec5b19cd628c0" lang="pt" xmltv_id="">Pluto TV Filmes de Luta</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6824ce10c5d53e1351ceb8d1" lang="pt" xmltv_id="NickClassico.us@Brazil">Nickelodeon Clássico</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6806d65e84f24b70109485fa" lang="pt" xmltv_id="PlutoTVAliens.us@BR">Pluto TV Aliens</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6806d62369aec5b19cd628c0" lang="pt" xmltv_id="PlutoTVFilmesdeLuta.us@BR">Pluto TV Filmes de Luta</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6824ce95f09106f4b18f4114" lang="pt" xmltv_id="">Nick Jr. Club</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6851bb3426beced4f2f67ee6" lang="pt" xmltv_id="">MTV Dating</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6851bdfc9ac48fde5e07f5ae" lang="pt" xmltv_id="">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6851bdfc9ac48fde5e07f5ae" lang="pt" xmltv_id="">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6888ee858f4a4aa11feb9430" lang="pt" xmltv_id="">Top Barça</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62052d3b4eeb740007fbe125" lang="pt" xmltv_id="">O Homem que veio do Céu</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#62310f66d5888f0007534342" lang="pt" xmltv_id="">CBS News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#62310f66d5888f0007534342" lang="pt" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#62545c0b002f4b0007688b61" lang="pt" xmltv_id="">Bob Esponja Calça Quadrada</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#62545ed3dab4380007582f7c" lang="pt" xmltv_id="">Pluto TV Cine Comédia Romântica</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#62545ed3dab4380007582f7c" lang="pt" xmltv_id="PlutoTVCineComediaRomantica.us@BR">Pluto TV Cine Comédia Romântica</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63221bafdc6e110007b50270" lang="pt" xmltv_id="">Oggy e as Baratas Tontas</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63221e41af69b500076f84e7" lang="pt" xmltv_id="">Os Padrinhos Mágicos</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63988a50be012600070f5db3" lang="pt" xmltv_id="">Yu-Gi-Oh</channel>
@@ -2486,6 +2534,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/br#63988c2750108d00072e2686" lang="pt" xmltv_id="">Super Onze</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#66997e8d3a4ad20008e50be9" lang="pt" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#67802a22a5d8215f99dcee30" lang="pt" xmltv_id="">Pegadinhas - Just for Laughs</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#67813f3162bf016db944c9ab" lang="pt" xmltv_id="">Red Bull TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#68641eb4852dfe78698c3390" lang="pt" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#69162ad79505d0f3b1ebf07d" lang="pt" xmltv_id="">Jornada nas Estrelas - A Nova Geração</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#69162af591700f4c4c135c95" lang="pt" xmltv_id="">Jornada nas Estrelas - Deep Space Nine</channel>
@@ -2497,64 +2546,72 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/br#681110afc188aa63faa147e0" lang="pt" xmltv_id="">MasterChef Brasil Profissionais</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#681111be5e0764e297fb200e" lang="pt" xmltv_id="">Mais MasterChef Brasil</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#687007a8ee4155e89a8f6d67" lang="pt" xmltv_id="">Pokémon</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#691627e4a29a6123e400b3e0" lang="pt" xmltv_id="">Pluto TV Séries Novelescas</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#6014761dfb91870008ea6463" lang="pt" xmltv_id="">Pluto TV Turbo</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#691627e4a29a6123e400b3e0" lang="pt" xmltv_id="PlutoTVSeriesNovelescas.us@BR">Pluto TV Séries Novelescas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#698392af0cca0cc3458666ab" lang="pt" xmltv_id="">AdoroCinema</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6014761dfb91870008ea6463" lang="pt" xmltv_id="PlutoTVTurbo.us@BR">Pluto TV Turbo</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#67603668f433320008760af1" lang="pt" xmltv_id="">Homeful</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#69162648d03565d6c8c8df97" lang="pt" xmltv_id="">Inspetor Bugiganga</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#625463563b8ddc0007134aeb" lang="pt" xmltv_id="">MTV Shore</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#61b790b985706b00072cb797" lang="pt" xmltv_id="AdrenalinaPuraTV.us@Brazil">Adrenalina Pura TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f4fb4cf605ddf000748e16f" lang="pt" xmltv_id="BabyFirst.us@Brazil">Babyfirst</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5ff768b6a4c8b80008498610" lang="pt" xmltv_id="BETPlutoTV.us@Brazil">BET Pluto TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f357e91b18f0b00073583d2" lang="pt" xmltv_id="ComedyCentralPlutoTV.us@Brazil">Comedy Central Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5ff768b6a4c8b80008498610" lang="pt" xmltv_id="BETPlutoTV.us@BR">BET Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#666c9c60a7efd40008f552f0" lang="pt" xmltv_id="BMCNews.br@SD">BM&amp;amp;C News</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12111c9e6c2c00078ef3bb" lang="pt" xmltv_id="CineTerror.us@BR">Pluto TV Cine Terror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f357e91b18f0b00073583d2" lang="pt" xmltv_id="ComedyCentralPlutoTV.us@BR">Comedy Central Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#609ae66b359b270007869ff1" lang="pt" xmltv_id="ComedyCentralSouthPark.us@Brazil">Comedy Central South Park</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f5141c1605ddf000748eb1b" lang="pt" xmltv_id="FailArmy.us@Brazil">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f171d3442a0500007362f22" lang="pt" xmltv_id="FilmesSuspense.us@Brazil">Filmes Suspense</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6317ba014d4d040007227f72" lang="pt" xmltv_id="JovemPanNews.br@SD">Jovem Pan NEWS</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5ffcc5130fd98c0007f2e216" lang="pt" xmltv_id="KenanKel.us@Brazil">Kenan &amp;amp; Kel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6077045b6031bd00078de127" lang="pt" xmltv_id="MasterChef.us@Brazil">MasterChef</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f6108d8cc331900075e98e4" lang="pt" xmltv_id="MTVAreyoutheOne.us@Brazil">MTV Are you the One?</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#6047fbdbbb776a0007e7f2ff" lang="pt" xmltv_id="MTVBiggestPop.us@Brazil">MTV Biggest Pop</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#61a528267e1b8b0007357920" lang="pt" xmltv_id="MTVComoEx.us@Brazil">MTV Com o Ex</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1212fb81e85c00077ae9ef" lang="pt" xmltv_id="MTVPlutoTV.us@Brazil">MTV Pluto TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1212fb81e85c00077ae9ef" lang="pt" xmltv_id="MTVPlutoTV.us@BR">MTV Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f6df5a173d7340007c559f7" lang="pt" xmltv_id="Naruto.us@Brazil">Naruto</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6824ce10c5d53e1351ceb8d1" lang="pt" xmltv_id="NickClassico.us@Brazil">Nickelodeon Clássico</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#60f5fabf0721880007cd50e3" lang="pt" xmltv_id="NickTeen.us@Brazil">Nickelodeon Teen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#61099df8cee03b00074b2ecf" lang="pt" xmltv_id="OEncantadordeCaes.us@Brazil">O Encantador de Cães</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f5c216df68f920007888315" lang="pt" xmltv_id="OReinoInfantil.us@Brazil">O Reino Infantil</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#61b790b985706b00072cb797" lang="pt" xmltv_id="AdrenalinaPuraTV.us@Brazil">Adrenalina Pura TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12136385bccc00070142ed" lang="pt" xmltv_id="PlutoTVAnime.us@Brazil">Pluto TV Anime</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b79c558393100078faeef" lang="pt" xmltv_id="PlutoTVAnimeAcao.us@Brazil">Pluto TV Anime Ação</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa1612a669ba0000702017b" lang="pt" xmltv_id="PlutoTVCineClassicos.us@Brazil">Pluto TV Cine Clássicos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12101f0b12f00007844c7c" lang="pt" xmltv_id="PlutoTVCineComedia.us@Brazil">Pluto TV Cine Comédia</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1210d14ae1f80007bafb1d" lang="pt" xmltv_id="PlutoTVCineDrama.us@Brazil">Pluto TV Cine Drama</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f171f032cd22e0007f17f3d" lang="pt" xmltv_id="PlutoTVCineFamilia.us@Brazil">Pluto TV Cine Família</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f171f988ab9780007fa95ea" lang="pt" xmltv_id="PlutoTVCineRomance.us@Brazil">Pluto TV Cine Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f120e94a5714d00074576a1" lang="pt" xmltv_id="PlutoTVCineSucessos.us@Brazil">Pluto TV Cine Sucessos</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa15ad6367e170007cdd098" lang="pt" xmltv_id="PlutoTVFiccaoCientifica.us@Brazil">Pluto TV Ficção Científica</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f120f41b7d403000783a6d6" lang="pt" xmltv_id="PlutoTVFilmesAcao.us@Brazil">Pluto TV Filmes Ação</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f5a545d0dbf7f0007c09408" lang="pt" xmltv_id="PlutoTVFilmesNacionais.us@Brazil">Pluto TV Filmes Nacionais</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32cf37c9ff2b00082adbc8" lang="pt" xmltv_id="PlutoTVInvestigacao.us@Brazil">Pluto TV Investigação</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12141b146d760007934ea7" lang="pt" xmltv_id="PlutoTVJunior.us@Brazil">Pluto TV Junior</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b99d633a72b00078e05ad" lang="pt" xmltv_id="PlutoTVKaraokeporStingray.us@Brazil">Pluto TV Karaokê por Stingray</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1214a637c6fd00079c652f" lang="pt" xmltv_id="PlutoTVKids.us@Brazil">Pluto TV Kids</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#61843f5e491af10007f7eefa" lang="pt" xmltv_id="PlutoTVMinhaObsessaoFavorita.us@Brazil">Pluto TV Minha Obsessão Favorita</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fac52f142044f00078e2a51" lang="pt" xmltv_id="PlutoTVMisterios.us@Brazil">Pluto TV Mistérios</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1213ba0ecebc00070e170f" lang="pt" xmltv_id="PlutoTVNatureza.us@Brazil">Pluto TV Natureza</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#604a8dedbca75b0007b1c753" lang="pt" xmltv_id="PlutoTVPaisagensporStingray.us@Brazil">Pluto TV Paisagens por Stingray</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1212ad1728050007a523b8" lang="pt" xmltv_id="PlutoTVRetro.us@Brazil">Pluto TV Retrô</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b91e0692f770007d9f33f" lang="pt" xmltv_id="PlutoTVShowsporStingray.us@Brazil">Pluto TV Shows por Stingray</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d4d9ec194100070c7449" lang="pt" xmltv_id="PlutoTVVidaReal.us@Brazil">Pluto TV Vida Real</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12136385bccc00070142ed" lang="pt" xmltv_id="PlutoTVAnime.us@BR">Pluto TV Anime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b79c558393100078faeef" lang="pt" xmltv_id="PlutoTVAnimeAcao.us@BR">Pluto TV Anime Ação</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa1612a669ba0000702017b" lang="pt" xmltv_id="PlutoTVCineClassicos.us@BR">Pluto TV Cine Clássicos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12101f0b12f00007844c7c" lang="pt" xmltv_id="PlutoTVCineComedia.us@BR">Pluto TV Cine Comédia</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1210d14ae1f80007bafb1d" lang="pt" xmltv_id="PlutoTVCineDrama.us@BR">Pluto TV Cine Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f171f032cd22e0007f17f3d" lang="pt" xmltv_id="PlutoTVCineFamilia.us@BR">Pluto TV Cine Família</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f171f988ab9780007fa95ea" lang="pt" xmltv_id="PlutoTVCineRomance.us@BR">Pluto TV Cine Romance</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f120e94a5714d00074576a1" lang="pt" xmltv_id="PlutoTVCineSucessos.us@BR">Pluto TV Cine Sucessos</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fa15ad6367e170007cdd098" lang="pt" xmltv_id="PlutoTVFiccaoCientifica.us@BR">Pluto TV Ficção Científica</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f120f41b7d403000783a6d6" lang="pt" xmltv_id="PlutoTVFilmesAcao.us@BR">Pluto TV Filmes Ação</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f5a545d0dbf7f0007c09408" lang="pt" xmltv_id="PlutoTVFilmesNacionais.us@BR">Pluto TV Filmes Nacionais</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32cf37c9ff2b00082adbc8" lang="pt" xmltv_id="PlutoTVInvestigacao.us@BR">Pluto TV Investigação</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f12141b146d760007934ea7" lang="pt" xmltv_id="PlutoTVJunior.us@BR">Pluto TV Junior</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b99d633a72b00078e05ad" lang="pt" xmltv_id="PlutoTVKaraokeporStingray.us@BR">Pluto TV Karaokê por Stingray</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1214a637c6fd00079c652f" lang="pt" xmltv_id="PlutoTVKids.us@BR">Pluto TV Kids</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#61843f5e491af10007f7eefa" lang="pt" xmltv_id="PlutoTVMinhaObsessaoFavorita.us@BR">Pluto TV Minha Obsessão Favorita</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5fac52f142044f00078e2a51" lang="pt" xmltv_id="PlutoTVMisterios.us@BR">Pluto TV Mistérios</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1213ba0ecebc00070e170f" lang="pt" xmltv_id="PlutoTVNatureza.us@BR">Pluto TV Natureza</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f512365abe1f50007d3ff56" lang="pt" xmltv_id="PlutoTVNovelas.us@BR">Pluto TV Novelas</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#604a8dedbca75b0007b1c753" lang="pt" xmltv_id="PlutoTVPaisagensporStingray.us@BR">Pluto TV Paisagens por Stingray</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f1212ad1728050007a523b8" lang="pt" xmltv_id="PlutoTVRetro.us@BR">Pluto TV Retrô</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#604b91e0692f770007d9f33f" lang="pt" xmltv_id="PlutoTVShowsporStingray.us@BR">Pluto TV Shows por Stingray</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#5f32d4d9ec194100070c7449" lang="pt" xmltv_id="PlutoTVVidaReal.us@BR">Pluto TV Vida Real</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#61bb72a7bf8c520007a8fd27" lang="pt" xmltv_id="ProntosocorroHistoriasDeEmergencia.us@Brazil">Pronto-socorro: Histórias De Emergência</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#63dac28760bc8f0008a7654b" lang="pt" xmltv_id="RealMadridTV.es@SD">Realmadrid TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/br#6298bd10d88ef000073f16b7" lang="pt" xmltv_id="SmithsonianChannelPlutoTV.us@BR">Smithsonian Channel Pluto TV</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5fd1419a3b4f4b000773ba85" lang="pt" xmltv_id="TastemadeBrasil.us@Brazil">Tastemade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f515ebac01c0f00080e8439" lang="pt" xmltv_id="ThePetCollective.us@Brazil">The Pet Collective</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5ff609de50ab210008025c1b" lang="pt" xmltv_id="Tokusato.us@Brazil">Tokusato</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/br#5f997e44949bc70007a6941e" lang="pt" xmltv_id="TurmadaMonica.us@Brazil">Turma da Mônica</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0ac242bb0cf0007015f89" lang="sv" xmltv_id="">Are You The One?</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0afa0a09bbe00078f8378" lang="sv" xmltv_id="">Pluto TV Film</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b6f028e94c000782684a" lang="sv" xmltv_id="">Pluto TV Tecknat</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b7eb8929e40007ff5125" lang="sv" xmltv_id="">Pluto TV Juniorklubben</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b36d18447e000717d686" lang="sv" xmltv_id="">Pluto TV Komedi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0afa0a09bbe00078f8378" lang="sv" xmltv_id="PlutoTVFilm.se@SE">Pluto TV Film</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b6f028e94c000782684a" lang="sv" xmltv_id="PlutoTVTecknat.se@SE">Pluto TV Tecknat</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b7eb8929e40007ff5125" lang="sv" xmltv_id="PlutoTVJuniorklubben.se@SE">Pluto TV Juniorklubben</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b36d18447e000717d686" lang="sv" xmltv_id="PlutoTVKomedi.se@SE">Pluto TV Komedi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b550e0d3a700072b6a2a" lang="sv" xmltv_id="">Comedy Central</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b627e3ed94000793c18a" lang="sv" xmltv_id="">South Park</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b0688a80a4000703fbcb" lang="sv" xmltv_id="">Pluto TV Action</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b438244e50000758083b" lang="sv" xmltv_id="">Pluto TV True Crime</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b0688a80a4000703fbcb" lang="sv" xmltv_id="PlutoTVAction.se@SE">Pluto TV Action</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0b438244e50000758083b" lang="sv" xmltv_id="PlutoTVTrueCrime.se@SE">Pluto TV True Crime</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c0ba0816e2fd00086cb6b1" lang="sv" xmltv_id="">SvampBob Fyrkant</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c08d7c73bdb800070eef0a" lang="sv" xmltv_id="">The Hills</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61c09a3894aa450007814aea" lang="sv" xmltv_id="">Pimp My Ride</channel>
@@ -2574,16 +2631,16 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61de8fa251cca800076dde41" lang="sv" xmltv_id="">Bloomberg TV+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61de90a47365340007f77c27" lang="sv" xmltv_id="">Euronews</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61f128f68a1dfc00086470af" lang="sv" xmltv_id="">Svenska Truckers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#61f9597e78607000074f6c2a" lang="sv" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#61f9597e78607000074f6c2a" lang="sv" xmltv_id="PlutoTVSciFi.se@SE">Pluto TV Sci-Fi</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61fb9907b1b78d000717ed9f" lang="sv" xmltv_id="">Smithsonian Channel Selects</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62a0b070d4566c0007a0d1bd" lang="sv" xmltv_id="">Melrose Place</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62a0b114a1c8650007e93688" lang="sv" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62b1e5e77d15410007f798c6" lang="sv" xmltv_id="">Doc Martin</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#62b1e4189f5db20007ff03be" lang="sv" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#62b1e2498261390007f25c98" lang="sv" xmltv_id="">Pluto TV Dokumentär</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#62b1e4189f5db20007ff03be" lang="sv" xmltv_id="PlutoTVParanormal.se@SE">Pluto TV Paranormal</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#62b1e2498261390007f25c98" lang="sv" xmltv_id="PlutoTVDokumentar.se@SE">Pluto TV Dokumentär</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62beb0de371e6c000775930c" lang="sv" xmltv_id="">Wildfire</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62beb6c0371e6c000775930f" lang="sv" xmltv_id="">Ice Road Truckers</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#62cd74e38f6f0d000798cd93" lang="sv" xmltv_id="">Pluto TV Sport</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#62cd74e38f6f0d000798cd93" lang="sv" xmltv_id="PlutoTVSport.se@SE">Pluto TV Sport</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62cda0dfddc1040008fccacc" lang="sv" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62cdad7b5c38c00007f566c2" lang="sv" xmltv_id="">On the Case</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62cdaef300a4b3000739b1bf" lang="sv" xmltv_id="">Ice Pilots</channel>
@@ -2591,21 +2648,19 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62e7babea3e6270007f5564a" lang="sv" xmltv_id="">Jakt är Jakt</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62f64ec9eb1045000728cad6" lang="sv" xmltv_id="">Viafree Movies</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#63a1c9c2847a090007f248da" lang="sv" xmltv_id="">Scorpion</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#63a19da6847a090007f230da" lang="sv" xmltv_id="">Pluto TV Romantik</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#63a19e1b9ab2df0007bef7a7" lang="sv" xmltv_id="">Pluto TV Horror</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#63a19da6847a090007f230da" lang="sv" xmltv_id="PlutoTVRomantik.se@SE">Pluto TV Romantik</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#63a19e1b9ab2df0007bef7a7" lang="sv" xmltv_id="PlutoTVHorror.se@SE">Pluto TV Horror</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#63a19eceb3d0eb0007439c34" lang="sv" xmltv_id="">MacGyver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#63c6a7544faf1c0007b496d7" lang="sv" xmltv_id="">Buying Blind Denmark</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#63c95491808b740007608a74" lang="sv" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#63dbe8a1c111bc0008dec8b8" lang="sv" xmltv_id="">Numb3rs</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#63dbe8c8a9957100087798a3" lang="sv" xmltv_id="">Pluto TV Kultfilmer</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#63dbe8c8a9957100087798a3" lang="sv" xmltv_id="PlutoTVKultfilmer.se@SE">Pluto TV Kultfilmer</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#64e7715c4c5ed800081230e4" lang="sv" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65a63ff00d9ab400080b101c" lang="sv" xmltv_id="">Klovn</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65a93be02fac9c00083cbac4" lang="sv" xmltv_id="">Car Chase</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b3d7b7c798e8000852ff0a" lang="sv" xmltv_id="">From South Park with Love</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b8f9d4d77d450008a3ef8f" lang="sv" xmltv_id="">PFL MMA</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b91b53dc10a40008d54777" lang="sv" xmltv_id="">Pluto TV Brittisk Crime &amp;amp; Drama</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b91b53dc10a40008d54777" lang="sv" xmltv_id="PlutoTVBrittiskCrimeDrama.se@SE">Pluto TV Brittisk Crime &amp;amp; Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65b1077e0d9ab40008245b20" lang="sv" xmltv_id="">Best of Paradise Hotel: Kyssar &amp;amp; kärlek</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b917720d9ab4000833f323" lang="sv" xmltv_id="">Pluto TV Bud &amp;amp; Terence</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#65b917720d9ab4000833f323" lang="sv" xmltv_id="PlutoTVBudTerence.se@SE">Pluto TV Bud &amp;amp; Terence</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65ba4e7bdc10a40008da084a" lang="sv" xmltv_id="">Rock Channel</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65c340983ba51e00083988e8" lang="sv" xmltv_id="">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65c0978360eb870008bc9d5b" lang="sv" xmltv_id="">The Daily Show</channel>
@@ -2617,7 +2672,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65d881d566eec8000887f6bb" lang="sv" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65d881914e01740008a36603" lang="sv" xmltv_id="">South Park: Stan Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65d882394e01740008a36768" lang="sv" xmltv_id="">South Park: Kyle Collection</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#65e9b6b58145cb00084d24ee" lang="sv" xmltv_id="">Glory Kickboxing</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65e97cd118036500082ed0ce" lang="sv" xmltv_id="">Best of Paradise Hotel: Skolveckan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65e97d41f7f0af0008da2543" lang="sv" xmltv_id="">Best of Paradise Hotel: Finalveckan</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#65e97d760d456100082da660" lang="sv" xmltv_id="">Best of Paradise Hotel: Pandoras Ask</channel>
@@ -2629,25 +2683,30 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#66bb36e03a4ad200082bb8fe" lang="sv" xmltv_id="">Pixel.tv</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#66c86fed85e28d0008f8a9ec" lang="sv" xmltv_id="">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#66d714d815d2c60008cec6d2" lang="sv" xmltv_id="">Escape to the Country</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#66fcee79565d3a00088ac033" lang="sv" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#67a09e5921af38000808900a" lang="sv" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#67a23bb777796f00080edaec" lang="sv" xmltv_id="">Dominance FC TV</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#67f3fc1707d2ba4121bd34a8" lang="sv" xmltv_id="">Pluto TV Ungdomsserier</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#67f3fc1707d2ba4121bd34a8" lang="sv" xmltv_id="PlutoTVUngdomsserier.se@SE">Pluto TV Ungdomsserier</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#67f7d328efc5473b6b4ac5f4" lang="sv" xmltv_id="">Lyxfällan Norge</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#67f5095a3481170e6843d95d" lang="sv" xmltv_id="">Pluto TV Tecknade klassiker</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#68ac52fac9b5923e0585578b" lang="sv" xmltv_id="">Pluto TV Motor</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#68ac56363efb41cd979a8005" lang="sv" xmltv_id="">Pluto TV Snooker 900</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#67f5095a3481170e6843d95d" lang="sv" xmltv_id="PlutoTVTecknadeklassiker.se@SE">Pluto TV Tecknade klassiker</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68ac52fac9b5923e0585578b" lang="sv" xmltv_id="PlutoTVMotor.se@SE">Pluto TV Motor</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68ac56363efb41cd979a8005" lang="sv" xmltv_id="PlutoTVSnooker900.se@SE">Pluto TV Snooker 900</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68adb11bf84960586ad4aae4" lang="sv" xmltv_id="">Smurfarna</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#68c01bed508ba507f0d0dd60" lang="sv" xmltv_id="">Pluto TV Harlequin</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68c01bed508ba507f0d0dd60" lang="sv" xmltv_id="PlutoTVHarlequin.se@SE">Pluto TV Harlequin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68c015dc6523408b14f54dee" lang="sv" xmltv_id="">Highway to Heaven</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#68c017bf337652ee75db201f" lang="sv" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68c017bf337652ee75db201f" lang="sv" xmltv_id="PlutoTVWildWest.se@SE">Pluto TV Wild West</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68c01954f89c82a68b084a50" lang="sv" xmltv_id="">Afterwork TV</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68d66a98508ba507f075c8da" lang="sv" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68dfa1e7fae18f8db6218703" lang="sv" xmltv_id="">Ridiculousness - Nya avsnitt</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#68dfa3e2cc3c6cd904052c41" lang="sv" xmltv_id="">Pluto TV Handboll Highlights</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#68dfa3e2cc3c6cd904052c41" lang="sv" xmltv_id="PlutoTVHandbollHighlights.se@SE">Pluto TV Handboll Highlights</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68f0f7dea362b63a8df50bd4" lang="sv" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68f0f642a25ba0aab3e64e66" lang="sv" xmltv_id="">Medium</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#68f0fb155d6fb43948165d32" lang="sv" xmltv_id="">Dynastin</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#69a164f76c0414a7ec68de54" lang="sv" xmltv_id="">Retake E-sport Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#69afecd4686531d5faac86e2" lang="sv" xmltv_id="">The 4400</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#69afef4b0306b277744de1e4" lang="sv" xmltv_id="">The Millers</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#69b16e2b65c1df7564fc750b" lang="sv" xmltv_id="">Space Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#69c2949dfb6a5281bc12c817" lang="sv" xmltv_id="">CNN Headlines International</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#69d7a0dc805a68fcc92037b7" lang="sv" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#619e4a3518d6970008bebc95" lang="sv" xmltv_id="">Homicide Hunter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#619e4726b9997a00072a4059" lang="sv" xmltv_id="">Ghost Dimension</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#619e4833244e500007564d5a" lang="sv" xmltv_id="">Nosey</channel>
@@ -2661,10 +2720,10 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#654a517ff91d250008ac2d4a" lang="sv" xmltv_id="">Love Boat</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#654a52254d6d8f00084eacfc" lang="sv" xmltv_id="">Happy Days</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#655caa815812e80008884322" lang="sv" xmltv_id="">Hot Ones</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#655caaaac0fc8800086f5d99" lang="sv" xmltv_id="">Pluto TV John Wayne</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#655caaaac0fc8800086f5d99" lang="sv" xmltv_id="PlutoTVJohnWayne.se@SE">Pluto TV John Wayne</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#660bfcd07bcd860008796ae8" lang="sv" xmltv_id="">FIFA+</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#660bff7dc8311c0008b4bdb4" lang="sv" xmltv_id="">South Park Armageddon</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#660d5f2a635c75000828855f" lang="sv" xmltv_id="">Pluto TV Buskis</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#660d5f2a635c75000828855f" lang="sv" xmltv_id="PlutoTVBuskis.se@SE">Pluto TV Buskis</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#660d6b3caec9680008f8debe" lang="sv" xmltv_id="">Jade Fever</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#660d67eec8311c0008b8c3f7" lang="sv" xmltv_id="">Bondi Rescue</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#660d7232635c75000828c95a" lang="sv" xmltv_id="">Realmadrid TV</channel>
@@ -2673,18 +2732,23 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#664f0eea0120f40008bf97d6" lang="sv" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#664f13aff9992200084a3532" lang="sv" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#668bf9be0642e5000815102d" lang="sv" xmltv_id="">Diagnosis Murder</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#668e60bfa4ee270008e3addf" lang="sv" xmltv_id="">Triton Poker</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#671b4e8bc7626f00089b7194" lang="sv" xmltv_id="">Horse &amp;amp; Country</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#672e16f5daad7f0008929a0d" lang="sv" xmltv_id="">Becker</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#677d3ad04bd63600082f7c54" lang="sv" xmltv_id="">Pluto TV Världskrigen</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#677d3ad04bd63600082f7c54" lang="sv" xmltv_id="PlutoTVVarldskrigen.se@SE">Pluto TV Världskrigen</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#682b39defaaa60cd7dbfa5c3" lang="sv" xmltv_id="">Iron Chef</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#686d01ad94a028da3aaca6b3" lang="sv" xmltv_id="">The Nanny &amp;amp; Mr Sheffield - A Fine Romance</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#686faf533ffa5e0c912688e7" lang="sv" xmltv_id="">Pluto TV Handboll Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#686faf533ffa5e0c912688e7" lang="sv" xmltv_id="PlutoTVHandbollLive.se@SE">Pluto TV Handboll Live</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#691ed77b1308fa77bb2d5562" lang="sv" xmltv_id="">Inter 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#692edd6bdb8695f63e14f3b9" lang="sv" xmltv_id="">Dating Naked UK</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#693ade4d569386f93f235bb6" lang="sv" xmltv_id="">Star Trek: The Original Series</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#693ae4ee25e9a6646b198fb0" lang="sv" xmltv_id="">The L Word</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#693ae5b792fad2e93412a2c7" lang="sv" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#693ae6bf0ddf7d2a40b7fd35" lang="sv" xmltv_id="">House of Lies</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#693ae39cc2fa3abe8ad8208c" lang="sv" xmltv_id="">Teen Wolf</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#697b5be36dc3c71eb14d728a" lang="sv" xmltv_id="">Everybody Hates Chris</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#698dde7c8b5c1e0795b85739" lang="sv" xmltv_id="">Flipper: The New Adventures</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#699c1c633d27d6da460bbcae" lang="sv" xmltv_id="">Farscape</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#699c1998d5b4d030870ff998" lang="sv" xmltv_id="">Renegade</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#699c169077cdde1f05252eb9" lang="sv" xmltv_id="">21 Jump Street</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6231e9b7f6deff00074674f4" lang="sv" xmltv_id="">CBS News 24/7</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6364f6cd308d210007b5eee9" lang="sv" xmltv_id="">Antiques Road Trip</channel>
@@ -2698,7 +2762,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6464cdcaee6a2f000822a7a8" lang="sv" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6486e8b48e3c0a0008e56914" lang="sv" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6501ae4998020f00085040ed" lang="sv" xmltv_id="">Mannen som talar med hundar</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#6501c86dbd341e000829a1cc" lang="sv" xmltv_id="">South Park Halloween</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6512d6a0a1217e00092c1214" lang="sv" xmltv_id="">Beauty and the Beast</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6512d6c92ce8e40008bd5c81" lang="sv" xmltv_id="">The Twilight Zone</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6512d72b473a540008592be5" lang="sv" xmltv_id="">Sabrina the Teenage Witch</channel>
@@ -2718,7 +2781,6 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61814b9a9704450007e52316" lang="sv" xmltv_id="">FBI Files</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#61814dd68a368d0007d78c53" lang="sv" xmltv_id="">The New Detectives</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#62724c8465731f0007b6cd86" lang="sv" xmltv_id="">Project Runway</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#62792dbd5e237b0007f84642" lang="sv" xmltv_id="">Bellator MMA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#64188b8483f58900083bc954" lang="sv" xmltv_id="">Skål</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#64268f52b065d900085eb42b" lang="sv" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#64424be3e94c380008d0a66d" lang="sv" xmltv_id="">Geordie Shore</channel>
@@ -2732,7 +2794,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/se#643808dce0789d00084797f6" lang="sv" xmltv_id="">Skönhetsfällan Danmark</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#657886bfb9adc40008025554" lang="sv" xmltv_id="">Dog The Bounty Hunter</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#657887d9dfed030008ce8aa8" lang="sv" xmltv_id="">I Survived</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/se#685139b0f7d8b74b62f41c96" lang="sv" xmltv_id="">MTV Reality</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/se#685139b0f7d8b74b62f41c96" lang="sv" xmltv_id="">MTV Pride</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#685140f121f49d1b9d178249" lang="sv" xmltv_id="">MTV Dating</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6178037c35922000072a2ff5" lang="sv" xmltv_id="">FailArmy</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/se#6181498caf6afc0007de9e72" lang="sv" xmltv_id="">Unsolved Mysteries</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_pluto.channels.xml
@@ -1069,7 +1069,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f77977bd924d80007eee60c" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5f4d882d5233170007ee880e" lang="en" xmltv_id="Misteriossinresolver.us@SD">Misterios sin resolver</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5e66968a70f34c0007d050be" lang="en" xmltv_id="MLB.us@SD">MLB</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#613260e4bdb71c00070d63fa" lang="en" xmltv_id="MoreTVDrama.us@SD">More TV Drama</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6132619f9ddaa50007e7dd86" lang="en" xmltv_id="MoreTVSitcoms.us@SD">More TV Sitcoms</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
@@ -1106,7 +1106,7 @@
   <channel site="i.mjh.nz" site_id="PlutoTV/us#640a64bd73e013000893d4e0" lang="en" xmltv_id="PBSNature.us@SD">PBS Nature</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#60fb2f47c133270007327375" lang="en" xmltv_id="PelisyPopcorn.us@SD">Cine aventura</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#6197086891ddd4000739941a" lang="en" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
-  <channel site="i.mjh.nz" site_id="PlutoTV/us#6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="PlutoTV/us#6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#66d885aef0f17500084b6750" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/us#5de94dacb394a300099fa22a" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="i.mjh.nz" site_id="PlutoTV/gb#5dbfeb961b411c00090b52b3" lang="en" xmltv_id="PlutoTVAction.de@UK">Pluto TV Action</channel>

--- a/sites/i.mjh.nz/i.mjh.nz_roku.channels.xml
+++ b/sites/i.mjh.nz/i.mjh.nz_roku.channels.xml
@@ -443,7 +443,7 @@
   <channel site="i.mjh.nz" site_id="Roku/all#a95f55f07381e71ee254ec15c5c7cbb5" lang="en" xmltv_id="">MotoGP</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#a96f9c338b3e5ab29ec3b436c01c84da" lang="en" xmltv_id="AmericasTestKitchen.us@SD">America&apos;s Test Kitchen</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#a164a2f39b815cb9b6559d99ae0f6e8c" lang="en" xmltv_id="Caillou.fr@SD">Caillou</channel>
-  <channel site="i.mjh.nz" site_id="Roku/all#a361d429db9e46665be277da42af89a4" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="i.mjh.nz" site_id="Roku/all#a361d429db9e46665be277da42af89a4" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#a480d18b23c655d38e2f2bf7275c02cb" lang="en" xmltv_id="WXFTDT71.us@HD">WLS ABC7 Chicago</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#a673e94f2e565b3ab01168183745a6c6" lang="en" xmltv_id="Teletubbies.uk@SD">Teletubbies</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#a61227fe8ede21ffc0e223763ccbe42f" lang="en" xmltv_id="">Cuando Los Angeles Caen</channel>
@@ -632,7 +632,7 @@
   <channel site="i.mjh.nz" site_id="Roku/all#e35e1503bdf85e0fbb406b4663137473" lang="en" xmltv_id="">Joel Osteen Network</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#e38d66dbb4e05f9690f6c573417fc231" lang="en" xmltv_id="WPXI111.us@HD">WPXI Pittsburgh</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#e43d478938ff53f1a6810a11a1192d74" lang="en" xmltv_id="">Tayo+</channel>
-  <channel site="i.mjh.nz" site_id="Roku/all#e46ac8cd0299b4c5f1403d999a432561" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="i.mjh.nz" site_id="Roku/all#e46ac8cd0299b4c5f1403d999a432561" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#e50a8f06d3245c95a4e250dc5c33c2be" lang="en" xmltv_id="VevoPop.us@SD">Vevo Pop</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#e52ec5f13f5b82dc44611384f2f6e89a" lang="en" xmltv_id="">Home Crashers</channel>
   <channel site="i.mjh.nz" site_id="Roku/all#e63d49e8acd7557596d091b3fa262999" lang="en" xmltv_id="">FGTeeV</channel>

--- a/sites/plex.tv/plex.tv_all.channels.xml
+++ b/sites/plex.tv/plex.tv_all.channels.xml
@@ -40,7 +40,7 @@
   <channel site="plex.tv" site_id="5fd115b7b7ef8d002dcf1814" lang="en" xmltv_id="HumorMill.us@SD">Humor Mill</channel>
   <channel site="plex.tv" site_id="66f6b6baac1a1890ef197a4b" lang="en" xmltv_id="Hunter.us@UK">Hunter</channel>
   <channel site="plex.tv" site_id="666e1820ce73ed6023b55a11" lang="en" xmltv_id="">Ice Pilots NWT</channel>
-  <channel site="plex.tv" site_id="6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.pl@Poland">JAIL</channel>
+  <channel site="plex.tv" site_id="6448ba1baf92c31f4a190c27" lang="en" xmltv_id="Jail.uk@Poland">JAIL</channel>
   <channel site="plex.tv" site_id="60d4edd6b2fdec002c141123" lang="en" xmltv_id="JohnnyCarsonTV.us@SD">Johnny Carson TV</channel>
   <channel site="plex.tv" site_id="5f0ff262d71dcb00449ec018" lang="en" xmltv_id="JudgeNosey.us@UK">Judge Nosey</channel>
   <channel site="plex.tv" site_id="656fb124cb7e8e6a9bc3f36a" lang="en" xmltv_id="">Kidz Bop TV</channel>
@@ -50,7 +50,7 @@
   <channel site="plex.tv" site_id="5ef4e1b40d9ad000423c4430" lang="en" xmltv_id="MaverickBlackCinema.us@SD">Maverick Black Cinema</channel>
   <channel site="plex.tv" site_id="68e9436dda6bb987138625c7" lang="en" xmltv_id="">Metal.Rocks</channel>
   <channel site="plex.tv" site_id="684c2379e32026b0c1f53793" lang="en" xmltv_id="">Million Dollar Dream Home</channel>
-  <channel site="plex.tv" site_id="6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="plex.tv" site_id="6615885e1eabecf2c9d56495" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="plex.tv" site_id="6112a9139894c8002c6cb87f" lang="en" xmltv_id="">More U</channel>
   <channel site="plex.tv" site_id="6196c8c01d310bf925e02615" lang="en" xmltv_id="">Music Legends</channel>
   <channel site="plex.tv" site_id="650b5bb3f4b2d9579946a500" lang="en" xmltv_id="">Mythical 24/7</channel>
@@ -62,7 +62,7 @@
   <channel site="plex.tv" site_id="6578e7b5eef129f30fb38df7" lang="en" xmltv_id="">Operation Repo</channel>
   <channel site="plex.tv" site_id="646c0dfbfb58444e4e1e262d" lang="en" xmltv_id="Pac12Insider.us@SD">Pac-12 Insider</channel>
   <channel site="plex.tv" site_id="5f0ff263d71dcb00449ec021" lang="en" xmltv_id="PeopleAreAwesome.us@SD">People are Awesome</channel>
-  <channel site="plex.tv" site_id="643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="plex.tv" site_id="643f0ecd76de2b4015ae6c01" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="plex.tv" site_id="60afc726623f2f002c5bb49f" lang="en" xmltv_id="">Poker Night TV</channel>
   <channel site="plex.tv" site_id="64ac687b4192b4e1bab96279" lang="en" xmltv_id="PokerGo.us@UK">PokerGO</channel>
   <channel site="plex.tv" site_id="62ee7992271f393d2d9f709c" lang="en" xmltv_id="StingrayPopAdult.ca@SD">Pop Adult</channel>
@@ -85,7 +85,7 @@
   <channel site="plex.tv" site_id="654eb862dde2222e8ba551f1" lang="en" xmltv_id="">Stingray Holidayscapes</channel>
   <channel site="plex.tv" site_id="61aa9e73784a2161d3caf7f9" lang="en" xmltv_id="StingrayHotCountry.ca@SD">Stingray Hot Country</channel>
   <channel site="plex.tv" site_id="61aaa17a784a2161d3caf801" lang="en" xmltv_id="StingraySoulStorm.ca@SD">Stingray Soul Storm</channel>
-  <channel site="plex.tv" site_id="644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions</channel>
+  <channel site="plex.tv" site_id="644b13a3a1c0a5b2024c8403" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions</channel>
   <channel site="plex.tv" site_id="656fbbd6dbcce28c3a41741b" lang="en" xmltv_id="">Surf Cinema</channel>
   <channel site="plex.tv" site_id="62ab5aabbb869dd0df6a3487" lang="en" xmltv_id="TED.us@SD">TED</channel>
   <channel site="plex.tv" site_id="6761f91555e174e95ccc4e4c" lang="en" xmltv_id="">Tennis+</channel>

--- a/sites/plex.tv/plex.tv_uk.channels.xml
+++ b/sites/plex.tv/plex.tv_uk.channels.xml
@@ -50,7 +50,7 @@
   <channel site="plex.tv" site_id="650b5ea1b2413c46bf584d84" lang="en" xmltv_id="">MagellanTV Wildest</channel>
   <channel site="plex.tv" site_id="690cd1fb750b5c46ff424c8e" lang="en" xmltv_id="">Mayday: Air Disaster</channel>
   <channel site="plex.tv" site_id="6943f7fa967bd8849e141979" lang="en" xmltv_id="">Medical Detectives</channel>
-  <channel site="plex.tv" site_id="692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
+  <channel site="plex.tv" site_id="692719bf5d6063fc5b96b699" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
   <channel site="plex.tv" site_id="606cbf167e9765002c2a6131" lang="en" xmltv_id="MovieSphere.us@UK">MOVIESPHERE</channel>
   <channel site="plex.tv" site_id="68db66b2475aa6420c85f22a" lang="en" xmltv_id="MutantX.us@UK">Mutant X</channel>
   <channel site="plex.tv" site_id="66c3cd45d263903b4c6d991c" lang="en" xmltv_id="MysteryTV.us@UK">MYSTERY TV</channel>

--- a/sites/plex.tv/plex.tv_us.channels.xml
+++ b/sites/plex.tv/plex.tv_us.channels.xml
@@ -324,7 +324,7 @@
   <channel site="plex.tv" site_id="60d4edd7b2fdec002c14112d" lang="en" xmltv_id="NEWKPOP.us@SD">NEW K-POP</channel>
   <channel site="plex.tv" site_id="60d4eddab2fdec002c141131" lang="en" xmltv_id="NEWKMOVIES.us@SD">NEW K.MOVIES</channel>
   <channel site="plex.tv" site_id="5fc6f3a62b6f7b002e77ffaa" lang="en" xmltv_id="News12NewYork.us@SD">News 12 New York</channel>
-  <channel site="plex.tv" site_id="66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.pl@FAST">NewsWorld</channel>
+  <channel site="plex.tv" site_id="66bfb2e6144c201b8b61c10f" lang="en" xmltv_id="NewsWorld.hk@FAST">NewsWorld</channel>
   <channel site="plex.tv" site_id="61e805952502a7a6fa84d70f" lang="en" xmltv_id="NFLChannel.us@SD">NFL Channel</channel>
   <channel site="plex.tv" site_id="69d54974022c0bcc7aa6c59f" lang="en" xmltv_id="">NFL Draft Vault</channel>
   <channel site="plex.tv" site_id="627ec46a92d8e6a705784bd1" lang="en" xmltv_id="NinjaKidzTV.us@SD">Ninja Kidz TV</channel>
@@ -544,7 +544,7 @@
   <channel site="plex.tv" site_id="5f74cf7effbe690040689f3e" lang="en" xmltv_id="">Xtreme Outdoor by HISTORY</channel>
   <channel site="plex.tv" site_id="68b0af6097cf9742e13391a5" lang="en" xmltv_id="">Yahoo! Sports Network</channel>
   <channel site="plex.tv" site_id="6617f52f0049fcb8e2b0d5b8" lang="en" xmltv_id="YuGiOh.us@SD">Yu-Gi-Oh!</channel>
-  <channel site="plex.tv" site_id="66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.pl@SD">Z Nation</channel>
+  <channel site="plex.tv" site_id="66ce3e009ac0b1441b19ca29" lang="en" xmltv_id="ZNation.us@SD">Z Nation</channel>
   <channel site="plex.tv" site_id="66fd3e25216b603e031725fe" lang="en" xmltv_id="">ZenLIFE by Stingray</channel>
   <channel site="plex.tv" site_id="6642a07d0e0ec7b4ce5eb294" lang="en" xmltv_id="">ZenLIFE by Stingray</channel>
   <channel site="plex.tv" site_id="62d1efa6c33948ea4ceedbcf" lang="es" xmltv_id="AMCenEspanol.us@SD">AMC en Español</channel>
@@ -591,7 +591,7 @@
   <channel site="plex.tv" site_id="66e0d0c4f70549a9bc1eceb0" lang="es" xmltv_id="">WAPA+</channel>
   <channel site="plex.tv" site_id="687ffd8e015fe7e375a1a0a6" lang="es" xmltv_id="">Wedotv Amor Piel Salvaje</channel>
   <channel site="plex.tv" site_id="693ebecae2cae3f1bc73ae45" lang="es" xmltv_id="">Western Bound Español</channel>
-  <channel site="plex.tv" site_id="682512b03d06c8e426a2941a" lang="es" xmltv_id="ZNation.pl@SD">Z Nation</channel>
+  <channel site="plex.tv" site_id="682512b03d06c8e426a2941a" lang="es" xmltv_id="ZNation.us@SD">Z Nation</channel>
   <channel site="plex.tv" site_id="65f0da6f046e6131ecc31841" lang="es" xmltv_id="">Zona Investigación</channel>
   <channel site="plex.tv" site_id="639baa971a12420ff66ae7b1" lang="zh" xmltv_id="">Jubao</channel>
 </channels>

--- a/sites/pluto.tv/pluto.tv_au.channels.xml
+++ b/sites/pluto.tv/pluto.tv_au.channels.xml
@@ -5,10 +5,8 @@
   <channel site="pluto.tv" site_id="65bcf7b7d77d450008b3c495" lang="en" xmltv_id="">Adult Animation</channel>
   <channel site="pluto.tv" site_id="6493f680ed26aa00081eb4d5" lang="en" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="65eed44c2873090008bdb4ab" lang="en" xmltv_id="">Anthony Bourdain: Parts Unknown</channel>
-  <channel site="pluto.tv" site_id="64805611dc7a7600088e8557" lang="en" xmltv_id="">Aussie Drama Pop-Up</channel>
   <channel site="pluto.tv" site_id="65bcf864ec452d00088e6716" lang="en" xmltv_id="">Australia&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="6493f7e316014400086995a7" lang="en" xmltv_id="">Becker</channel>
-  <channel site="pluto.tv" site_id="691709142a2463ca0ff1a4fb" lang="en" xmltv_id="">Christmas Movies</channel>
   <channel site="pluto.tv" site_id="65eed3bb66eec80008b6954a" lang="en" xmltv_id="">Cops</channel>
   <channel site="pluto.tv" site_id="65c24f1aec452d0008989ee4" lang="en" xmltv_id="">Crime Hunters</channel>
   <channel site="pluto.tv" site_id="66c3514421a4740008487dc7" lang="en" xmltv_id="">Crime Time</channel>
@@ -17,9 +15,7 @@
   <channel site="pluto.tv" site_id="656712d9954b020008dac069" lang="en" xmltv_id="">Documentary Channel</channel>
   <channel site="pluto.tv" site_id="66c35172ed4b8a0008a914e2" lang="en" xmltv_id="">Embarrassing Bodies</channel>
   <channel site="pluto.tv" site_id="65c24ee011ced700080e199b" lang="en" xmltv_id="">Ghost Hunters</channel>
-  <channel site="pluto.tv" site_id="65e06535332fec0008485bf4" lang="en" xmltv_id="">Good Chef Bad Chef</channel>
   <channel site="pluto.tv" site_id="674dbb77afc24200083c25ba" lang="en" xmltv_id="">Have You Been Paying Attention?</channel>
-  <channel site="pluto.tv" site_id="6493f6141601440008699442" lang="en" xmltv_id="">Judge Judy</channel>
   <channel site="pluto.tv" site_id="64805544f77b61000828ec65" lang="en" xmltv_id="">MasterChef</channel>
   <channel site="pluto.tv" site_id="6480562d4cfc2c0008a78285" lang="en" xmltv_id="">Medical Emergency</channel>
   <channel site="pluto.tv" site_id="65a904554a10d8000863911b" lang="en" xmltv_id="">MTV Geordie Shore</channel>
@@ -32,15 +28,13 @@
   <channel site="pluto.tv" site_id="6493f5634c014a00083d2e35" lang="en" xmltv_id="">NickToons</channel>
   <channel site="pluto.tv" site_id="64805525536e0c0008a19ca8" lang="en" xmltv_id="">NickToons 90s</channel>
   <channel site="pluto.tv" site_id="65eed4168b24c800080f3ebd" lang="en" xmltv_id="">Prisoner: Cell Block H</channel>
-  <channel site="pluto.tv" site_id="691708d8f692e47a533d6a9c" lang="en" xmltv_id="">Puberty Blues</channel>
+  <channel site="pluto.tv" site_id="6968b88e3b9ce349c9d434f7" lang="en" xmltv_id="">Romance Movies</channel>
   <channel site="pluto.tv" site_id="64e33abb9c1e3900083eaf1e" lang="en" xmltv_id="">Seasonal Movies</channel>
   <channel site="pluto.tv" site_id="64a670f4bc3ab4000831b94e" lang="en" xmltv_id="">South Park</channel>
   <channel site="pluto.tv" site_id="65df4bb6332fec000845e088" lang="en" xmltv_id="">South Park 2</channel>
-  <channel site="pluto.tv" site_id="6917099f427d68a118dbe035" lang="en" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="pluto.tv" site_id="65bcf669ec452d00088e6459" lang="en" xmltv_id="">SpongeBob SquarePants</channel>
   <channel site="pluto.tv" site_id="65bcf9beec452d00088e68e5" lang="en" xmltv_id="">Thank God You’re Here</channel>
   <channel site="pluto.tv" site_id="65c24efb11ced700080e1a72" lang="en" xmltv_id="">The Cheap Seats</channel>
-  <channel site="pluto.tv" site_id="64e33a6dc630a900088aa4a0" lang="en" xmltv_id="">The Dog House</channel>
   <channel site="pluto.tv" site_id="66f2ba358131f10008c427bc" lang="en" xmltv_id="">The Only Way is Essex</channel>
   <channel site="pluto.tv" site_id="6493f76666e485000853d723" lang="en" xmltv_id="">The Twilight Zone</channel>
   <channel site="pluto.tv" site_id="64805505536e0c0008a19c86" lang="en" xmltv_id="">True Stories</channel>

--- a/sites/pluto.tv/pluto.tv_br.channels.xml
+++ b/sites/pluto.tv/pluto.tv_br.channels.xml
@@ -9,17 +9,17 @@
   <channel site="pluto.tv" site_id="6759eeb1bd523200083b4f29" lang="pt" xmltv_id="">Avatar: A lenda de Aang</channel>
   <channel site="pluto.tv" site_id="63da6bcd60bc8f0008a5d364" lang="pt" xmltv_id="">Baby Shark TV</channel>
   <channel site="pluto.tv" site_id="5f4fb4cf605ddf000748e16f" lang="pt" xmltv_id="BabyFirst.us@Brazil">Babyfirst</channel>
-  <channel site="pluto.tv" site_id="5ff768b6a4c8b80008498610" lang="pt" xmltv_id="BETPlutoTV.us@Brazil">BET Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5ff768b6a4c8b80008498610" lang="pt" xmltv_id="BETPlutoTV.us@BR">BET Pluto TV</channel>
   <channel site="pluto.tv" site_id="633dc392e0282400071b0d39" lang="pt" xmltv_id="">Beyblade</channel>
   <channel site="pluto.tv" site_id="666c9c60a7efd40008f552f0" lang="pt" xmltv_id="BMCNews.br@SD">BM&amp;C News</channel>
   <channel site="pluto.tv" site_id="62545c0b002f4b0007688b61" lang="pt" xmltv_id="">Bob Esponja Calça Quadrada</channel>
   <channel site="pluto.tv" site_id="656f389c3944b60008e5bdab" lang="pt" xmltv_id="">Boruto: Naruto Next Generations</channel>
   <channel site="pluto.tv" site_id="656e2a10954b020008ed167c" lang="pt" xmltv_id="">Caçadores de Óvnis</channel>
-  <channel site="pluto.tv" site_id="62310f66d5888f0007534342" lang="pt" xmltv_id="">CBS News</channel>
+  <channel site="pluto.tv" site_id="62310f66d5888f0007534342" lang="pt" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="67f9602ee173fa5664fafae8" lang="pt" xmltv_id="">Charmed: Jovens Bruxas</channel>
   <channel site="pluto.tv" site_id="64e501eec630a900088ed0f8" lang="pt" xmltv_id="">Clube do Terror</channel>
   <channel site="pluto.tv" site_id="62d969fd8451a30007f0fd94" lang="pt" xmltv_id="">Cocoricó</channel>
-  <channel site="pluto.tv" site_id="5f357e91b18f0b00073583d2" lang="pt" xmltv_id="ComedyCentralPlutoTV.us@Brazil">Comedy Central Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f357e91b18f0b00073583d2" lang="pt" xmltv_id="ComedyCentralPlutoTV.us@BR">Comedy Central Pluto TV</channel>
   <channel site="pluto.tv" site_id="609ae66b359b270007869ff1" lang="pt" xmltv_id="ComedyCentralSouthPark.us@Brazil">Comedy Central South Park</channel>
   <channel site="pluto.tv" site_id="63eb9c5351f5d000085e8d7e" lang="pt" xmltv_id="">CSI: Miami</channel>
   <channel site="pluto.tv" site_id="64df7ab4dfa32400083c517b" lang="pt" xmltv_id="">DAZN Combat</channel>
@@ -57,8 +57,8 @@
   <channel site="pluto.tv" site_id="645111f1d8436e00081bb2bd" lang="pt" xmltv_id="">MTV Drag</channel>
   <channel site="pluto.tv" site_id="620fdc7d8a36fc000710e3ba" lang="pt" xmltv_id="">MTV Jovens e Mães</channel>
   <channel site="pluto.tv" site_id="63988b61c8d285000798a22a" lang="pt" xmltv_id="">MTV Just Tattoo of Us</channel>
-  <channel site="pluto.tv" site_id="5f1212fb81e85c00077ae9ef" lang="pt" xmltv_id="">MTV Pluto TV</channel>
-  <channel site="pluto.tv" site_id="6851bdfc9ac48fde5e07f5ae" lang="pt" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="5f1212fb81e85c00077ae9ef" lang="pt" xmltv_id="MTVPlutoTV.us@BR">MTV Pluto TV</channel>
+  <channel site="pluto.tv" site_id="6851bdfc9ac48fde5e07f5ae" lang="pt" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="68641eb4852dfe78698c3390" lang="pt" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="66a01e07d2d50d0008100d6a" lang="pt" xmltv_id="">MTV Rocks</channel>
   <channel site="pluto.tv" site_id="625463563b8ddc0007134aeb" lang="pt" xmltv_id="">MTV Shore</channel>
@@ -84,71 +84,73 @@
   <channel site="pluto.tv" site_id="68b88ae1943f6fb1fb2ad749" lang="pt" xmltv_id="">Os Smurfs</channel>
   <channel site="pluto.tv" site_id="67802a22a5d8215f99dcee30" lang="pt" xmltv_id="">Pegadinhas - Just for Laughs</channel>
   <channel site="pluto.tv" site_id="64f6180130ab3300083d896b" lang="pt" xmltv_id="">PFL MMA</channel>
-  <channel site="pluto.tv" site_id="6806d65e84f24b70109485fa" lang="pt" xmltv_id="">Pluto TV Aliens</channel>
-  <channel site="pluto.tv" site_id="6474aa984cfc2c0008883a92" lang="pt" xmltv_id="">Pluto TV Animais</channel>
-  <channel site="pluto.tv" site_id="5f12136385bccc00070142ed" lang="pt" xmltv_id="PlutoTVAnime.us@Brazil">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="604b79c558393100078faeef" lang="pt" xmltv_id="PlutoTVAnimeAcao.us@Brazil">Pluto TV Anime Ação</channel>
-  <channel site="pluto.tv" site_id="663b9dc7cb3ea10008f1a0ce" lang="pt" xmltv_id="">Pluto TV Bang Bang</channel>
-  <channel site="pluto.tv" site_id="64b9370b409629000802d32b" lang="pt" xmltv_id="">Pluto TV Canal UOL</channel>
-  <channel site="pluto.tv" site_id="5fa1612a669ba0000702017b" lang="pt" xmltv_id="PlutoTVCineClassicos.us@Brazil">Pluto TV Cine Clássicos</channel>
-  <channel site="pluto.tv" site_id="5f12101f0b12f00007844c7c" lang="pt" xmltv_id="">Pluto TV Cine Comédia</channel>
-  <channel site="pluto.tv" site_id="62545ed3dab4380007582f7c" lang="pt" xmltv_id="">Pluto TV Cine Comédia Romântica</channel>
-  <channel site="pluto.tv" site_id="6479ff764f5ba5000878dfe2" lang="pt" xmltv_id="">Pluto TV Cine Crime</channel>
-  <channel site="pluto.tv" site_id="5f1210d14ae1f80007bafb1d" lang="pt" xmltv_id="PlutoTVCineDrama.us@Brazil">Pluto TV Cine Drama</channel>
-  <channel site="pluto.tv" site_id="5f171f032cd22e0007f17f3d" lang="pt" xmltv_id="PlutoTVCineFamilia.us@Brazil">Pluto TV Cine Família</channel>
-  <channel site="pluto.tv" site_id="5fa991b1f09e020007e78626" lang="pt" xmltv_id="">Pluto TV Cine Inspiração</channel>
-  <channel site="pluto.tv" site_id="5f171f988ab9780007fa95ea" lang="pt" xmltv_id="PlutoTVCineRomance.us@Brazil">Pluto TV Cine Romance</channel>
-  <channel site="pluto.tv" site_id="5f120e94a5714d00074576a1" lang="pt" xmltv_id="PlutoTVCineSucessos.us@Brazil">Pluto TV Cine Sucessos</channel>
-  <channel site="pluto.tv" site_id="5f12111c9e6c2c00078ef3bb" lang="pt" xmltv_id="CineTerror.us@Brazil">Pluto TV Cine Terror</channel>
-  <channel site="pluto.tv" site_id="5f1ef23020a5ac0007e5e8ea" lang="pt" xmltv_id="">Pluto TV Cozinha</channel>
-  <channel site="pluto.tv" site_id="6474aadc8e3c0a0008b98493" lang="pt" xmltv_id="">Pluto TV Curiosidade</channel>
-  <channel site="pluto.tv" site_id="655e5c4d2c46f3000877a54b" lang="pt" xmltv_id="">Pluto TV Desenhos Clássicos</channel>
-  <channel site="pluto.tv" site_id="5f32d2db0af67400077f29c4" lang="pt" xmltv_id="">Pluto TV Esportes</channel>
-  <channel site="pluto.tv" site_id="5fa15ad6367e170007cdd098" lang="pt" xmltv_id="PlutoTVFiccaoCientifica.us@Brazil">Pluto TV Ficção Científica</channel>
-  <channel site="pluto.tv" site_id="5f120f41b7d403000783a6d6" lang="pt" xmltv_id="PlutoTVFilmesAcao.us@Brazil">Pluto TV Filmes Ação</channel>
-  <channel site="pluto.tv" site_id="66c79a4262e5510008ff68a5" lang="pt" xmltv_id="">Pluto TV Filmes Aventura</channel>
-  <channel site="pluto.tv" site_id="6806d62369aec5b19cd628c0" lang="pt" xmltv_id="">Pluto TV Filmes de Luta</channel>
-  <channel site="pluto.tv" site_id="5f5a545d0dbf7f0007c09408" lang="pt" xmltv_id="PlutoTVFilmesNacionais.us@Brazil">Pluto TV Filmes Nacionais</channel>
-  <channel site="pluto.tv" site_id="64c815e8a1c6130008fef928" lang="pt" xmltv_id="">Pluto TV Gaming por Ubisoft</channel>
-  <channel site="pluto.tv" site_id="5f1ef1a8cec6be00072a7ac9" lang="pt" xmltv_id="">Pluto TV História</channel>
-  <channel site="pluto.tv" site_id="5f32cf37c9ff2b00082adbc8" lang="pt" xmltv_id="PlutoTVInvestigacao.us@Brazil">Pluto TV Investigação</channel>
-  <channel site="pluto.tv" site_id="5f12141b146d760007934ea7" lang="pt" xmltv_id="PlutoTVJunior.us@Brazil">Pluto TV Junior</channel>
-  <channel site="pluto.tv" site_id="604b99d633a72b00078e05ad" lang="pt" xmltv_id="PlutoTVKaraokeporStingray.us@Brazil">Pluto TV Karaokê por Stingray</channel>
-  <channel site="pluto.tv" site_id="633ee9ba83c08f00076b60a6" lang="pt" xmltv_id="">Pluto TV KFOOD</channel>
-  <channel site="pluto.tv" site_id="5f1214a637c6fd00079c652f" lang="pt" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="pluto.tv" site_id="66c8cae7fed35b0008580ec0" lang="pt" xmltv_id="">Pluto TV Kids Club</channel>
-  <channel site="pluto.tv" site_id="61843f5e491af10007f7eefa" lang="pt" xmltv_id="PlutoTVMinhaObsessaoFavorita.us@Brazil">Pluto TV Minha Obsessão Favorita</channel>
-  <channel site="pluto.tv" site_id="5fac52f142044f00078e2a51" lang="pt" xmltv_id="PlutoTVMisterios.us@Brazil">Pluto TV Mistérios</channel>
-  <channel site="pluto.tv" site_id="5f1213ba0ecebc00070e170f" lang="pt" xmltv_id="PlutoTVNatureza.us@Brazil">Pluto TV Natureza</channel>
-  <channel site="pluto.tv" site_id="64ad7394798def00087b2bfe" lang="pt" xmltv_id="">Pluto TV Negócio Fechado</channel>
-  <channel site="pluto.tv" site_id="663b9de4f999220008230fa8" lang="pt" xmltv_id="">Pluto TV Netmovies</channel>
-  <channel site="pluto.tv" site_id="5f512365abe1f50007d3ff56" lang="pt" xmltv_id="PlutoTVNovelas.us@SD">Pluto TV Novelas</channel>
-  <channel site="pluto.tv" site_id="604a8dedbca75b0007b1c753" lang="pt" xmltv_id="PlutoTVPaisagensporStingray.us@Brazil">Pluto TV Paisagens por Stingray</channel>
-  <channel site="pluto.tv" site_id="678fdf9e3de7c8cf948e8824" lang="pt" xmltv_id="">Pluto TV Policial</channel>
-  <channel site="pluto.tv" site_id="6102e04e9ab1db0007a980a1" lang="pt" xmltv_id="">Pluto TV Record News</channel>
-  <channel site="pluto.tv" site_id="5f1212ad1728050007a523b8" lang="pt" xmltv_id="PlutoTVRetro.us@Brazil">Pluto TV Retrô</channel>
-  <channel site="pluto.tv" site_id="6474ab1da51cb80008bfb5f4" lang="pt" xmltv_id="">Pluto TV Séries Ação</channel>
-  <channel site="pluto.tv" site_id="655e5bc94261ca000810cb17" lang="pt" xmltv_id="">Pluto TV Séries Comédia</channel>
-  <channel site="pluto.tv" site_id="6474ab5cdc7a760008745008" lang="pt" xmltv_id="">Pluto TV Séries Criminais</channel>
-  <channel site="pluto.tv" site_id="65f060d84e01740008d7421f" lang="pt" xmltv_id="">Pluto TV Séries Drama</channel>
-  <channel site="pluto.tv" site_id="691627e4a29a6123e400b3e0" lang="pt" xmltv_id="">Pluto TV Séries Novelescas</channel>
-  <channel site="pluto.tv" site_id="63d2ba2f60bc8f0008981a0e" lang="pt" xmltv_id="">Pluto TV Séries Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="604b91e0692f770007d9f33f" lang="pt" xmltv_id="PlutoTVShowsporStingray.us@Brazil">Pluto TV Shows por Stingray</channel>
-  <channel site="pluto.tv" site_id="5f99ac4fded33000078f29ab" lang="pt" xmltv_id="">Pluto TV Star Trek</channel>
-  <channel site="pluto.tv" site_id="66aa67493a4ad2000806d91b" lang="pt" xmltv_id="">Pluto TV Terror Trash</channel>
-  <channel site="pluto.tv" site_id="6014761dfb91870008ea6463" lang="pt" xmltv_id="">Pluto TV Turbo</channel>
-  <channel site="pluto.tv" site_id="5f32d432d612e50007e56133" lang="pt" xmltv_id="">Pluto TV Viagens</channel>
-  <channel site="pluto.tv" site_id="5f32d4d9ec194100070c7449" lang="pt" xmltv_id="PlutoTVVidaReal.us@Brazil">Pluto TV Vida Real</channel>
+  <channel site="pluto.tv" site_id="6806d65e84f24b70109485fa" lang="pt" xmltv_id="PlutoTVAliens.us@BR">Pluto TV Aliens</channel>
+  <channel site="pluto.tv" site_id="6474aa984cfc2c0008883a92" lang="pt" xmltv_id="PlutoTVAnimais.us@BR">Pluto TV Animais</channel>
+  <channel site="pluto.tv" site_id="5f12136385bccc00070142ed" lang="pt" xmltv_id="PlutoTVAnime.us@BR">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="604b79c558393100078faeef" lang="pt" xmltv_id="PlutoTVAnimeAcao.us@BR">Pluto TV Anime Ação</channel>
+  <channel site="pluto.tv" site_id="663b9dc7cb3ea10008f1a0ce" lang="pt" xmltv_id="PlutoTVBangBang.us@BR">Pluto TV Bang Bang</channel>
+  <channel site="pluto.tv" site_id="64b9370b409629000802d32b" lang="pt" xmltv_id="PlutoTVCanalUOL.us@BR">Pluto TV Canal UOL</channel>
+  <channel site="pluto.tv" site_id="5fa1612a669ba0000702017b" lang="pt" xmltv_id="PlutoTVCineClassicos.us@BR">Pluto TV Cine Clássicos</channel>
+  <channel site="pluto.tv" site_id="5f12101f0b12f00007844c7c" lang="pt" xmltv_id="PlutoTVCineComedia.us@BR">Pluto TV Cine Comédia</channel>
+  <channel site="pluto.tv" site_id="62545ed3dab4380007582f7c" lang="pt" xmltv_id="PlutoTVCineComediaRomantica.us@BR">Pluto TV Cine Comédia Romântica</channel>
+  <channel site="pluto.tv" site_id="6479ff764f5ba5000878dfe2" lang="pt" xmltv_id="PlutoTVCineCrime.us@BR">Pluto TV Cine Crime</channel>
+  <channel site="pluto.tv" site_id="5f1210d14ae1f80007bafb1d" lang="pt" xmltv_id="PlutoTVCineDrama.us@BR">Pluto TV Cine Drama</channel>
+  <channel site="pluto.tv" site_id="5f171f032cd22e0007f17f3d" lang="pt" xmltv_id="PlutoTVCineFamilia.us@BR">Pluto TV Cine Família</channel>
+  <channel site="pluto.tv" site_id="5fa991b1f09e020007e78626" lang="pt" xmltv_id="PlutoTVCineInspiracao.us@BR">Pluto TV Cine Inspiração</channel>
+  <channel site="pluto.tv" site_id="5f171f988ab9780007fa95ea" lang="pt" xmltv_id="PlutoTVCineRomance.us@BR">Pluto TV Cine Romance</channel>
+  <channel site="pluto.tv" site_id="5f120e94a5714d00074576a1" lang="pt" xmltv_id="PlutoTVCineSucessos.us@BR">Pluto TV Cine Sucessos</channel>
+  <channel site="pluto.tv" site_id="5f12111c9e6c2c00078ef3bb" lang="pt" xmltv_id="CineTerror.us@BR">Pluto TV Cine Terror</channel>
+  <channel site="pluto.tv" site_id="5f1ef23020a5ac0007e5e8ea" lang="pt" xmltv_id="PlutoTVCozinha.us@BR">Pluto TV Cozinha</channel>
+  <channel site="pluto.tv" site_id="6474aadc8e3c0a0008b98493" lang="pt" xmltv_id="PlutoTVCuriosidade.us@BR">Pluto TV Curiosidade</channel>
+  <channel site="pluto.tv" site_id="655e5c4d2c46f3000877a54b" lang="pt" xmltv_id="PlutoTVDesenhosClassicos.us@BR">Pluto TV Desenhos Clássicos</channel>
+  <channel site="pluto.tv" site_id="5f32d2db0af67400077f29c4" lang="pt" xmltv_id="PlutoTVEsportes.us@BR">Pluto TV Esportes</channel>
+  <channel site="pluto.tv" site_id="5fa15ad6367e170007cdd098" lang="pt" xmltv_id="PlutoTVFiccaoCientifica.us@BR">Pluto TV Ficção Científica</channel>
+  <channel site="pluto.tv" site_id="5f120f41b7d403000783a6d6" lang="pt" xmltv_id="PlutoTVFilmesAcao.us@BR">Pluto TV Filmes Ação</channel>
+  <channel site="pluto.tv" site_id="66c79a4262e5510008ff68a5" lang="pt" xmltv_id="PlutoTVFilmesAventura.us@BR">Pluto TV Filmes Aventura</channel>
+  <channel site="pluto.tv" site_id="6806d62369aec5b19cd628c0" lang="pt" xmltv_id="PlutoTVFilmesdeLuta.us@BR">Pluto TV Filmes de Luta</channel>
+  <channel site="pluto.tv" site_id="5f5a545d0dbf7f0007c09408" lang="pt" xmltv_id="PlutoTVFilmesNacionais.us@BR">Pluto TV Filmes Nacionais</channel>
+  <channel site="pluto.tv" site_id="64c815e8a1c6130008fef928" lang="pt" xmltv_id="PlutoTVGamingporUbisoft.us@BR">Pluto TV Gaming por Ubisoft</channel>
+  <channel site="pluto.tv" site_id="5f1ef1a8cec6be00072a7ac9" lang="pt" xmltv_id="PlutoTVHistoria.us@BR">Pluto TV História</channel>
+  <channel site="pluto.tv" site_id="5f32cf37c9ff2b00082adbc8" lang="pt" xmltv_id="PlutoTVInvestigacao.us@BR">Pluto TV Investigação</channel>
+  <channel site="pluto.tv" site_id="5f12141b146d760007934ea7" lang="pt" xmltv_id="PlutoTVJunior.us@BR">Pluto TV Junior</channel>
+  <channel site="pluto.tv" site_id="604b99d633a72b00078e05ad" lang="pt" xmltv_id="PlutoTVKaraokeporStingray.us@BR">Pluto TV Karaokê por Stingray</channel>
+  <channel site="pluto.tv" site_id="633ee9ba83c08f00076b60a6" lang="pt" xmltv_id="PlutoTVKFOOD.us@BR">Pluto TV KFOOD</channel>
+  <channel site="pluto.tv" site_id="5f1214a637c6fd00079c652f" lang="pt" xmltv_id="PlutoTVKids.us@BR">Pluto TV Kids</channel>
+  <channel site="pluto.tv" site_id="66c8cae7fed35b0008580ec0" lang="pt" xmltv_id="PlutoTVKidsClub.us@BR">Pluto TV Kids Club</channel>
+  <channel site="pluto.tv" site_id="61843f5e491af10007f7eefa" lang="pt" xmltv_id="PlutoTVMinhaObsessaoFavorita.us@BR">Pluto TV Minha Obsessão Favorita</channel>
+  <channel site="pluto.tv" site_id="5fac52f142044f00078e2a51" lang="pt" xmltv_id="PlutoTVMisterios.us@BR">Pluto TV Mistérios</channel>
+  <channel site="pluto.tv" site_id="5f1213ba0ecebc00070e170f" lang="pt" xmltv_id="PlutoTVNatureza.us@BR">Pluto TV Natureza</channel>
+  <channel site="pluto.tv" site_id="64ad7394798def00087b2bfe" lang="pt" xmltv_id="PlutoTVNegocioFechado.us@BR">Pluto TV Negócio Fechado</channel>
+  <channel site="pluto.tv" site_id="663b9de4f999220008230fa8" lang="pt" xmltv_id="PlutoTVNetmovies.us@BR">Pluto TV Netmovies</channel>
+  <channel site="pluto.tv" site_id="5f512365abe1f50007d3ff56" lang="pt" xmltv_id="PlutoTVNovelas.us@BR">Pluto TV Novelas</channel>
+  <channel site="pluto.tv" site_id="604a8dedbca75b0007b1c753" lang="pt" xmltv_id="PlutoTVPaisagensporStingray.us@BR">Pluto TV Paisagens por Stingray</channel>
+  <channel site="pluto.tv" site_id="678fdf9e3de7c8cf948e8824" lang="pt" xmltv_id="PlutoTVPolicial.us@BR">Pluto TV Policial</channel>
+  <channel site="pluto.tv" site_id="6102e04e9ab1db0007a980a1" lang="pt" xmltv_id="PlutoTVRecordNews.us@BR">Pluto TV Record News</channel>
+  <channel site="pluto.tv" site_id="5f1212ad1728050007a523b8" lang="pt" xmltv_id="PlutoTVRetro.us@BR">Pluto TV Retrô</channel>
+  <channel site="pluto.tv" site_id="6474ab1da51cb80008bfb5f4" lang="pt" xmltv_id="PlutoTVSeriesAcao.us@BR">Pluto TV Séries Ação</channel>
+  <channel site="pluto.tv" site_id="655e5bc94261ca000810cb17" lang="pt" xmltv_id="PlutoTVSeriesComedia.us@BR">Pluto TV Séries Comédia</channel>
+  <channel site="pluto.tv" site_id="6474ab5cdc7a760008745008" lang="pt" xmltv_id="PlutoTVSeriesCriminais.us@BR">Pluto TV Séries Criminais</channel>
+  <channel site="pluto.tv" site_id="65f060d84e01740008d7421f" lang="pt" xmltv_id="PlutoTVSeriesDrama.us@BR">Pluto TV Séries Drama</channel>
+  <channel site="pluto.tv" site_id="691627e4a29a6123e400b3e0" lang="pt" xmltv_id="PlutoTVSeriesNovelescas.us@BR">Pluto TV Séries Novelescas</channel>
+  <channel site="pluto.tv" site_id="63d2ba2f60bc8f0008981a0e" lang="pt" xmltv_id="PlutoTVSeriesSciFi.us@BR">Pluto TV Séries Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="604b91e0692f770007d9f33f" lang="pt" xmltv_id="PlutoTVShowsporStingray.us@BR">Pluto TV Shows por Stingray</channel>
+  <channel site="pluto.tv" site_id="5f99ac4fded33000078f29ab" lang="pt" xmltv_id="StarTrek.us@BR">Pluto TV Star Trek</channel>
+  <channel site="pluto.tv" site_id="66aa67493a4ad2000806d91b" lang="pt" xmltv_id="PlutoTVTerrorTrash.us@BR">Pluto TV Terror Trash</channel>
+  <channel site="pluto.tv" site_id="6014761dfb91870008ea6463" lang="pt" xmltv_id="PlutoTVTurbo.us@BR">Pluto TV Turbo</channel>
+  <channel site="pluto.tv" site_id="5f32d432d612e50007e56133" lang="pt" xmltv_id="PlutoTVViagens.us@BR">Pluto TV Viagens</channel>
+  <channel site="pluto.tv" site_id="5f32d4d9ec194100070c7449" lang="pt" xmltv_id="PlutoTVVidaReal.us@BR">Pluto TV Vida Real</channel>
   <channel site="pluto.tv" site_id="687007a8ee4155e89a8f6d67" lang="pt" xmltv_id="">Pokémon</channel>
   <channel site="pluto.tv" site_id="677d93f37bffa600080795e7" lang="pt" xmltv_id="">Popeye</channel>
+  <channel site="pluto.tv" site_id="69440d0611f6c6384ab78306" lang="pt" xmltv_id="">PORTATV</channel>
   <channel site="pluto.tv" site_id="61bb72a7bf8c520007a8fd27" lang="pt" xmltv_id="">Pronto-socorro: Histórias De Emergência</channel>
   <channel site="pluto.tv" site_id="65a6818c7bdc8d0008457b21" lang="pt" xmltv_id="">RACER Brasil</channel>
   <channel site="pluto.tv" site_id="63dac28760bc8f0008a7654b" lang="pt" xmltv_id="RealMadridTV.es@SD">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="67813f3162bf016db944c9ab" lang="pt" xmltv_id="">Red Bull TV</channel>
   <channel site="pluto.tv" site_id="64ff2d8c6625510008c5a512" lang="pt" xmltv_id="">Rookie Blue</channel>
   <channel site="pluto.tv" site_id="62c5d32e2c48f9000715b6e9" lang="pt" xmltv_id="">Runtime</channel>
   <channel site="pluto.tv" site_id="66a7d0e0cd0d310008448610" lang="pt" xmltv_id="">Salon Line</channel>
   <channel site="pluto.tv" site_id="6660b636cb3ea10008429c6a" lang="pt" xmltv_id="">SFT Combat</channel>
-  <channel site="pluto.tv" site_id="6298bd10d88ef000073f16b7" lang="pt" xmltv_id="SmithsonianChannelSelects.us@SD">Smithsonian Channel Pluto TV</channel>
+  <channel site="pluto.tv" site_id="6298bd10d88ef000073f16b7" lang="pt" xmltv_id="SmithsonianChannelPlutoTV.us@BR">Smithsonian Channel Pluto TV</channel>
   <channel site="pluto.tv" site_id="6647c0b91050b60008390de4" lang="pt" xmltv_id="">Sony One Shark Tank Brasil</channel>
   <channel site="pluto.tv" site_id="65df71008b24c80008f04281" lang="pt" xmltv_id="">South Park: Coleção Cartman</channel>
   <channel site="pluto.tv" site_id="65df704366eec8000898e32f" lang="pt" xmltv_id="">South Park: Coleção Kenny</channel>
@@ -164,8 +166,10 @@
   <channel site="pluto.tv" site_id="63dac32bda711800088a2ba3" lang="pt" xmltv_id="">TikTok Radio Brasil</channel>
   <channel site="pluto.tv" site_id="679a973a97782f0008ff4bb6" lang="pt" xmltv_id="">Times Brasil | CNBC</channel>
   <channel site="pluto.tv" site_id="5ff609de50ab210008025c1b" lang="pt" xmltv_id="Tokusato.us@Brazil">Tokusato</channel>
+  <channel site="pluto.tv" site_id="6888ee858f4a4aa11feb9430" lang="pt" xmltv_id="">Top Barça</channel>
   <channel site="pluto.tv" site_id="5f997e44949bc70007a6941e" lang="pt" xmltv_id="TurmadaMonica.us@Brazil">Turma da Mônica</channel>
   <channel site="pluto.tv" site_id="62e010e6cd663f0007e57dc8" lang="pt" xmltv_id="">TV Cultura</channel>
+  <channel site="pluto.tv" site_id="69a20556814d27f4ae630a92" lang="pt" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="63eba66da8b2270008436b10" lang="pt" xmltv_id="">World Poker Tour</channel>
   <channel site="pluto.tv" site_id="63988a50be012600070f5db3" lang="pt" xmltv_id="">Yu-Gi-Oh</channel>
   <channel site="pluto.tv" site_id="66b3af48d2d50d00083d6936" lang="pt" xmltv_id="">Z Nation</channel>

--- a/sites/pluto.tv/pluto.tv_ca.channels.xml
+++ b/sites/pluto.tv/pluto.tv_ca.channels.xml
@@ -2,6 +2,7 @@
 <channels>
   <channel site="pluto.tv" site_id="62e925bc68d18a00077bb990" lang="en" xmltv_id="">48 Hours</channel>
   <channel site="pluto.tv" site_id="63e36b374e83e70008987c58" lang="en" xmltv_id="">Aftershock</channel>
+  <channel site="pluto.tv" site_id="69b03041cafd86d9dc5763c3" lang="en" xmltv_id="">All My Children</channel>
   <channel site="pluto.tv" site_id="69172f1699758a0f03459c5b" lang="en" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="pluto.tv" site_id="68679fc6bb46d0bdd38ac9a4" lang="en" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="6408ae8f9b39550008caf94f" lang="en" xmltv_id="">American Pickers</channel>
@@ -20,6 +21,7 @@
   <channel site="pluto.tv" site_id="6310cbee5a8ad300070fdb7c" lang="en" xmltv_id="">Best of The Drew Barrymore Show</channel>
   <channel site="pluto.tv" site_id="62fb9844db5a4a0007ebc2a3" lang="en" xmltv_id="">Beyond History</channel>
   <channel site="pluto.tv" site_id="62b976b93279cb000772c6f9" lang="en" xmltv_id="">Bloomberg TV+</channel>
+  <channel site="pluto.tv" site_id="696e647b07ea70192d49f6a5" lang="en" xmltv_id="">Bonanza</channel>
   <channel site="pluto.tv" site_id="66166989635c7500084105a2" lang="en" xmltv_id="">Bondi Rescue</channel>
   <channel site="pluto.tv" site_id="62fb9c4539183b00076a3875" lang="en" xmltv_id="">Busted at the Border</channel>
   <channel site="pluto.tv" site_id="64f8a2a23a0d700008a6ed7b" lang="en" xmltv_id="">Catfish</channel>
@@ -37,11 +39,9 @@
   <channel site="pluto.tv" site_id="638e0f4832494900074481e7" lang="en" xmltv_id="">Confess by Nosey</channel>
   <channel site="pluto.tv" site_id="6601948129adfd0008a1c0ba" lang="en" xmltv_id="">Crime &amp; Justice</channel>
   <channel site="pluto.tv" site_id="6703a96763292d000836b4fa" lang="en" xmltv_id="">Crime Up Close</channel>
-  <channel site="pluto.tv" site_id="62e9224f41d5e100076db2b6" lang="en" xmltv_id="">CSI</channel>
   <channel site="pluto.tv" site_id="6540fec1770cf1000866b65b" lang="en" xmltv_id="">Dance Moms</channel>
   <channel site="pluto.tv" site_id="647f07e74cfc2c0008a2e557" lang="en" xmltv_id="">DAZN TV</channel>
   <channel site="pluto.tv" site_id="62e92951c2db99000787c00d" lang="en" xmltv_id="">Deal or no Deal</channel>
-  <channel site="pluto.tv" site_id="62bdaf9cf1bdc500073a8bcb" lang="en" xmltv_id="">Declassified</channel>
   <channel site="pluto.tv" site_id="62bdaf3470f09a000714a2f6" lang="en" xmltv_id="">Degrassi</channel>
   <channel site="pluto.tv" site_id="65fd548f29adfd00089c662c" lang="en" xmltv_id="">Diagnosis Murder</channel>
   <channel site="pluto.tv" site_id="62e922f6675f71000736db3b" lang="en" xmltv_id="">Doc Martin</channel>
@@ -78,7 +78,10 @@
   <channel site="pluto.tv" site_id="62ea45010d0611000839868c" lang="en" xmltv_id="">Gordon Ramsay&apos;s Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="62e916affb29c60007211c8a" lang="en" xmltv_id="">Gunsmoke</channel>
   <channel site="pluto.tv" site_id="62e917b5e354cf0007b97a67" lang="en" xmltv_id="">Happy Days</channel>
+  <channel site="pluto.tv" site_id="691b012d1148fa1cd8a75d5c" lang="en" xmltv_id="">Hardcore Pawn</channel>
   <channel site="pluto.tv" site_id="63934c218ef524000757b122" lang="en" xmltv_id="">HauntTV</channel>
+  <channel site="pluto.tv" site_id="69dd5d7bfcb9bf5e3063cb16" lang="en" xmltv_id="">History &amp; Warfare</channel>
+  <channel site="pluto.tv" site_id="69b83e4169056557a9252f61" lang="en" xmltv_id="">Hit Sitcoms</channel>
   <channel site="pluto.tv" site_id="62e92967cd663f0007e604fd" lang="en" xmltv_id="">Homeful</channel>
   <channel site="pluto.tv" site_id="65a803b607e03a0008925118" lang="en" xmltv_id="">Hot Ones</channel>
   <channel site="pluto.tv" site_id="63a2f1dda0d69700078b7cba" lang="en" xmltv_id="">I Love Lucy</channel>
@@ -91,9 +94,10 @@
   <channel site="pluto.tv" site_id="62e91b5ca909cb0008114ae4" lang="en" xmltv_id="">Leave it to Bryan</channel>
   <channel site="pluto.tv" site_id="64c2201a2a7f2200089a0af2" lang="en" xmltv_id="">Let&apos;s Make a deal</channel>
   <channel site="pluto.tv" site_id="62b97c5f0d8c8e0007cf48b9" lang="en" xmltv_id="">Life &amp; Legend of Wyatt Earp</channel>
-  <channel site="pluto.tv" site_id="66166ccaaec96800080f6b59" lang="en" xmltv_id="">Massive Makers</channel>
+  <channel site="pluto.tv" site_id="66bb3212fe11e5000883ea6b" lang="en" xmltv_id="">Married... with Children</channel>
   <channel site="pluto.tv" site_id="63da365f60bc8f0008a50f44" lang="en" xmltv_id="">Matlock</channel>
   <channel site="pluto.tv" site_id="62fb6a4feb32e8000708f4d0" lang="en" xmltv_id="">Max &amp; Ruby</channel>
+  <channel site="pluto.tv" site_id="64e89cfc9c1e3900084ca663" lang="en" xmltv_id="">Mayday: Air Disaster</channel>
   <channel site="pluto.tv" site_id="62e92447ea1e2a000735ed33" lang="en" xmltv_id="">Midsomer Murders</channel>
   <channel site="pluto.tv" site_id="62ea43aa0c43540007f2db96" lang="en" xmltv_id="">Mission Impossible</channel>
   <channel site="pluto.tv" site_id="6540ff2d770cf1000866b90a" lang="en" xmltv_id="">Modern Marvels</channel>
@@ -112,41 +116,43 @@
   <channel site="pluto.tv" site_id="65cf8d7428730900087c5907" lang="en" xmltv_id="">Nashville</channel>
   <channel site="pluto.tv" site_id="62f4f5de1c100100075665ef" lang="en" xmltv_id="">NCIS</channel>
   <channel site="pluto.tv" site_id="66a106c8a79dea0008aa5ef3" lang="en" xmltv_id="">NCIS: Los Angeles</channel>
-  <channel site="pluto.tv" site_id="62bdb75c3afd1200079146a6" lang="en" xmltv_id="">Nick Jr. Pluto TV</channel>
+  <channel site="pluto.tv" site_id="62bdb75c3afd1200079146a6" lang="en" xmltv_id="NickJrPlutoTV.us@CA">Nick Jr. Pluto TV</channel>
   <channel site="pluto.tv" site_id="654ca7f92c1d3300086b608c" lang="en" xmltv_id="">NickToons</channel>
   <channel site="pluto.tv" site_id="62fb9ade112ca70007d8441d" lang="en" xmltv_id="">Nonstop Drama</channel>
   <channel site="pluto.tv" site_id="62e93d0a80d8d10008a0181e" lang="en" xmltv_id="">Nosey</channel>
   <channel site="pluto.tv" site_id="62e94ec74823db0007277a8f" lang="en" xmltv_id="">One Piece</channel>
-  <channel site="pluto.tv" site_id="6368e15a51e9560007c592ed" lang="en" xmltv_id="">Out TV Proud</channel>
+  <channel site="pluto.tv" site_id="6368e15a51e9560007c592ed" lang="en" xmltv_id="">OUTflix Movies</channel>
   <channel site="pluto.tv" site_id="63e20bd160bc8f0008b4c949" lang="en" xmltv_id="">Perry Mason</channel>
   <channel site="pluto.tv" site_id="66dad50215d2c60008d7afbd" lang="en" xmltv_id="">Pluto Classic Movie Westerns</channel>
-  <channel site="pluto.tv" site_id="66d717c6abec540008ba7eb5" lang="en" xmltv_id="">Pluto TV 80&apos;s Action</channel>
-  <channel site="pluto.tv" site_id="62ea3c2e4823db00072788ed" lang="en" xmltv_id="">Pluto TV Action Movies</channel>
-  <channel site="pluto.tv" site_id="653bdb0fbdf3cf00089cc395" lang="en" xmltv_id="">Pluto TV Adventure</channel>
-  <channel site="pluto.tv" site_id="68d25b620a0f3829b116bb6f" lang="en" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="638e11951177840007fdd6b2" lang="en" xmltv_id="">Pluto TV British Comedy</channel>
-  <channel site="pluto.tv" site_id="62e91af00c43540007f2bb43" lang="en" xmltv_id="">Pluto TV Classic TV Families</channel>
-  <channel site="pluto.tv" site_id="68d25c623175a2780d051d3a" lang="en" xmltv_id="">Pluto TV Classic TV Variety</channel>
-  <channel site="pluto.tv" site_id="62e92178946c8000079a3160" lang="en" xmltv_id="">Pluto TV Comedy</channel>
-  <channel site="pluto.tv" site_id="62ea3d24b8e02600071fa296" lang="en" xmltv_id="">Pluto TV Comedy Movies</channel>
-  <channel site="pluto.tv" site_id="62e92708a7ce600007b2676a" lang="en" xmltv_id="">Pluto TV Crime Drama</channel>
-  <channel site="pluto.tv" site_id="62bdb0bcd707b9000739d2e5" lang="en" xmltv_id="">Pluto TV Drama Movies</channel>
-  <channel site="pluto.tv" site_id="693adae77f21340ef9746f56" lang="en" xmltv_id="">Pluto TV FBI</channel>
-  <channel site="pluto.tv" site_id="66fe4f71b2ffb100080baae3" lang="en" xmltv_id="">Pluto TV Hibernation Movies</channel>
-  <channel site="pluto.tv" site_id="62ea3f8a38acc80007072d26" lang="en" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="62e92a58f3e4290007290c96" lang="en" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="67922858b83355184c699699" lang="en" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="630f1e6073bd1800082107f0" lang="en" xmltv_id="">Pluto TV Retro Crime Drama</channel>
-  <channel site="pluto.tv" site_id="6408b41b83f58900081d91ad" lang="en" xmltv_id="">Pluto TV Retro Kid</channel>
-  <channel site="pluto.tv" site_id="66166cb1307fa30008f275e7" lang="en" xmltv_id="">Pluto TV Sci-fi</channel>
-  <channel site="pluto.tv" site_id="639b4f75d3d35c0007d37b30" lang="en" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="62e9289f8d467f0007fbc701" lang="en" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="62bdacc96a3751000811842d" lang="en" xmltv_id="">Pluto TV Westerns</channel>
+  <channel site="pluto.tv" site_id="66d717c6abec540008ba7eb5" lang="en" xmltv_id="PlutoTV80sAction.us@CA">Pluto TV 80&apos;s Action</channel>
+  <channel site="pluto.tv" site_id="62ea3c2e4823db00072788ed" lang="en" xmltv_id="PlutoTVActionMovies.us@CA">Pluto TV Action Movies</channel>
+  <channel site="pluto.tv" site_id="653bdb0fbdf3cf00089cc395" lang="en" xmltv_id="PlutoTVAdventure.us@CA">Pluto TV Adventure</channel>
+  <channel site="pluto.tv" site_id="68d25b620a0f3829b116bb6f" lang="en" xmltv_id="PlutoTVAnime.us@CA">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="638e11951177840007fdd6b2" lang="en" xmltv_id="BritishComedy.us@CA">Pluto TV British Comedy</channel>
+  <channel site="pluto.tv" site_id="69c592dff0f1a7d732dc6e36" lang="en" xmltv_id="PlutoTVCars.us@CA">Pluto TV Cars</channel>
+  <channel site="pluto.tv" site_id="62e91af00c43540007f2bb43" lang="en" xmltv_id="ClassicTVFamilies.us@CA">Pluto TV Classic TV Families</channel>
+  <channel site="pluto.tv" site_id="68d25c623175a2780d051d3a" lang="en" xmltv_id="PlutoTVClassicTVVariety.us@CA">Pluto TV Classic TV Variety</channel>
+  <channel site="pluto.tv" site_id="62e92178946c8000079a3160" lang="en" xmltv_id="PlutoTVComedy.us@CA">Pluto TV Comedy</channel>
+  <channel site="pluto.tv" site_id="62ea3d24b8e02600071fa296" lang="en" xmltv_id="PlutoTVComedyMovies.us@CA">Pluto TV Comedy Movies</channel>
+  <channel site="pluto.tv" site_id="62e92708a7ce600007b2676a" lang="en" xmltv_id="PlutoTVCrimeDrama.us@CA">Pluto TV Crime Drama</channel>
+  <channel site="pluto.tv" site_id="62bdb0bcd707b9000739d2e5" lang="en" xmltv_id="PlutoTVDramaMovies.us@CA">Pluto TV Drama Movies</channel>
+  <channel site="pluto.tv" site_id="693adae77f21340ef9746f56" lang="en" xmltv_id="PlutoTVFBI.us@CA">Pluto TV FBI</channel>
+  <channel site="pluto.tv" site_id="62ea3f8a38acc80007072d26" lang="en" xmltv_id="PlutoTVHorror.us@CA">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="62e92a58f3e4290007290c96" lang="en" xmltv_id="PlutoTVParanormal.us@CA">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="67922858b83355184c699699" lang="en" xmltv_id="PlutoTVReality.us@CA">Pluto TV Reality</channel>
+  <channel site="pluto.tv" site_id="69a9ae4d3bd16a4ed04240d7" lang="en" xmltv_id="PlutoTVRetroActionMovies.us@CA">Pluto TV Retro Action Movies</channel>
+  <channel site="pluto.tv" site_id="69aee8a1acb7eb0bb68df641" lang="en" xmltv_id="PlutoTVRetroCrimeAction.us@CA">Pluto TV Retro Crime Action</channel>
+  <channel site="pluto.tv" site_id="630f1e6073bd1800082107f0" lang="en" xmltv_id="PlutoTVRetroCrimeDrama.us@CA">Pluto TV Retro Crime Drama</channel>
+  <channel site="pluto.tv" site_id="6408b41b83f58900081d91ad" lang="en" xmltv_id="PlutoTVRetroKid.us@CA">Pluto TV Retro Kid</channel>
+  <channel site="pluto.tv" site_id="66166cb1307fa30008f275e7" lang="en" xmltv_id="PlutoTVSciFi.us@CA">Pluto TV Sci-fi</channel>
+  <channel site="pluto.tv" site_id="639b4f75d3d35c0007d37b30" lang="en" xmltv_id="PlutoTVSnooker900.us@CA">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="62e9289f8d467f0007fbc701" lang="en" xmltv_id="PlutoTVTrueCrime.us@CA">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="62bdacc96a3751000811842d" lang="en" xmltv_id="PlutoTVWesterns.us@CA">Pluto TV Westerns</channel>
   <channel site="pluto.tv" site_id="66ebf4a88131f10008b74739" lang="en" xmltv_id="">Pokémon</channel>
   <channel site="pluto.tv" site_id="681b16158f97d58ff194a3a9" lang="en" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="696e61287d2afdec4ff2cb75" lang="en" xmltv_id="">Puto TV Classic TV Crime Drama</channel>
   <channel site="pluto.tv" site_id="64240d3d466225000827412b" lang="en" xmltv_id="">Qello Concerts</channel>
   <channel site="pluto.tv" site_id="65660223635c3c00086c2578" lang="en" xmltv_id="">Rawhide</channel>
-  <channel site="pluto.tv" site_id="64e89cfc9c1e3900084ca663" lang="en" xmltv_id="">Real Disaster Channel</channel>
   <channel site="pluto.tv" site_id="62fb61992443200008c59aef" lang="en" xmltv_id="">Reno Duo</channel>
   <channel site="pluto.tv" site_id="62fb6057f923fb0007eafb24" lang="en" xmltv_id="">Reno Rehab</channel>
   <channel site="pluto.tv" site_id="681b196b896dcc617f8558fe" lang="en" xmltv_id="">RigTV</channel>
@@ -154,7 +160,6 @@
   <channel site="pluto.tv" site_id="64a28c62d609b60008ca4933" lang="en" xmltv_id="">Rock Channel</channel>
   <channel site="pluto.tv" site_id="62fb6cd97b90e60007bc318a" lang="en" xmltv_id="">Romance 365</channel>
   <channel site="pluto.tv" site_id="6874ad2f3484d60732267ba8" lang="en" xmltv_id="">Scare Tactics</channel>
-  <channel site="pluto.tv" site_id="63920159db0dea0007dd9932" lang="en" xmltv_id="">Shades of Black</channel>
   <channel site="pluto.tv" site_id="62bdb1c5e25122000798ac79" lang="en" xmltv_id="">South Park</channel>
   <channel site="pluto.tv" site_id="65df4934f7f0af0008c32545" lang="en" xmltv_id="">South Park: Cartman Collection</channel>
   <channel site="pluto.tv" site_id="65df47f428730900089f83ac" lang="en" xmltv_id="">South Park: Kenny Collection</channel>
@@ -162,10 +167,9 @@
   <channel site="pluto.tv" site_id="65df48ba28730900089f8480" lang="en" xmltv_id="">South Park: Stan Collection</channel>
   <channel site="pluto.tv" site_id="663115d923e24f000843b49c" lang="en" xmltv_id="">South Park: Welcome to Canada!</channel>
   <channel site="pluto.tv" site_id="63f87d057533d80008ab9549" lang="en" xmltv_id="">SpongeBob SquarePants</channel>
-  <channel site="pluto.tv" site_id="66601d838ce3110008a9d7bf" lang="en" xmltv_id="">Star Trek: The Next Generation</channel>
-  <channel site="pluto.tv" site_id="66601e338ea5560008f7820e" lang="en" xmltv_id="">Star Trek: The Original Series</channel>
-  <channel site="pluto.tv" site_id="693a85c44b296a40bb0cb3b8" lang="en" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="pluto.tv" site_id="693bf37b75432d022c85ef01" lang="en" xmltv_id="">Stargate</channel>
+  <channel site="pluto.tv" site_id="6654adb1f99922000854388c" lang="en" xmltv_id="">Summer of Movies</channel>
+  <channel site="pluto.tv" site_id="68d66a89064e0a4756f0b3fe" lang="en" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="pluto.tv" site_id="6729d651c7626f0008b5dacf" lang="en" xmltv_id="">Super Channel Hearties</channel>
   <channel site="pluto.tv" site_id="6874ac742704ca31d815b8ed" lang="en" xmltv_id="">Survivor</channel>
   <channel site="pluto.tv" site_id="62e9186f8b685d000773cf58" lang="en" xmltv_id="">Taxi</channel>
@@ -175,7 +179,6 @@
   <channel site="pluto.tv" site_id="66e2a94d167a8b000813485d" lang="en" xmltv_id="">The Conners</channel>
   <channel site="pluto.tv" site_id="62e91384210bec0007ba714c" lang="en" xmltv_id="">The Dick Van Dyke Show</channel>
   <channel site="pluto.tv" site_id="66289716039f940008cf20a2" lang="en" xmltv_id="">The Dog Whisperer with Caesar Millan</channel>
-  <channel site="pluto.tv" site_id="62ea459c8d467f0007fbec86" lang="en" xmltv_id="">The Emeril Lagasse Channel</channel>
   <channel site="pluto.tv" site_id="66166ce7aec96800080f6bd3" lang="en" xmltv_id="">The Graham Norton Show</channel>
   <channel site="pluto.tv" site_id="62e92e536f28870007fa9b3a" lang="en" xmltv_id="">The Judge Judy Channel</channel>
   <channel site="pluto.tv" site_id="62e91563ce7ce300076f917e" lang="en" xmltv_id="">The Love Boat</channel>
@@ -192,14 +195,16 @@
   <channel site="pluto.tv" site_id="6540ff4f7312a40008297b59" lang="en" xmltv_id="">Tiny House Nation</channel>
   <channel site="pluto.tv" site_id="62ea4dadce395f0007086df2" lang="en" xmltv_id="">TNA Wrestling</channel>
   <channel site="pluto.tv" site_id="638e10220aa6a6000726979f" lang="en" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="62e93b8eb8e02600071f8b1d" lang="en" xmltv_id="">Total Crime</channel>
   <channel site="pluto.tv" site_id="62e95265c9fd030007268fb9" lang="en" xmltv_id="">Totally Turtles</channel>
   <channel site="pluto.tv" site_id="63da36dea995710008727d4d" lang="en" xmltv_id="">Transformers</channel>
+  <channel site="pluto.tv" site_id="69dd5d9dceddf13a1a7e39c2" lang="en" xmltv_id="">True Crime Now</channel>
   <channel site="pluto.tv" site_id="66ed3eb27358ce000830df49" lang="en" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="62e924f2be69bc0007b7d53d" lang="en" xmltv_id="">Unsolved Mysteries</channel>
   <channel site="pluto.tv" site_id="635659445b4c4700076d2ad1" lang="en" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="pluto.tv" site_id="688a44cf5d73ec0a3f49718b" lang="en" xmltv_id="">Weeds / Nurse Jackie</channel>
   <channel site="pluto.tv" site_id="6728c561daad7f000881ac83" lang="en" xmltv_id="">Wicked Tuna</channel>
+  <channel site="pluto.tv" site_id="6972546cc62833833a187f50" lang="en" xmltv_id="">Willow Sports</channel>
+  <channel site="pluto.tv" site_id="667d419415f35c0008942dd1" lang="en" xmltv_id="">World of Love Island</channel>
   <channel site="pluto.tv" site_id="62ea4b755e8e770007387b79" lang="en" xmltv_id="">World Poker Tour</channel>
   <channel site="pluto.tv" site_id="654102ed770cf1000866c307" lang="en" xmltv_id="">Yo! MTV</channel>
   <channel site="pluto.tv" site_id="66588931a3865300085ca800" lang="fr" xmltv_id="">Bob l&apos;éponge</channel>

--- a/sites/pluto.tv/pluto.tv_de.channels.xml
+++ b/sites/pluto.tv/pluto.tv_de.channels.xml
@@ -7,12 +7,10 @@
   <channel site="pluto.tv" site_id="655ca57e4261ca00080b3a04" lang="de" xmltv_id="">Anger Management</channel>
   <channel site="pluto.tv" site_id="65a7d99f4a10d800086083a9" lang="de" xmltv_id="">Assassination Classroom</channel>
   <channel site="pluto.tv" site_id="5ede45d077746000072be0fe" lang="de" xmltv_id="">Auction Hunters</channel>
-  <channel site="pluto.tv" site_id="61fbf91afb1b10000880dd08" lang="de" xmltv_id="">Auf Achse</channel>
   <channel site="pluto.tv" site_id="5f760c3d41aa2d0007bfde19" lang="de" xmltv_id="">Auto Motor Sport</channel>
-  <channel site="pluto.tv" site_id="600adbdf8c554e00072125c9" lang="de" xmltv_id="Avatar.us@Germany">Avatar</channel>
   <channel site="pluto.tv" site_id="62bc1784120ba80007935aaa" lang="de" xmltv_id="">Awkward</channel>
+  <channel site="pluto.tv" site_id="6914913274601d957ae35565" lang="de" xmltv_id="">Ax Men - Die Holzfäller</channel>
   <channel site="pluto.tv" site_id="667d63d236a2f90008f72269" lang="de" xmltv_id="">Axel!</channel>
-  <channel site="pluto.tv" site_id="65819e62b228b70008570e9f" lang="de" xmltv_id="">Baywatch</channel>
   <channel site="pluto.tv" site_id="60e4519e6873180007d3cddb" lang="de" xmltv_id="BBCTravel.us@Germany">BBC Travel</channel>
   <channel site="pluto.tv" site_id="630348a54c48ce00077eb6c7" lang="de" xmltv_id="">Becker</channel>
   <channel site="pluto.tv" site_id="67fe498f9ebfe4142424c55d" lang="de" xmltv_id="">Beelzebub</channel>
@@ -21,22 +19,25 @@
   <channel site="pluto.tv" site_id="67ff7dd84906b1acfad97330" lang="de" xmltv_id="">Blue Mountain State</channel>
   <channel site="pluto.tv" site_id="684ac10236c9361b1977f7bc" lang="de" xmltv_id="">Bronco</channel>
   <channel site="pluto.tv" site_id="66337ea1307fa300082c28a0" lang="de" xmltv_id="">BVB-Frauen</channel>
+  <channel site="pluto.tv" site_id="69776f2b2c00406316a01945" lang="de" xmltv_id="">Call My Agent!</channel>
   <channel site="pluto.tv" site_id="62441d6ded1827000763dcda" lang="de" xmltv_id="">CBS News 24/7</channel>
-  <channel site="pluto.tv" site_id="5d4947590ba40f75dc29c26b" lang="de" xmltv_id="CCPlutoTV.us@Germany">CC Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5d4947590ba40f75dc29c26b" lang="de" xmltv_id="CCPlutoTV.de@DACH">CC Pluto TV</channel>
   <channel site="pluto.tv" site_id="60afbad343e3840007164348" lang="de" xmltv_id="ChaosCity.us@Germany">Chaos City</channel>
   <channel site="pluto.tv" site_id="611e7f224676bf00076a4d8d" lang="de" xmltv_id="Cheers.us@Germany">Cheers</channel>
-  <channel site="pluto.tv" site_id="66337e365a402e00087eccaf" lang="de" xmltv_id="">CNN Headlines</channel>
+  <channel site="pluto.tv" site_id="66337e365a402e00087eccaf" lang="de" xmltv_id="">CNN Headlines International</channel>
   <channel site="pluto.tv" site_id="66c45b1803e3b20008d8c200" lang="de" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
   <channel site="pluto.tv" site_id="60c716084d842c00085f6e64" lang="de" xmltv_id="ComedyCentralSouthPark.us@Germany">Comedy Central South Park</channel>
-  <channel site="pluto.tv" site_id="64b67f0424ade50008a3be17" lang="de" xmltv_id="">DAZN Darts x Pluto TV</channel>
-  <channel site="pluto.tv" site_id="6683f7fe36a2f9000804940c" lang="de" xmltv_id="">DAZN Handball x Pluto TV</channel>
-  <channel site="pluto.tv" site_id="64afe50c5dc16600087f3227" lang="de" xmltv_id="">DAZN Heldinnen x Pluto TV</channel>
+  <channel site="pluto.tv" site_id="691b2b690d121b44ad4a53ef" lang="de" xmltv_id="">Dating hinter Gittern</channel>
+  <channel site="pluto.tv" site_id="64b67f0424ade50008a3be17" lang="de" xmltv_id="DAZNDartsxPlutoTV.de@DACH">DAZN Darts x Pluto TV</channel>
+  <channel site="pluto.tv" site_id="6683f7fe36a2f9000804940c" lang="de" xmltv_id="DAZNHandballxPlutoTV.de@DACH">DAZN Handball x Pluto TV</channel>
+  <channel site="pluto.tv" site_id="64afe50c5dc16600087f3227" lang="de" xmltv_id="DAZNHeldinnenxPlutoTV.de@DACH">DAZN Heldinnen x Pluto TV</channel>
+  <channel site="pluto.tv" site_id="69b0167477cdde1f05c8a625" lang="de" xmltv_id="">Der Bergdoktor</channel>
   <channel site="pluto.tv" site_id="67dc21ce5a15c0759a07ee19" lang="de" xmltv_id="">Der Chef</channel>
   <channel site="pluto.tv" site_id="62cebd7302478b00073a6b71" lang="de" xmltv_id="">Der Denver-Clan</channel>
   <channel site="pluto.tv" site_id="688734b9035d6ef9c34aac16" lang="de" xmltv_id="">Die fliegenden Ärzte</channel>
+  <channel site="pluto.tv" site_id="69c2ac2b14c0213702da7a29" lang="de" xmltv_id="">Die glorreichen Sieben</channel>
   <channel site="pluto.tv" site_id="66c6fc06489bab0008b6f9da" lang="de" xmltv_id="">Die Nanny</channel>
   <channel site="pluto.tv" site_id="677fb078a4af36ad50111032" lang="de" xmltv_id="">Die Sieben-Millionen-Dollar-Frau</channel>
-  <channel site="pluto.tv" site_id="6447df8cd3fdde0008f1f627" lang="de" xmltv_id="">Die Thundermans</channel>
   <channel site="pluto.tv" site_id="685aaec481c345899e4458bb" lang="de" xmltv_id="">Dominance FC TV</channel>
   <channel site="pluto.tv" site_id="686d004094a028da3aac8cb0" lang="de" xmltv_id="">Don Matteo</channel>
   <channel site="pluto.tv" site_id="65a67c494a10d800085cab06" lang="de" xmltv_id="">Drake &amp; Josh</channel>
@@ -46,22 +47,21 @@
   <channel site="pluto.tv" site_id="67a324d221af380008105d6f" lang="de" xmltv_id="">Eine schrecklich nette Familie</channel>
   <channel site="pluto.tv" site_id="6639d7d4b18d700008da5316" lang="de" xmltv_id="EuronewsGerman.fr@SD">Euronews</channel>
   <channel site="pluto.tv" site_id="64eddce19001910008df22b8" lang="de" xmltv_id="">F.B.I. Files</channel>
-  <channel site="pluto.tv" site_id="65819f14b9adc4000813ee39" lang="de" xmltv_id="">Familie Dr. Kleist</channel>
   <channel site="pluto.tv" site_id="663a15d7cb3ea10008edac88" lang="de" xmltv_id="">Farmland TV</channel>
   <channel site="pluto.tv" site_id="660bfc032433010008def35a" lang="de" xmltv_id="">FIFA+</channel>
   <channel site="pluto.tv" site_id="6305ca798bd95300072d2f93" lang="de" xmltv_id="">Filmgold</channel>
   <channel site="pluto.tv" site_id="68d277fb12bf71eaaed3e9f1" lang="de" xmltv_id="">Flipper</channel>
   <channel site="pluto.tv" site_id="62a0b2aff4cf470007e47e29" lang="de" xmltv_id="">Fluss-Monster</channel>
   <channel site="pluto.tv" site_id="62cebf042ffc6d0007c4e59a" lang="de" xmltv_id="">Frasier</channel>
-  <channel site="pluto.tv" site_id="67d4572a8d8dc3d775aa4428" lang="de" xmltv_id="">Frasier VIDAA TEST</channel>
+  <channel site="pluto.tv" site_id="6790fa9e1cfc4aa96dfadcef" lang="de" xmltv_id="">Frasier: Berühmte Gäste</channel>
+  <channel site="pluto.tv" site_id="6270ea4345f5bc0007823048" lang="de" xmltv_id="">Fury</channel>
   <channel site="pluto.tv" site_id="6447dea7e94c380008dba94c" lang="de" xmltv_id="">Germany Shore</channel>
+  <channel site="pluto.tv" site_id="68d27437e6767bdeb23f0336" lang="de" xmltv_id="">Gigolos</channel>
   <channel site="pluto.tv" site_id="622f6faf65be650007f57aab" lang="de" xmltv_id="">Hausmeister Krause</channel>
   <channel site="pluto.tv" site_id="680f375e6798ccd1185b58f9" lang="de" xmltv_id="">Heartland</channel>
   <channel site="pluto.tv" site_id="644257fe7cb4b100081ed874" lang="de" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="5e8b580a233dc90007f0cb9d" lang="de" xmltv_id="iCarly.us@Germany">iCarly</channel>
   <channel site="pluto.tv" site_id="5ce40f42ba7f7f5ea9518fe1" lang="de" xmltv_id="IcePilots.us@Germany">Ice Pilots</channel>
-  <channel site="pluto.tv" site_id="67d4586be979b84e78f064d0" lang="de" xmltv_id="">Ice Pilots VIDAA TEST</channel>
-  <channel site="pluto.tv" site_id="67a2367e9a300a00086f2688" lang="de" xmltv_id="">Jackie Chan Adventures</channel>
   <channel site="pluto.tv" site_id="61b33085897b9d000702b72e" lang="de" xmltv_id="">Just.fishing</channel>
   <channel site="pluto.tv" site_id="5cb5cfe5caf83414128f209e" lang="de" xmltv_id="">KultKrimi</channel>
   <channel site="pluto.tv" site_id="65dde5ef28730900089af7cf" lang="de" xmltv_id="">KultKrimi: Der Alte</channel>
@@ -79,12 +79,13 @@
   <channel site="pluto.tv" site_id="634fe5afece2e60007c9d8b8" lang="de" xmltv_id="">Mission Impossible</channel>
   <channel site="pluto.tv" site_id="6824539e1295f98347e95242" lang="de" xmltv_id="">Missions</channel>
   <channel site="pluto.tv" site_id="66337e6ba0a74e000889563b" lang="de" xmltv_id="">MODUS Super Series Darts</channel>
+  <channel site="pluto.tv" site_id="642ad2127ef83900085f8910" lang="de" xmltv_id="">Mork vom Ork</channel>
   <channel site="pluto.tv" site_id="615c1e5ce3039400070a0547" lang="de" xmltv_id="Moviedome.us@Germany">MOVIEDOME</channel>
-  <channel site="pluto.tv" site_id="65a67d572fac9c000835eb3a" lang="de" xmltv_id="">Moviepilot TV mit Pluto TV</channel>
+  <channel site="pluto.tv" site_id="65a67d572fac9c000835eb3a" lang="de" xmltv_id="MoviepilotTVmitPlutoTV.de@DACH">Moviepilot TV mit Pluto TV</channel>
   <channel site="pluto.tv" site_id="5db6a697d5f34a000934cd13" lang="de" xmltv_id="MTVCatfishTVShow.us@Germany">MTV Catfish TV Show</channel>
   <channel site="pluto.tv" site_id="5caf330ea5068259a32320fd" lang="de" xmltv_id="MTVDating.us@Germany">MTV Dating</channel>
-  <channel site="pluto.tv" site_id="5caf325764025859afdd6c4d" lang="de" xmltv_id="MTVPlutoTV.us@Germany">MTV Pluto TV</channel>
-  <channel site="pluto.tv" site_id="685136fb33a52de120bbb086" lang="de" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="5caf325764025859afdd6c4d" lang="de" xmltv_id="MTVPlutoTV.de@DACH">MTV Pluto TV</channel>
+  <channel site="pluto.tv" site_id="685136fb33a52de120bbb086" lang="de" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="5f9847fd513250000728a9a5" lang="de" xmltv_id="MTVRidiculousness.us@Germany">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="5cffcf5686dfe15595fb3f56" lang="de" xmltv_id="MTVTeenMom.us@Germany">MTV Teen Mom</channel>
   <channel site="pluto.tv" site_id="5caf32c2a5068259a32320fc" lang="de" xmltv_id="MTVTheShores.us@Germany">MTV The Shores</channel>
@@ -95,54 +96,59 @@
   <channel site="pluto.tv" site_id="5f0d668b872e4400073acc68" lang="de" xmltv_id="NickelodeonTeen.fr">Nickelodeon Teen</channel>
   <channel site="pluto.tv" site_id="5ede448d3d50590007a4419e" lang="de" xmltv_id="">Nickelodeon Toons</channel>
   <channel site="pluto.tv" site_id="686cfef52704ca31d85c4bf1" lang="de" xmltv_id="">Pastewka</channel>
-  <channel site="pluto.tv" site_id="655ca4b94261ca00080b38d2" lang="de" xmltv_id="">Pensacola – Flügel aus Stahl</channel>
   <channel site="pluto.tv" site_id="64eddc3485efec00085b0369" lang="de" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
-  <channel site="pluto.tv" site_id="65004605110545000842035d" lang="de" xmltv_id="">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="67f68bd2135aeda9ddf0ef54" lang="de" xmltv_id="">Pluto TV Adult Animation</channel>
-  <channel site="pluto.tv" site_id="5d767ae7b456c8cf265ce922" lang="de" xmltv_id="PlutoTVAnimals.us@Germany">Pluto TV Animals</channel>
-  <channel site="pluto.tv" site_id="608181d420fc8500075f612a" lang="de" xmltv_id="PlutoTVAnime.us@Germany">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="67fe495d9ebfe4142424b7a7" lang="de" xmltv_id="">Pluto TV Anime: Fantasy</channel>
-  <channel site="pluto.tv" site_id="677e5a3d7bffa6000808dbf2" lang="de" xmltv_id="">Pluto TV Britische Serien</channel>
-  <channel site="pluto.tv" site_id="5e7b6c60fd20c50007910bf5" lang="de" xmltv_id="PlutoTVCrime.us@Germany">Pluto TV Crime</channel>
-  <channel site="pluto.tv" site_id="67b481cc1a5ca760801c6c5e" lang="de" xmltv_id="">Pluto TV Darts</channel>
-  <channel site="pluto.tv" site_id="6672f49f61a39900089db68e" lang="de" xmltv_id="">Pluto TV Deutsche Comedy</channel>
-  <channel site="pluto.tv" site_id="68b176c2a4841127a8ed1ade" lang="de" xmltv_id="">Pluto TV Europäische Krimis</channel>
-  <channel site="pluto.tv" site_id="5ad9b8551b95267e225e59c1" lang="de" xmltv_id="PlutoTVExplore.us@Germany">Pluto TV Explore</channel>
-  <channel site="pluto.tv" site_id="68245366b19ce6d4a30b7687" lang="de" xmltv_id="">Pluto TV Femme Fatale</channel>
-  <channel site="pluto.tv" site_id="68ada46d5190a45dc9c45af1" lang="de" xmltv_id="">Pluto TV Ferne Galaxien</channel>
-  <channel site="pluto.tv" site_id="5dc280c9aa218c0009724b4b" lang="de" xmltv_id="PlutoTVFood.us@Germany">Pluto TV Food</channel>
-  <channel site="pluto.tv" site_id="64526a145a0cd50008632bfa" lang="de" xmltv_id="">Pluto TV heiße Nächte</channel>
-  <channel site="pluto.tv" site_id="664f10c4f9992200084a2f47" lang="de" xmltv_id="">Pluto TV Heiße Nächte Retro</channel>
-  <channel site="pluto.tv" site_id="68ada3395190a45dc9c445cf" lang="de" xmltv_id="">Pluto TV Historische Serien</channel>
-  <channel site="pluto.tv" site_id="5d767b1c126c65d0a307355f" lang="de" xmltv_id="PlutoTVHistory.us@Germany">Pluto TV History</channel>
-  <channel site="pluto.tv" site_id="62f4f4b88157cf00075c22db" lang="de" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="67ff7d9c7fc25e0e72451bc9" lang="de" xmltv_id="">Pluto TV Horror-Serien</channel>
-  <channel site="pluto.tv" site_id="66337de656fc840008ff7a65" lang="de" xmltv_id="">Pluto TV Kult Comedies</channel>
-  <channel site="pluto.tv" site_id="5dde47b63585b500099f74ec" lang="de" xmltv_id="PlutoTVKultfilme.us@Germany">Pluto TV Kultfilme</channel>
-  <channel site="pluto.tv" site_id="5c5c3b948002db3c3e0b262e" lang="de" xmltv_id="PlutoTVMovies.us@Germany">Pluto TV Movies</channel>
-  <channel site="pluto.tv" site_id="617aad99b68ef100072608cd" lang="de" xmltv_id="">Pluto TV Mystery</channel>
-  <channel site="pluto.tv" site_id="5be1c3f9851dd5632e2c91b2" lang="de" xmltv_id="PlutoTVNature.us@Germany">Pluto TV Nature</channel>
-  <channel site="pluto.tv" site_id="67d984408d8dc3d7754dccf2" lang="de" xmltv_id="">Pluto TV Nordic Crime</channel>
-  <channel site="pluto.tv" site_id="5f98487036af340008da1e37" lang="de" xmltv_id="PlutoTVParanormal.us@Germany">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="64be64445dc166000899ce75" lang="de" xmltv_id="">Pluto TV Polizeiserien</channel>
-  <channel site="pluto.tv" site_id="68ada399247c66a111528aaa" lang="de" xmltv_id="">Pluto TV Popkultur</channel>
-  <channel site="pluto.tv" site_id="67ebc1b6432a0e406f141341" lang="de" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="68ada3edf84960586ad31c7d" lang="de" xmltv_id="">Pluto TV Reportagen</channel>
-  <channel site="pluto.tv" site_id="67d983d6a1609bdb523f5f9b" lang="de" xmltv_id="">Pluto TV Sanfte Berührungen</channel>
-  <channel site="pluto.tv" site_id="60ed498c4248a400077c0b9d" lang="de" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="5d767b4889bca2ce7b73ef2e" lang="de" xmltv_id="">Pluto TV Science</channel>
-  <channel site="pluto.tv" site_id="5dc190f7bfed110009d934c3" lang="de" xmltv_id="">Pluto TV Serie</channel>
-  <channel site="pluto.tv" site_id="5ddbf866b1862a0009a0648e" lang="de" xmltv_id="">Pluto TV Serie+</channel>
-  <channel site="pluto.tv" site_id="669526d232e25300084bb47b" lang="de" xmltv_id="">Pluto TV Sharks</channel>
-  <channel site="pluto.tv" site_id="5d767ab2b456c8cf265ce921" lang="de" xmltv_id="PlutoTVSitcoms.us@Germany">Pluto TV Sitcoms</channel>
-  <channel site="pluto.tv" site_id="5cd149f021cb6c55e258bbe8" lang="de" xmltv_id="">Pluto TV Sitcoms+</channel>
-  <channel site="pluto.tv" site_id="68ac5543a1ac0c90f2c8943e" lang="de" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="61409f8d6feb30000766b675" lang="de" xmltv_id="PlutoTVSpace.us@Germany">Pluto TV Space</channel>
-  <channel site="pluto.tv" site_id="6152ee71bf99590007893a11" lang="de" xmltv_id="">Pluto TV Star Trek</channel>
-  <channel site="pluto.tv" site_id="5e1efdbf90ba3e0009d99082" lang="de" xmltv_id="PlutoTVThrillers.us@Germany">Pluto TV Thriller</channel>
-  <channel site="pluto.tv" site_id="615333098185f00008715a56" lang="de" xmltv_id="PlutoTVTrueCrime.us@Germany">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="630dd3b2605f140007e002f5" lang="de" xmltv_id="">Pluto TV Western</channel>
+  <channel site="pluto.tv" site_id="65004605110545000842035d" lang="de" xmltv_id="PlutoTVAction.de@DACH">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="67f68bd2135aeda9ddf0ef54" lang="de" xmltv_id="PlutoTVAdultAnimation.de@DACH">Pluto TV Adult Animation</channel>
+  <channel site="pluto.tv" site_id="5d767ae7b456c8cf265ce922" lang="de" xmltv_id="PlutoTVAnimals.de@DACH">Pluto TV Animals</channel>
+  <channel site="pluto.tv" site_id="608181d420fc8500075f612a" lang="de" xmltv_id="PlutoTVAnime.de@DACH">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="677e5a3d7bffa6000808dbf2" lang="de" xmltv_id="PlutoTVBritischeSerien.de@DACH">Pluto TV Britische Serien</channel>
+  <channel site="pluto.tv" site_id="64be7398e4391c0008cdedfe" lang="de" xmltv_id="">Pluto TV Bud &amp; Terence</channel>
+  <channel site="pluto.tv" site_id="661801e871e8c30008a73f7b" lang="de" xmltv_id="">Pluto TV Camp</channel>
+  <channel site="pluto.tv" site_id="69b968ba255fecb01f602257" lang="de" xmltv_id="PlutoTVComedyTherapie.de@DACH">Pluto TV Comedy Therapie</channel>
+  <channel site="pluto.tv" site_id="5e7b6c60fd20c50007910bf5" lang="de" xmltv_id="PlutoTVCrime.de@DACH">Pluto TV Crime</channel>
+  <channel site="pluto.tv" site_id="6672f49f61a39900089db68e" lang="de" xmltv_id="PlutoTVDeutscheComedy.de@DACH">Pluto TV Deutsche Comedy</channel>
+  <channel site="pluto.tv" site_id="5ad9b8551b95267e225e59c1" lang="de" xmltv_id="PlutoTVExplore.de@DACH">Pluto TV Explore</channel>
+  <channel site="pluto.tv" site_id="68ada46d5190a45dc9c45af1" lang="de" xmltv_id="PlutoTVFerneGalaxien.de@DACH">Pluto TV Ferne Galaxien</channel>
+  <channel site="pluto.tv" site_id="5dc280c9aa218c0009724b4b" lang="de" xmltv_id="PlutoTVFood.de@DACH">Pluto TV Food</channel>
+  <channel site="pluto.tv" site_id="69b968e011fc7b9e27c0d958" lang="de" xmltv_id="PlutoTVFranBesteMamaMomente.de@DACH">Pluto TV Fran: Beste Mama-Momente</channel>
+  <channel site="pluto.tv" site_id="69b015c5d29cc97de7da4af8" lang="de" xmltv_id="">Pluto TV Haialarm</channel>
+  <channel site="pluto.tv" site_id="64526a145a0cd50008632bfa" lang="de" xmltv_id="PlutoTVheisseNachte.de@DACH">Pluto TV heiße Nächte</channel>
+  <channel site="pluto.tv" site_id="664f10c4f9992200084a2f47" lang="de" xmltv_id="PlutoTVHeisseNachteRetro.de@DACH">Pluto TV Heiße Nächte Retro</channel>
+  <channel site="pluto.tv" site_id="68ada3395190a45dc9c445cf" lang="de" xmltv_id="PlutoTVHistorischeSerien.de@DACH">Pluto TV Historische Serien</channel>
+  <channel site="pluto.tv" site_id="5d767b1c126c65d0a307355f" lang="de" xmltv_id="PlutoTVHistory.de@DACH">Pluto TV History</channel>
+  <channel site="pluto.tv" site_id="62f4f4b88157cf00075c22db" lang="de" xmltv_id="PlutoTVHorror.de@DACH">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="67ff7d9c7fc25e0e72451bc9" lang="de" xmltv_id="PlutoTVHorrorSerien.de@DACH">Pluto TV Horror-Serien</channel>
+  <channel site="pluto.tv" site_id="66337de656fc840008ff7a65" lang="de" xmltv_id="PlutoTVKultComedies.de@DACH">Pluto TV Kult Comedies</channel>
+  <channel site="pluto.tv" site_id="5dde47b63585b500099f74ec" lang="de" xmltv_id="PlutoTVKultfilme.de@DACH">Pluto TV Kultfilme</channel>
+  <channel site="pluto.tv" site_id="69a554179a3f3bb488c7d2be" lang="de" xmltv_id="">Pluto TV Laughs in Spanish</channel>
+  <channel site="pluto.tv" site_id="5c5c3b948002db3c3e0b262e" lang="de" xmltv_id="PlutoTVMovies.de@DACH">Pluto TV Movies</channel>
+  <channel site="pluto.tv" site_id="617aad99b68ef100072608cd" lang="de" xmltv_id="PlutoTVMystery.de@DACH">Pluto TV Mystery</channel>
+  <channel site="pluto.tv" site_id="5be1c3f9851dd5632e2c91b2" lang="de" xmltv_id="PlutoTVNature.de@DACH">Pluto TV Nature</channel>
+  <channel site="pluto.tv" site_id="67d984408d8dc3d7754dccf2" lang="de" xmltv_id="PlutoTVNordicCrime.de@DACH">Pluto TV Nordic Crime</channel>
+  <channel site="pluto.tv" site_id="5f98487036af340008da1e37" lang="de" xmltv_id="PlutoTVParanormal.de@DACH">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="64be64445dc166000899ce75" lang="de" xmltv_id="PlutoTVPolizeiserien.de@DACH">Pluto TV Polizeiserien</channel>
+  <channel site="pluto.tv" site_id="69f209cd0ed14e790bddeb46" lang="de" xmltv_id="">Pluto TV Pride</channel>
+  <channel site="pluto.tv" site_id="67ebc1b6432a0e406f141341" lang="de" xmltv_id="PlutoTVReality.de@DACH">Pluto TV Reality</channel>
+  <channel site="pluto.tv" site_id="68ada3edf84960586ad31c7d" lang="de" xmltv_id="PlutoTVReportagen.de@DACH">Pluto TV Reportagen</channel>
+  <channel site="pluto.tv" site_id="5dc287ce3086a20009f5024c" lang="de" xmltv_id="">Pluto TV Romance</channel>
+  <channel site="pluto.tv" site_id="67d983d6a1609bdb523f5f9b" lang="de" xmltv_id="PlutoTVSanfteBeruhrungen.de@DACH">Pluto TV Sanfte Berührungen</channel>
+  <channel site="pluto.tv" site_id="60ed498c4248a400077c0b9d" lang="de" xmltv_id="PlutoTVSciFi.de@DACH">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="5d767b4889bca2ce7b73ef2e" lang="de" xmltv_id="PlutoTVScience.de@DACH">Pluto TV Science</channel>
+  <channel site="pluto.tv" site_id="5dc190f7bfed110009d934c3" lang="de" xmltv_id="PlutoTVSerie.de@DACH">Pluto TV Serie</channel>
+  <channel site="pluto.tv" site_id="5ddbf866b1862a0009a0648e" lang="de" xmltv_id="PlutoTVSerie.de@DACHPlus">Pluto TV Serie+</channel>
+  <channel site="pluto.tv" site_id="5d767ab2b456c8cf265ce921" lang="de" xmltv_id="PlutoTVSitcoms.de@DACH">Pluto TV Sitcoms</channel>
+  <channel site="pluto.tv" site_id="5cd149f021cb6c55e258bbe8" lang="de" xmltv_id="PlutoTVSitcoms.de@DACHPlus">Pluto TV Sitcoms+</channel>
+  <channel site="pluto.tv" site_id="68ac5543a1ac0c90f2c8943e" lang="de" xmltv_id="PlutoTVSnooker900.de@DACH">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="61409f8d6feb30000766b675" lang="de" xmltv_id="PlutoTVSpace.de@DACH">Pluto TV Space</channel>
+  <channel site="pluto.tv" site_id="6152ee71bf99590007893a11" lang="de" xmltv_id="PlutoTVStarTrek.de@DACH">Pluto TV Star Trek</channel>
+  <channel site="pluto.tv" site_id="69492467ae33e24d916e56cf" lang="de" xmltv_id="PlutoTVStarTrekAnimation.de@DACH">Pluto TV Star Trek: Animation</channel>
+  <channel site="pluto.tv" site_id="615333098185f00008715a56" lang="de" xmltv_id="PlutoTVTrueCrime.de@DACH">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="642ad072283aa4000806148c" lang="de" xmltv_id="">Pluto TV Weihnachten im Sommer</channel>
+  <channel site="pluto.tv" site_id="630dd3b2605f140007e002f5" lang="de" xmltv_id="PlutoTVWestern.de@DACH">Pluto TV Western</channel>
+  <channel site="pluto.tv" site_id="682453215c646751955e1204" lang="de" xmltv_id="PlutoTVWesternSerien.de@DACH">Pluto TV Western Serien</channel>
+  <channel site="pluto.tv" site_id="69b968ca1c36025fd0a3d92d" lang="de" xmltv_id="PlutoTVWorstofBundy.de@DACH">Pluto TV Worst of Bundy</channel>
   <channel site="pluto.tv" site_id="67d984c989788ef7f058b084" lang="de" xmltv_id="">Profiling Paris</channel>
+  <channel site="pluto.tv" site_id="677fafd91da79bfe4fb0b4ec" lang="de" xmltv_id="">Quantum Leap</channel>
   <channel site="pluto.tv" site_id="638f2bc7bc363100072f02dd" lang="de" xmltv_id="">Rauchende Colts</channel>
   <channel site="pluto.tv" site_id="638f2983dcd9100008c2374d" lang="de" xmltv_id="">Rawhide - Tausend Meilen Staub</channel>
   <channel site="pluto.tv" site_id="5e7cb84a172a0f0007da69e4" lang="de" xmltv_id="RedBullTV.at@SD">Red Bull TV</channel>
@@ -151,43 +157,50 @@
   <channel site="pluto.tv" site_id="680f462556ff83bcd6ba2816" lang="de" xmltv_id="">Rookie Blue</channel>
   <channel site="pluto.tv" site_id="64be635a40962900080aaca5" lang="de" xmltv_id="">Rules of Engagement</channel>
   <channel site="pluto.tv" site_id="622f40c901d4b70007ad7609" lang="de" xmltv_id="">Sabrina - Total verhext!</channel>
-  <channel site="pluto.tv" site_id="66c6fb43489bab0008b6f7cd" lang="de" xmltv_id="">Scorpion</channel>
+  <channel site="pluto.tv" site_id="666fe4768768aa0008c31ddf" lang="de" xmltv_id="">Saving Hope</channel>
+  <channel site="pluto.tv" site_id="69b01641a9b840a456a11c18" lang="de" xmltv_id="">Schlosshotel Orth</channel>
+  <channel site="pluto.tv" site_id="69b968a58323ef2714d1aa36" lang="de" xmltv_id="">Schnell ermittelt</channel>
   <channel site="pluto.tv" site_id="688735087b2cf33d01a2d411" lang="de" xmltv_id="">Sea Patrol</channel>
+  <channel site="pluto.tv" site_id="69b14863dd687227e1e4b6b2" lang="de" xmltv_id="">Seaquest</channel>
+  <channel site="pluto.tv" site_id="660c010ce8fba800084f0697" lang="de" xmltv_id="">South Park Armageddon</channel>
+  <channel site="pluto.tv" site_id="664f12bb3d173b0008168c1f" lang="de" xmltv_id="">South Park Rocks!</channel>
   <channel site="pluto.tv" site_id="646b14a0e94c3800082a8d3a" lang="de" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="pluto.tv" site_id="646b14747cb4b1000875724d" lang="de" xmltv_id="">South Park: Cartman Collection</channel>
   <channel site="pluto.tv" site_id="646b1404ee6a2f00082b5d66" lang="de" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="pluto.tv" site_id="646b14d0e1979c0008915a09" lang="de" xmltv_id="">South Park: Kyle Collection</channel>
   <channel site="pluto.tv" site_id="646b1438e94c3800082a8cff" lang="de" xmltv_id="">South Park: Stan Collection</channel>
+  <channel site="pluto.tv" site_id="664f0d373d173b0008164948" lang="de" xmltv_id="">South Park: Stars &amp; Sternchen</channel>
+  <channel site="pluto.tv" site_id="69a554497ed3b3fff0b9ca80" lang="de" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="6576c20fb3801200084786c9" lang="de" xmltv_id="CuriosityChannel.de@SD">SPIEGEL TV</channel>
   <channel site="pluto.tv" site_id="65b9268fc798e800085add89" lang="de" xmltv_id="">SPIEGEL TV Konflikte</channel>
   <channel site="pluto.tv" site_id="5d00e8adaab96b5635b2a005" lang="de" xmltv_id="SpongeBobSchwammkopf.us@Germany">SpongeBob Schwammkopf</channel>
   <channel site="pluto.tv" site_id="663e09b341af640008c1b68c" lang="de" xmltv_id="">Stand-up Comedy</channel>
-  <channel site="pluto.tv" site_id="65a67d200c7ff50008cb131a" lang="de" xmltv_id="">Star Trek: Deep Space Nine</channel>
-  <channel site="pluto.tv" site_id="66337ed7a0a74e0008895699" lang="de" xmltv_id="">Star Trek: Enterprise</channel>
-  <channel site="pluto.tv" site_id="6690fcb7d51259000880d479" lang="de" xmltv_id="">Star Trek: Voyager</channel>
+  <channel site="pluto.tv" site_id="69776ce979545c21a1220bff" lang="de" xmltv_id="">Star Trek: The Next Generation</channel>
+  <channel site="pluto.tv" site_id="69776b58036e883f39e5ab8a" lang="de" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="pluto.tv" site_id="686cff3224918d4300fa542b" lang="de" xmltv_id="">Stromberg</channel>
+  <channel site="pluto.tv" site_id="68d669f9508ba507f075b5fe" lang="de" xmltv_id="">SUMO Paris 2026</channel>
+  <channel site="pluto.tv" site_id="691491c6bb69fb3258c3524a" lang="de" xmltv_id="">Swamp People</channel>
   <channel site="pluto.tv" site_id="6054a9f4bc8a5f000771504c" lang="de" xmltv_id="TakeshisCastle.us@Germany">Takeshi&apos;s Castle</channel>
   <channel site="pluto.tv" site_id="642abea1283aa4000805bb5b" lang="de" xmltv_id="">Täterjagd</channel>
   <channel site="pluto.tv" site_id="5cb5d043a461406ffe3fb2de" lang="de" xmltv_id="">Telenovela ZDF</channel>
   <channel site="pluto.tv" site_id="6870c9333ffa5e0c914e9205" lang="de" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
   <channel site="pluto.tv" site_id="65b923f90cb1a100088a03ab" lang="de" xmltv_id="TerraMaterWILD.de@German">Terra Mater WILD</channel>
+  <channel site="pluto.tv" site_id="68d2759a59fd82da3226492d" lang="de" xmltv_id="">The L Word – Wenn Frauen lieben</channel>
+  <channel site="pluto.tv" site_id="67b481cc1a5ca760801c6c5e" lang="de" xmltv_id="">The Last Flight</channel>
+  <channel site="pluto.tv" site_id="6989b64839dd847194cadcd7" lang="de" xmltv_id="">The Librarians</channel>
+  <channel site="pluto.tv" site_id="6996f0335452cb4f0a2c4153" lang="de" xmltv_id="">The Nanny &amp; Mr Sheffield - A Fine Romance</channel>
+  <channel site="pluto.tv" site_id="68ad90673efb41cd97c95825" lang="de" xmltv_id="">The Outer Limits</channel>
   <channel site="pluto.tv" site_id="677fb0231da79bfe4fb0bf4e" lang="de" xmltv_id="">The Real Housewives</channel>
-  <channel site="pluto.tv" site_id="677fafd91da79bfe4fb0b4ec" lang="de" xmltv_id="">Top Chef</channel>
   <channel site="pluto.tv" site_id="64c109735dc1660008a4a2dc" lang="de" xmltv_id="">Top Gear</channel>
+  <channel site="pluto.tv" site_id="66a10384d5125900089dfd04" lang="de" xmltv_id="">Top Gear Challenge</channel>
   <channel site="pluto.tv" site_id="5d6792bd6be2998ad0ccce30" lang="de" xmltv_id="TotallyTurtles.us@Germany">Totally Turtles</channel>
-  <channel site="pluto.tv" site_id="643683519b32b400094e0a40" lang="de" xmltv_id="">Transformers TV</channel>
   <channel site="pluto.tv" site_id="650adc3198020f000862eed4" lang="de" xmltv_id="">Unentdeckt – Mörder unter uns</channel>
-  <channel site="pluto.tv" site_id="650adb92a1217e00091a3eff" lang="de" xmltv_id="">Unforgettable</channel>
-  <channel site="pluto.tv" site_id="5e8b5e43f294f8000793c3d7" lang="de" xmltv_id="Victorious.us@Germany">Victorious</channel>
-  <channel site="pluto.tv" site_id="67ebc104f7c5d70b90368360" lang="de" xmltv_id="">Wentworth</channel>
-  <channel site="pluto.tv" site_id="609539fa709d6b0007b19887" lang="de" xmltv_id="">Wer ist hier der Boss?</channel>
+  <channel site="pluto.tv" site_id="69b0160da9b840a456a11b4a" lang="de" xmltv_id="">Vier Frauen und ein Todesfall</channel>
   <channel site="pluto.tv" site_id="65253d66c52b3600083d8dd2" lang="de" xmltv_id="">Wicked Tuna</channel>
-  <channel site="pluto.tv" site_id="627d2d1d05e09f00073ccdff" lang="de" xmltv_id="">Willkommen bei den Louds</channel>
-  <channel site="pluto.tv" site_id="65b38e310d9ab400082bdec2" lang="de" xmltv_id="">Wings – Die Überflieger</channel>
+  <channel site="pluto.tv" site_id="697a0577f9c3aa5a215a4ef8" lang="de" xmltv_id="">Will&amp;Grace</channel>
   <channel site="pluto.tv" site_id="5ad9b7aae738977e2c312132" lang="de" xmltv_id="WorldPokerTour.us@Germany">World Poker Tour</channel>
   <channel site="pluto.tv" site_id="642d7e029189ce0008958af5" lang="de" xmltv_id="">X-Factor: Das Unfassbare</channel>
-  <channel site="pluto.tv" site_id="655ca2c99d5ac400080d1324" lang="de" xmltv_id="">Xena – Die Kriegerprinzessin</channel>
   <channel site="pluto.tv" site_id="642d4493aa2d690008f0a03f" lang="de" xmltv_id="">Yu-Gi-Oh!</channel>
-  <channel site="pluto.tv" site_id="63c69e6c4207be0007f73c22" lang="de" xmltv_id="">Zoey 101</channel>
+  <channel site="pluto.tv" site_id="67ebc04855de98dc71428538" lang="en" xmltv_id="PlutoTVEmmanuelleFilme.de@DACH">Pluto TV Emmanuelle Filme</channel>
   <channel site="pluto.tv" site_id="646b150a15939400089e2702" lang="en" xmltv_id="">South Park: Original Version</channel>
 </channels>

--- a/sites/pluto.tv/pluto.tv_dk.channels.xml
+++ b/sites/pluto.tv/pluto.tv_dk.channels.xml
@@ -2,12 +2,15 @@
 <channels>
   <channel site="pluto.tv" site_id="65b915780cb1a1000889b837" lang="da" xmltv_id="">3point.dk</channel>
   <channel site="pluto.tv" site_id="6728c9c85534bb0008b320a4" lang="da" xmltv_id="">7th Heaven</channel>
+  <channel site="pluto.tv" site_id="699c15a9f0b71f2e2eec4393" lang="da" xmltv_id="">21 Jump Street</channel>
   <channel site="pluto.tv" site_id="6346937a46f9a2000889073d" lang="da" xmltv_id="">48 Hours</channel>
   <channel site="pluto.tv" site_id="6720bc6cdaad7f000872a6e2" lang="da" xmltv_id="">2900 Happiness</channel>
+  <channel site="pluto.tv" site_id="6915e0eda570568f53435398" lang="da" xmltv_id="">Afterwork TV</channel>
   <channel site="pluto.tv" site_id="6577224bb3801200084865d6" lang="da" xmltv_id="">All exclusive</channel>
   <channel site="pluto.tv" site_id="69143de2a570568f53230cab" lang="da" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="pluto.tv" site_id="6464cc595a0cd500088c7749" lang="da" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="6177fb39b68ef1000725e59e" lang="da" xmltv_id="">Andromeda</channel>
+  <channel site="pluto.tv" site_id="6964b6f5f7f6b0334bbf6cdb" lang="da" xmltv_id="">Anger Management</channel>
   <channel site="pluto.tv" site_id="61c091c39863900007ac9e8f" lang="da" xmltv_id="">Are You The One?</channel>
   <channel site="pluto.tv" site_id="62da73c4ec46c000070f4cb1" lang="da" xmltv_id="">Auction Hunters</channel>
   <channel site="pluto.tv" site_id="61c09b48d6d97900076e91c5" lang="da" xmltv_id="">Avatar</channel>
@@ -17,7 +20,6 @@
   <channel site="pluto.tv" site_id="6512ec7a2ce8e40008bdb433" lang="da" xmltv_id="">Beauty and the Beast</channel>
   <channel site="pluto.tv" site_id="6486e8984cfc2c0008b6844e" lang="da" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="pluto.tv" site_id="672e157d7d5da5000812872d" lang="da" xmltv_id="">Becker</channel>
-  <channel site="pluto.tv" site_id="62792f34f3aa05000728841e" lang="da" xmltv_id="">Bellator MMA</channel>
   <channel site="pluto.tv" site_id="632aff5e44111b00076ad9b1" lang="da" xmltv_id="">Best of MTV</channel>
   <channel site="pluto.tv" site_id="62beb692cda2b10007d5fd76" lang="da" xmltv_id="">Best of The Drew Barrymore Show</channel>
   <channel site="pluto.tv" site_id="61c1939b8929e40007ff6382" lang="da" xmltv_id="">BET</channel>
@@ -29,9 +31,9 @@
   <channel site="pluto.tv" site_id="67a09ddc21af380008088dc3" lang="da" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="65cba73611ced700082123bc" lang="da" xmltv_id="">Broad City</channel>
   <channel site="pluto.tv" site_id="685029cda1e091e16ff57fc8" lang="da" xmltv_id="">Brøndby TV</channel>
+  <channel site="pluto.tv" site_id="6964b982ca459f9b939da8e6" lang="da" xmltv_id="">Bull</channel>
   <channel site="pluto.tv" site_id="65a93b0607e03a000895abda" lang="da" xmltv_id="">Car Chase</channel>
   <channel site="pluto.tv" site_id="66a7aa44cd0d31000843942b" lang="da" xmltv_id="">Caroline in the City</channel>
-  <channel site="pluto.tv" site_id="64e87cc644fe100009ccad13" lang="da" xmltv_id="">Casualty 24/7</channel>
   <channel site="pluto.tv" site_id="61e82af27027f9000753c6e4" lang="da" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="65788076b228b7000843fc9a" lang="da" xmltv_id="">Celeb Reality</channel>
   <channel site="pluto.tv" site_id="65e976ad0d456100082d9b74" lang="da" xmltv_id="">Chappelle&apos;s Show</channel>
@@ -40,12 +42,15 @@
   <channel site="pluto.tv" site_id="61c0989431084d0007eab12d" lang="da" xmltv_id="">Comedy Central</channel>
   <channel site="pluto.tv" site_id="6641fd41b18d700008e7e2b8" lang="da" xmltv_id="">Comedy Central Roast</channel>
   <channel site="pluto.tv" site_id="6400bc50953da40008b94668" lang="da" xmltv_id="">COPS</channel>
+  <channel site="pluto.tv" site_id="693ae5660eedebc8d5db6579" lang="da" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="pluto.tv" site_id="657880c46e4f6a00087404d0" lang="da" xmltv_id="">Crime 360</channel>
   <channel site="pluto.tv" site_id="6426a821a3ade7000800031c" lang="da" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="pluto.tv" site_id="6525419dc52b3600083db9c3" lang="da" xmltv_id="">CSI</channel>
   <channel site="pluto.tv" site_id="64e87c6b28cec700088ceb55" lang="da" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="pluto.tv" site_id="65787eefcbd0d60008f85b3f" lang="da" xmltv_id="">Dance Moms</channel>
-  <channel site="pluto.tv" site_id="64805922536e0c0008a1a1e6" lang="da" xmltv_id="">DAZN Combat</channel>
+  <channel site="pluto.tv" site_id="692edc78d52ea9e4858cf78f" lang="da" xmltv_id="">Dating Naked UK</channel>
+  <channel site="pluto.tv" site_id="64805922536e0c0008a1a1e6" lang="da" xmltv_id="">DAZN Ringside</channel>
+  <channel site="pluto.tv" site_id="69172a4fcf4a1101befdd894" lang="da" xmltv_id="">De unge mødre</channel>
   <channel site="pluto.tv" site_id="689a0ab0f4af1aaca24530ae" lang="da" xmltv_id="">Den gode gerning</channel>
   <channel site="pluto.tv" site_id="66b22714d512590008c3d573" lang="da" xmltv_id="">Den gule sofa med Allan Sindberg</channel>
   <channel site="pluto.tv" site_id="660d6bc10cd4630008f4a25a" lang="da" xmltv_id="">Det sene show med Christian Fuhlendorff</channel>
@@ -55,43 +60,40 @@
   <channel site="pluto.tv" site_id="65787fb36e4f6a0008740127" lang="da" xmltv_id="">Dog The Bounty Hunter</channel>
   <channel site="pluto.tv" site_id="68f0fa98fae18f8db62a920a" lang="da" xmltv_id="">Dollars</channel>
   <channel site="pluto.tv" site_id="67a23b4e15d6eb000827a20d" lang="da" xmltv_id="">Dominance FC TV</channel>
-  <channel site="pluto.tv" site_id="68f0f71bb45f4453e05c0863" lang="da" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
   <channel site="pluto.tv" site_id="65787e8232c1b300089a8482" lang="da" xmltv_id="">Duck Dynasty</channel>
-  <channel site="pluto.tv" site_id="68adad09e7bb4fffe8a9461b" lang="da" xmltv_id="">Ernest goes to Pluto TV</channel>
   <channel site="pluto.tv" site_id="66d712fdabec540008ba66cd" lang="da" xmltv_id="">Escape to the Country</channel>
   <channel site="pluto.tv" site_id="61de96114757070008d33cae" lang="da" xmltv_id="">Euronews</channel>
   <channel site="pluto.tv" site_id="63a1cab19ab2df0007bf1c8b" lang="da" xmltv_id="">Everybody Hates Chris</channel>
   <channel site="pluto.tv" site_id="61c0909b872c650008ed42e4" lang="da" xmltv_id="">Ex On The Beach</channel>
-  <channel site="pluto.tv" site_id="65ba4c9adc10a40008d9fecc" lang="da" xmltv_id="">Explore TV</channel>
   <channel site="pluto.tv" site_id="6177f6bf7693550007531275" lang="da" xmltv_id="">FailArmy</channel>
   <channel site="pluto.tv" site_id="61c19c8c9863900007acaa57" lang="da" xmltv_id="">Familien fra Bryggen</channel>
+  <channel site="pluto.tv" site_id="654a4a3ef91d250008ac089b" lang="da" xmltv_id="">Family Ties</channel>
+  <channel site="pluto.tv" site_id="699c1b4c9c3b075ecd513139" lang="da" xmltv_id="">Farscape</channel>
   <channel site="pluto.tv" site_id="61814659533163000748aa04" lang="da" xmltv_id="">FBI Files</channel>
   <channel site="pluto.tv" site_id="6790d6c7bc03978b9bfbfd44" lang="da" xmltv_id="">FBoy Island</channel>
   <channel site="pluto.tv" site_id="68ac5403de4a734954b5ab75" lang="da" xmltv_id="">FCK Løvinderne</channel>
   <channel site="pluto.tv" site_id="660bfc7b2433010008def3e3" lang="da" xmltv_id="">FIFA+</channel>
+  <channel site="pluto.tv" site_id="698ddd6ec144dcc29b866133" lang="da" xmltv_id="">Flipper: The New Adventures</channel>
   <channel site="pluto.tv" site_id="6272511cb389bb0007b30b09" lang="da" xmltv_id="">For lækker til love</channel>
   <channel site="pluto.tv" site_id="6181241c1a35d50007874c27" lang="da" xmltv_id="">Forensic Files</channel>
   <channel site="pluto.tv" site_id="61c19dcefbb4b50007d242e1" lang="da" xmltv_id="">Forsidefruer</channel>
   <channel site="pluto.tv" site_id="6400c095498393000878a634" lang="da" xmltv_id="">Frasier</channel>
-  <channel site="pluto.tv" site_id="6825f91b5c64675195a57f29" lang="da" xmltv_id="">Frasier: Det bedste med Niles</channel>
-  <channel site="pluto.tv" site_id="6708f022565d3a0008a552f3" lang="da" xmltv_id="">Frasiers bedste gæstestjerner</channel>
-  <channel site="pluto.tv" site_id="6708f068a07d1a000800b403" lang="da" xmltv_id="">Frasiers herlige højtider</channel>
-  <channel site="pluto.tv" site_id="65b3d7c033ea860008516824" lang="da" xmltv_id="">From South Park with Love</channel>
+  <channel site="pluto.tv" site_id="6969fc6c3b9ce349c9e41670" lang="da" xmltv_id="">Fristet</channel>
   <channel site="pluto.tv" site_id="6442512cee6a2f0008d3351f" lang="da" xmltv_id="">Geordie Shore</channel>
   <channel site="pluto.tv" site_id="619e1bb3e9af5a0007f235ad" lang="da" xmltv_id="">Ghost Dimension</channel>
-  <channel site="pluto.tv" site_id="65e9b6498b24c8000806b982" lang="da" xmltv_id="">Glory Kickboxing</channel>
-  <channel site="pluto.tv" site_id="654a4e29ab05240008a18625" lang="da" xmltv_id="">Happy Days</channel>
+  <channel site="pluto.tv" site_id="69c290eeed1b1f1acb446dd8" lang="da" xmltv_id="">Gustav &amp; Linse på udebane</channel>
   <channel site="pluto.tv" site_id="6909fc4b74601d957a380613" lang="da" xmltv_id="">Hardcore Pawn</channel>
   <channel site="pluto.tv" site_id="61c194ff6f23a7000780073a" lang="da" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="68bff9a63efb41cd97562e46" lang="da" xmltv_id="">Highway to Heaven</channel>
-  <channel site="pluto.tv" site_id="64e87ce528cec700088cec55" lang="da" xmltv_id="">Hoarders &amp; Dirty Home Rescue</channel>
   <channel site="pluto.tv" site_id="619e21b213ef6b0007d8c17a" lang="da" xmltv_id="">Homicide Hunter</channel>
   <channel site="pluto.tv" site_id="671b4dc049c4060008f91d3a" lang="da" xmltv_id="">Horse &amp; Country</channel>
   <channel site="pluto.tv" site_id="655ca7405812e80008883d4e" lang="da" xmltv_id="">Hot Ones</channel>
+  <channel site="pluto.tv" site_id="693ae62a43fe00a023e76e0d" lang="da" xmltv_id="">House of Lies</channel>
   <channel site="pluto.tv" site_id="6501af923a0d700008b71b53" lang="da" xmltv_id="">Hundehviskeren</channel>
   <channel site="pluto.tv" site_id="657881c46e4f6a00087414c2" lang="da" xmltv_id="">I Survived</channel>
   <channel site="pluto.tv" site_id="62cd97fb9f8154000727516c" lang="da" xmltv_id="">Ice Pilots</channel>
   <channel site="pluto.tv" site_id="633560bfa693390008b99cf0" lang="da" xmltv_id="">Ice Road Truckers</channel>
+  <channel site="pluto.tv" site_id="691ed751bef819002f2c7296" lang="da" xmltv_id="">Inter 24/7</channel>
   <channel site="pluto.tv" site_id="682b385876963fba9abf0f26" lang="da" xmltv_id="">Iron Chef</channel>
   <channel site="pluto.tv" site_id="660d6ade0cd4630008f4a127" lang="da" xmltv_id="">Jade Fever</channel>
   <channel site="pluto.tv" site_id="654a4ab92c1d330008657ae5" lang="da" xmltv_id="">JAG</channel>
@@ -100,18 +102,19 @@
   <channel site="pluto.tv" site_id="6380c36389eccc000858c50f" lang="da" xmltv_id="">Judge Judy</channel>
   <channel site="pluto.tv" site_id="6177fd9812fe0c000726f9eb" lang="da" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="pluto.tv" site_id="65cba715dc10a40008034917" lang="da" xmltv_id="">Key &amp; Peele</channel>
-  <channel site="pluto.tv" site_id="659fbb566e4f6a0008b868e6" lang="da" xmltv_id="">Kickin&apos;it</channel>
   <channel site="pluto.tv" site_id="660d667519ca71000849a1e1" lang="da" xmltv_id="">Koch&apos;en på toppen</channel>
   <channel site="pluto.tv" site_id="657c0954dfed030008d82ea1" lang="da" xmltv_id="">Kvart i Bold</channel>
   <channel site="pluto.tv" site_id="654a3fe6986ad20008a42add" lang="da" xmltv_id="">Langt fra Bryggen</channel>
   <channel site="pluto.tv" site_id="654a4cc3f91d250008ac11f6" lang="da" xmltv_id="">Love Boat</channel>
   <channel site="pluto.tv" site_id="61c19bfb3bf4940007804d32" lang="da" xmltv_id="">Love Island Danmark</channel>
   <channel site="pluto.tv" site_id="62bed7cb3279cb0007735327" lang="da" xmltv_id="">Love Island UK</channel>
+  <channel site="pluto.tv" site_id="695e2857026be6e9d3ad59d3" lang="da" xmltv_id="">Love Island USA</channel>
   <channel site="pluto.tv" site_id="68ad8bececd330dcb0f050b5" lang="da" xmltv_id="">Love Island: All Stars</channel>
   <channel site="pluto.tv" site_id="61c19b7785706b00072d421a" lang="da" xmltv_id="">Luksusfælden</channel>
   <channel site="pluto.tv" site_id="654a59742c1d33000865a797" lang="da" xmltv_id="">MacGyver</channel>
   <channel site="pluto.tv" site_id="678f88bb272ded16b1558c5e" lang="da" xmltv_id="">Man with a Plan</channel>
   <channel site="pluto.tv" site_id="61c19edbf535220007075c4e" lang="da" xmltv_id="">MasterChef Danmarks største madtalenter</channel>
+  <channel site="pluto.tv" site_id="66290a779e68c20008a18cf3" lang="da" xmltv_id="">Matlock</channel>
   <channel site="pluto.tv" site_id="63e3b33e8795f300087e6a46" lang="da" xmltv_id="">Med kniven for struben</channel>
   <channel site="pluto.tv" site_id="66952e1ed512590008867b5a" lang="da" xmltv_id="">Mediano TV</channel>
   <channel site="pluto.tv" site_id="68f0f54ca362b63a8df4d5a9" lang="da" xmltv_id="">Medium</channel>
@@ -124,7 +127,7 @@
   <channel site="pluto.tv" site_id="65c33fd4dc10a40008f26af8" lang="da" xmltv_id="">Monster Jam</channel>
   <channel site="pluto.tv" site_id="6177fe76691b2e000702c7fc" lang="da" xmltv_id="">MTV Catfish</channel>
   <channel site="pluto.tv" site_id="6851407c21f49d1b9d177493" lang="da" xmltv_id="">MTV Dating</channel>
-  <channel site="pluto.tv" site_id="685137f4a1e091e16f2dd471" lang="da" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="685137f4a1e091e16f2dd471" lang="da" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="62cd9641393d8400076f34db" lang="da" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="61c092157e1b8b0007372a35" lang="da" xmltv_id="">MTV Teen Mom</channel>
   <channel site="pluto.tv" site_id="6319ec31c62c3f00075c90b1" lang="da" xmltv_id="">NCIS</channel>
@@ -139,46 +142,51 @@
   <channel site="pluto.tv" site_id="629e095e511d4b00070c9f44" lang="da" xmltv_id="">Paradise</channel>
   <channel site="pluto.tv" site_id="61c19af83fae0a00078c8918" lang="da" xmltv_id="">Paradise Hotel</channel>
   <channel site="pluto.tv" site_id="662b71658dd8160008fc3abf" lang="da" xmltv_id="">Paradise Hotel: Under lagnerne</channel>
-  <channel site="pluto.tv" site_id="65b8f959eb87e30008333201" lang="da" xmltv_id="">PFL MMA</channel>
   <channel site="pluto.tv" site_id="66c870112630fc0008137ae2" lang="da" xmltv_id="">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="61c091343bf4940007803e03" lang="da" xmltv_id="">Pimp My Ride</channel>
   <channel site="pluto.tv" site_id="62790dc1c733e8000733ba4d" lang="da" xmltv_id="">Pixel.tv</channel>
-  <channel site="pluto.tv" site_id="61c095861782bd000780e0ba" lang="da" xmltv_id="">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="650999b86a841400083bd1ab" lang="da" xmltv_id="">Pluto TV Alien Invasion</channel>
-  <channel site="pluto.tv" site_id="65b915b1dc10a40008d53797" lang="da" xmltv_id="">Pluto TV Bud &amp; Terence</channel>
-  <channel site="pluto.tv" site_id="67d2b814fe36d6e7b1d2318a" lang="da" xmltv_id="">Pluto TV Danske klassikere</channel>
-  <channel site="pluto.tv" site_id="62b30b0060a9ca0007d628b4" lang="da" xmltv_id="">Pluto TV Dokumentar</channel>
-  <channel site="pluto.tv" site_id="61c09515fbb4b50007d221f5" lang="da" xmltv_id="">Pluto TV Film</channel>
-  <channel site="pluto.tv" site_id="619e1874e0d3a7000729a036" lang="da" xmltv_id="">Pluto TV Fishing</channel>
-  <channel site="pluto.tv" site_id="68dfa431cc3c6cd904053100" lang="da" xmltv_id="">Pluto TV Håndbold Highlights</channel>
-  <channel site="pluto.tv" site_id="6618f54baec96800081525ec" lang="da" xmltv_id="">Pluto TV Håndbold Live</channel>
-  <channel site="pluto.tv" site_id="63a1c9790cc44a0007dc8857" lang="da" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="61c0974945b45d0007aaa5ac" lang="da" xmltv_id="">Pluto TV Humor</channel>
-  <channel site="pluto.tv" site_id="655ca7aa635c3c000855d655" lang="da" xmltv_id="">Pluto TV John Wayne</channel>
-  <channel site="pluto.tv" site_id="61c09a78bd194c0008decc28" lang="da" xmltv_id="">Pluto TV Juniorklubben</channel>
-  <channel site="pluto.tv" site_id="67f508992ebe80e2929b5c98" lang="da" xmltv_id="">Pluto TV Klassiske tegnefilm</channel>
-  <channel site="pluto.tv" site_id="63dbe7ed51f5d000083e9499" lang="da" xmltv_id="">Pluto TV Kultfilm</channel>
-  <channel site="pluto.tv" site_id="63a1c954d3897300079fcb12" lang="da" xmltv_id="">Pluto TV Romantik</channel>
-  <channel site="pluto.tv" site_id="61f9598588f86000078ee7d6" lang="da" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="68ac55bb3efb41cd979a65ec" lang="da" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="61b86c6ef30f5d0007e4c6d1" lang="da" xmltv_id="">Pluto TV Space</channel>
-  <channel site="pluto.tv" site_id="6357f3de3643ba0007bc0b50" lang="da" xmltv_id="">Pluto TV Sport</channel>
-  <channel site="pluto.tv" site_id="61c1979dfa307000070bbe4d" lang="da" xmltv_id="">Pluto TV Star Trek</channel>
-  <channel site="pluto.tv" site_id="61c09938e0d3a700072b68b1" lang="da" xmltv_id="">Pluto TV Tegnefilm</channel>
-  <channel site="pluto.tv" site_id="61c097ec8bb1830008e3f962" lang="da" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="67f3fb1cdea1c5e0d588ac1b" lang="da" xmltv_id="">Pluto TV Ungdomsserier</channel>
-  <channel site="pluto.tv" site_id="677d397b60fbeb00084b0bff" lang="da" xmltv_id="">Pluto TV Verdenskrigene</channel>
-  <channel site="pluto.tv" site_id="68c01732b3900870ec74766f" lang="da" xmltv_id="">Pluto TV Wild West</channel>
-  <channel site="pluto.tv" site_id="67f79fdb3481170e68c0bc38" lang="da" xmltv_id="">PodRadio på Pluto TV</channel>
+  <channel site="pluto.tv" site_id="61c095861782bd000780e0ba" lang="da" xmltv_id="PlutoTVAction.se@DK">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="650999b86a841400083bd1ab" lang="da" xmltv_id="PlutoTVAlienInvasion.se@DK">Pluto TV Alien Invasion</channel>
+  <channel site="pluto.tv" site_id="65b915b1dc10a40008d53797" lang="da" xmltv_id="PlutoTVBudTerence.se@DK">Pluto TV Bud &amp; Terence</channel>
+  <channel site="pluto.tv" site_id="67d2b814fe36d6e7b1d2318a" lang="da" xmltv_id="PlutoTVDanskeklassikere.se@DK">Pluto TV Danske klassikere</channel>
+  <channel site="pluto.tv" site_id="62b30b0060a9ca0007d628b4" lang="da" xmltv_id="PlutoTVDokumentar.se@DK">Pluto TV Dokumentar</channel>
+  <channel site="pluto.tv" site_id="61c09515fbb4b50007d221f5" lang="da" xmltv_id="PlutoTVFilm.se@DK">Pluto TV Film</channel>
+  <channel site="pluto.tv" site_id="619e1874e0d3a7000729a036" lang="da" xmltv_id="PlutoTVFishing.se@DK">Pluto TV Fishing</channel>
+  <channel site="pluto.tv" site_id="68dfa431cc3c6cd904053100" lang="da" xmltv_id="PlutoTVHandboldHighlights.se@DK">Pluto TV Håndbold Highlights</channel>
+  <channel site="pluto.tv" site_id="6618f54baec96800081525ec" lang="da" xmltv_id="PlutoTVHandboldLive.se@DK">Pluto TV Håndbold Live</channel>
+  <channel site="pluto.tv" site_id="68c01afa3efb41cd9759dafb" lang="da" xmltv_id="PlutoTVHarlequin.se@DK">Pluto TV Harlequin</channel>
+  <channel site="pluto.tv" site_id="63a1c9790cc44a0007dc8857" lang="da" xmltv_id="PlutoTVHorror.se@DK">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="61c0974945b45d0007aaa5ac" lang="da" xmltv_id="PlutoTVHumor.se@DK">Pluto TV Humor</channel>
+  <channel site="pluto.tv" site_id="655ca7aa635c3c000855d655" lang="da" xmltv_id="PlutoTVJohnWayne.se@DK">Pluto TV John Wayne</channel>
+  <channel site="pluto.tv" site_id="61c09a78bd194c0008decc28" lang="da" xmltv_id="PlutoTVJuniorklubben.se@DK">Pluto TV Juniorklubben</channel>
+  <channel site="pluto.tv" site_id="67f508992ebe80e2929b5c98" lang="da" xmltv_id="PlutoTVKlassisketegnefilm.se@DK">Pluto TV Klassiske tegnefilm</channel>
+  <channel site="pluto.tv" site_id="63dbe7ed51f5d000083e9499" lang="da" xmltv_id="PlutoTVKultfilm.se@DK">Pluto TV Kultfilm</channel>
+  <channel site="pluto.tv" site_id="68ac51dede4a734954b5a67a" lang="da" xmltv_id="PlutoTVMotor.se@DK">Pluto TV Motor</channel>
+  <channel site="pluto.tv" site_id="62b30beb81f89900071fc7b9" lang="da" xmltv_id="PlutoTVParanormal.se@DK">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="63a1c954d3897300079fcb12" lang="da" xmltv_id="PlutoTVRomantik.se@DK">Pluto TV Romantik</channel>
+  <channel site="pluto.tv" site_id="61f9598588f86000078ee7d6" lang="da" xmltv_id="PlutoTVSciFi.se@DK">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="68ac55bb3efb41cd979a65ec" lang="da" xmltv_id="PlutoTVSnooker900.se@DK">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="61b86c6ef30f5d0007e4c6d1" lang="da" xmltv_id="PlutoTVSpace.se@DK">Pluto TV Space</channel>
+  <channel site="pluto.tv" site_id="6357f3de3643ba0007bc0b50" lang="da" xmltv_id="PlutoTVSport.se@DK">Pluto TV Sport</channel>
+  <channel site="pluto.tv" site_id="61c1979dfa307000070bbe4d" lang="da" xmltv_id="PlutoTVStarTrek.se@DK">Pluto TV Star Trek</channel>
+  <channel site="pluto.tv" site_id="61c09938e0d3a700072b68b1" lang="da" xmltv_id="PlutoTVTegnefilm.se@DK">Pluto TV Tegnefilm</channel>
+  <channel site="pluto.tv" site_id="61c097ec8bb1830008e3f962" lang="da" xmltv_id="PlutoTVTrueCrime.se@DK">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="67f3fb1cdea1c5e0d588ac1b" lang="da" xmltv_id="PlutoTVUngdomsserier.se@DK">Pluto TV Ungdomsserier</channel>
+  <channel site="pluto.tv" site_id="677d397b60fbeb00084b0bff" lang="da" xmltv_id="PlutoTVVerdenskrigene.se@DK">Pluto TV Verdenskrigene</channel>
+  <channel site="pluto.tv" site_id="68c01732b3900870ec74766f" lang="da" xmltv_id="PlutoTVWildWest.se@DK">Pluto TV Wild West</channel>
+  <channel site="pluto.tv" site_id="67f79fdb3481170e68c0bc38" lang="da" xmltv_id="PodRadiopaPlutoTV.se@DK">PodRadio på Pluto TV</channel>
   <channel site="pluto.tv" site_id="627254d6ba35210007e5d4ca" lang="da" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="698ddf5a8c21a5f2d64c14a8" lang="da" xmltv_id="">r8Dio TV</channel>
+  <channel site="pluto.tv" site_id="6964ba787e92438c2754e924" lang="da" xmltv_id="">Rawhide</channel>
   <channel site="pluto.tv" site_id="692ec3a76f84242a60f75f59" lang="da" xmltv_id="">Reality Awards</channel>
   <channel site="pluto.tv" site_id="660d714719ca71000849cc1f" lang="da" xmltv_id="">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="699c18cbf2ad90a4792fd5b8" lang="da" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="65e9766eec9fda0008cb418a" lang="da" xmltv_id="">Reno 911</channel>
+  <channel site="pluto.tv" site_id="66fd1338ec9d6d00081e0443" lang="da" xmltv_id="">Retake E-sport Live</channel>
   <channel site="pluto.tv" site_id="68dfa160cc3c6cd90404d798" lang="da" xmltv_id="">Ridiculousness - Nye afsnit</channel>
   <channel site="pluto.tv" site_id="662a271c06839f0008ccf733" lang="da" xmltv_id="">River Monsters</channel>
   <channel site="pluto.tv" site_id="63a42df60cc44a0007dd47f8" lang="da" xmltv_id="">Robinson Ekspeditionen</channel>
   <channel site="pluto.tv" site_id="6512ecf63a0d700008db506a" lang="da" xmltv_id="">Sabrina the Teenage Witch</channel>
-  <channel site="pluto.tv" site_id="63e3b2cba99571000887a6ce" lang="da" xmltv_id="">Sams Bar</channel>
   <channel site="pluto.tv" site_id="63a1caefc8d285000799e8af" lang="da" xmltv_id="">Scorpion</channel>
   <channel site="pluto.tv" site_id="67334bed030a2c000805e414" lang="da" xmltv_id="">Se og Hør – rød løber</channel>
   <channel site="pluto.tv" site_id="688a20c69034bd35f34aaa9e" lang="da" xmltv_id="">Simba Prisen</channel>
@@ -190,28 +198,32 @@
   <channel site="pluto.tv" site_id="664f132c8ea5560008ce4d86" lang="da" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="pluto.tv" site_id="65d87a66ec9fda0008a5ac11" lang="da" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="pluto.tv" site_id="65d87a058145cb0008265c2e" lang="da" xmltv_id="">South Park: Cartman Collection</channel>
-  <channel site="pluto.tv" site_id="66fcedd95049580008d17ddf" lang="da" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="pluto.tv" site_id="664f0eaa8ce31100088036bd" lang="da" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="pluto.tv" site_id="65d879bd0d4561000805d190" lang="da" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="pluto.tv" site_id="65d87a908145cb0008265c6d" lang="da" xmltv_id="">South Park: Kyle Collection</channel>
   <channel site="pluto.tv" site_id="65d879e266eec8000887e91b" lang="da" xmltv_id="">South Park: Stan Collection</channel>
+  <channel site="pluto.tv" site_id="69b16dc543d0f313203b714c" lang="da" xmltv_id="">Space Live</channel>
+  <channel site="pluto.tv" site_id="693add137e308621c051e733" lang="da" xmltv_id="">Star Trek: The Original Series</channel>
+  <channel site="pluto.tv" site_id="68d66a37508ba507f075bd8c" lang="da" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="pluto.tv" site_id="61c09ac98a80a4000703f992" lang="da" xmltv_id="">SvampeBob Firkant</channel>
   <channel site="pluto.tv" site_id="63c96203636b7e0007d35090" lang="da" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
   <channel site="pluto.tv" site_id="66b229b0d2d50d00083990b2" lang="da" xmltv_id="">Taxi</channel>
+  <channel site="pluto.tv" site_id="693ae3294258f18a3e117b26" lang="da" xmltv_id="">Teen Wolf</channel>
+  <channel site="pluto.tv" site_id="69afec3af59c873b7b874520" lang="da" xmltv_id="">The 4400</channel>
   <channel site="pluto.tv" site_id="65c096d23ba51e0008305a75" lang="da" xmltv_id="">The Daily Show</channel>
   <channel site="pluto.tv" site_id="6915dd5ca570568f53431c7f" lang="da" xmltv_id="">The Graham Norton Show</channel>
   <channel site="pluto.tv" site_id="61c09039ebd75200072587f9" lang="da" xmltv_id="">The Hills</channel>
+  <channel site="pluto.tv" site_id="693ae48864476d678e9b6235" lang="da" xmltv_id="">The L Word</channel>
+  <channel site="pluto.tv" site_id="69afeefa0a7f2095e768401c" lang="da" xmltv_id="">The Millers</channel>
   <channel site="pluto.tv" site_id="6391cef9edb23c0008598cee" lang="da" xmltv_id="">The Nanny</channel>
   <channel site="pluto.tv" site_id="686d0130ed17cf4c902cbd19" lang="da" xmltv_id="">The Nanny &amp; Mr Sheffield - A Fine Romance</channel>
   <channel site="pluto.tv" site_id="618147d2a814250007b42916" lang="da" xmltv_id="">The New Detectives</channel>
   <channel site="pluto.tv" site_id="6512ec9f3a0d700008db4f0c" lang="da" xmltv_id="">The Twilight Zone</channel>
+  <channel site="pluto.tv" site_id="6964bc3806d76f50db3e315e" lang="da" xmltv_id="">The Wild Wild West</channel>
   <channel site="pluto.tv" site_id="69256bd7db5cc2f81d8a1a08" lang="da" xmltv_id="">Til julefrokost hos r8Dio</channel>
   <channel site="pluto.tv" site_id="61c1a05ef30f5d0007e562f3" lang="da" xmltv_id="">Til Middag Hos</channel>
   <channel site="pluto.tv" site_id="620234d766314700075cac86" lang="da" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="660d6360c8311c0008b8a7c6" lang="da" xmltv_id="">Top Gear Classics</channel>
   <channel site="pluto.tv" site_id="65e977042873090008b48be9" lang="da" xmltv_id="">Tosh.0</channel>
-  <channel site="pluto.tv" site_id="668e5f2bcd0d3100080f6952" lang="da" xmltv_id="">Triton Poker</channel>
-  <channel site="pluto.tv" site_id="64e87d090f73a800080e9ca5" lang="da" xmltv_id="">Trucking Hell</channel>
   <channel site="pluto.tv" site_id="6792044b680721c77c5b9ba2" lang="da" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="61813fbfa19d830007b456c2" lang="da" xmltv_id="">Unsolved Mysteries</channel>
   <channel site="pluto.tv" site_id="62bebc3459624e00078209c3" lang="da" xmltv_id="">Viafree Movies</channel>
@@ -222,11 +234,10 @@
   <channel site="pluto.tv" site_id="6177f8fdef21ab0007332b53" lang="da" xmltv_id="">World Poker Tour</channel>
   <channel site="pluto.tv" site_id="61de991729cd4a00079f812b" lang="en" xmltv_id="">Bloomberg TV+</channel>
   <channel site="pluto.tv" site_id="6400c281dff38e00083f59da" lang="en" xmltv_id="">Star Trek Movies</channel>
-  <channel site="pluto.tv" site_id="654a4a3ef91d250008ac089b" lang="no" xmltv_id="">Family Ties</channel>
+  <channel site="pluto.tv" site_id="68f0f71bb45f4453e05c0863" lang="no" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
+  <channel site="pluto.tv" site_id="654a4e29ab05240008a18625" lang="no" xmltv_id="">Happy Days</channel>
   <channel site="pluto.tv" site_id="61c0b9aab7facb0007913908" lang="no" xmltv_id="">iCarly</channel>
-  <channel site="pluto.tv" site_id="66290a779e68c20008a18cf3" lang="no" xmltv_id="">Matlock</channel>
-  <channel site="pluto.tv" site_id="62b30beb81f89900071fc7b9" lang="no" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="66fd1338ec9d6d00081e0443" lang="no" xmltv_id="">Retake E-sport Live</channel>
-  <channel site="pluto.tv" site_id="6501c8c76625510008cbe20f" lang="no" xmltv_id="">South Park Halloween</channel>
+  <channel site="pluto.tv" site_id="692ec3f475169f09b5c0a8b3" lang="no" xmltv_id="">Robert Prisen</channel>
+  <channel site="pluto.tv" site_id="63e3b2cba99571000887a6ce" lang="no" xmltv_id="">Sams Bar</channel>
   <channel site="pluto.tv" site_id="61c0bbd95df1da0007bed5a0" lang="no" xmltv_id="">Totally Turtles</channel>
 </channels>

--- a/sites/pluto.tv/pluto.tv_es.channels.xml
+++ b/sites/pluto.tv/pluto.tv_es.channels.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
+  <channel site="pluto.tv" site_id="65dded6966eec80008947157" lang="es" xmltv_id="">¡Llama a la Comadrona!</channel>
   <channel site="pluto.tv" site_id="67517fae5534bb0008187997" lang="es" xmltv_id="">Actualidad 360</channel>
   <channel site="pluto.tv" site_id="6812206e1b3e3be031a5c363" lang="es" xmltv_id="">Águila Roja</channel>
   <channel site="pluto.tv" site_id="65b91e530d9ab40008340d8d" lang="es" xmltv_id="">Al salir de clase</channel>
+  <channel site="pluto.tv" site_id="69c51060ed1b1f1acb5092dc" lang="es" xmltv_id="">Alaska y Mario</channel>
   <channel site="pluto.tv" site_id="664c76d68ea5560008c6c7a4" lang="es" xmltv_id="">Alerta Cobra</channel>
   <channel site="pluto.tv" site_id="66d71f8ee5de930008016f83" lang="es" xmltv_id="">Alice Nevers</channel>
+  <channel site="pluto.tv" site_id="686cd84603ad75cfd132d672" lang="es" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="5f1acce7f17797000718f9be" lang="es" xmltv_id="">Ana y los 7</channel>
   <channel site="pluto.tv" site_id="5f984f4a09e92d0007d74647" lang="es" xmltv_id="">Archivos Forenses</channel>
-  <channel site="pluto.tv" site_id="61373c865ed5810007173fbc" lang="es" xmltv_id="">Avatar</channel>
   <channel site="pluto.tv" site_id="688892172928933015abe479" lang="es" xmltv_id="">Barbie &amp; Friends</channel>
-  <channel site="pluto.tv" site_id="60dafb9a0df1ba000758d37b" lang="es" xmltv_id="">BBC Drama</channel>
+  <channel site="pluto.tv" site_id="60dafb9a0df1ba000758d37b" lang="es" xmltv_id="">BBC Series</channel>
   <channel site="pluto.tv" site_id="5f1aca0b4e448e00075e7c5e" lang="es" xmltv_id="">Bob Esponja</channel>
-  <channel site="pluto.tv" site_id="65dded6966eec80008947157" lang="es" xmltv_id="">Call the Midwife</channel>
   <channel site="pluto.tv" site_id="60ed5fb9c4716d0007d180c5" lang="es" xmltv_id="">Cazador de Homicidas</channel>
   <channel site="pluto.tv" site_id="6335a6b6e6f7a600076e589e" lang="es" xmltv_id="">Cazasubastas</channel>
   <channel site="pluto.tv" site_id="6231ede1be5b460007f91bc1" lang="es" xmltv_id="">CBS News 24/7</channel>
-  <channel site="pluto.tv" site_id="68f103545c876cf7307b4e37" lang="es" xmltv_id="">Cheers</channel>
   <channel site="pluto.tv" site_id="66d71c656b63480008cf0427" lang="es" xmltv_id="">Cherif</channel>
   <channel site="pluto.tv" site_id="622f42b831233300078658cc" lang="es" xmltv_id="">Ciudadanos por el mundo</channel>
-  <channel site="pluto.tv" site_id="66c45c0de7f5e80008b82005" lang="es" xmltv_id="">CNN Headlines</channel>
-  <channel site="pluto.tv" site_id="68de3db35fc0afe85de0b843" lang="es" xmltv_id="">Comedia a lo bestia de Pluto TV</channel>
+  <channel site="pluto.tv" site_id="66c45c0de7f5e80008b82005" lang="es" xmltv_id="">CNN Headlines International</channel>
+  <channel site="pluto.tv" site_id="68de3db35fc0afe85de0b843" lang="es" xmltv_id="ComediaalobestiadePlutoTV.de@ES">Comedia a lo bestia de Pluto TV</channel>
   <channel site="pluto.tv" site_id="5f5a0a0109d930000711e610" lang="es" xmltv_id="">Comedia Made in Spain+</channel>
   <channel site="pluto.tv" site_id="6554bd45aa9ffb00088e5589" lang="es" xmltv_id="">COPS</channel>
   <channel site="pluto.tv" site_id="64ddcbb14c5ed80008fad416" lang="es" xmltv_id="">Crimen &amp; Historia</channel>
   <channel site="pluto.tv" site_id="5f1acd36779de70007a680d1" lang="es" xmltv_id="">Curro Jiménez</channel>
   <channel site="pluto.tv" site_id="629a066860ef810008267b70" lang="es" xmltv_id="">Detective Conan</channel>
-  <channel site="pluto.tv" site_id="6720e2bddaad7f000872f274" lang="es" xmltv_id="">DFB Play TV</channel>
+  <channel site="pluto.tv" site_id="69f9c50202b6c1c00a213519" lang="es" xmltv_id="">Dominance FC TV</channel>
   <channel site="pluto.tv" site_id="685a996c7c4f2ad40cb4f276" lang="es" xmltv_id="">Dragon Ball</channel>
   <channel site="pluto.tv" site_id="68e8fd7c3ede4398bc69af93" lang="es" xmltv_id="">Dragon Ball Z</channel>
   <channel site="pluto.tv" site_id="60c343007bcabe0007242aa6" lang="es" xmltv_id="">El Comisario</channel>
   <channel site="pluto.tv" site_id="619b9f16b8fee4000832d447" lang="es" xmltv_id="">El Detective Endeavour</channel>
   <channel site="pluto.tv" site_id="60e45687313c5f0007bc8e94" lang="es" xmltv_id="">El encantador de perros</channel>
-  <channel site="pluto.tv" site_id="68751aab3484d607323b6d50" lang="es" xmltv_id="">El mundo de los Gnomos de Pluto TV</channel>
+  <channel site="pluto.tv" site_id="690dd10a37b131228d76d5b1" lang="es" xmltv_id="">El Mueble</channel>
   <channel site="pluto.tv" site_id="6523f672a6c38300088cb807" lang="es" xmltv_id="">El Reino Infantil</channel>
   <channel site="pluto.tv" site_id="657868a7a620e30008fdbfeb" lang="es" xmltv_id="">Embrujadas</channel>
   <channel site="pluto.tv" site_id="60218baa464ef900073168c1" lang="es" xmltv_id="">Empeños a lo bestia</channel>
@@ -40,19 +40,16 @@
   <channel site="pluto.tv" site_id="60d3583ef310610007fb02b1" lang="es" xmltv_id="">Euronews</channel>
   <channel site="pluto.tv" site_id="5f1abf5fafb5ee0007d4d0ca" lang="es" xmltv_id="">FailArmy</channel>
   <channel site="pluto.tv" site_id="660c29f80cd4630008f1547c" lang="es" xmltv_id="">FIFA+</channel>
-  <channel site="pluto.tv" site_id="663a440c8ea5560008a4db8a" lang="es" xmltv_id="">Gaming Central: League of Legends</channel>
-  <channel site="pluto.tv" site_id="6618e22624e1d000087a111c" lang="es" xmltv_id="">Gaming Central: Shooters</channel>
-  <channel site="pluto.tv" site_id="66fd36ca9269330008412b6c" lang="es" xmltv_id="">Gol Classics</channel>
+  <channel site="pluto.tv" site_id="69c5100c3d2597380f0f6422" lang="es" xmltv_id="">Gata salvaje</channel>
   <channel site="pluto.tv" site_id="68779a09c691b3f0964127c6" lang="es" xmltv_id="">Heidi</channel>
   <channel site="pluto.tv" site_id="67517f923a61d40008c451f0" lang="es" xmltv_id="">Historia y Vida</channel>
   <channel site="pluto.tv" site_id="65786abdb3801200084c593a" lang="es" xmltv_id="">Homeful</channel>
   <channel site="pluto.tv" site_id="6181404ef48321000797bc41" lang="es" xmltv_id="">iCarly</channel>
   <channel site="pluto.tv" site_id="61b9edc4a4ca6100070bb407" lang="es" xmltv_id="">Ice Pilots</channel>
   <channel site="pluto.tv" site_id="632c6df43d2bc5000751f621" lang="es" xmltv_id="">Inazuma Eleven</channel>
-  <channel site="pluto.tv" site_id="67b4ade18344dd9333978a1f" lang="es" xmltv_id="">La Abeja Maya</channel>
   <channel site="pluto.tv" site_id="65254e8d81f9420008342cee" lang="es" xmltv_id="">La fiebre del Jade</channel>
-  <channel site="pluto.tv" site_id="68751b556dce17bae3b6b98f" lang="es" xmltv_id="">La vuelta al mundo de Willy Fog</channel>
   <channel site="pluto.tv" site_id="61373f1a12dd9f00077dcd6f" lang="es" xmltv_id="">Las Tortugas Ninja</channel>
+  <channel site="pluto.tv" site_id="6964d2179ba4ac18051a18ce" lang="es" xmltv_id="">Léo Mattéï: Brigada de protección</channel>
   <channel site="pluto.tv" site_id="5f1acbed25948a0007ffbe65" lang="es" xmltv_id="">Los archivos del FBI</channel>
   <channel site="pluto.tv" site_id="5f1aca8310a30e00074fab92" lang="es" xmltv_id="">Los Asesinatos de Midsomer</channel>
   <channel site="pluto.tv" site_id="680ba8c3a48b3ead0db701cc" lang="es" xmltv_id="">Los caballeros del Zodiaco</channel>
@@ -61,7 +58,6 @@
   <channel site="pluto.tv" site_id="5f1acba0d1f6340007db8843" lang="es" xmltv_id="">Los nuevos detectives</channel>
   <channel site="pluto.tv" site_id="68d27949793c71d988ca624c" lang="es" xmltv_id="">Los Pitufos</channel>
   <channel site="pluto.tv" site_id="683457e5f59cc6a13212fce4" lang="es" xmltv_id="">Lupin</channel>
-  <channel site="pluto.tv" site_id="687799f86255fd1c0c419c84" lang="es" xmltv_id="">Marco</channel>
   <channel site="pluto.tv" site_id="6888928eb52fb742416673d2" lang="es" xmltv_id="">Mattel Junior</channel>
   <channel site="pluto.tv" site_id="6578808014fbe400086e21bc" lang="es" xmltv_id="">Medium</channel>
   <channel site="pluto.tv" site_id="6245c03922d9d4000760d205" lang="es" xmltv_id="">Melrose Place</channel>
@@ -69,6 +65,7 @@
   <channel site="pluto.tv" site_id="686cd8bb9d079f48dbbdfecb" lang="es" xmltv_id="">Metal Rocks</channel>
   <channel site="pluto.tv" site_id="60e4573c9f963e00077ecf25" lang="es" xmltv_id="">Mi Extraña Obsesión</channel>
   <channel site="pluto.tv" site_id="67164414e40c4a00087f450d" lang="es" xmltv_id="">MODUS Super Series Darts</channel>
+  <channel site="pluto.tv" site_id="68e8fe3bcba140ddfe903677" lang="es" xmltv_id="">Monster High</channel>
   <channel site="pluto.tv" site_id="5f1ab3c7778230000735cf41" lang="es" xmltv_id="">MTV Catfish TV Show</channel>
   <channel site="pluto.tv" site_id="5f5a0a5ea82f7200075cb926" lang="es" xmltv_id="">MTV Cribs+</channel>
   <channel site="pluto.tv" site_id="600169ec77e6f70008fa9cf0" lang="es" xmltv_id="">MTV Dating</channel>
@@ -76,61 +73,62 @@
   <channel site="pluto.tv" site_id="627d3176d7dfa500077042f1" lang="es" xmltv_id="">MTV Geordies</channel>
   <channel site="pluto.tv" site_id="62ac3d7dc23b400008ae5b5a" lang="es" xmltv_id="">MTV Jerseys</channel>
   <channel site="pluto.tv" site_id="5f1aadf373bed3000794d1d7" lang="es" xmltv_id="">MTV Originals</channel>
-  <channel site="pluto.tv" site_id="6130d8dc943001000708548d" lang="es" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="6130d8dc943001000708548d" lang="es" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="611b87946b7f420007c22361" lang="es" xmltv_id="">MTV Tattoo a dos</channel>
   <channel site="pluto.tv" site_id="604f81a49ef73300070e554f" lang="es" xmltv_id="">MTV Teen Mom</channel>
   <channel site="pluto.tv" site_id="63eb9495a8b227000841bf64" lang="es" xmltv_id="">MTV Vergüenza ajena</channel>
   <channel site="pluto.tv" site_id="60dd6b1da79e4d0007309455" lang="es" xmltv_id="">Nature Time</channel>
   <channel site="pluto.tv" site_id="680ba8992472a7200a183eb5" lang="es" xmltv_id="">One Piece</channel>
-  <channel site="pluto.tv" site_id="68d566603d3a9580eb461251" lang="es" xmltv_id="">Paramount Network de Pluto TV</channel>
-  <channel site="pluto.tv" site_id="68751a3bfd6704e9d3cc7b3d" lang="es" xmltv_id="">Pequeños aventureros de Pluto TV</channel>
-  <channel site="pluto.tv" site_id="600ae6a78d801e0007117d21" lang="es" xmltv_id="">Pluto TV Animales</channel>
-  <channel site="pluto.tv" site_id="608035b8d8705f0007260287" lang="es" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="645a309c5a0cd5000873f609" lang="es" xmltv_id="">Pluto TV Catástrofes</channel>
-  <channel site="pluto.tv" site_id="5f1ac2591dd8880007bb7d6d" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="pluto.tv" site_id="64f5a87ad661bb000814db89" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="pluto.tv" site_id="61373bb45168fe000773eecd" lang="es" xmltv_id="">Pluto TV Cine Clásico</channel>
-  <channel site="pluto.tv" site_id="5f1ac8099c49f600076579b2" lang="es" xmltv_id="">Pluto TV Cine Comedia</channel>
-  <channel site="pluto.tv" site_id="60cc807324d60a0007708dc8" lang="es" xmltv_id="">Pluto TV Cine de autor</channel>
-  <channel site="pluto.tv" site_id="5f1ac947dcd00d0007937c08" lang="es" xmltv_id="">Pluto TV Cine Drama</channel>
-  <channel site="pluto.tv" site_id="5f1ac1f1b66c76000790ef27" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="pluto.tv" site_id="5f59f50cc36a94000749fd3f" lang="es" xmltv_id="">Pluto TV Cine Estelar+</channel>
-  <channel site="pluto.tv" site_id="5f1ac9a2d3611d0007a844bb" lang="es" xmltv_id="">Pluto TV Cine Romántico</channel>
-  <channel site="pluto.tv" site_id="5f1acdaa8ba90f0007d5e760" lang="es" xmltv_id="">Pluto TV Cocina</channel>
-  <channel site="pluto.tv" site_id="5f1abce155a03d0007718834" lang="es" xmltv_id="">Pluto TV Comedia made in Spain</channel>
-  <channel site="pluto.tv" site_id="655b5d865812e80008843bd1" lang="es" xmltv_id="">Pluto TV Comedias Románticas</channel>
-  <channel site="pluto.tv" site_id="64db2e0835425100080f2f5a" lang="es" xmltv_id="">Pluto TV Diseño</channel>
-  <channel site="pluto.tv" site_id="65bd0f53dc10a40008e68b96" lang="es" xmltv_id="">Pluto TV Gasolina</channel>
-  <channel site="pluto.tv" site_id="66b0dfa1d512590008bfa7fd" lang="es" xmltv_id="">Pluto TV Gore &amp; Slasher</channel>
-  <channel site="pluto.tv" site_id="61cd7b49543066000713b620" lang="es" xmltv_id="">Pluto TV Historia</channel>
-  <channel site="pluto.tv" site_id="6267d4d1fb694f0007a6af0e" lang="es" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="68adc697116b783a33f99e6c" lang="es" xmltv_id="">Pluto TV Impacto</channel>
-  <channel site="pluto.tv" site_id="654a35ce346f420008d5c36e" lang="es" xmltv_id="">Pluto TV Invasión Alien</channel>
-  <channel site="pluto.tv" site_id="5f1aa9bcd8160700076d45d1" lang="es" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="pluto.tv" site_id="6475bfec536e0c0008858e9f" lang="es" xmltv_id="">Pluto TV K-Drama</channel>
-  <channel site="pluto.tv" site_id="5f1aab1d29b39600073e243f" lang="es" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="pluto.tv" site_id="609e7e423e9173000706a681" lang="es" xmltv_id="">Pluto TV Kids Classics</channel>
-  <channel site="pluto.tv" site_id="6080345ebb49b90007ce0baf" lang="es" xmltv_id="">Pluto TV Motor</channel>
-  <channel site="pluto.tv" site_id="612ce5214bb5790007ad3016" lang="es" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="65ce480a78df2200131c597b" lang="es" xmltv_id="">Pluto TV Psycho</channel>
-  <channel site="pluto.tv" site_id="61b87bc867b03a0007864e0d" lang="es" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="5f6a38eaa5b68b0007a00e7a" lang="es" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="5f1ac8f49205650007bc15f1" lang="es" xmltv_id="">Pluto TV Series</channel>
-  <channel site="pluto.tv" site_id="65cf6ab58145cb0008129ca8" lang="es" xmltv_id="">Pluto TV Series criminales</channel>
-  <channel site="pluto.tv" site_id="65ddec1ef7f0af0008be4b65" lang="es" xmltv_id="">Pluto TV Series Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="69148c470155f9b136b5d856" lang="es" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="63eb944dc111bc0008fe7021" lang="es" xmltv_id="">Pluto TV Teen</channel>
-  <channel site="pluto.tv" site_id="60b4c06717da110007ee1af6" lang="es" xmltv_id="">Pluto TV Telenovelas</channel>
-  <channel site="pluto.tv" site_id="662a69daa0a74e00087a1c72" lang="es" xmltv_id="">Pluto TV Telenovelas Clásicas</channel>
-  <channel site="pluto.tv" site_id="5f1ac8a87cd38d000745d7cf" lang="es" xmltv_id="">Pluto TV Thrillers</channel>
-  <channel site="pluto.tv" site_id="6880aa28164eb4890282e803" lang="es" xmltv_id="">Pluto TV Toons</channel>
-  <channel site="pluto.tv" site_id="64a3f200f238ce0008d47247" lang="es" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="6385e82900ab2e000768a058" lang="es" xmltv_id="">Pluto TV Western</channel>
-  <channel site="pluto.tv" site_id="65786888b228b7000843ad9a" lang="es" xmltv_id="">Pluto TV Zombies</channel>
+  <channel site="pluto.tv" site_id="68d566603d3a9580eb461251" lang="es" xmltv_id="ParamountNetworkdePlutoTV.de@ES">Paramount Network de Pluto TV</channel>
+  <channel site="pluto.tv" site_id="600ae6a78d801e0007117d21" lang="es" xmltv_id="PlutoTVAnimales.de@ES">Pluto TV Animales</channel>
+  <channel site="pluto.tv" site_id="608035b8d8705f0007260287" lang="es" xmltv_id="PlutoTVAnime.de@ES">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="645a309c5a0cd5000873f609" lang="es" xmltv_id="PlutoTVCatastrofes.de@ES">Pluto TV Catástrofes</channel>
+  <channel site="pluto.tv" site_id="5f1ac2591dd8880007bb7d6d" lang="es" xmltv_id="PlutoTVCineAccion.de@ES">Pluto TV Cine Acción</channel>
+  <channel site="pluto.tv" site_id="64f5a87ad661bb000814db89" lang="es" xmltv_id="PlutoTVCineAccion.de@ESPlus">Pluto TV Cine Acción</channel>
+  <channel site="pluto.tv" site_id="61373bb45168fe000773eecd" lang="es" xmltv_id="PlutoTVCineClasico.de@ES">Pluto TV Cine Clásico</channel>
+  <channel site="pluto.tv" site_id="5f1ac8099c49f600076579b2" lang="es" xmltv_id="PlutoTVCineComedia.de@ES">Pluto TV Cine Comedia</channel>
+  <channel site="pluto.tv" site_id="60cc807324d60a0007708dc8" lang="es" xmltv_id="PlutoTVCinedeautor.de@ES">Pluto TV Cine de autor</channel>
+  <channel site="pluto.tv" site_id="5f1ac947dcd00d0007937c08" lang="es" xmltv_id="PlutoTVCineDrama.de@ES">Pluto TV Cine Drama</channel>
+  <channel site="pluto.tv" site_id="5f1ac1f1b66c76000790ef27" lang="es" xmltv_id="PlutoTVCineEstelar.de@ES">Pluto TV Cine Estelar</channel>
+  <channel site="pluto.tv" site_id="5f59f50cc36a94000749fd3f" lang="es" xmltv_id="PlutoTVCineEstelar.de@ESPlus">Pluto TV Cine Estelar+</channel>
+  <channel site="pluto.tv" site_id="5f1ac9a2d3611d0007a844bb" lang="es" xmltv_id="PlutoTVCineRomantico.de@ES">Pluto TV Cine Romántico</channel>
+  <channel site="pluto.tv" site_id="5f1acdaa8ba90f0007d5e760" lang="es" xmltv_id="PlutoTVCocina.de@ES">Pluto TV Cocina</channel>
+  <channel site="pluto.tv" site_id="5f1abce155a03d0007718834" lang="es" xmltv_id="PlutoTVComediamadeinSpain.de@ES">Pluto TV Comedia made in Spain</channel>
+  <channel site="pluto.tv" site_id="655b5d865812e80008843bd1" lang="es" xmltv_id="PlutoTVComediasRomanticas.de@ES">Pluto TV Comedias Románticas</channel>
+  <channel site="pluto.tv" site_id="64db2e0835425100080f2f5a" lang="es" xmltv_id="PlutoTVDiseno.de@ES">Pluto TV Diseño</channel>
+  <channel site="pluto.tv" site_id="691ddf2a3ae32cf55263476d" lang="es" xmltv_id="PlutoTVForeverKids.de@ES">Pluto TV Forever Kids</channel>
+  <channel site="pluto.tv" site_id="69f0bb1a00ad62de02a6b716" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
+  <channel site="pluto.tv" site_id="65bd0f53dc10a40008e68b96" lang="es" xmltv_id="PlutoTVGasolina.de@ES">Pluto TV Gasolina</channel>
+  <channel site="pluto.tv" site_id="66b0dfa1d512590008bfa7fd" lang="es" xmltv_id="PlutoTVGoreSlasher.de@ES">Pluto TV Gore &amp; Slasher</channel>
+  <channel site="pluto.tv" site_id="61cd7b49543066000713b620" lang="es" xmltv_id="PlutoTVHistoria.de@ES">Pluto TV Historia</channel>
+  <channel site="pluto.tv" site_id="6267d4d1fb694f0007a6af0e" lang="es" xmltv_id="PlutoTVHorror.de@ES">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="68adc697116b783a33f99e6c" lang="es" xmltv_id="PlutoTVImpacto.de@ES">Pluto TV Impacto</channel>
+  <channel site="pluto.tv" site_id="654a35ce346f420008d5c36e" lang="es" xmltv_id="PlutoTVInvasionAlien.de@ES">Pluto TV Invasión Alien</channel>
+  <channel site="pluto.tv" site_id="5f1aa9bcd8160700076d45d1" lang="es" xmltv_id="PlutoTVJunior.de@ES">Pluto TV Junior</channel>
+  <channel site="pluto.tv" site_id="6475bfec536e0c0008858e9f" lang="es" xmltv_id="PlutoTVKDrama.de@ES">Pluto TV K-Drama</channel>
+  <channel site="pluto.tv" site_id="5f1aab1d29b39600073e243f" lang="es" xmltv_id="PlutoTVKids.de@ES">Pluto TV Kids</channel>
+  <channel site="pluto.tv" site_id="609e7e423e9173000706a681" lang="es" xmltv_id="PlutoTVKidsClassics.de@ES">Pluto TV Kids Classics</channel>
+  <channel site="pluto.tv" site_id="6080345ebb49b90007ce0baf" lang="es" xmltv_id="PlutoTVMotor.de@ES">Pluto TV Motor</channel>
+  <channel site="pluto.tv" site_id="63fe0111dff38e00083510f9" lang="es" xmltv_id="">Pluto TV Orgullo</channel>
+  <channel site="pluto.tv" site_id="612ce5214bb5790007ad3016" lang="es" xmltv_id="PlutoTVParanormal.de@ES">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="65ce480a78df2200131c597b" lang="es" xmltv_id="PlutoTVPsycho.de@ES">Pluto TV Psycho</channel>
+  <channel site="pluto.tv" site_id="5f6a38eaa5b68b0007a00e7a" lang="es" xmltv_id="PlutoTVSciFi.de@ES">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="5f1ac8f49205650007bc15f1" lang="es" xmltv_id="PlutoTVSeries.de@ES">Pluto TV Series</channel>
+  <channel site="pluto.tv" site_id="65cf6ab58145cb0008129ca8" lang="es" xmltv_id="PlutoTVSeriescriminales.de@ES">Pluto TV Series criminales</channel>
+  <channel site="pluto.tv" site_id="65ddec1ef7f0af0008be4b65" lang="es" xmltv_id="PlutoTVSeriesSciFi.de@ES">Pluto TV Series Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="69148c470155f9b136b5d856" lang="es" xmltv_id="PlutoTVSnooker900.de@ES">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="63eb944dc111bc0008fe7021" lang="es" xmltv_id="PlutoTVTeen.de@ES">Pluto TV Teen</channel>
+  <channel site="pluto.tv" site_id="60b4c06717da110007ee1af6" lang="es" xmltv_id="PlutoTVTelenovelas.de@ES">Pluto TV Telenovelas</channel>
+  <channel site="pluto.tv" site_id="662a69daa0a74e00087a1c72" lang="es" xmltv_id="PlutoTVTelenovelasClasicas.de@ES">Pluto TV Telenovelas Clásicas</channel>
+  <channel site="pluto.tv" site_id="5f1ac8a87cd38d000745d7cf" lang="es" xmltv_id="PlutoTVThrillers.de@ES">Pluto TV Thrillers</channel>
+  <channel site="pluto.tv" site_id="6880aa28164eb4890282e803" lang="es" xmltv_id="PlutoTVToons.de@ES">Pluto TV Toons</channel>
+  <channel site="pluto.tv" site_id="64a3f200f238ce0008d47247" lang="es" xmltv_id="PlutoTVTrueCrime.de@ES">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="6385e82900ab2e000768a058" lang="es" xmltv_id="PlutoTVWestern.de@ES">Pluto TV Western</channel>
+  <channel site="pluto.tv" site_id="65786888b228b7000843ad9a" lang="es" xmltv_id="PlutoTVZombies.de@ES">Pluto TV Zombies</channel>
   <channel site="pluto.tv" site_id="6304f530440dc90007f514d3" lang="es" xmltv_id="">Poirot &amp; Miss Marple</channel>
   <channel site="pluto.tv" site_id="65dded9a0d456100081417ae" lang="es" xmltv_id="">Primeval</channel>
+  <channel site="pluto.tv" site_id="696e02423b9ce349c90edef9" lang="es" xmltv_id="">Rally TV</channel>
   <channel site="pluto.tv" site_id="65f96cd34e01740008ef1c97" lang="es" xmltv_id="">Realmadrid TV</channel>
-  <channel site="pluto.tv" site_id="68751b006dce17bae3b694f0" lang="es" xmltv_id="">RETRO KIDS de Pluto TV</channel>
   <channel site="pluto.tv" site_id="6745f0643a61d40008a61510" lang="es" xmltv_id="">Rookie Blue</channel>
   <channel site="pluto.tv" site_id="610c09219fc0430007a3fce6" lang="es" xmltv_id="">Rugrats</channel>
   <channel site="pluto.tv" site_id="6086d3f420fc8500075f8dbf" lang="es" xmltv_id="">Runtime</channel>
@@ -138,11 +136,12 @@
   <channel site="pluto.tv" site_id="6578836cdfed030008ce5bdb" lang="es" xmltv_id="">Sí quiero ese vestido</channel>
   <channel site="pluto.tv" site_id="628751bb7154a40007168843" lang="es" xmltv_id="">South Park</channel>
   <channel site="pluto.tv" site_id="63d7a8e5a9957100086bfc23" lang="es" xmltv_id="">South Park Versión Original</channel>
+  <channel site="pluto.tv" site_id="69b3db5d61e8e298254c7108" lang="es" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="65786b94cbd0d60008f7e4d9" lang="es" xmltv_id="">Star Trek: The Next Generation</channel>
   <channel site="pluto.tv" site_id="65787f2eb228b7000843fa5c" lang="es" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="pluto.tv" site_id="685a995b460ac82fa504342c" lang="es" xmltv_id="">The Good Wife</channel>
+  <channel site="pluto.tv" site_id="6793ac47f5c74bff95d18a99" lang="es" xmltv_id="">TOP BARÇA</channel>
   <channel site="pluto.tv" site_id="60d356a534f63f000850cdd7" lang="es" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="66448a5a8ce31100086ae45e" lang="es" xmltv_id="">Ubeat lite</channel>
   <channel site="pluto.tv" site_id="67921b873de7c8cf94233f52" lang="es" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="61bb2814ac085a00074309a6" lang="es" xmltv_id="">Unidad de investigación</channel>
   <channel site="pluto.tv" site_id="5f28009b150b2500077766b8" lang="es" xmltv_id="">Vaya semanita</channel>

--- a/sites/pluto.tv/pluto.tv_fi.channels.xml
+++ b/sites/pluto.tv/pluto.tv_fi.channels.xml
@@ -1,30 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
+  <channel site="pluto.tv" site_id="69e0f423ed1b1f1acbd7c93c" lang="fi" xmltv_id="">7th Heaven</channel>
+  <channel site="pluto.tv" site_id="699c16c6b21b0f7c5ba6a0c3" lang="fi" xmltv_id="">21 Jump Street</channel>
+  <channel site="pluto.tv" site_id="69afed76958a20b22a4e3d1b" lang="fi" xmltv_id="">48 hours</channel>
   <channel site="pluto.tv" site_id="69144baea570568f53239bc2" lang="fi" xmltv_id="">America&apos;s Funniest Home Videos</channel>
+  <channel site="pluto.tv" site_id="69f84e53d37cdd39e2f212e9" lang="fi" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="67090a7ba07d1a0008012df9" lang="fi" xmltv_id="">Auction Hunters</channel>
   <channel site="pluto.tv" site_id="661d209794db1400081e523f" lang="fi" xmltv_id="">Avatar</channel>
   <channel site="pluto.tv" site_id="683027f815186188018f5319" lang="fi" xmltv_id="">AWSN</channel>
   <channel site="pluto.tv" site_id="650998fa98020f00085fd326" lang="fi" xmltv_id="">Beavis and Butt-Head</channel>
+  <channel site="pluto.tv" site_id="69d7a0e814c021370234de18" lang="fi" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="pluto.tv" site_id="66fd543c926933000841d209" lang="fi" xmltv_id="">Bloomberg TV+</channel>
   <channel site="pluto.tv" site_id="660d681a0cd4630008f48f65" lang="fi" xmltv_id="">Bondi Rescue</channel>
   <channel site="pluto.tv" site_id="65e6d1a118036500082911d6" lang="fi" xmltv_id="">Broad City</channel>
+  <channel site="pluto.tv" site_id="6964ba0c07ea70192df2a635" lang="fi" xmltv_id="">Bull</channel>
   <channel site="pluto.tv" site_id="65a6469b0d9ab400080b1a33" lang="fi" xmltv_id="">Burgerimies</channel>
   <channel site="pluto.tv" site_id="65a93c4d2fac9c00083cbb73" lang="fi" xmltv_id="">Car Chase</channel>
+  <channel site="pluto.tv" site_id="678e291e1cfc4aa96d64b5c5" lang="fi" xmltv_id="">Catfish: OMG!</channel>
   <channel site="pluto.tv" site_id="640ae4876d549900084af535" lang="fi" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="65e9789e66eec80008add673" lang="fi" xmltv_id="">Chappelle&apos;s Show</channel>
   <channel site="pluto.tv" site_id="642e9575af2bd900088527dd" lang="fi" xmltv_id="">Cheers</channel>
   <channel site="pluto.tv" site_id="65d72513ec9fda00089e67c8" lang="fi" xmltv_id="">Come Dine with Me</channel>
   <channel site="pluto.tv" site_id="6634b769cb3ea10008e5211f" lang="fi" xmltv_id="">Comedy Central Roast</channel>
+  <channel site="pluto.tv" site_id="693ae5dc587d9f5d9792e59c" lang="fi" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="pluto.tv" site_id="6745cd272fb8a1000861264f" lang="fi" xmltv_id="">Crime Scene Solvers</channel>
-  <channel site="pluto.tv" site_id="64b8de4be4391c0008c52941" lang="fi" xmltv_id="">DAZN Combat</channel>
+  <channel site="pluto.tv" site_id="64b8de4be4391c0008c52941" lang="fi" xmltv_id="">DAZN Ringside</channel>
   <channel site="pluto.tv" site_id="66461f8f41af640008d29ca0" lang="fi" xmltv_id="">DFB Play TV</channel>
+  <channel site="pluto.tv" site_id="69e0ff98549828202b3d752e" lang="fi" xmltv_id="">Diagnosis Murder</channel>
   <channel site="pluto.tv" site_id="67d29f6783048b14be7569d4" lang="fi" xmltv_id="">Dominance FC TV</channel>
   <channel site="pluto.tv" site_id="64fad4ce30ab330008480bcf" lang="fi" xmltv_id="">Duudsonit</channel>
   <channel site="pluto.tv" site_id="68f61057a362b63a8d2f9066" lang="fi" xmltv_id="">Dynastia</channel>
-  <channel site="pluto.tv" site_id="68adafd8f7d7f0a9b9ff3ea9" lang="fi" xmltv_id="">Ernest goes to Pluto TV</channel>
   <channel site="pluto.tv" site_id="66d71520dd2d690008ae49c1" lang="fi" xmltv_id="">Escape to the Country</channel>
   <channel site="pluto.tv" site_id="67851de6311f01000784ccba" lang="fi" xmltv_id="">Euronews</channel>
+  <channel site="pluto.tv" site_id="697b5c921f25e8eb7d4b5e22" lang="fi" xmltv_id="">Everybody Hates Chris</channel>
+  <channel site="pluto.tv" site_id="699c1cd30a7f2095e7c1438f" lang="fi" xmltv_id="">Farscape</channel>
   <channel site="pluto.tv" site_id="660bfd05635c75000823d978" lang="fi" xmltv_id="">FIFA+</channel>
+  <channel site="pluto.tv" site_id="698ddedba62a37ac6f06f031" lang="fi" xmltv_id="">Flipper: The New Adventures</channel>
   <channel site="pluto.tv" site_id="6745cc56cf557100088b7db9" lang="fi" xmltv_id="">Forensic Files</channel>
   <channel site="pluto.tv" site_id="642e9a4f25ea4d0008472901" lang="fi" xmltv_id="">Frasier</channel>
   <channel site="pluto.tv" site_id="6825f999ba490a2800981ca1" lang="fi" xmltv_id="">Frasier: Nilesin parhaat</channel>
@@ -35,8 +46,10 @@
   <channel site="pluto.tv" site_id="68c0167fb3900870ec746969" lang="fi" xmltv_id="">Highway to Heaven</channel>
   <channel site="pluto.tv" site_id="671b4efc7d5da50008e9de75" lang="fi" xmltv_id="">Horse &amp; Country</channel>
   <channel site="pluto.tv" site_id="6634b8363d173b0008e31fbb" lang="fi" xmltv_id="">Hot Ones</channel>
+  <channel site="pluto.tv" site_id="693ae6e856acdcad6abe6ec5" lang="fi" xmltv_id="">House of Lies</channel>
   <channel site="pluto.tv" site_id="643ea2a9ae30f40008da12df" lang="fi" xmltv_id="">Huvila &amp; Huussi</channel>
   <channel site="pluto.tv" site_id="68df7d8a1d2614017512dffb" lang="fi" xmltv_id="">Ihmemies MacGyver</channel>
+  <channel site="pluto.tv" site_id="691ed78cc83327d400a36b86" lang="fi" xmltv_id="">Inter 24/7</channel>
   <channel site="pluto.tv" site_id="682b3a778fec2b054e9bf839" lang="fi" xmltv_id="">Iron Chef</channel>
   <channel site="pluto.tv" site_id="6915e0828643dc1657b640a9" lang="fi" xmltv_id="">IS esittää: Sain sen videolle</channel>
   <channel site="pluto.tv" site_id="660d6b7f7bcd8600087d08c0" lang="fi" xmltv_id="">Jade Fever</channel>
@@ -53,6 +66,7 @@
   <channel site="pluto.tv" site_id="654a530df9cc82000868cac3" lang="fi" xmltv_id="">Kunnian miehet</channel>
   <channel site="pluto.tv" site_id="67090d89a07d1a0008016e65" lang="fi" xmltv_id="">Lain nimessä</channel>
   <channel site="pluto.tv" site_id="654a5331986ad20008a45e55" lang="fi" xmltv_id="">Lemmenlaiva</channel>
+  <channel site="pluto.tv" site_id="69afeb8d3d5dba980794e499" lang="fi" xmltv_id="">Lexx</channel>
   <channel site="pluto.tv" site_id="6825f030641c35a1670ed11b" lang="fi" xmltv_id="">Man with a Plan</channel>
   <channel site="pluto.tv" site_id="66290ca45e23700008fd0b89" lang="fi" xmltv_id="">Matlock</channel>
   <channel site="pluto.tv" site_id="642e96ed25ea4d00084722fe" lang="fi" xmltv_id="">Melrose Place</channel>
@@ -66,7 +80,7 @@
   <channel site="pluto.tv" site_id="642e9b32240d6f0008aa4760" lang="fi" xmltv_id="">MTV Ex On The Beach</channel>
   <channel site="pluto.tv" site_id="642e9cf6ae30f40008ba6464" lang="fi" xmltv_id="">MTV Geordie Shore</channel>
   <channel site="pluto.tv" site_id="642e9c07479f6400085d75f1" lang="fi" xmltv_id="">MTV Jersey Shore</channel>
-  <channel site="pluto.tv" site_id="68513a02ce36f0644ffaa02b" lang="fi" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="68513a02ce36f0644ffaa02b" lang="fi" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="642ea1149b32b4000942b19d" lang="fi" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="642ea0cd240d6f0008aa5431" lang="fi" xmltv_id="">MTV Siesta Key</channel>
   <channel site="pluto.tv" site_id="642e9ba382a18e00089e48eb" lang="fi" xmltv_id="">MTV Teen Mom</channel>
@@ -82,52 +96,63 @@
   <channel site="pluto.tv" site_id="654a53d3056b97000888144f" lang="fi" xmltv_id="">Onnen päivät</channel>
   <channel site="pluto.tv" site_id="642e99b6af2bd90008854dab" lang="fi" xmltv_id="">Paavo Pesusieni</channel>
   <channel site="pluto.tv" site_id="654a52b64d6d8f00084eae44" lang="fi" xmltv_id="">Perhe on paras</channel>
-  <channel site="pluto.tv" site_id="65b8fa70c798e800085a1473" lang="fi" xmltv_id="">PFL MMA</channel>
   <channel site="pluto.tv" site_id="66c88a9efed35b000856f845" lang="fi" xmltv_id="">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="6634b8fa3d173b0008e3204e" lang="fi" xmltv_id="">Pimp My Ride</channel>
-  <channel site="pluto.tv" site_id="65b917d333ea860008598a05" lang="fi" xmltv_id="">Pluto TV Bud &amp; Terence</channel>
-  <channel site="pluto.tv" site_id="66cd908a167a8b0008e97801" lang="fi" xmltv_id="">Pluto TV Dokkarit</channel>
-  <channel site="pluto.tv" site_id="66290356cee0d9000864766e" lang="fi" xmltv_id="">Pluto TV John Wayne</channel>
-  <channel site="pluto.tv" site_id="642e9857479f6400085d7252" lang="fi" xmltv_id="">Pluto TV Juniorikerho</channel>
-  <channel site="pluto.tv" site_id="66cd8d67f0f17500083252c0" lang="fi" xmltv_id="">Pluto TV Kauhu</channel>
-  <channel site="pluto.tv" site_id="642e990dae30f40008ba5bec" lang="fi" xmltv_id="">Pluto TV Komedia</channel>
-  <channel site="pluto.tv" site_id="67090b9ba07d1a0008016a5d" lang="fi" xmltv_id="">Pluto TV Kulttileffat</channel>
-  <channel site="pluto.tv" site_id="642e987882a18e00089e3f8f" lang="fi" xmltv_id="">Pluto TV Leffat</channel>
-  <channel site="pluto.tv" site_id="685d1e5e0a2df05f686742b5" lang="fi" xmltv_id="">Pluto TV Maailmansodat</channel>
-  <channel site="pluto.tv" site_id="65f449162873090008cb05e7" lang="fi" xmltv_id="">Pluto TV Paranormaali</channel>
-  <channel site="pluto.tv" site_id="642e989b240d6f0008aa34b3" lang="fi" xmltv_id="">Pluto TV Romantiikka</channel>
-  <channel site="pluto.tv" site_id="68b17496a4841127a8ece8b2" lang="fi" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="66cf1860dd2d6900089f5e91" lang="fi" xmltv_id="">Pluto TV Toiminta</channel>
-  <channel site="pluto.tv" site_id="6810aace54c3b6934b1f0e5e" lang="fi" xmltv_id="">Pluto TV Toimintasankarit</channel>
-  <channel site="pluto.tv" site_id="66cf15f861dbf00008d9b8e1" lang="fi" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="651d3e423099fc000841b0d6" lang="fi" xmltv_id="">Pluto TV Vintage</channel>
-  <channel site="pluto.tv" site_id="68c017fcf89c82a68b08329b" lang="fi" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="pluto.tv" site_id="6969fc329174e77a0eb53158" lang="fi" xmltv_id="PlutoTVBritit.de@FI">Pluto TV Britit</channel>
+  <channel site="pluto.tv" site_id="65b917d333ea860008598a05" lang="fi" xmltv_id="PlutoTVBudTerence.de@FI">Pluto TV Bud &amp; Terence</channel>
+  <channel site="pluto.tv" site_id="66cd908a167a8b0008e97801" lang="fi" xmltv_id="PlutoTVDokkarit.de@FI">Pluto TV Dokkarit</channel>
+  <channel site="pluto.tv" site_id="68c01c2474f43c4c1f99a91c" lang="fi" xmltv_id="PlutoTVHarlequin.de@FI">Pluto TV Harlequin</channel>
+  <channel site="pluto.tv" site_id="66290356cee0d9000864766e" lang="fi" xmltv_id="PlutoTVJohnWayne.de@FI">Pluto TV John Wayne</channel>
+  <channel site="pluto.tv" site_id="642e9857479f6400085d7252" lang="fi" xmltv_id="PlutoTVJuniorikerho.de@FI">Pluto TV Juniorikerho</channel>
+  <channel site="pluto.tv" site_id="66cd8d67f0f17500083252c0" lang="fi" xmltv_id="PlutoTVKauhu.de@FI">Pluto TV Kauhu</channel>
+  <channel site="pluto.tv" site_id="642e990dae30f40008ba5bec" lang="fi" xmltv_id="PlutoTVKomedia.de@FI">Pluto TV Komedia</channel>
+  <channel site="pluto.tv" site_id="67090b9ba07d1a0008016a5d" lang="fi" xmltv_id="PlutoTVKulttileffat.de@FI">Pluto TV Kulttileffat</channel>
+  <channel site="pluto.tv" site_id="642e987882a18e00089e3f8f" lang="fi" xmltv_id="PlutoTVLeffat.de@FI">Pluto TV Leffat</channel>
+  <channel site="pluto.tv" site_id="685d1e5e0a2df05f686742b5" lang="fi" xmltv_id="PlutoTVMaailmansodat.de@FI">Pluto TV Maailmansodat</channel>
+  <channel site="pluto.tv" site_id="68ac533ff7d7f0a9b9d21eff" lang="fi" xmltv_id="PlutoTVMoottorit.de@FI">Pluto TV Moottorit</channel>
+  <channel site="pluto.tv" site_id="6969fb878a457abd8d1b5e8a" lang="fi" xmltv_id="PlutoTVPalkitut.de@FI">Pluto TV Palkitut</channel>
+  <channel site="pluto.tv" site_id="65f449162873090008cb05e7" lang="fi" xmltv_id="PlutoTVParanormaali.de@FI">Pluto TV Paranormaali</channel>
+  <channel site="pluto.tv" site_id="642e989b240d6f0008aa34b3" lang="fi" xmltv_id="PlutoTVRomantiikka.de@FI">Pluto TV Romantiikka</channel>
+  <channel site="pluto.tv" site_id="69afe99a69056557a9e8599c" lang="fi" xmltv_id="PlutoTVSciFi.de@FI">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="68b17496a4841127a8ece8b2" lang="fi" xmltv_id="PlutoTVSnooker900.de@FI">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="66cf1860dd2d6900089f5e91" lang="fi" xmltv_id="PlutoTVToiminta.de@FI">Pluto TV Toiminta</channel>
+  <channel site="pluto.tv" site_id="6810aace54c3b6934b1f0e5e" lang="fi" xmltv_id="PlutoTVToimintasankarit.de@FI">Pluto TV Toimintasankarit</channel>
+  <channel site="pluto.tv" site_id="66cf15f861dbf00008d9b8e1" lang="fi" xmltv_id="PlutoTVTrueCrime.de@FI">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="651d3e423099fc000841b0d6" lang="fi" xmltv_id="PlutoTVVintage.de@FI">Pluto TV Vintage</channel>
+  <channel site="pluto.tv" site_id="68c017fcf89c82a68b08329b" lang="fi" xmltv_id="PlutoTVWildWest.de@FI">Pluto TV Wild West</channel>
   <channel site="pluto.tv" site_id="68de776ffae18f8db601d3e7" lang="fi" xmltv_id="">Poliisit</channel>
   <channel site="pluto.tv" site_id="664c93738ce31100087836ca" lang="fi" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="6964bb9f29b8a1f0e79e5cf7" lang="fi" xmltv_id="">Rawhide</channel>
   <channel site="pluto.tv" site_id="660d728024e1d000085ef51c" lang="fi" xmltv_id="">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="699c19f48a48c63241ca5a1e" lang="fi" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="65e97880332fec00085a4636" lang="fi" xmltv_id="">Reno 911</channel>
-  <channel site="pluto.tv" site_id="6915df4fa3a4b4970678ceb9" lang="fi" xmltv_id="">Roni Back Top 10</channel>
-  <channel site="pluto.tv" site_id="65f448220d45610008476127" lang="fi" xmltv_id="">Ruutu Futis</channel>
-  <channel site="pluto.tv" site_id="65f4485ef7f0af0008f2e912" lang="fi" xmltv_id="">Ruutu Pesis</channel>
+  <channel site="pluto.tv" site_id="69e0fe11217b4abc74b0ee5d" lang="fi" xmltv_id="">Riptide</channel>
   <channel site="pluto.tv" site_id="692438a2ad364b298f8a6b57" lang="fi" xmltv_id="">Sabrina, teininoita</channel>
   <channel site="pluto.tv" site_id="642e93c59b32b400094270a1" lang="fi" xmltv_id="">Scorpion</channel>
   <channel site="pluto.tv" site_id="642e9a8bae30f40008ba61e2" lang="fi" xmltv_id="">Smithsonian Channel Selects</channel>
   <channel site="pluto.tv" site_id="68adb16df7d7f0a9b9ffa7a5" lang="fi" xmltv_id="">Smurffit</channel>
   <channel site="pluto.tv" site_id="642e9ad5e8a4aa0008bbaa1d" lang="fi" xmltv_id="">South Park</channel>
+  <channel site="pluto.tv" site_id="69b16e513bd16a4ed07b1744" lang="fi" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="642e99c3240d6f0008aa3a67" lang="fi" xmltv_id="">Spin City</channel>
   <channel site="pluto.tv" site_id="642e965a240d6f0008aa23fe" lang="fi" xmltv_id="">Star Trek: The Next Generation</channel>
+  <channel site="pluto.tv" site_id="693adecd09b38429bd5e651a" lang="fi" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="pluto.tv" site_id="6790e4efbc03978b9bff0d8e" lang="fi" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="pluto.tv" site_id="643ea26025ea4d0008669fc7" lang="fi" xmltv_id="">Suomen Huutokauppakeisari</channel>
   <channel site="pluto.tv" site_id="643ea447af2bd90008a44433" lang="fi" xmltv_id="">Syke</channel>
   <channel site="pluto.tv" site_id="661d21a9c8311c0008d94121" lang="fi" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
   <channel site="pluto.tv" site_id="683eb0f25195c2a60a57be26" lang="fi" xmltv_id="">Team Ahma</channel>
+  <channel site="pluto.tv" site_id="693ae417ddba450b34a4fac7" lang="fi" xmltv_id="">Teen Wolf</channel>
   <channel site="pluto.tv" site_id="6870c9fd3ffa5e0c914e99aa" lang="fi" xmltv_id="">Tennis Channel</channel>
+  <channel site="pluto.tv" site_id="69afebc7814d27f4aec2fdc5" lang="fi" xmltv_id="">The 4400</channel>
   <channel site="pluto.tv" site_id="65c377a53a116800078ce425" lang="fi" xmltv_id="">The Daily Show</channel>
   <channel site="pluto.tv" site_id="6916de3ee9dec35c929a4290" lang="fi" xmltv_id="">The Graham Norton Show</channel>
+  <channel site="pluto.tv" site_id="693ae51f75432d022c7ff628" lang="fi" xmltv_id="">The L Word</channel>
+  <channel site="pluto.tv" site_id="69970db307ccf09a393b33bf" lang="fi" xmltv_id="">The Millers</channel>
+  <channel site="pluto.tv" site_id="6964bd5453dc20932040147a" lang="fi" xmltv_id="">The Wild Wild West</channel>
   <channel site="pluto.tv" site_id="68f0f81ea25ba0aab3e66aba" lang="fi" xmltv_id="">Tohtori tuli kaupunkiin</channel>
   <channel site="pluto.tv" site_id="64c8e75ae849b50008beb33f" lang="fi" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="660d65f20cd4630008f48b86" lang="fi" xmltv_id="">Top Gear Classics</channel>
   <channel site="pluto.tv" site_id="679b600697bed7000809d425" lang="fi" xmltv_id="">Totally Turtles</channel>
+  <channel site="pluto.tv" site_id="69d7a1b059dbbc59c03c81e4" lang="fi" xmltv_id="">Touched by an Angel</channel>
   <channel site="pluto.tv" site_id="67920729f5c74bff956bc135" lang="fi" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="642e990ac91e10000884de93" lang="fi" xmltv_id="">Walker Texas Ranger</channel>
   <channel site="pluto.tv" site_id="65c9ceaad77d450008c97d3d" lang="fi" xmltv_id="">Wildfire</channel>

--- a/sites/pluto.tv/pluto.tv_fr.channels.xml
+++ b/sites/pluto.tv/pluto.tv_fr.channels.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="pluto.tv" site_id="5e46ae801f347500099d461a" lang="en" xmltv_id="">Pluto TV Classic TV FR</channel>
+  <channel site="pluto.tv" site_id="5e46ae801f347500099d461a" lang="en" xmltv_id="PlutoTVClassicTVFR.de@FR">Pluto TV Classic TV FR</channel>
   <channel site="pluto.tv" site_id="64bab8ba5dc1660008969b5a" lang="fr" xmltv_id="">Adjugé, vendu !</channel>
   <channel site="pluto.tv" site_id="60afaa535580be0007ac9ee4" lang="fr" xmltv_id="">Alerte à Malibu</channel>
   <channel site="pluto.tv" site_id="62f3e4bc08f5ec000744f552" lang="fr" xmltv_id="">Alerte Cobra</channel>
   <channel site="pluto.tv" site_id="6618e3037bcd8600089b62a8" lang="fr" xmltv_id="">Allociné</channel>
-  <channel site="pluto.tv" site_id="60b4c17a81e29300071d3a39" lang="fr" xmltv_id="">Avatar</channel>
   <channel site="pluto.tv" site_id="686e7499e0ecf0e0cc25dbe3" lang="fr" xmltv_id="">Barbie &amp; Friends</channel>
-  <channel site="pluto.tv" site_id="60d35a74c63c3c0008df6a90" lang="fr" xmltv_id="">BBC Drama</channel>
+  <channel site="pluto.tv" site_id="60d35a74c63c3c0008df6a90" lang="fr" xmltv_id="">BBC Series</channel>
   <channel site="pluto.tv" site_id="664c8ba33d173b00080ef0c8" lang="fr" xmltv_id="">Beyblade</channel>
   <channel site="pluto.tv" site_id="66f55a9a747bfa0008521859" lang="fr" xmltv_id="">Blue Bloods</channel>
   <channel site="pluto.tv" site_id="5ffc8c345822750007e167de" lang="fr" xmltv_id="">Bob l&apos;éponge</channel>
@@ -16,21 +15,21 @@
   <channel site="pluto.tv" site_id="6231ec93779a9d00079ba8e2" lang="fr" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="60dc6937b450ad0007377e48" lang="fr" xmltv_id="">Charlotte aux Fraises</channel>
   <channel site="pluto.tv" site_id="65cce14060eb870008dbd003" lang="fr" xmltv_id="">Cheers</channel>
-  <channel site="pluto.tv" site_id="6823648580b2665220d9e69a" lang="fr" xmltv_id="">Ciné 666 by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5f8ed1ff5c39700007e2204a" lang="fr" xmltv_id="">Ciné Action by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5f8ed0f17564a300082b676a" lang="fr" xmltv_id="">Ciné by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="65a69ef53af63d000825e0ee" lang="fr" xmltv_id="">Ciné Catastrophe by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="62f3e2d000418d00070f7dbc" lang="fr" xmltv_id="">Ciné d&apos;Asie by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="66e1978babec540008ce41ac" lang="fr" xmltv_id="">Ciné Horreur by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5f8ed168f72fcd0007e56269" lang="fr" xmltv_id="">Ciné Rétro by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="60812fc8539963000707d1e1" lang="fr" xmltv_id="">Ciné Romance by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="60c34592c911890007f29a73" lang="fr" xmltv_id="">Ciné Sci-Fi by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="60c3472a51a2050008dad272" lang="fr" xmltv_id="">Ciné Thrillers by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="65cca3e2ec452d0008af3a65" lang="fr" xmltv_id="">Ciné Western by Pluto TV</channel>
-  <channel site="pluto.tv" site_id="66c45b36a72e7b0008a2b291" lang="fr" xmltv_id="">CNN Headlines</channel>
-  <channel site="pluto.tv" site_id="62f3dd1c2f29ce0007e18596" lang="fr" xmltv_id="">Coeur Océan</channel>
+  <channel site="pluto.tv" site_id="6823648580b2665220d9e69a" lang="fr" xmltv_id="Cine666byPlutoTV.de@FR">Ciné 666 by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f8ed1ff5c39700007e2204a" lang="fr" xmltv_id="CineActionbyPlutoTV.de@FR">Ciné Action by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f8ed0f17564a300082b676a" lang="fr" xmltv_id="CinebyPlutoTV.de@FR">Ciné by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="65a69ef53af63d000825e0ee" lang="fr" xmltv_id="CineCatastrophebyPlutoTV.de@FR">Ciné Catastrophe by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="62f3e2d000418d00070f7dbc" lang="fr" xmltv_id="CinedAsiebyPlutoTV.de@FR">Ciné d&apos;Asie by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="66e1978babec540008ce41ac" lang="fr" xmltv_id="CineHorreurbyPlutoTV.de@FR">Ciné Horreur by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f8ed168f72fcd0007e56269" lang="fr" xmltv_id="CineRetrobyPlutoTV.de@FR">Ciné Rétro by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="60812fc8539963000707d1e1" lang="fr" xmltv_id="CineRomancebyPlutoTV.de@FR">Ciné Romance by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="60c34592c911890007f29a73" lang="fr" xmltv_id="CineSciFibyPlutoTV.de@FR">Ciné Sci-Fi by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="60c3472a51a2050008dad272" lang="fr" xmltv_id="CineThrillersbyPlutoTV.de@FR">Ciné Thrillers by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="65cca3e2ec452d0008af3a65" lang="fr" xmltv_id="CineWesternbyPlutoTV.de@FR">Ciné Western by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="66c45b36a72e7b0008a2b291" lang="fr" xmltv_id="">CNN Headlines International</channel>
   <channel site="pluto.tv" site_id="6683b680efa2a10008e8a393" lang="fr" xmltv_id="">Daria</channel>
-  <channel site="pluto.tv" site_id="64d626ac9b414d000820e2fc" lang="fr" xmltv_id="">DAZN Combat</channel>
+  <channel site="pluto.tv" site_id="69aadc5551df9542f2521e1a" lang="fr" xmltv_id="">Dawson</channel>
+  <channel site="pluto.tv" site_id="64d626ac9b414d000820e2fc" lang="fr" xmltv_id="">DAZN Ringside</channel>
   <channel site="pluto.tv" site_id="611e71322f5f180007001dde" lang="fr" xmltv_id="">Degrassi</channel>
   <channel site="pluto.tv" site_id="62f3e8ad2a8e8000077b013d" lang="fr" xmltv_id="">Detective Conan</channel>
   <channel site="pluto.tv" site_id="6671b26836a2f90008d9333c" lang="fr" xmltv_id="">Diane, femme flic</channel>
@@ -43,11 +42,9 @@
   <channel site="pluto.tv" site_id="60d35bcaf1ff4a00078af0a6" lang="fr" xmltv_id="">Euronews</channel>
   <channel site="pluto.tv" site_id="5f8ecd9169d2d4000864a974" lang="fr" xmltv_id="">FailArmy</channel>
   <channel site="pluto.tv" site_id="662a622b5e2370000800f392" lang="fr" xmltv_id="">Faites entrer l&apos;accusé</channel>
-  <channel site="pluto.tv" site_id="64c9260ac0222700089ee62b" lang="fr" xmltv_id="">Family Club</channel>
   <channel site="pluto.tv" site_id="660c2a2d2433010008df7e92" lang="fr" xmltv_id="">FIFA+</channel>
   <channel site="pluto.tv" site_id="66d71ff86b63480008cf15c5" lang="fr" xmltv_id="">Flashpoint</channel>
   <channel site="pluto.tv" site_id="68d292d554c61bfff220a635" lang="fr" xmltv_id="">Flynn Carson et The Outpost</channel>
-  <channel site="pluto.tv" site_id="67b4b44a8344dd93339d3757" lang="fr" xmltv_id="">Forensic Files</channel>
   <channel site="pluto.tv" site_id="60afb203ec391c00070ea1bf" lang="fr" xmltv_id="">Génération Sitcoms</channel>
   <channel site="pluto.tv" site_id="604f8de01b479400078fb1e7" lang="fr" xmltv_id="">Hélène et les garçons</channel>
   <channel site="pluto.tv" site_id="63921a3d00c96100082a3cb4" lang="fr" xmltv_id="">Homicide</channel>
@@ -56,19 +53,17 @@
   <channel site="pluto.tv" site_id="611e75226b7f420007c3f319" lang="fr" xmltv_id="">Inazuma Eleven</channel>
   <channel site="pluto.tv" site_id="66f55d205e4a6e0008c2b92b" lang="fr" xmltv_id="">Incroyables Transformations</channel>
   <channel site="pluto.tv" site_id="60549e98061b5f000776866a" lang="fr" xmltv_id="">Instant Saga</channel>
-  <channel site="pluto.tv" site_id="6683cd2fca74680008772545" lang="fr" xmltv_id="">Investigation by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="6683cd2fca74680008772545" lang="fr" xmltv_id="InvestigationbyPlutoTV.de@FR">Investigation by Pluto TV</channel>
   <channel site="pluto.tv" site_id="65ccd26060eb870008db95fc" lang="fr" xmltv_id="">JAG</channel>
   <channel site="pluto.tv" site_id="6304f20c941c5d00089634e7" lang="fr" xmltv_id="">Just Tattoo of Us</channel>
   <channel site="pluto.tv" site_id="60afa1508284e60007163c08" lang="fr" xmltv_id="">Juste pour Rire GAGS</channel>
   <channel site="pluto.tv" site_id="685a999bd33909bdd7d2fb1e" lang="fr" xmltv_id="">La maison France 5</channel>
-  <channel site="pluto.tv" site_id="650aff3398020f00086380cd" lang="fr" xmltv_id="">Le Figaro TV</channel>
   <channel site="pluto.tv" site_id="60549c238c3f21000753d3e0" lang="fr" xmltv_id="">Le miracle de l&apos;amour</channel>
   <channel site="pluto.tv" site_id="66b228d4cd0d3100085d27b7" lang="fr" xmltv_id="">Les Anges</channel>
   <channel site="pluto.tv" site_id="60afae68a7fc50000737186d" lang="fr" xmltv_id="">Les Années fac</channel>
   <channel site="pluto.tv" site_id="60549d97cd7b090007c73314" lang="fr" xmltv_id="">Les filles d&apos;à côté</channel>
   <channel site="pluto.tv" site_id="66f55d565e4a6e0008c2b9d2" lang="fr" xmltv_id="">Les Marseillais</channel>
   <channel site="pluto.tv" site_id="5f8edb6df1ebb800072edf10" lang="fr" xmltv_id="">Les Nouveaux Detectives</channel>
-  <channel site="pluto.tv" site_id="66f55c55940963000810bb14" lang="fr" xmltv_id="">Les Reines du Shopping</channel>
   <channel site="pluto.tv" site_id="65cce23bdc10a400080645ad" lang="fr" xmltv_id="">Les Routes du Paradis</channel>
   <channel site="pluto.tv" site_id="68b16d2282862c1f067dc763" lang="fr" xmltv_id="">Les Schtroumpfs</channel>
   <channel site="pluto.tv" site_id="652d0b756208700008d758ad" lang="fr" xmltv_id="">Les Z&apos;amours</channel>
@@ -80,51 +75,56 @@
   <channel site="pluto.tv" site_id="671643fc5534bb00089187ad" lang="fr" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="pluto.tv" site_id="66d722d31878f200081c2c64" lang="fr" xmltv_id="">Most Haunted</channel>
   <channel site="pluto.tv" site_id="5f92b56a367e170007cd43f4" lang="fr" xmltv_id="">MTV CLASSICS</channel>
-  <channel site="pluto.tv" site_id="5ff5ec5500d4c70007341c7c" lang="fr" xmltv_id="">MTV Classics+</channel>
   <channel site="pluto.tv" site_id="61fc0df14159c40007250432" lang="fr" xmltv_id="">Nature Time</channel>
+  <channel site="pluto.tv" site_id="692ec6d82329c10c5166f436" lang="fr" xmltv_id="">Nina</channel>
   <channel site="pluto.tv" site_id="662a63275a402e00086bc8a5" lang="fr" xmltv_id="">Olive &amp; Tom</channel>
   <channel site="pluto.tv" site_id="6380c94947c72b0007ee9a13" lang="fr" xmltv_id="">One Piece</channel>
-  <channel site="pluto.tv" site_id="68d279fc840d8021ee1f1e50" lang="fr" xmltv_id="">Pacific Blue</channel>
   <channel site="pluto.tv" site_id="678f894ef5c74bff95c20a7f" lang="fr" xmltv_id="">Pêche à haut risque</channel>
+  <channel site="pluto.tv" site_id="692ec71425eaa17b6daf2a11" lang="fr" xmltv_id="">PJ</channel>
   <channel site="pluto.tv" site_id="662a6309307fa30008196b4e" lang="fr" xmltv_id="">Plus Belle la Vie 2</channel>
-  <channel site="pluto.tv" site_id="66b4990746762a00084c2f78" lang="fr" xmltv_id="">Pluto TV 90&apos;s Classics</channel>
-  <channel site="pluto.tv" site_id="66b498bc14a2bb00086965bc" lang="fr" xmltv_id="">Pluto TV 2010&apos;s Classics</channel>
-  <channel site="pluto.tv" site_id="60925a44f0350600075a1fdc" lang="fr" xmltv_id="">Pluto TV Animaux</channel>
-  <channel site="pluto.tv" site_id="611e7811eb9daf000764cbfd" lang="fr" xmltv_id="">Pluto TV Aventure</channel>
-  <channel site="pluto.tv" site_id="684bf01df7d8b74b625b7dd1" lang="fr" xmltv_id="">Pluto TV Brigade Criminelle</channel>
-  <channel site="pluto.tv" site_id="5ff5eb810e2996000768c0e2" lang="fr" xmltv_id="">Pluto TV Ciné+</channel>
-  <channel site="pluto.tv" site_id="5f8eb91bb9b9e7000817e67f" lang="fr" xmltv_id="">Pluto TV Comédie</channel>
-  <channel site="pluto.tv" site_id="67b4b2d976a934282e92d71c" lang="fr" xmltv_id="">Pluto TV Comédies Cultes</channel>
-  <channel site="pluto.tv" site_id="5f8ed48146ba9e00078424b6" lang="fr" xmltv_id="">Pluto TV Cuisine</channel>
-  <channel site="pluto.tv" site_id="682318568e6c0f2f6c6e0038" lang="fr" xmltv_id="">Pluto TV Dating</channel>
-  <channel site="pluto.tv" site_id="62f3e0522443200008c567d7" lang="fr" xmltv_id="">Pluto TV French Collection</channel>
-  <channel site="pluto.tv" site_id="611e771e2f5f180007002224" lang="fr" xmltv_id="">Pluto TV Histoire</channel>
-  <channel site="pluto.tv" site_id="5f8ed3892ed7bb000741a1d2" lang="fr" xmltv_id="">Pluto TV Inside</channel>
-  <channel site="pluto.tv" site_id="5f8ecb336537e8000764a17f" lang="fr" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="pluto.tv" site_id="654a58dbf9cc82000868f0fb" lang="fr" xmltv_id="">Pluto TV Kids Classics</channel>
-  <channel site="pluto.tv" site_id="611e6ddc7fcd580007d1eb5f" lang="fr" xmltv_id="">Pluto TV Kids Club</channel>
-  <channel site="pluto.tv" site_id="5f8ed9461b35690007a0bc3a" lang="fr" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="5f8ed4dbf6bb0800071ffbcb" lang="fr" xmltv_id="">Pluto TV Polar</channel>
-  <channel site="pluto.tv" site_id="5ffebbeabd18520007b37709" lang="fr" xmltv_id="">Pluto TV Polar+</channel>
-  <channel site="pluto.tv" site_id="6092544e7639460007d4835e" lang="fr" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="611e6a9b4bb5790007a6f0f8" lang="fr" xmltv_id="">Pluto TV Retro Toons</channel>
-  <channel site="pluto.tv" site_id="625ec7a1c853fd00073b38fd" lang="fr" xmltv_id="">Pluto TV Séries Fantastiques</channel>
-  <channel site="pluto.tv" site_id="66fd35e44ca31f0008060b77" lang="fr" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="652557d93fd33c000802f995" lang="fr" xmltv_id="">Pluto TV Super Kids</channel>
-  <channel site="pluto.tv" site_id="5f8eb99ff17815000784a3b0" lang="fr" xmltv_id="">Pluto TV Teen</channel>
-  <channel site="pluto.tv" site_id="5f8eba14a4ffb8000764e950" lang="fr" xmltv_id="">Pluto TV Toons</channel>
+  <channel site="pluto.tv" site_id="66b4990746762a00084c2f78" lang="fr" xmltv_id="PlutoTV90sClassics.de@FR">Pluto TV 90&apos;s Classics</channel>
+  <channel site="pluto.tv" site_id="66b498bc14a2bb00086965bc" lang="fr" xmltv_id="PlutoTV2010sClassics.de@FR">Pluto TV 2010&apos;s Classics</channel>
+  <channel site="pluto.tv" site_id="60925a44f0350600075a1fdc" lang="fr" xmltv_id="PlutoTVAnimaux.de@FR">Pluto TV Animaux</channel>
+  <channel site="pluto.tv" site_id="691b3669c48674840c3b832a" lang="fr" xmltv_id="PlutoTVANIMEGO.de@FR">Pluto TV ANIME GO!</channel>
+  <channel site="pluto.tv" site_id="611e7811eb9daf000764cbfd" lang="fr" xmltv_id="PlutoTVAventure.de@FR">Pluto TV Aventure</channel>
+  <channel site="pluto.tv" site_id="684bf01df7d8b74b625b7dd1" lang="fr" xmltv_id="PlutoTVBrigadeCriminelle.de@FR">Pluto TV Brigade Criminelle</channel>
+  <channel site="pluto.tv" site_id="5ff5eb810e2996000768c0e2" lang="fr" xmltv_id="PlutoTVCine.de@FRPlus">Pluto TV Ciné+</channel>
+  <channel site="pluto.tv" site_id="5f8eb91bb9b9e7000817e67f" lang="fr" xmltv_id="PlutoTVComedie.de@FR">Pluto TV Comédie</channel>
+  <channel site="pluto.tv" site_id="67b4b2d976a934282e92d71c" lang="fr" xmltv_id="PlutoTVComediesCultes.de@FR">Pluto TV Comédies Cultes</channel>
+  <channel site="pluto.tv" site_id="5f8ed48146ba9e00078424b6" lang="fr" xmltv_id="PlutoTVCuisine.de@FR">Pluto TV Cuisine</channel>
+  <channel site="pluto.tv" site_id="682318568e6c0f2f6c6e0038" lang="fr" xmltv_id="PlutoTVDating.de@FR">Pluto TV Dating</channel>
+  <channel site="pluto.tv" site_id="69c2ae0d1f1accd54916c825" lang="fr" xmltv_id="">Pluto TV Footanim&apos;</channel>
+  <channel site="pluto.tv" site_id="62f3e0522443200008c567d7" lang="fr" xmltv_id="PlutoTVFrenchCollection.de@FR">Pluto TV French Collection</channel>
+  <channel site="pluto.tv" site_id="611e771e2f5f180007002224" lang="fr" xmltv_id="PlutoTVHistoire.de@FR">Pluto TV Histoire</channel>
+  <channel site="pluto.tv" site_id="5f8ed3892ed7bb000741a1d2" lang="fr" xmltv_id="PlutoTVInside.de@FR">Pluto TV Inside</channel>
+  <channel site="pluto.tv" site_id="5f8ecb336537e8000764a17f" lang="fr" xmltv_id="PlutoTVJunior.de@FR">Pluto TV Junior</channel>
+  <channel site="pluto.tv" site_id="654a58dbf9cc82000868f0fb" lang="fr" xmltv_id="PlutoTVKidsClassics.de@FR">Pluto TV Kids Classics</channel>
+  <channel site="pluto.tv" site_id="611e6ddc7fcd580007d1eb5f" lang="fr" xmltv_id="PlutoTVKidsClub.de@FR">Pluto TV Kids Club</channel>
+  <channel site="pluto.tv" site_id="5f8ed9461b35690007a0bc3a" lang="fr" xmltv_id="PlutoTVParanormal.de@FR">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="5f8ed4dbf6bb0800071ffbcb" lang="fr" xmltv_id="PlutoTVPolar.de@FR">Pluto TV Polar</channel>
+  <channel site="pluto.tv" site_id="5ffebbeabd18520007b37709" lang="fr" xmltv_id="PlutoTVPolar.de@FRPlus">Pluto TV Polar+</channel>
+  <channel site="pluto.tv" site_id="6092544e7639460007d4835e" lang="fr" xmltv_id="PlutoTVReality.de@FR">Pluto TV Pride</channel>
+  <channel site="pluto.tv" site_id="611e6a9b4bb5790007a6f0f8" lang="fr" xmltv_id="PlutoTVRetroToons.de@FR">Pluto TV Retro Toons</channel>
+  <channel site="pluto.tv" site_id="625ec7a1c853fd00073b38fd" lang="fr" xmltv_id="PlutoTVSeriesFantastiques.de@FR">Pluto TV Séries Fantastiques</channel>
+  <channel site="pluto.tv" site_id="66fd35e44ca31f0008060b77" lang="fr" xmltv_id="PlutoTVSnooker900.de@FR">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="652557d93fd33c000802f995" lang="fr" xmltv_id="PlutoTVSuperKids.de@FR">Pluto TV Super Kids</channel>
+  <channel site="pluto.tv" site_id="5f8eb99ff17815000784a3b0" lang="fr" xmltv_id="PlutoTVTeen.de@FR">Pluto TV Teen</channel>
+  <channel site="pluto.tv" site_id="699865ccac36b147e74619fe" lang="fr" xmltv_id="">Pluto TV Téléréalité France</channel>
+  <channel site="pluto.tv" site_id="5f8eba14a4ffb8000764e950" lang="fr" xmltv_id="PlutoTVToons.de@FR">Pluto TV Toons</channel>
   <channel site="pluto.tv" site_id="652d0b9ceb72580008a4ea5b" lang="fr" xmltv_id="">Qui veut gagner des millions?</channel>
+  <channel site="pluto.tv" site_id="691b332aa4385c191ee44b57" lang="fr" xmltv_id="">Rex, chien flic</channel>
   <channel site="pluto.tv" site_id="5f8eb8a8b2619a000710605c" lang="fr" xmltv_id="">Ridiculousness</channel>
-  <channel site="pluto.tv" site_id="5f8ed2d1c34c2300073bf02c" lang="fr" xmltv_id="">Series by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f8ed2d1c34c2300073bf02c" lang="fr" xmltv_id="SeriesbyPlutoTV.de@FR">Series by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="697a34496f47f39d31ff8bde" lang="fr" xmltv_id="">Si près de chez vous</channel>
+  <channel site="pluto.tv" site_id="69b3db536c0414a7ecf564fb" lang="fr" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="67b4b3c51a5ca760802cc1c7" lang="fr" xmltv_id="">Star Trek: The Original Series</channel>
+  <channel site="pluto.tv" site_id="6a1ecc3d7120a26f0dcf89e7" lang="fr" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="pluto.tv" site_id="62f3f05505e621000783df2f" lang="fr" xmltv_id="">Teen Mom</channel>
-  <channel site="pluto.tv" site_id="65251c3a9c7aeb00083741c9" lang="fr" xmltv_id="">Téléfilms de Noël by Pluto TV</channel>
   <channel site="pluto.tv" site_id="5f8ece1a89d79800072510e6" lang="fr" xmltv_id="">The Asylum</channel>
   <channel site="pluto.tv" site_id="64c1093824ade50008bd117f" lang="fr" xmltv_id="">Top Gear</channel>
   <channel site="pluto.tv" site_id="5f8ecc1b37867f00071469e9" lang="fr" xmltv_id="">Tortues Ninja TV</channel>
   <channel site="pluto.tv" site_id="67b4b4a21a5ca760802d25fd" lang="fr" xmltv_id="">Tout le monde déteste Chris</channel>
-  <channel site="pluto.tv" site_id="62f3e6aebcdda4000754fa47" lang="fr" xmltv_id="">Toute une histoire</channel>
-  <channel site="pluto.tv" site_id="5f914f4b36d67d0007a91a04" lang="fr" xmltv_id="">True Crime by Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5f914f4b36d67d0007a91a04" lang="fr" xmltv_id="TrueCrimebyPlutoTV.de@FR">True Crime by Pluto TV</channel>
   <channel site="pluto.tv" site_id="66f55c3955567d0008ef9b68" lang="fr" xmltv_id="">Turbo</channel>
   <channel site="pluto.tv" site_id="67921b78b83355184c667770" lang="fr" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="62f3ece7b09fd6000783bfb9" lang="fr" xmltv_id="">Un gars, une fille</channel>

--- a/sites/pluto.tv/pluto.tv_it.channels.xml
+++ b/sites/pluto.tv/pluto.tv_it.channels.xml
@@ -4,9 +4,10 @@
   <channel site="pluto.tv" site_id="64ec5c6644fe100009d114ae" lang="it" xmltv_id="">Affare Fatto</channel>
   <channel site="pluto.tv" site_id="66d9aa4315d2c60008d4ac40" lang="it" xmltv_id="">Alice Nevers</channel>
   <channel site="pluto.tv" site_id="60802d37ee238e0007c94e64" lang="it" xmltv_id="">Andromeda</channel>
+  <channel site="pluto.tv" site_id="6971fc6dca441014e4600f2c" lang="it" xmltv_id="">Automoto</channel>
   <channel site="pluto.tv" site_id="638f286445264d00084ec6dc" lang="it" xmltv_id="">Autostop per il cielo</channel>
   <channel site="pluto.tv" site_id="686cfdf894a028da3aac4252" lang="it" xmltv_id="">Barbie &amp; Friends</channel>
-  <channel site="pluto.tv" site_id="62e7fa5ab5062e0007dcf97d" lang="it" xmltv_id="">BBC Drama</channel>
+  <channel site="pluto.tv" site_id="62e7fa5ab5062e0007dcf97d" lang="it" xmltv_id="">BBC Series</channel>
   <channel site="pluto.tv" site_id="66a0eea88561260008b1c5d0" lang="it" xmltv_id="">Carabinieri</channel>
   <channel site="pluto.tv" site_id="6093f9ed2c75660007322bb7" lang="it" xmltv_id="">Catfish</channel>
   <channel site="pluto.tv" site_id="6231ec4b62cd1f0007093c7b" lang="it" xmltv_id="">CBS News 24/7</channel>
@@ -14,9 +15,7 @@
   <channel site="pluto.tv" site_id="65cb78b83a116800079e2e35" lang="it" xmltv_id="">Cin Cin</channel>
   <channel site="pluto.tv" site_id="671754d8e482950008962aaf" lang="it" xmltv_id="">Cinema Poliziottesco</channel>
   <channel site="pluto.tv" site_id="653660b4295b840008a70ba3" lang="it" xmltv_id="">CineThriller</channel>
-  <channel site="pluto.tv" site_id="66c45ba803e3b20008d8c294" lang="it" xmltv_id="">CNN Headlines</channel>
-  <channel site="pluto.tv" site_id="66c3139c21a4740008466116" lang="it" xmltv_id="">Desi Play TV</channel>
-  <channel site="pluto.tv" site_id="66461e4394d5580008cfd9c5" lang="it" xmltv_id="">DFB Play TV</channel>
+  <channel site="pluto.tv" site_id="66c45ba803e3b20008d8c294" lang="it" xmltv_id="">CNN Headlines International</channel>
   <channel site="pluto.tv" site_id="65f865a62873090008d06382" lang="it" xmltv_id="">Duri a Morire</channel>
   <channel site="pluto.tv" site_id="65cb76ea11ced70008206b66" lang="it" xmltv_id="">Dynasty</channel>
   <channel site="pluto.tv" site_id="61b86ea479a4390007c6d5fc" lang="it" xmltv_id="">Euronews</channel>
@@ -25,100 +24,108 @@
   <channel site="pluto.tv" site_id="660bfc4424e1d000085b5f93" lang="it" xmltv_id="">FIFA+</channel>
   <channel site="pluto.tv" site_id="66d7120815d2c60008cec006" lang="it" xmltv_id="">Flashpoint</channel>
   <channel site="pluto.tv" site_id="64ec5cf50f73a800081310a5" lang="it" xmltv_id="">Forensic Files</channel>
+  <channel site="pluto.tv" site_id="6971fc07c945e6e4e5bc46bf" lang="it" xmltv_id="">Gambero Rosso</channel>
   <channel site="pluto.tv" site_id="619263ee9541940007d20d60" lang="it" xmltv_id="">Geordie Shore</channel>
   <channel site="pluto.tv" site_id="6536608b4f123d000876b78b" lang="it" xmltv_id="">Gli Immortali | Van Damme vs Lundgren</channel>
   <channel site="pluto.tv" site_id="66a8c64814a2bb00084d09d6" lang="it" xmltv_id="">Gormiti</channel>
   <channel site="pluto.tv" site_id="664f0ddbf78a8500092dcffa" lang="it" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="66c35c0c92b1af0008c8e83a" lang="it" xmltv_id="">Horror Club</channel>
+  <channel site="pluto.tv" site_id="62442f28afe626000747f195" lang="it" xmltv_id="">I Jefferson</channel>
   <channel site="pluto.tv" site_id="68adb5853efb41cd97ce413d" lang="it" xmltv_id="">I Puffi</channel>
   <channel site="pluto.tv" site_id="6602acadb2abe500081cf28a" lang="it" xmltv_id="">I soliti idioti</channel>
   <channel site="pluto.tv" site_id="60e4507a06171800072339a3" lang="it" xmltv_id="">Il Banco dei Pugni</channel>
+  <channel site="pluto.tv" site_id="6971fc932c004063166ac8fd" lang="it" xmltv_id="">Il Sole24Ore TV</channel>
   <channel site="pluto.tv" site_id="61fbd3f0733df400076c9a2d" lang="it" xmltv_id="">Il Testimone</channel>
   <channel site="pluto.tv" site_id="612375086abc84000738fc03" lang="it" xmltv_id="">Inazuma Eleven</channel>
+  <channel site="pluto.tv" site_id="691c5bef3a369d8f40192e71" lang="it" xmltv_id="">Inter 24/7</channel>
   <channel site="pluto.tv" site_id="6093f48c95132a00075fd859" lang="it" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="pluto.tv" site_id="60a2837f8154ab0007c4dcdf" lang="it" xmltv_id="">Le sorelle McLeod</channel>
   <channel site="pluto.tv" site_id="65d7211d0d45610008ffcf92" lang="it" xmltv_id="">LOL Just For Laughs</channel>
   <channel site="pluto.tv" site_id="65cb76723a116800079e1fc3" lang="it" xmltv_id="">Love Boat</channel>
   <channel site="pluto.tv" site_id="6349279ed5023700078f2bc2" lang="it" xmltv_id="">Mai dire sì</channel>
   <channel site="pluto.tv" site_id="686cfe983ffa5e0c91cdb5df" lang="it" xmltv_id="">Mattel Junior</channel>
+  <channel site="pluto.tv" site_id="690cb9140d121b44ad925ac9" lang="it" xmltv_id="">Mayday: Disastro Aereo</channel>
   <channel site="pluto.tv" site_id="65cb77853ba51e00084cba02" lang="it" xmltv_id="">Mission Impossible</channel>
   <channel site="pluto.tv" site_id="671655b2daad7f00085d202d" lang="it" xmltv_id="">MODUS Super Series Darts</channel>
   <channel site="pluto.tv" site_id="610a9ebe8c2ac2000734776e" lang="it" xmltv_id="">Naturescape</channel>
-  <channel site="pluto.tv" site_id="636a4eaf77279a0007f14861" lang="it" xmltv_id="">Pimp My Ride</channel>
-  <channel site="pluto.tv" site_id="661f8f01801af800083d9d81" lang="it" xmltv_id="">Pluto TV Alberto Sordi</channel>
-  <channel site="pluto.tv" site_id="65b90daed77d450008a43345" lang="it" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="612e05b885183d0007958101" lang="it" xmltv_id="">Pluto TV Christmas</channel>
-  <channel site="pluto.tv" site_id="688244e00a154253b39f3e44" lang="it" xmltv_id="">Pluto TV Christmas Family</channel>
-  <channel site="pluto.tv" site_id="608aa7d8359b270007861489" lang="it" xmltv_id="">Pluto TV Cinema Italiano</channel>
-  <channel site="pluto.tv" site_id="6786235bd648bf0008c2780a" lang="it" xmltv_id="">Pluto TV Cinema Orientale</channel>
-  <channel site="pluto.tv" site_id="608aa718a8ec810007d87fee" lang="it" xmltv_id="">Pluto TV Cucina</channel>
-  <channel site="pluto.tv" site_id="6875080e3484d607323641f8" lang="it" xmltv_id="">Pluto TV Dive Italiane</channel>
-  <channel site="pluto.tv" site_id="608aa8a5709d6b0007b132fe" lang="it" xmltv_id="">Pluto TV Documentari</channel>
-  <channel site="pluto.tv" site_id="66335489307fa300082bd6e4" lang="it" xmltv_id="">Pluto TV Eros</channel>
-  <channel site="pluto.tv" site_id="608aa17fb9f4490007e6419a" lang="it" xmltv_id="">Pluto TV Film</channel>
-  <channel site="pluto.tv" site_id="65158fe20371a8000868809a" lang="it" xmltv_id="">Pluto TV Film</channel>
-  <channel site="pluto.tv" site_id="608aa20a2e7f270007c4878d" lang="it" xmltv_id="">Pluto TV Film Azione</channel>
-  <channel site="pluto.tv" site_id="651593a42c585100085b9d09" lang="it" xmltv_id="">Pluto TV Film Azione</channel>
-  <channel site="pluto.tv" site_id="628deda4b9a7650007de2384" lang="it" xmltv_id="">Pluto TV Film Azione+</channel>
-  <channel site="pluto.tv" site_id="608aa512d67fd900072323db" lang="it" xmltv_id="">Pluto TV Film Commedia</channel>
-  <channel site="pluto.tv" site_id="628deea29e29d0000765e910" lang="it" xmltv_id="">Pluto TV Film Commedia+</channel>
-  <channel site="pluto.tv" site_id="608aa4a4cc92820007b663af" lang="it" xmltv_id="">Pluto TV Film Romantici</channel>
-  <channel site="pluto.tv" site_id="611644bd5f76a40007d26296" lang="it" xmltv_id="">Pluto TV Film Romantici+</channel>
-  <channel site="pluto.tv" site_id="68750875759366af05a151ce" lang="it" xmltv_id="">Pluto TV Film Storici</channel>
-  <channel site="pluto.tv" site_id="608aa5e995132a00075f7005" lang="it" xmltv_id="">Pluto TV Film Thriller</channel>
-  <channel site="pluto.tv" site_id="6116413793706b0007f04bb1" lang="it" xmltv_id="">Pluto TV Film+</channel>
-  <channel site="pluto.tv" site_id="612ce23f51cce000078eeed5" lang="it" xmltv_id="">Pluto TV Fireplace</channel>
-  <channel site="pluto.tv" site_id="61c09e3ac210ed0007606620" lang="it" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="64808a8c536e0c0008a276d1" lang="it" xmltv_id="">Pluto TV Legami Letali</channel>
-  <channel site="pluto.tv" site_id="60802b37709d6b0007b0c549" lang="it" xmltv_id="">Pluto TV Natura</channel>
-  <channel site="pluto.tv" site_id="6911c9b88caba6f046c5ca8f" lang="it" xmltv_id="">Pluto TV Notti di Crimine</channel>
-  <channel site="pluto.tv" site_id="6911c9704316999535eb21cf" lang="it" xmltv_id="">Pluto TV Notti di Passione</channel>
-  <channel site="pluto.tv" site_id="6911c92b4316999535eb1e08" lang="it" xmltv_id="">Pluto TV Notti di Sangue</channel>
-  <channel site="pluto.tv" site_id="6911c8dd8caba6f046c5c5d5" lang="it" xmltv_id="">Pluto TV Notti di Terrore</channel>
-  <channel site="pluto.tv" site_id="66c70033b1a34600087bb09a" lang="it" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="60801976f92a750007a0699c" lang="it" xmltv_id="">Pluto TV Real Life</channel>
-  <channel site="pluto.tv" site_id="6116424f5f76a40007d2616e" lang="it" xmltv_id="">Pluto TV Real Life+</channel>
-  <channel site="pluto.tv" site_id="609404b0a8ec810007d8de9d" lang="it" xmltv_id="">Pluto TV Scherzi e risate</channel>
-  <channel site="pluto.tv" site_id="61728bb9ee3773000840c1fa" lang="it" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="60b9ff2722bfa400072676ef" lang="it" xmltv_id="">Pluto TV Serie</channel>
-  <channel site="pluto.tv" site_id="608aa777b907770007e5d05d" lang="it" xmltv_id="">Pluto TV Serie Crime</channel>
-  <channel site="pluto.tv" site_id="67ed14aaf7c5d70b9089c3bf" lang="it" xmltv_id="">Pluto TV Serie Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="61163de693706b0007f04898" lang="it" xmltv_id="">Pluto TV Serie+</channel>
-  <channel site="pluto.tv" site_id="67e3b0d2443f0671bc8a1297" lang="it" xmltv_id="">Pluto TV Shore</channel>
-  <channel site="pluto.tv" site_id="69148c76e9dec35c9269a16c" lang="it" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="608030eff4b6f70007e1684c" lang="it" xmltv_id="">Pluto TV Sport</channel>
-  <channel site="pluto.tv" site_id="65253fdf3fd33c00080214a3" lang="it" xmltv_id="">Pluto TV Storia</channel>
-  <channel site="pluto.tv" site_id="65253f9881f942000833ccd5" lang="it" xmltv_id="">Pluto TV Totò</channel>
-  <channel site="pluto.tv" site_id="66d9ab4bf0f17500084e9b7e" lang="it" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="63c923944207be0007fd0887" lang="it" xmltv_id="">Pluto TV Viaggi</channel>
-  <channel site="pluto.tv" site_id="62e7fb67478a5b0007e6c50c" lang="it" xmltv_id="">Pluto TV Western</channel>
+  <channel site="pluto.tv" site_id="6500457d3efb510008315e59" lang="it" xmltv_id="">New Tricks</channel>
+  <channel site="pluto.tv" site_id="691c5b2e74baa89ef7230baf" lang="it" xmltv_id="">Nina</channel>
+  <channel site="pluto.tv" site_id="69affcad8940750a23a7231a" lang="it" xmltv_id="">One Piece</channel>
+  <channel site="pluto.tv" site_id="661f8f01801af800083d9d81" lang="it" xmltv_id="PlutoTVAlbertoSordi.de@IT">Pluto TV Alberto Sordi</channel>
+  <channel site="pluto.tv" site_id="65b90daed77d450008a43345" lang="it" xmltv_id="PlutoTVAnime.de@IT">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="6994800c470389f33df8e090" lang="it" xmltv_id="PlutoTVAzioneCult.de@IT">Pluto TV Azione Cult</channel>
+  <channel site="pluto.tv" site_id="612e05b885183d0007958101" lang="it" xmltv_id="PlutoTVChristmastuttolanno.de@IT">Pluto TV Christmas tutto l&apos;anno</channel>
+  <channel site="pluto.tv" site_id="608aa7d8359b270007861489" lang="it" xmltv_id="PlutoTVCinemaItaliano.de@IT">Pluto TV Cinema Italiano</channel>
+  <channel site="pluto.tv" site_id="6786235bd648bf0008c2780a" lang="it" xmltv_id="PlutoTVCinemaOrientale.de@IT">Pluto TV Cinema Orientale</channel>
+  <channel site="pluto.tv" site_id="608aa718a8ec810007d87fee" lang="it" xmltv_id="PlutoTVCucina.de@IT">Pluto TV Cucina</channel>
+  <channel site="pluto.tv" site_id="6875080e3484d607323641f8" lang="it" xmltv_id="PlutoTVDiveItaliane.de@IT">Pluto TV Dive Italiane</channel>
+  <channel site="pluto.tv" site_id="608aa8a5709d6b0007b132fe" lang="it" xmltv_id="PlutoTVDocumentari.de@IT">Pluto TV Documentari</channel>
+  <channel site="pluto.tv" site_id="66335489307fa300082bd6e4" lang="it" xmltv_id="PlutoTVEros.de@IT">Pluto TV Eros</channel>
+  <channel site="pluto.tv" site_id="608aa17fb9f4490007e6419a" lang="it" xmltv_id="PlutoTVFilm.de@IT">Pluto TV Film</channel>
+  <channel site="pluto.tv" site_id="65158fe20371a8000868809a" lang="it" xmltv_id="PlutoTVFilm.de@ITPlus2">Pluto TV Film</channel>
+  <channel site="pluto.tv" site_id="699d87093d5dba980705cca8" lang="it" xmltv_id="PlutoTVFilmAncoraPiuRomantici.de@IT">Pluto TV Film Ancora Più Romantici</channel>
+  <channel site="pluto.tv" site_id="608aa20a2e7f270007c4878d" lang="it" xmltv_id="PlutoTVFilmAzione.de@IT">Pluto TV Film Azione</channel>
+  <channel site="pluto.tv" site_id="651593a42c585100085b9d09" lang="it" xmltv_id="PlutoTVFilmAzione.de@ITPlus2">Pluto TV Film Azione</channel>
+  <channel site="pluto.tv" site_id="628deda4b9a7650007de2384" lang="it" xmltv_id="PlutoTVFilmAzione.de@ITPlus">Pluto TV Film Azione+</channel>
+  <channel site="pluto.tv" site_id="608aa512d67fd900072323db" lang="it" xmltv_id="PlutoTVFilmCommedia.de@IT">Pluto TV Film Commedia</channel>
+  <channel site="pluto.tv" site_id="628deea29e29d0000765e910" lang="it" xmltv_id="PlutoTVFilmCommedia.de@ITPlus">Pluto TV Film Commedia+</channel>
+  <channel site="pluto.tv" site_id="608aa4a4cc92820007b663af" lang="it" xmltv_id="PlutoTVFilmRomantici.de@IT">Pluto TV Film Romantici</channel>
+  <channel site="pluto.tv" site_id="611644bd5f76a40007d26296" lang="it" xmltv_id="PlutoTVFilmRomantici.de@ITPlus">Pluto TV Film Romantici+</channel>
+  <channel site="pluto.tv" site_id="68750875759366af05a151ce" lang="it" xmltv_id="PlutoTVFilmStorici.de@IT">Pluto TV Film Storici</channel>
+  <channel site="pluto.tv" site_id="608aa5e995132a00075f7005" lang="it" xmltv_id="PlutoTVFilmThriller.de@IT">Pluto TV Film Thriller</channel>
+  <channel site="pluto.tv" site_id="6116413793706b0007f04bb1" lang="it" xmltv_id="PlutoTVFilm.de@ITPlus">Pluto TV Film+</channel>
+  <channel site="pluto.tv" site_id="61c09e3ac210ed0007606620" lang="it" xmltv_id="PlutoTVHorror.de@IT">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="64808a8c536e0c0008a276d1" lang="it" xmltv_id="PlutoTVLegamiLetali.de@IT">Pluto TV Legami Letali</channel>
+  <channel site="pluto.tv" site_id="60802b37709d6b0007b0c549" lang="it" xmltv_id="PlutoTVNatura.de@IT">Pluto TV Natura</channel>
+  <channel site="pluto.tv" site_id="6911c9704316999535eb21cf" lang="it" xmltv_id="PlutoTVNottidiPassione.de@IT">Pluto TV Notti di Passione</channel>
+  <channel site="pluto.tv" site_id="6911c92b4316999535eb1e08" lang="it" xmltv_id="PlutoTVNottidiSangue.de@IT">Pluto TV Notti di Sangue</channel>
+  <channel site="pluto.tv" site_id="6911c8dd8caba6f046c5c5d5" lang="it" xmltv_id="PlutoTVNottidiTerrore.de@IT">Pluto TV Notti di Terrore</channel>
+  <channel site="pluto.tv" site_id="66c70033b1a34600087bb09a" lang="it" xmltv_id="PlutoTVParanormal.de@IT">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="60801976f92a750007a0699c" lang="it" xmltv_id="PlutoTVRealLife.de@IT">Pluto TV Real Life</channel>
+  <channel site="pluto.tv" site_id="6116424f5f76a40007d2616e" lang="it" xmltv_id="PlutoTVRealLife.de@ITPlus">Pluto TV Real Life+</channel>
+  <channel site="pluto.tv" site_id="609404b0a8ec810007d8de9d" lang="it" xmltv_id="PlutoTVScherzierisate.de@IT">Pluto TV Scherzi e risate</channel>
+  <channel site="pluto.tv" site_id="61728bb9ee3773000840c1fa" lang="it" xmltv_id="PlutoTVSciFi.de@IT">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="60b9ff2722bfa400072676ef" lang="it" xmltv_id="PlutoTVSerie.de@IT">Pluto TV Serie</channel>
+  <channel site="pluto.tv" site_id="608aa777b907770007e5d05d" lang="it" xmltv_id="PlutoTVSerieCrime.de@IT">Pluto TV Serie Crime</channel>
+  <channel site="pluto.tv" site_id="67ed14aaf7c5d70b9089c3bf" lang="it" xmltv_id="PlutoTVSerieSciFi.de@IT">Pluto TV Serie Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="61163de693706b0007f04898" lang="it" xmltv_id="PlutoTVSerie.de@ITPlus">Pluto TV Serie+</channel>
+  <channel site="pluto.tv" site_id="67e3b0d2443f0671bc8a1297" lang="it" xmltv_id="PlutoTVShore.de@IT">Pluto TV Shore</channel>
+  <channel site="pluto.tv" site_id="69148c76e9dec35c9269a16c" lang="it" xmltv_id="PlutoTVSnooker900.de@IT">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="608030eff4b6f70007e1684c" lang="it" xmltv_id="PlutoTVSport.de@IT">Pluto TV Sport</channel>
+  <channel site="pluto.tv" site_id="65253fdf3fd33c00080214a3" lang="it" xmltv_id="PlutoTVStoria.de@IT">Pluto TV Storia</channel>
+  <channel site="pluto.tv" site_id="63eb573ba99571000897135b" lang="it" xmltv_id="PlutoTVTeen.de@IT">Pluto TV Teen</channel>
+  <channel site="pluto.tv" site_id="65253f9881f942000833ccd5" lang="it" xmltv_id="PlutoTVToto.de@IT">Pluto TV Totò</channel>
+  <channel site="pluto.tv" site_id="66d9ab4bf0f17500084e9b7e" lang="it" xmltv_id="PlutoTVTrueCrime.de@IT">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="63c923944207be0007fd0887" lang="it" xmltv_id="PlutoTVViaggi.de@IT">Pluto TV Viaggi</channel>
+  <channel site="pluto.tv" site_id="62e7fb67478a5b0007e6c50c" lang="it" xmltv_id="PlutoTVWestern.de@IT">Pluto TV Western</channel>
+  <channel site="pluto.tv" site_id="696e0fe49ba4ac18057433ac" lang="it" xmltv_id="">Rally TV</channel>
   <channel site="pluto.tv" site_id="67d9836ba1609bdb523f0c9d" lang="it" xmltv_id="">Relic Hunter</channel>
   <channel site="pluto.tv" site_id="634926e4b51d2d00077819a2" lang="it" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="63eb57d6c111bc0008fe2658" lang="it" xmltv_id="">Sanctuary</channel>
   <channel site="pluto.tv" site_id="6245d3792792150007e20634" lang="it" xmltv_id="">Settimo Cielo</channel>
   <channel site="pluto.tv" site_id="62bc1f502b70e3000706298e" lang="it" xmltv_id="">South Park</channel>
+  <channel site="pluto.tv" site_id="69b1489b5828e7c242d83064" lang="it" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="625e6cc905e09f00073addee" lang="it" xmltv_id="">Squadra Speciale Cobra 11</channel>
-  <channel site="pluto.tv" site_id="6581a09edfed030008e12b39" lang="it" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="pluto.tv" site_id="65cb73d33ba51e00084cabad" lang="it" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="pluto.tv" site_id="66177d18c8311c0008d077d0" lang="it" xmltv_id="">Storie Criminali</channel>
   <channel site="pluto.tv" site_id="66d9a98961dbf00008efb5fc" lang="it" xmltv_id="">Sulle tracce del crimine</channel>
-  <channel site="pluto.tv" site_id="666174c9f999220008769012" lang="it" xmltv_id="">Super! Big Time Rush</channel>
   <channel site="pluto.tv" site_id="6093f6f8351eb0000754afb8" lang="it" xmltv_id="">Super! Cartoni Animati</channel>
   <channel site="pluto.tv" site_id="609401db8cf51c00084b592e" lang="it" xmltv_id="">Super! iCarly</channel>
   <channel site="pluto.tv" site_id="67f4f99729b03f18cb36647e" lang="it" xmltv_id="">Super! Kids Classics</channel>
   <channel site="pluto.tv" site_id="6093f7b5bb49b90007cecaad" lang="it" xmltv_id="">Super! Pop</channel>
   <channel site="pluto.tv" site_id="6093f9281db477000759fce0" lang="it" xmltv_id="">Super! SpongeBob</channel>
-  <channel site="pluto.tv" site_id="63c012504faf1c0007abfa93" lang="it" xmltv_id="">Super! Victorious</channel>
-  <channel site="pluto.tv" site_id="6304ed62410a4c00083c0291" lang="it" xmltv_id="">Super! Zoey 101</channel>
   <channel site="pluto.tv" site_id="66a8c8b3d2d50d000821fc4c" lang="it" xmltv_id="">Tandem</channel>
   <channel site="pluto.tv" site_id="62e7fc8c0d061100083946a9" lang="it" xmltv_id="">Teen Mom</channel>
   <channel site="pluto.tv" site_id="62619405c733e8000732d1fe" lang="it" xmltv_id="">Teenage Mutant Ninja Turtles</channel>
+  <channel site="pluto.tv" site_id="69ef53e12f4d2b4f9c582e76" lang="it" xmltv_id="">That&apos;s 70s</channel>
+  <channel site="pluto.tv" site_id="69ef54f3c700cf0140272def" lang="it" xmltv_id="">That&apos;s 80s</channel>
+  <channel site="pluto.tv" site_id="69ef55c3b80e144b55d74e36" lang="it" xmltv_id="">That&apos;s 90s/00s</channel>
+  <channel site="pluto.tv" site_id="69ef5682980899a9edf1a884" lang="it" xmltv_id="">That&apos;s Rock</channel>
   <channel site="pluto.tv" site_id="62e8d5369e48940007fc1dc1" lang="it" xmltv_id="">The Asylum</channel>
+  <channel site="pluto.tv" site_id="69664afedcbf5c784492e422" lang="it" xmltv_id="">The Intern</channel>
   <channel site="pluto.tv" site_id="64c109a4798def0008a6e03e" lang="it" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="6616a51124e1d00008761a7e" lang="it" xmltv_id="">Triton Poker</channel>
   <channel site="pluto.tv" site_id="679203d4bc03978b9b4b79a6" lang="it" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="67c832cc9b53325ee16fb899" lang="it" xmltv_id="">Wicked Tuna</channel>
-  <channel site="pluto.tv" site_id="67851bd7d648bf0008c00bc2" lang="it" xmltv_id="">Winx Club</channel>
   <channel site="pluto.tv" site_id="608016e446d73500075ea7e0" lang="it" xmltv_id="">World Poker Tour</channel>
   <channel site="pluto.tv" site_id="63eb82e24e83e70008ab735f" lang="it" xmltv_id="">Yu-Gi-Oh!</channel>
 </channels>

--- a/sites/pluto.tv/pluto.tv_latam.channels.xml
+++ b/sites/pluto.tv/pluto.tv_latam.channels.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="pluto.tv" site_id="61a52615cbef2500072876e2" lang="es" xmltv_id="">Acapulco Shore Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5de802659167b10009e7deba" lang="en" xmltv_id="PlutoTVSeriesRetro.us@LatAm">Pluto TV Series Retro</channel>
+  <channel site="pluto.tv" site_id="61a52615cbef2500072876e2" lang="es" xmltv_id="AcapulcoShore.us@LatAm">Acapulco Shore Pluto TV</channel>
   <channel site="pluto.tv" site_id="646ccd3681844c000974d6f4" lang="es" xmltv_id="">ADN Noticias</channel>
   <channel site="pluto.tv" site_id="61b793ccf571b80007b7a610" lang="es" xmltv_id="">Adrenalina Pura TV</channel>
   <channel site="pluto.tv" site_id="68ba0910e1d03fec7d5c084f" lang="es" xmltv_id="">Al Ritmo del Jaripeo</channel>
-  <channel site="pluto.tv" site_id="67e598e28b99330f75b4c629" lang="es" xmltv_id="">Andromeda</channel>
   <channel site="pluto.tv" site_id="645d1abbe1979c0008779d5a" lang="es" xmltv_id="">Archivos Extraterrestres</channel>
   <channel site="pluto.tv" site_id="5efb8c19b2678b000780d032" lang="es" xmltv_id="">Archivos Forenses</channel>
   <channel site="pluto.tv" site_id="6759ee82bd523200083b4f0f" lang="es" xmltv_id="">Avatar: La Leyenda de Aang</channel>
@@ -22,26 +22,28 @@
   <channel site="pluto.tv" site_id="68224482c5d53e1351aaf2f2" lang="es" xmltv_id="">Canal Claro</channel>
   <channel site="pluto.tv" site_id="64666345f3f5b1000882bfb4" lang="es" xmltv_id="">Captain Tsubasa</channel>
   <channel site="pluto.tv" site_id="6109a9f5531b840007a4a187" lang="es" xmltv_id="">Cazador de Homicidas</channel>
-  <channel site="pluto.tv" site_id="62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News</channel>
+  <channel site="pluto.tv" site_id="62310d5a5dc9550007c6f580" lang="es" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="6320d80a66666000086712d7" lang="es" xmltv_id="">Claro Sports</channel>
   <channel site="pluto.tv" site_id="6320d2755e54db000783fd87" lang="es" xmltv_id="">Claro Sports Mexico</channel>
-  <channel site="pluto.tv" site_id="5ffcc21a432945000762d06b" lang="es" xmltv_id="">Comedy Central Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5ffcc21a432945000762d06b" lang="es" xmltv_id="ComedyCentralPlutoTV.us@LatAm">Comedy Central Pluto TV</channel>
   <channel site="pluto.tv" site_id="609ae5cd48d3200007b0a98e" lang="es" xmltv_id="">Comedy Central South Park</channel>
   <channel site="pluto.tv" site_id="6868152657543d1f8be4ece3" lang="es" xmltv_id="">Concert Channel</channel>
   <channel site="pluto.tv" site_id="5f85ca40eda1b10007b967cd" lang="es" xmltv_id="">Conciertos por Stingray</channel>
   <channel site="pluto.tv" site_id="6419ab7c9189ce000865a469" lang="es" xmltv_id="">COPS</channel>
   <channel site="pluto.tv" site_id="646ccdd0939a5900088a1980" lang="es" xmltv_id="">Corazón</channel>
   <channel site="pluto.tv" site_id="63eb9255c111bc0008fe6ec4" lang="es" xmltv_id="">CSI: Miami</channel>
+  <channel site="pluto.tv" site_id="699769fa19ac123965833fd3" lang="es" xmltv_id="">Cuando los Ángeles Caen</channel>
   <channel site="pluto.tv" site_id="62d0895ebe7a970008785244" lang="es" xmltv_id="">Daria</channel>
   <channel site="pluto.tv" site_id="64df7a9a44fe100009b6ac5a" lang="es" xmltv_id="">DAZN Combat</channel>
   <channel site="pluto.tv" site_id="626c2ed933a2890007e91422" lang="es" xmltv_id="">Death Note</channel>
   <channel site="pluto.tv" site_id="6495af324c014a000842e923" lang="es" xmltv_id="">Desafío Super Humanos</channel>
-  <channel site="pluto.tv" site_id="67e5987eef24f48ffca08fd7" lang="es" xmltv_id="">Doc Martin</channel>
   <channel site="pluto.tv" site_id="5f9992c685a2a80007fa414a" lang="es" xmltv_id="">Dog el cazarrecompensas</channel>
+  <channel site="pluto.tv" site_id="697c9bc2a7ce9d5a3d83504a" lang="es" xmltv_id="">Dr. G</channel>
   <channel site="pluto.tv" site_id="6894fc3f66f164e402f4fd14" lang="es" xmltv_id="">Dulce by elGourmet</channel>
   <channel site="pluto.tv" site_id="61099f2b40d0640007fc5aa2" lang="es" xmltv_id="">El Encantador de Perros</channel>
   <channel site="pluto.tv" site_id="5f4d3d06fb60d8000781fce8" lang="es" xmltv_id="">El Reino Infantil</channel>
   <channel site="pluto.tv" site_id="5f23102d5e239d00074b092a" lang="es" xmltv_id="">Empeños a lo bestia</channel>
+  <channel site="pluto.tv" site_id="699763d184235f26d5056002" lang="es" xmltv_id="">Enchufe.TV</channel>
   <channel site="pluto.tv" site_id="5e972a21ad709d00074195ba" lang="es" xmltv_id="">Estrellas de Acción</channel>
   <channel site="pluto.tv" site_id="619d59b7cbef25000728221c" lang="es" xmltv_id="">Euronews Español</channel>
   <channel site="pluto.tv" site_id="5ebaccf1734aaf0007142c86" lang="es" xmltv_id="">FailArmy</channel>
@@ -53,11 +55,13 @@
   <channel site="pluto.tv" site_id="5f4d3696d938c900072679fd" lang="es" xmltv_id="">Historias de Ultratumba</channel>
   <channel site="pluto.tv" site_id="64fb1f6e6625510008c00848" lang="es" xmltv_id="">Homeful</channel>
   <channel site="pluto.tv" site_id="65d916a2f7f0af0008b6540d" lang="es" xmltv_id="">Hunter x Hunter</channel>
+  <channel site="pluto.tv" site_id="69fcaaa1853a01a827bcd056" lang="es" xmltv_id="">I Shouldn&apos;t Be Alive</channel>
   <channel site="pluto.tv" site_id="62154548a2be360007cb02f0" lang="es" xmltv_id="">Ice Pilots</channel>
   <channel site="pluto.tv" site_id="64e35aff6b1fdb0008ea8441" lang="es" xmltv_id="">Imagen TV+</channel>
   <channel site="pluto.tv" site_id="66b26665d512590008c507b7" lang="es" xmltv_id="">Inuyasha</channel>
   <channel site="pluto.tv" site_id="63f7e3f9dff38e00082a57af" lang="es" xmltv_id="">ITV Deportes</channel>
   <channel site="pluto.tv" site_id="66c790f780a0af0008583aa4" lang="es" xmltv_id="">JoJo’s Bizarre Adventure</channel>
+  <channel site="pluto.tv" site_id="699762a0172a5c3296892d92" lang="es" xmltv_id="">Juana La Virgen</channel>
   <channel site="pluto.tv" site_id="5f85cf621d6d2200079f1de0" lang="es" xmltv_id="">Karaoke por Stingray</channel>
   <channel site="pluto.tv" site_id="5fcea93ffcf94500071c4b2f" lang="es" xmltv_id="">Kenan y Kel</channel>
   <channel site="pluto.tv" site_id="62d08af527ce19000731eaa0" lang="es" xmltv_id="">La Familia del Barrio</channel>
@@ -69,15 +73,20 @@
   <channel site="pluto.tv" site_id="68a3a97fd8f7693ae3f8575f" lang="es" xmltv_id="">Los Pitufos</channel>
   <channel site="pluto.tv" site_id="5f99a772c54853000797bf18" lang="es" xmltv_id="">Lucha Libre AAA</channel>
   <channel site="pluto.tv" site_id="63eb95baa99571000898a078" lang="es" xmltv_id="">MacGyver</channel>
-  <channel site="pluto.tv" site_id="5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef</channel>
+  <channel site="pluto.tv" site_id="69b32974814d27f4aed90fdd" lang="es" xmltv_id="">Madre</channel>
+  <channel site="pluto.tv" site_id="69fcaa88e022927e1c94c533" lang="es" xmltv_id="">MasterChef Argentina</channel>
+  <channel site="pluto.tv" site_id="69fcaa71ea95ffff0987f555" lang="es" xmltv_id="">MasterChef Colombia</channel>
+  <channel site="pluto.tv" site_id="5e3ddbd27091820009f86dd9" lang="es" xmltv_id="">MasterChef México</channel>
   <channel site="pluto.tv" site_id="68ffc086a530e036bc8f0305" lang="es" xmltv_id="">Mi Bella Genio</channel>
   <channel site="pluto.tv" site_id="656e2536fbc15b00084ae29d" lang="es" xmltv_id="">Mi Coche Clásico</channel>
+  <channel site="pluto.tv" site_id="699763787cfe0ffadadd106f" lang="es" xmltv_id="">Mi Gorda Bella</channel>
   <channel site="pluto.tv" site_id="652e922db4b047000825f975" lang="es" xmltv_id="">Milenio Televisión</channel>
   <channel site="pluto.tv" site_id="5e46e64dc73db400094b5f0b" lang="es" xmltv_id="">Minuto Para Ganar</channel>
   <channel site="pluto.tv" site_id="5f230e416b68ff00075b0139" lang="es" xmltv_id="">Misterios Medicos</channel>
   <channel site="pluto.tv" site_id="5f610042272f68000867685b" lang="es" xmltv_id="">Misterios sin Resolver</channel>
   <channel site="pluto.tv" site_id="66a92375cd0d31000847b219" lang="es" xmltv_id="">Monstruos de Rio</channel>
   <channel site="pluto.tv" site_id="60e5ea9a9bb4200008376f76" lang="es" xmltv_id="">Motorvision TV</channel>
+  <channel site="pluto.tv" site_id="69fca9f9b9c0f0d444f631ca" lang="es" xmltv_id="">Mr. Bean Animated</channel>
   <channel site="pluto.tv" site_id="6047fabfce6e8e00070bcc9f" lang="es" xmltv_id="">MTV Biggest Pop</channel>
   <channel site="pluto.tv" site_id="625461ef01f27a0007976ad1" lang="es" xmltv_id="">MTV Catfish</channel>
   <channel site="pluto.tv" site_id="66a11a21a79dea0008aa90ca" lang="es" xmltv_id="">MTV Classic</channel>
@@ -85,8 +94,8 @@
   <channel site="pluto.tv" site_id="6851b909954170e0128bc71d" lang="es" xmltv_id="">MTV Dating</channel>
   <channel site="pluto.tv" site_id="64510d3ad3fdde00080951f2" lang="es" xmltv_id="">MTV Drag</channel>
   <channel site="pluto.tv" site_id="62b218fc511d4b00070ddc0c" lang="es" xmltv_id="">MTV Flow Latino</channel>
-  <channel site="pluto.tv" site_id="5fab088b3279760007d4e4fd" lang="es" xmltv_id="">MTV Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="5fab088b3279760007d4e4fd" lang="es" xmltv_id="MTVPlutoTV.us@LatAm">MTV Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5de91b7ea86ee60009d89e75" lang="es" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="5e98a911c881310007d7aae2" lang="es" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="66a01b52a4ee27000808ea36" lang="es" xmltv_id="">MTV Rocks</channel>
   <channel site="pluto.tv" site_id="620fd9f4afb9a80007a9c6d5" lang="es" xmltv_id="">MTV Teen Mom</channel>
@@ -106,62 +115,64 @@
   <channel site="pluto.tv" site_id="5f4fed840a2764000720d966" lang="es" xmltv_id="">Paisajes por Stingray</channel>
   <channel site="pluto.tv" site_id="64f6163a30ab3300083d870e" lang="es" xmltv_id="">PFL MMA</channel>
   <channel site="pluto.tv" site_id="6894febddbd49c964f3b66c8" lang="es" xmltv_id="">Plato del Dia by elGourmet</channel>
-  <channel site="pluto.tv" site_id="5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="">Pluto TV A La Mexicana</channel>
-  <channel site="pluto.tv" site_id="5dcde17bf6591d0009839e02" lang="es" xmltv_id="">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="5ddc266f80e3550009136843" lang="es" xmltv_id="">Pluto TV Aventura</channel>
-  <channel site="pluto.tv" site_id="5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="pluto.tv" site_id="670edb8149c4060008e3aec8" lang="es" xmltv_id="">Pluto TV Cine Acción</channel>
-  <channel site="pluto.tv" site_id="609059dc63be6e0007b4eca6" lang="es" xmltv_id="">Pluto TV Cine Clásico</channel>
-  <channel site="pluto.tv" site_id="5dcdde78f080d900098550e4" lang="es" xmltv_id="">Pluto TV Cine Comedia</channel>
-  <channel site="pluto.tv" site_id="624af40c004f8000079b784d" lang="es" xmltv_id="">Pluto TV Cine Crimen</channel>
-  <channel site="pluto.tv" site_id="5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="">Pluto TV Cine Drama</channel>
-  <channel site="pluto.tv" site_id="5dcde437229eff00091b6c30" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="pluto.tv" site_id="670ed8dfc7626f000884c3a8" lang="es" xmltv_id="">Pluto TV Cine Estelar</channel>
-  <channel site="pluto.tv" site_id="5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="">Pluto TV Cine Familia</channel>
-  <channel site="pluto.tv" site_id="6806d519fea7414f33f57016" lang="es" xmltv_id="">Pluto TV Cine Inspirador</channel>
-  <channel site="pluto.tv" site_id="5dd7ea2aeab5230009986735" lang="es" xmltv_id="">Pluto TV Cine Romance</channel>
-  <channel site="pluto.tv" site_id="5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="">Pluto TV Cine Suspenso</channel>
-  <channel site="pluto.tv" site_id="5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="">Pluto TV Cine Terror</channel>
-  <channel site="pluto.tv" site_id="5dd6d935d000120009bc1132" lang="es" xmltv_id="">Pluto TV Competencias</channel>
-  <channel site="pluto.tv" site_id="6838a98df9bd067a38d1b8f7" lang="es" xmltv_id="">Pluto TV Criaturas Malditas</channel>
-  <channel site="pluto.tv" site_id="5dcde07af1c85b0009b18651" lang="es" xmltv_id="">Pluto TV Deportes</channel>
-  <channel site="pluto.tv" site_id="5ddc503ac7ef120009b101a2" lang="es" xmltv_id="">Pluto TV Documentales</channel>
-  <channel site="pluto.tv" site_id="6185a9a88b2ce30007de5128" lang="es" xmltv_id="">Pluto TV Dramas Coreanos</channel>
-  <channel site="pluto.tv" site_id="6661d5424b10960008599fa3" lang="es" xmltv_id="">Pluto TV Dramas Coreanos Teen</channel>
-  <channel site="pluto.tv" site_id="5ff3934600d4c7000733ff49" lang="es" xmltv_id="">Pluto TV E-Sports</channel>
-  <channel site="pluto.tv" site_id="5dcde0657444a40009cd2422" lang="es" xmltv_id="">Pluto TV Estilo de Vida</channel>
-  <channel site="pluto.tv" site_id="5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="">Pluto TV Historia</channel>
-  <channel site="pluto.tv" site_id="5e8397936791b30007ebb5a7" lang="es" xmltv_id="">Pluto TV Humor</channel>
-  <channel site="pluto.tv" site_id="5dcde27ffae9520009c0c75a" lang="es" xmltv_id="">Pluto TV Investiga</channel>
-  <channel site="pluto.tv" site_id="5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="">Pluto TV Junior</channel>
-  <channel site="pluto.tv" site_id="5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="">Pluto TV Kids</channel>
-  <channel site="pluto.tv" site_id="6109ab25b84d6a0007504886" lang="es" xmltv_id="">Pluto TV Mi Obsesión Favorita</channel>
-  <channel site="pluto.tv" site_id="5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="">Pluto TV Misterios</channel>
-  <channel site="pluto.tv" site_id="5dd85eac039bba0009e86d1d" lang="es" xmltv_id="">Pluto TV Naturaleza</channel>
-  <channel site="pluto.tv" site_id="5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="">Pluto TV Novelas</channel>
-  <channel site="pluto.tv" site_id="6474a7958e3c0a0008b97cae" lang="es" xmltv_id="">Pluto TV Novelas de México</channel>
-  <channel site="pluto.tv" site_id="686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="">Pluto TV Novelas de Otros Continentes</channel>
-  <channel site="pluto.tv" site_id="6474a86917f5e100089a0c1c" lang="es" xmltv_id="">Pluto TV Novelas de Venezuela</channel>
-  <channel site="pluto.tv" site_id="5defde6d6c07b50009cf0757" lang="es" xmltv_id="">Pluto TV Nuestro Cine</channel>
-  <channel site="pluto.tv" site_id="5e98b0447665f200078caded" lang="es" xmltv_id="">Pluto TV Peleas</channel>
-  <channel site="pluto.tv" site_id="5dcde197f6591d0009839e04" lang="es" xmltv_id="">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="5f2817d3d7573a00080f9175" lang="es" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="5dcde1317578340009b751d0" lang="es" xmltv_id="">Pluto TV Series</channel>
-  <channel site="pluto.tv" site_id="6479ff1c17f5e10008ad2797" lang="es" xmltv_id="">Pluto TV Series de Acción</channel>
-  <channel site="pluto.tv" site_id="655f626d57fe4a00085c7c3e" lang="es" xmltv_id="">Pluto TV Series de Comedia</channel>
-  <channel site="pluto.tv" site_id="655f62ff954b020008c91ec6" lang="es" xmltv_id="">Pluto TV Series de Crimen</channel>
-  <channel site="pluto.tv" site_id="655f636d954b020008c93299" lang="es" xmltv_id="">Pluto TV Series de Drama</channel>
-  <channel site="pluto.tv" site_id="6806d570c178637410ae4962" lang="es" xmltv_id="">Pluto TV Series de Otros Continentes</channel>
-  <channel site="pluto.tv" site_id="65662f8a2c46f300088a84cc" lang="es" xmltv_id="">Pluto TV Series de Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="5dd837642c6e9300098ad484" lang="es" xmltv_id="">Pluto TV Series Latinas</channel>
-  <channel site="pluto.tv" site_id="5de802659167b10009e7deba" lang="es" xmltv_id="">Pluto TV Series Retro</channel>
-  <channel site="pluto.tv" site_id="5ec5761aabe4690007f6e047" lang="es" xmltv_id="">Pluto TV Star Trek</channel>
-  <channel site="pluto.tv" site_id="5dd6dc7480e3550009133d4a" lang="es" xmltv_id="">Pluto TV Velocidad</channel>
-  <channel site="pluto.tv" site_id="5df265697ec3510009df1ef0" lang="es" xmltv_id="">Pluto TV Vida Real</channel>
+  <channel site="pluto.tv" site_id="5dfcde52d28b09000a42d7a2" lang="es" xmltv_id="PlutoTVALaMexicana.us@LatAm">Pluto TV A La Mexicana</channel>
+  <channel site="pluto.tv" site_id="698a45156dc3c71eb1ba6599" lang="es" xmltv_id="PlutoTVAmoryMentiras.us@LatAm">Pluto TV Amor y Mentiras</channel>
+  <channel site="pluto.tv" site_id="5dcde17bf6591d0009839e02" lang="es" xmltv_id="PlutoTVAnime.us@LatAm">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="5ddc266f80e3550009136843" lang="es" xmltv_id="PlutoTVAventura.us@LatAm">Pluto TV Aventura</channel>
+  <channel site="pluto.tv" site_id="5dcb62e63d4d8f0009f36881" lang="es" xmltv_id="PlutoTVCineAccion.us@LatAm">Pluto TV Cine Acción</channel>
+  <channel site="pluto.tv" site_id="670edb8149c4060008e3aec8" lang="es" xmltv_id="PlutoTVCineAccion.us@LatAm">Pluto TV Cine Acción</channel>
+  <channel site="pluto.tv" site_id="609059dc63be6e0007b4eca6" lang="es" xmltv_id="PlutoTVCineClasico.us@LatAm">Pluto TV Cine Clásico</channel>
+  <channel site="pluto.tv" site_id="5dcdde78f080d900098550e4" lang="es" xmltv_id="PlutoTVCineComedia.us@LatAm">Pluto TV Cine Comedia</channel>
+  <channel site="pluto.tv" site_id="624af40c004f8000079b784d" lang="es" xmltv_id="PlutoTVCineCrimen.us@LatAm">Pluto TV Cine Crimen</channel>
+  <channel site="pluto.tv" site_id="5dcddfcb229eff00091b6bdf" lang="es" xmltv_id="PlutoTVCineDrama.us@LatAm">Pluto TV Cine Drama</channel>
+  <channel site="pluto.tv" site_id="5dcde437229eff00091b6c30" lang="es" xmltv_id="PlutoTVCineEstelar.us@LatAm">Pluto TV Cine Estelar</channel>
+  <channel site="pluto.tv" site_id="670ed8dfc7626f000884c3a8" lang="es" xmltv_id="PlutoTVCineEstelar.us@LatAm">Pluto TV Cine Estelar</channel>
+  <channel site="pluto.tv" site_id="5dd6ddb30a1d8a000908ed4c" lang="es" xmltv_id="PlutoTVCineFamilia.us@LatAm">Pluto TV Cine Familia</channel>
+  <channel site="pluto.tv" site_id="6806d519fea7414f33f57016" lang="es" xmltv_id="PlutoTVCineInspirador.us@LatAm">Pluto TV Cine Inspirador</channel>
+  <channel site="pluto.tv" site_id="5dd7ea2aeab5230009986735" lang="es" xmltv_id="PlutoTVCineRomance.us@LatAm">Pluto TV Cine Romance</channel>
+  <channel site="pluto.tv" site_id="5ddc4e8bcbb9010009b4e84f" lang="es" xmltv_id="PlutoTVCineSuspenso.us@LatAm">Pluto TV Cine Suspenso</channel>
+  <channel site="pluto.tv" site_id="5dcddf1ed95e740009fef7ab" lang="es" xmltv_id="CineTerror.us@LatAm">Pluto TV Cine Terror</channel>
+  <channel site="pluto.tv" site_id="5dd6d935d000120009bc1132" lang="es" xmltv_id="PlutoTVCompetencias.us@LatAm">Pluto TV Competencias</channel>
+  <channel site="pluto.tv" site_id="5dcde07af1c85b0009b18651" lang="es" xmltv_id="PlutoTVDeportes.us@LatAm">Pluto TV Deportes</channel>
+  <channel site="pluto.tv" site_id="5ddc503ac7ef120009b101a2" lang="es" xmltv_id="PlutoTVDocumentales.us@LatAm">Pluto TV Documentales</channel>
+  <channel site="pluto.tv" site_id="6185a9a88b2ce30007de5128" lang="es" xmltv_id="PlutoTVDramasCoreanos.us@LatAm">Pluto TV Dramas Coreanos</channel>
+  <channel site="pluto.tv" site_id="6661d5424b10960008599fa3" lang="es" xmltv_id="PlutoTVDramasCoreanosTeen.us@LatAm">Pluto TV Dramas Coreanos Teen</channel>
+  <channel site="pluto.tv" site_id="5ff3934600d4c7000733ff49" lang="es" xmltv_id="PlutoTVESports.us@LatAm">Pluto TV E-Sports</channel>
+  <channel site="pluto.tv" site_id="5dcde0657444a40009cd2422" lang="es" xmltv_id="PlutoTVEstilodeVida.us@LatAm">Pluto TV Estilo de Vida</channel>
+  <channel site="pluto.tv" site_id="63c6e37e636b7e0007ccb635" lang="es" xmltv_id="">Pluto TV Fútbol</channel>
+  <channel site="pluto.tv" site_id="5de5758e1a30dc00094fcd6c" lang="es" xmltv_id="PlutoTVHistoria.us@LatAm">Pluto TV Historia</channel>
+  <channel site="pluto.tv" site_id="5e8397936791b30007ebb5a7" lang="es" xmltv_id="PlutoTVHumor.us@LatAm">Pluto TV Humor</channel>
+  <channel site="pluto.tv" site_id="5dcde27ffae9520009c0c75a" lang="es" xmltv_id="Investiga.us@LatAm">Pluto TV Investiga</channel>
+  <channel site="pluto.tv" site_id="5dcde2ac4bc6c500094ab45b" lang="es" xmltv_id="PlutoTVJunior.us@LatAm">Pluto TV Junior</channel>
+  <channel site="pluto.tv" site_id="5dd6dae8ce788b0009eaf77b" lang="es" xmltv_id="PlutoTVKids.us@LatAm">Pluto TV Kids</channel>
+  <channel site="pluto.tv" site_id="6109ab25b84d6a0007504886" lang="es" xmltv_id="PlutoTVMiObsesionFavorita.us@LatAm">Pluto TV Mi Obsesión Favorita</channel>
+  <channel site="pluto.tv" site_id="5dcde2f53449c50009b2b4dc" lang="es" xmltv_id="PlutoTVMisterios.us@LatAm">Pluto TV Misterios</channel>
+  <channel site="pluto.tv" site_id="5dd85eac039bba0009e86d1d" lang="es" xmltv_id="PlutoTVNaturaleza.us@LatAm">Pluto TV Naturaleza</channel>
+  <channel site="pluto.tv" site_id="5dcde0cc2efd2700090b7ff4" lang="es" xmltv_id="PlutoTVNovelas.us@LatAm">Pluto TV Novelas</channel>
+  <channel site="pluto.tv" site_id="6474a7958e3c0a0008b97cae" lang="es" xmltv_id="PlutoTVNovelasdeMexico.us@LatAm">Pluto TV Novelas de México</channel>
+  <channel site="pluto.tv" site_id="686eed4c677f2f98b4a1ccd4" lang="es" xmltv_id="PlutoTVNovelasdeOtrosContinentes.us@LatAm">Pluto TV Novelas de Otros Continentes</channel>
+  <channel site="pluto.tv" site_id="6474a86917f5e100089a0c1c" lang="es" xmltv_id="PlutoTVNovelasdeVenezuela.us@LatAm">Pluto TV Novelas de Venezuela</channel>
+  <channel site="pluto.tv" site_id="5defde6d6c07b50009cf0757" lang="es" xmltv_id="PlutoTVNuestroCine.us@LatAm">Pluto TV Nuestro Cine</channel>
+  <channel site="pluto.tv" site_id="5e98b0447665f200078caded" lang="es" xmltv_id="PlutoTVPeleas.us@LatAm">Pluto TV Peleas</channel>
+  <channel site="pluto.tv" site_id="5dcde197f6591d0009839e04" lang="es" xmltv_id="PlutoTVReality.us@LatAm">Pluto TV Reality</channel>
+  <channel site="pluto.tv" site_id="5f2817d3d7573a00080f9175" lang="es" xmltv_id="PlutoTVSciFi.us@LatAm">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="5dcde1317578340009b751d0" lang="es" xmltv_id="PlutoTVSeries.us@LatAm">Pluto TV Series</channel>
+  <channel site="pluto.tv" site_id="6479ff1c17f5e10008ad2797" lang="es" xmltv_id="PlutoTVSeriesdeAccion.us@LatAm">Pluto TV Series de Acción</channel>
+  <channel site="pluto.tv" site_id="655f626d57fe4a00085c7c3e" lang="es" xmltv_id="PlutoTVSeriesdeComedia.us@LatAm">Pluto TV Series de Comedia</channel>
+  <channel site="pluto.tv" site_id="655f62ff954b020008c91ec6" lang="es" xmltv_id="PlutoTVSeriesdeCrimen.us@LatAm">Pluto TV Series de Crimen</channel>
+  <channel site="pluto.tv" site_id="655f636d954b020008c93299" lang="es" xmltv_id="PlutoTVSeriesdeDrama.us@LatAm">Pluto TV Series de Drama</channel>
+  <channel site="pluto.tv" site_id="6806d570c178637410ae4962" lang="es" xmltv_id="PlutoTVSeriesdeOtrosContinentes.us@LatAm">Pluto TV Series de Otros Continentes</channel>
+  <channel site="pluto.tv" site_id="65662f8a2c46f300088a84cc" lang="es" xmltv_id="PlutoTVSeriesdeSciFi.us@LatAm">Pluto TV Series de Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="5dd837642c6e9300098ad484" lang="es" xmltv_id="PlutoTVSeriesLatinas.us@LatAm">Pluto TV Series Latinas</channel>
+  <channel site="pluto.tv" site_id="5ec5761aabe4690007f6e047" lang="es" xmltv_id="StarTrek.us@LatAm">Pluto TV Star Trek</channel>
+  <channel site="pluto.tv" site_id="5dd6dc7480e3550009133d4a" lang="es" xmltv_id="PlutoTVVelocidad.us@LatAm">Pluto TV Velocidad</channel>
+  <channel site="pluto.tv" site_id="5df265697ec3510009df1ef0" lang="es" xmltv_id="PlutoTVVidaReal.us@LatAm">Pluto TV Vida Real</channel>
   <channel site="pluto.tv" site_id="6870072ca9d5c45c3e9466f1" lang="es" xmltv_id="">Pokémon</channel>
   <channel site="pluto.tv" site_id="677d93afe650a700081e5f18" lang="es" xmltv_id="">Popeye</channel>
+  <channel site="pluto.tv" site_id="69de4ad924a6d521f8b0a348" lang="es" xmltv_id="">RCN Más</channel>
   <channel site="pluto.tv" site_id="67d9b0ebc290c9499046e88f" lang="es" xmltv_id="">RCN Noticias</channel>
   <channel site="pluto.tv" site_id="67a3b45a21af380008133aa4" lang="es" xmltv_id="">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="67813f893886aa863497733d" lang="es" xmltv_id="">Red Bull TV</channel>
   <channel site="pluto.tv" site_id="67e5941f0812459cb682d9c6" lang="es" xmltv_id="">Relic Hunter</channel>
   <channel site="pluto.tv" site_id="6320ddef274b1b0007b2ee88" lang="es" xmltv_id="">Revive Gran Hermano</channel>
   <channel site="pluto.tv" site_id="64ff270f30ab3300084e259c" lang="es" xmltv_id="">Rookie Blue: Policías Novatos</channel>
@@ -169,13 +180,14 @@
   <channel site="pluto.tv" site_id="62c5d80dc6de440007e033eb" lang="es" xmltv_id="">Runtime</channel>
   <channel site="pluto.tv" site_id="68b784d03e17b7676a0378f7" lang="es" xmltv_id="">Shockwave</channel>
   <channel site="pluto.tv" site_id="604bdf4e6d0abc0007ba77ad" lang="es" xmltv_id="">Sin Tetas No Hay Paraíso</channel>
-  <channel site="pluto.tv" site_id="63a084934734f30007457b2c" lang="es" xmltv_id="">Smithsonian Channel Pluto TV</channel>
-  <channel site="pluto.tv" site_id="662bf39756fc840008f25cb9" lang="es" xmltv_id="">Sony One Competencias</channel>
+  <channel site="pluto.tv" site_id="63a084934734f30007457b2c" lang="es" xmltv_id="SmithsonianChannelPlutoTV.us@LatAm">Smithsonian Channel Pluto TV</channel>
+  <channel site="pluto.tv" site_id="662bf39756fc840008f25cb9" lang="es" xmltv_id="">Sony One Escape Perfecto</channel>
   <channel site="pluto.tv" site_id="6647c02422494d000804b13a" lang="es" xmltv_id="">Sony One Shark Tank México</channel>
   <channel site="pluto.tv" site_id="65df731cec9fda0008b7aa8d" lang="es" xmltv_id="">South Park: Colección Cartman</channel>
   <channel site="pluto.tv" site_id="65df7272ec9fda0008b7a970" lang="es" xmltv_id="">South Park: Colección Kenny</channel>
   <channel site="pluto.tv" site_id="65df73520d4561000817c29b" lang="es" xmltv_id="">South Park: Colección Kyle</channel>
   <channel site="pluto.tv" site_id="65df72db18036500081a8292" lang="es" xmltv_id="">South Park: Colección Stan</channel>
+  <channel site="pluto.tv" site_id="69fca9dd14a5dfae8875a3be" lang="es" xmltv_id="">Survivor México</channel>
   <channel site="pluto.tv" site_id="5f998c1fc54853000797bacd" lang="es" xmltv_id="">Tastemade</channel>
   <channel site="pluto.tv" site_id="68b887c2e77777498226a0de" lang="es" xmltv_id="">Tastemade Hogar</channel>
   <channel site="pluto.tv" site_id="68b88712e777774982269ce9" lang="es" xmltv_id="">Tastemade Viajes</channel>
@@ -185,6 +197,7 @@
   <channel site="pluto.tv" site_id="678aa0b3680721c77c5035dd" lang="es" xmltv_id="">The Walking Dead by AMC</channel>
   <channel site="pluto.tv" site_id="63dac1b78795f300086d5ca6" lang="es" xmltv_id="">TikTok Radio en Español</channel>
   <channel site="pluto.tv" site_id="5ff608e60e2996000768c366" lang="es" xmltv_id="">Tokusato</channel>
+  <channel site="pluto.tv" site_id="67a52c8397782f00081879aa" lang="es" xmltv_id="">Top Barça</channel>
   <channel site="pluto.tv" site_id="67a52cd4ec91870008a62164" lang="es" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="678533155e0e6a000828cd48" lang="es" xmltv_id="">Untold Stories of the ER</channel>
   <channel site="pluto.tv" site_id="639751f81a36b400072b8f5a" lang="es" xmltv_id="">Vive Kanal D Drama</channel>

--- a/sites/pluto.tv/pluto.tv_no.channels.xml
+++ b/sites/pluto.tv/pluto.tv_no.channels.xml
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="pluto.tv" site_id="6728ca75529ac9000830ab14" lang="no" xmltv_id="">7th Heaven</channel>
+  <channel site="pluto.tv" site_id="6728ca75529ac9000830ab14" lang="da" xmltv_id="">7th Heaven</channel>
+  <channel site="pluto.tv" site_id="67a23b899a300a00086f3371" lang="da" xmltv_id="">Dominance FC TV</channel>
+  <channel site="pluto.tv" site_id="660bfca524e1d000085b6007" lang="da" xmltv_id="">FIFA+</channel>
+  <channel site="pluto.tv" site_id="6380c428dd0f47000799907c" lang="da" xmltv_id="">Judge Judy</channel>
+  <channel site="pluto.tv" site_id="65b916ec3af63d00084c5841" lang="da" xmltv_id="PlutoTVBudTerence.se@NO">Pluto TV Bud &amp; Terence</channel>
+  <channel site="pluto.tv" site_id="61c1e1e55deef000075aed0c" lang="da" xmltv_id="PlutoTVFilm.se@NO">Pluto TV Film</channel>
+  <channel site="pluto.tv" site_id="61c1e88cd168ea0007068133" lang="da" xmltv_id="">South Park</channel>
+  <channel site="pluto.tv" site_id="699c162a684d0f308795258f" lang="no" xmltv_id="">21 Jump Street</channel>
   <channel site="pluto.tv" site_id="634690323ce5fa0007c621f2" lang="no" xmltv_id="">48 Hours</channel>
+  <channel site="pluto.tv" site_id="6915e15ea570568f53438feb" lang="no" xmltv_id="">Afterwork TV</channel>
   <channel site="pluto.tv" site_id="69143e3abb69fb3258ba4944" lang="no" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="pluto.tv" site_id="6464cd7c7cb4b100086c71c9" lang="no" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="6178156e54712100072d6b2b" lang="no" xmltv_id="">Andromeda</channel>
+  <channel site="pluto.tv" site_id="6964b77dff4f2148e520fa9b" lang="no" xmltv_id="">Anger Management</channel>
   <channel site="pluto.tv" site_id="61c1db8ed6d97900076ea15c" lang="no" xmltv_id="">Are You The One?</channel>
   <channel site="pluto.tv" site_id="62da7159ca8f220008032730" lang="no" xmltv_id="">Auction Hunters</channel>
   <channel site="pluto.tv" site_id="6266951ed7dfa500076ee9e2" lang="no" xmltv_id="">Avatar+</channel>
@@ -12,7 +21,7 @@
   <channel site="pluto.tv" site_id="6512d36ca765070008836eac" lang="no" xmltv_id="">Beauty and the Beast</channel>
   <channel site="pluto.tv" site_id="6486e8328e3c0a0008e5686c" lang="no" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="pluto.tv" site_id="672e1634e482950008c759a5" lang="no" xmltv_id="">Becker</channel>
-  <channel site="pluto.tv" site_id="62792d003b8ddc000714f43a" lang="no" xmltv_id="">Bellator MMA</channel>
+  <channel site="pluto.tv" site_id="69d7a0d0f57dc59a5f928fb2" lang="no" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="pluto.tv" site_id="632afc466699570007ed1106" lang="no" xmltv_id="">Best of MTV</channel>
   <channel site="pluto.tv" site_id="630478cfdb5a4a0007ec255e" lang="no" xmltv_id="">Best of The Drew Barrymore Show</channel>
   <channel site="pluto.tv" site_id="61dd5bf8db0b8e00080804ff" lang="no" xmltv_id="">BET</channel>
@@ -22,10 +31,10 @@
   <channel site="pluto.tv" site_id="660d67c419ca71000849a4e9" lang="no" xmltv_id="">Bondi Rescue</channel>
   <channel site="pluto.tv" site_id="67a09e25c070cf00083c40fa" lang="no" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="65cba778ec452d0008acbe86" lang="no" xmltv_id="">Broad City</channel>
+  <channel site="pluto.tv" site_id="6964b9b97d2afdec4f9390f6" lang="no" xmltv_id="">Bull</channel>
   <channel site="pluto.tv" site_id="61c1dce2fb9ae40007d0ac15" lang="no" xmltv_id="">Camp Kulinaris</channel>
   <channel site="pluto.tv" site_id="65a93b870c7ff50008d1ca47" lang="no" xmltv_id="">Car Chase</channel>
   <channel site="pluto.tv" site_id="66a7aac9d512590008ab2dcb" lang="no" xmltv_id="">Caroline in the City</channel>
-  <channel site="pluto.tv" site_id="64e770614c5ed800081225c4" lang="no" xmltv_id="">Casualty 24/7</channel>
   <channel site="pluto.tv" site_id="6231e909bc960f00075d8e7c" lang="no" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="6578843432c1b300089a9a98" lang="no" xmltv_id="">Celeb Reality</channel>
   <channel site="pluto.tv" site_id="65e977a618036500082ec972" lang="no" xmltv_id="">Chappelle&apos;s Show</channel>
@@ -34,56 +43,54 @@
   <channel site="pluto.tv" site_id="63e389dcc111bc0008ee5b8c" lang="no" xmltv_id="">Cheers</channel>
   <channel site="pluto.tv" site_id="65d7243c4e017400089e14a8" lang="no" xmltv_id="">Come Dine with Me</channel>
   <channel site="pluto.tv" site_id="6400bdb1219c4c00081751aa" lang="no" xmltv_id="">COPS</channel>
+  <channel site="pluto.tv" site_id="693ae58fc2d0f38be38df821" lang="no" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="pluto.tv" site_id="6578848a6e4f6a0008741910" lang="no" xmltv_id="">Crime 360</channel>
   <channel site="pluto.tv" site_id="6426900ea3ade70008ffcb20" lang="no" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="pluto.tv" site_id="64e77016324d190008291c13" lang="no" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="pluto.tv" site_id="657882efb3801200084caa77" lang="no" xmltv_id="">Dance Moms</channel>
-  <channel site="pluto.tv" site_id="648056f0f77b61000828f1ba" lang="no" xmltv_id="">DAZN Combat</channel>
+  <channel site="pluto.tv" site_id="692edcff77f0147d69f19498" lang="no" xmltv_id="">Dating Naked UK</channel>
+  <channel site="pluto.tv" site_id="648056f0f77b61000828f1ba" lang="no" xmltv_id="">DAZN Ringside</channel>
   <channel site="pluto.tv" site_id="668bf91208d5490008065ffd" lang="no" xmltv_id="">Diagnosis Murder</channel>
   <channel site="pluto.tv" site_id="62724ae034f5190007b63424" lang="no" xmltv_id="">Doc Martin</channel>
   <channel site="pluto.tv" site_id="65788362cbd0d60008f8729a" lang="no" xmltv_id="">Dog The Bounty Hunter</channel>
-  <channel site="pluto.tv" site_id="67a23b899a300a00086f3371" lang="no" xmltv_id="">Dominance FC TV</channel>
   <channel site="pluto.tv" site_id="68f0f7571d26140175255e43" lang="no" xmltv_id="">Dr. Quinn, Medicine Woman</channel>
   <channel site="pluto.tv" site_id="657739fcb9adc40008fe02f4" lang="no" xmltv_id="">Duck Dynasty</channel>
   <channel site="pluto.tv" site_id="68f0fad2fae18f8db62a9f37" lang="no" xmltv_id="">Dynastiet</channel>
-  <channel site="pluto.tv" site_id="68adaf5c247c66a111555ad4" lang="no" xmltv_id="">Ernest goes to Pluto TV</channel>
   <channel site="pluto.tv" site_id="66d71485167a8b0008fd3345" lang="no" xmltv_id="">Escape to the Country</channel>
   <channel site="pluto.tv" site_id="61de8e502c8e9400077e5de7" lang="no" xmltv_id="">Euronews</channel>
   <channel site="pluto.tv" site_id="61c1de93244e500007581d69" lang="no" xmltv_id="">Eventyrlig Oppussing</channel>
+  <channel site="pluto.tv" site_id="697b5a6c9567bf7b5f71a350" lang="no" xmltv_id="">Everybody Hates Chris</channel>
   <channel site="pluto.tv" site_id="61c1d66518447e000717e4c2" lang="no" xmltv_id="">Ex On The Beach</channel>
   <channel site="pluto.tv" site_id="61781077929e930007c194ee" lang="no" xmltv_id="">FailArmy</channel>
   <channel site="pluto.tv" site_id="654a4f7bf9cc8200086877d5" lang="no" xmltv_id="">Family Ties</channel>
   <channel site="pluto.tv" site_id="65cb8bd911ced7000820bff2" lang="no" xmltv_id="">Fangene på Fortet</channel>
+  <channel site="pluto.tv" site_id="699c1bd39a3f3bb4887e045e" lang="no" xmltv_id="">Farscape</channel>
   <channel site="pluto.tv" site_id="61815067b9802500076e16e0" lang="no" xmltv_id="">FBI Files</channel>
-  <channel site="pluto.tv" site_id="660bfca524e1d000085b6007" lang="no" xmltv_id="">FIFA+</channel>
+  <channel site="pluto.tv" site_id="698dde17c7f3f49e64e3414a" lang="no" xmltv_id="">Flipper: The New Adventures</channel>
   <channel site="pluto.tv" site_id="6181262dc68b92000780fed2" lang="no" xmltv_id="">Forensic Files</channel>
-  <channel site="pluto.tv" site_id="61c1df1cc210ed0007607b9b" lang="no" xmltv_id="">Forsidefruer</channel>
-  <channel site="pluto.tv" site_id="65b3d7c80cb1a10008822e85" lang="no" xmltv_id="">From South Park with Love</channel>
   <channel site="pluto.tv" site_id="64424a1d5a0cd500083ed27c" lang="no" xmltv_id="">Geordie Shore</channel>
   <channel site="pluto.tv" site_id="619e259fd8b672000729b1d7" lang="no" xmltv_id="">Ghost Dimension</channel>
-  <channel site="pluto.tv" site_id="65e9b676332fec00085b300e" lang="no" xmltv_id="">Glory Kickboxing</channel>
   <channel site="pluto.tv" site_id="654a508d986ad20008a456a5" lang="no" xmltv_id="">Happy Days</channel>
   <channel site="pluto.tv" site_id="62022f7b9fcc3800076f8c26" lang="no" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="68c014ee337652ee75dab43b" lang="no" xmltv_id="">Highway to Heaven</channel>
-  <channel site="pluto.tv" site_id="64e7708a44fe100009c89007" lang="no" xmltv_id="">Hoarders &amp; Dirty Home Rescue</channel>
   <channel site="pluto.tv" site_id="619e286e093e7c0007489e6a" lang="no" xmltv_id="">Homicide Hunter</channel>
   <channel site="pluto.tv" site_id="671b4e47daad7f000868b840" lang="no" xmltv_id="">Horse &amp; Country</channel>
   <channel site="pluto.tv" site_id="655ca968c917a5000830f8f5" lang="no" xmltv_id="">Hot Ones</channel>
+  <channel site="pluto.tv" site_id="693ae65fab5959c036fa6c1e" lang="no" xmltv_id="">House of Lies</channel>
   <channel site="pluto.tv" site_id="6501ad3a98020f0008503dba" lang="no" xmltv_id="">Hundehviskeren</channel>
   <channel site="pluto.tv" site_id="6578852bcbd0d60008f876d7" lang="no" xmltv_id="">I Survived</channel>
   <channel site="pluto.tv" site_id="61c1d9b31a9c310008f8ee57" lang="no" xmltv_id="">iCarly</channel>
   <channel site="pluto.tv" site_id="62cd9fee6187a70007784cdd" lang="no" xmltv_id="">Ice Pilots</channel>
   <channel site="pluto.tv" site_id="657884cba620e30008fe33e1" lang="no" xmltv_id="">Ice Road Truckers</channel>
+  <channel site="pluto.tv" site_id="691ed76a9c828fb484f7c2e5" lang="no" xmltv_id="">Inter 24/7</channel>
   <channel site="pluto.tv" site_id="682b3932faaa60cd7dbf87b4" lang="no" xmltv_id="">Iron Chef</channel>
   <channel site="pluto.tv" site_id="660d6b00635c75000828aa27" lang="no" xmltv_id="">Jade Fever</channel>
   <channel site="pluto.tv" site_id="654a4fc753fc9700083ae79f" lang="no" xmltv_id="">JAG</channel>
   <channel site="pluto.tv" site_id="62e7ba25be69bc0007b77fdc" lang="no" xmltv_id="">Jakt är Jakt</channel>
   <channel site="pluto.tv" site_id="64424b21e1979c0008379681" lang="no" xmltv_id="">Jersey Shore</channel>
   <channel site="pluto.tv" site_id="6728c87cc7626f0008b28149" lang="no" xmltv_id="">Jersey Shore Family Vacation</channel>
-  <channel site="pluto.tv" site_id="6380c428dd0f47000799907c" lang="no" xmltv_id="">Judge Judy</channel>
   <channel site="pluto.tv" site_id="61781878a3580d0008967df8" lang="no" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="pluto.tv" site_id="65cba7573ba51e00084d76e1" lang="no" xmltv_id="">Key &amp; Peele</channel>
-  <channel site="pluto.tv" site_id="659fbb9432c1b30008de2ed6" lang="no" xmltv_id="">Kickin&apos;it</channel>
   <channel site="pluto.tv" site_id="654a4fe9056b9700088804a0" lang="no" xmltv_id="">Love Boat</channel>
   <channel site="pluto.tv" site_id="61c1e060197fe600073c1ffb" lang="no" xmltv_id="">Luksusfellen</channel>
   <channel site="pluto.tv" site_id="61c1e0f1d6d97900076ea16f" lang="no" xmltv_id="">Luksusfellen Sverige</channel>
@@ -100,7 +107,7 @@
   <channel site="pluto.tv" site_id="65c340383a116800078c8454" lang="no" xmltv_id="">Monster Jam</channel>
   <channel site="pluto.tv" site_id="61781a52a3638a00078fa57e" lang="no" xmltv_id="">MTV Catfish</channel>
   <channel site="pluto.tv" site_id="685140bd21f49d1b9d177e21" lang="no" xmltv_id="">MTV Dating</channel>
-  <channel site="pluto.tv" site_id="68513950f212bedacf8ec48f" lang="no" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="68513950f212bedacf8ec48f" lang="no" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="62cd9e0d10bb020007005628" lang="no" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="61c1df62b7672a0007b6c9ba" lang="no" xmltv_id="">MTV Teen Mom</channel>
   <channel site="pluto.tv" site_id="6728d30cdaad7f000881d979" lang="no" xmltv_id="">NonStop Kung Fu</channel>
@@ -108,68 +115,70 @@
   <channel site="pluto.tv" site_id="619e279d45b45d0007a8d839" lang="no" xmltv_id="">Nosey</channel>
   <channel site="pluto.tv" site_id="63dbe78051f5d000083e9249" lang="no" xmltv_id="">Numb3rs</channel>
   <channel site="pluto.tv" site_id="62cd9f1cda044a00077b8f41" lang="no" xmltv_id="">On the Case</channel>
-  <channel site="pluto.tv" site_id="629e0a068261390007f13d47" lang="no" xmltv_id="">Paradise</channel>
   <channel site="pluto.tv" site_id="61c1db901346480007b7c345" lang="no" xmltv_id="">Paradise Hotel</channel>
-  <channel site="pluto.tv" site_id="65b8f87ac798e800085a123f" lang="no" xmltv_id="">PFL MMA</channel>
   <channel site="pluto.tv" site_id="66c86fff9ba9e800080d8ebe" lang="no" xmltv_id="">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="61c1d6e1f5acaf0007f8381d" lang="no" xmltv_id="">Pimp My Ride</channel>
   <channel site="pluto.tv" site_id="66bb374ba4ee27000841a62c" lang="no" xmltv_id="">Pixel.tv</channel>
-  <channel site="pluto.tv" site_id="61c1e270489a9c000874d209" lang="no" xmltv_id="">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="65b916ec3af63d00084c5841" lang="no" xmltv_id="">Pluto TV Bud &amp; Terence</channel>
-  <channel site="pluto.tv" site_id="61c1e1e55deef000075aed0c" lang="no" xmltv_id="">Pluto TV Film</channel>
-  <channel site="pluto.tv" site_id="63a19cb7847a090007f230d7" lang="no" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="655ca99dfbc15b00081f209c" lang="no" xmltv_id="">Pluto TV John Wayne</channel>
-  <channel site="pluto.tv" site_id="61c1d459fbb4b50007d24647" lang="no" xmltv_id="">Pluto TV Juniorklubben</channel>
-  <channel site="pluto.tv" site_id="67f508f68ddd60c57dc44766" lang="no" xmltv_id="">Pluto TV Klassiske tegnefilmer</channel>
-  <channel site="pluto.tv" site_id="61c1e3a679a4390007c78136" lang="no" xmltv_id="">Pluto TV Komedie</channel>
-  <channel site="pluto.tv" site_id="63dbe80f60bc8f0008aa7c78" lang="no" xmltv_id="">Pluto TV Kultfilmer</channel>
-  <channel site="pluto.tv" site_id="61c1e74354d923000731bf7c" lang="no" xmltv_id="">Pluto TV Overnaturlig</channel>
-  <channel site="pluto.tv" site_id="63a19bb5e6914b000721b5c0" lang="no" xmltv_id="">Pluto TV Romantikk</channel>
-  <channel site="pluto.tv" site_id="61f957e051cca800076f2358" lang="no" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="68ac55fe3efb41cd979a6877" lang="no" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="6357f33cb51d2d00077927c6" lang="no" xmltv_id="">Pluto TV Sport</channel>
-  <channel site="pluto.tv" site_id="61c1e914bf8c520007a93ff1" lang="no" xmltv_id="">Pluto TV Tegnefilm</channel>
-  <channel site="pluto.tv" site_id="61c1e51354d923000731bf78" lang="no" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="67f3fb7d07d2ba4121bd0c8b" lang="no" xmltv_id="">Pluto TV Ungdomsserier</channel>
-  <channel site="pluto.tv" site_id="677d3a424bd63600082f7baf" lang="no" xmltv_id="">Pluto TV Verdenskrigene</channel>
-  <channel site="pluto.tv" site_id="68c01785b3900870ec7480e4" lang="no" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="pluto.tv" site_id="61c1e270489a9c000874d209" lang="no" xmltv_id="PlutoTVAction.se@NO">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="68c01b9a6bdcf3b9a64febcc" lang="no" xmltv_id="PlutoTVHarlequin.se@NO">Pluto TV Harlequin</channel>
+  <channel site="pluto.tv" site_id="63a19cb7847a090007f230d7" lang="no" xmltv_id="PlutoTVHorror.se@NO">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="655ca99dfbc15b00081f209c" lang="no" xmltv_id="PlutoTVJohnWayne.se@NO">Pluto TV John Wayne</channel>
+  <channel site="pluto.tv" site_id="61c1d459fbb4b50007d24647" lang="no" xmltv_id="PlutoTVJuniorklubben.se@NO">Pluto TV Juniorklubben</channel>
+  <channel site="pluto.tv" site_id="67f508f68ddd60c57dc44766" lang="no" xmltv_id="PlutoTVKlassisketegnefilmer.se@NO">Pluto TV Klassiske tegnefilmer</channel>
+  <channel site="pluto.tv" site_id="61c1e3a679a4390007c78136" lang="no" xmltv_id="PlutoTVKomedie.se@NO">Pluto TV Komedie</channel>
+  <channel site="pluto.tv" site_id="63dbe80f60bc8f0008aa7c78" lang="no" xmltv_id="PlutoTVKultfilmer.se@NO">Pluto TV Kultfilmer</channel>
+  <channel site="pluto.tv" site_id="68ac52b05190a45dc990ee39" lang="no" xmltv_id="PlutoTVMotor.se@NO">Pluto TV Motor</channel>
+  <channel site="pluto.tv" site_id="61c1e74354d923000731bf7c" lang="no" xmltv_id="PlutoTVOvernaturlig.se@NO">Pluto TV Overnaturlig</channel>
+  <channel site="pluto.tv" site_id="63a19bb5e6914b000721b5c0" lang="no" xmltv_id="PlutoTVRomantikk.se@NO">Pluto TV Romantikk</channel>
+  <channel site="pluto.tv" site_id="61f957e051cca800076f2358" lang="no" xmltv_id="PlutoTVSciFi.se@NO">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="68ac55fe3efb41cd979a6877" lang="no" xmltv_id="PlutoTVSnooker900.se@NO">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="6357f33cb51d2d00077927c6" lang="no" xmltv_id="PlutoTVSport.se@NO">Pluto TV Sport</channel>
+  <channel site="pluto.tv" site_id="61c1e914bf8c520007a93ff1" lang="no" xmltv_id="PlutoTVTegnefilm.se@NO">Pluto TV Tegnefilm</channel>
+  <channel site="pluto.tv" site_id="61c1e51354d923000731bf78" lang="no" xmltv_id="PlutoTVTrueCrime.se@NO">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="67f3fb7d07d2ba4121bd0c8b" lang="no" xmltv_id="PlutoTVUngdomsserier.se@NO">Pluto TV Ungdomsserier</channel>
+  <channel site="pluto.tv" site_id="677d3a424bd63600082f7baf" lang="no" xmltv_id="PlutoTVVerdenskrigene.se@NO">Pluto TV Verdenskrigene</channel>
+  <channel site="pluto.tv" site_id="68c01785b3900870ec7480e4" lang="no" xmltv_id="PlutoTVWildWest.se@NO">Pluto TV Wild West</channel>
   <channel site="pluto.tv" site_id="61814ff322e67b00074a5c43" lang="no" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="6964baa63dfd98e10945ac51" lang="no" xmltv_id="">Rawhide</channel>
   <channel site="pluto.tv" site_id="660d71e2aec9680008f8f18a" lang="no" xmltv_id="">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="699c192688133556bd253602" lang="no" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="65e977874e01740008c9fb4c" lang="no" xmltv_id="">Reno 911</channel>
+  <channel site="pluto.tv" site_id="69a162eb762ae48b4302fb7c" lang="no" xmltv_id="">Retake E-sport Live</channel>
   <channel site="pluto.tv" site_id="68dfa1a7fae18f8db6218222" lang="no" xmltv_id="">Ridiculousness - Nye episoder</channel>
   <channel site="pluto.tv" site_id="662a26f3cd439400084fc8b8" lang="no" xmltv_id="">River Monsters</channel>
   <channel site="pluto.tv" site_id="6512d3c96a84140008513ff5" lang="no" xmltv_id="">Sabrina the Teenage Witch</channel>
   <channel site="pluto.tv" site_id="63a1c959d9dd51000825d659" lang="no" xmltv_id="">Scorpion</channel>
   <channel site="pluto.tv" site_id="643810f2e8a4aa0008ccf575" lang="no" xmltv_id="">Skjønnhetsfellen Danmark</channel>
   <channel site="pluto.tv" site_id="68adb0a9f84960586ad4a334" lang="no" xmltv_id="">Smurfene</channel>
-  <channel site="pluto.tv" site_id="61c1e88cd168ea0007068133" lang="no" xmltv_id="">South Park</channel>
   <channel site="pluto.tv" site_id="660bff5724e1d000085b7c07" lang="no" xmltv_id="">South Park Armageddon</channel>
-  <channel site="pluto.tv" site_id="6501c7ea9201e80008bb17b9" lang="no" xmltv_id="">South Park Halloween</channel>
   <channel site="pluto.tv" site_id="664f1370f78a8500092df452" lang="no" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="pluto.tv" site_id="65d87fcb66eec8000887f4aa" lang="no" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="pluto.tv" site_id="65d87fa0f7f0af0008b2358b" lang="no" xmltv_id="">South Park: Cartman Collection</channel>
-  <channel site="pluto.tv" site_id="66fcee104ca31f00080492e0" lang="no" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="pluto.tv" site_id="664f0ecc41af640008e37b43" lang="no" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="pluto.tv" site_id="65d87f53ec9fda0008a5b810" lang="no" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="pluto.tv" site_id="65d88004ec9fda0008a5b8b3" lang="no" xmltv_id="">South Park: Kyle Collection</channel>
   <channel site="pluto.tv" site_id="65d87f7a28730900088e7fbf" lang="no" xmltv_id="">South Park: Stan Collection</channel>
-  <channel site="pluto.tv" site_id="6400c228498393000878a9b7" lang="no" xmltv_id="">Star Trek Movies</channel>
+  <channel site="pluto.tv" site_id="69b16df6ed2a2444365e7ff1" lang="no" xmltv_id="">Space Live</channel>
+  <channel site="pluto.tv" site_id="693addd62bf6cf7414c4b2fc" lang="no" xmltv_id="">Star Trek: The Original Series</channel>
+  <channel site="pluto.tv" site_id="68d66a69508ba507f075c185" lang="no" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="pluto.tv" site_id="61c1d59a244e500007581861" lang="no" xmltv_id="">SvampeBob Firkant</channel>
   <channel site="pluto.tv" site_id="645cc855e1979c000875ee47" lang="no" xmltv_id="">Svenske Truckers</channel>
   <channel site="pluto.tv" site_id="63c95451d3485c0007734f55" lang="no" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
   <channel site="pluto.tv" site_id="66b22b748561260008dae057" lang="no" xmltv_id="">Taxi</channel>
+  <channel site="pluto.tv" site_id="693ae3624258f18a3e117b8b" lang="no" xmltv_id="">Teen Wolf</channel>
   <channel site="pluto.tv" site_id="6870c97b759366af055fe371" lang="no" xmltv_id="">Tennis Channel</channel>
+  <channel site="pluto.tv" site_id="69afeca6ac36b147e7ef33a7" lang="no" xmltv_id="">The 4400</channel>
   <channel site="pluto.tv" site_id="65c0973311ced7000808d255" lang="no" xmltv_id="">The Daily Show</channel>
   <channel site="pluto.tv" site_id="6915ddcb0d121b44ad1b6bf2" lang="no" xmltv_id="">The Graham Norton Show</channel>
   <channel site="pluto.tv" site_id="61c1d56f28e94c0007827bdb" lang="no" xmltv_id="">The Hills</channel>
+  <channel site="pluto.tv" site_id="693ae4b616c2bba998852c21" lang="no" xmltv_id="">The L Word</channel>
+  <channel site="pluto.tv" site_id="69afef233bd16a4ed07108e9" lang="no" xmltv_id="">The Millers</channel>
   <channel site="pluto.tv" site_id="6181511c1e13690007b143c2" lang="no" xmltv_id="">The New Detectives</channel>
   <channel site="pluto.tv" site_id="6512d3a0bdcb19000799cc82" lang="no" xmltv_id="">The Twilight Zone</channel>
+  <channel site="pluto.tv" site_id="6964bca2a6c400fd418854a2" lang="no" xmltv_id="">The Wild Wild West</channel>
   <channel site="pluto.tv" site_id="6202357dea93940007d723ca" lang="no" xmltv_id="">Top Gear</channel>
-  <channel site="pluto.tv" site_id="660d64a7aec9680008f8ba77" lang="no" xmltv_id="">Top Gear Classics</channel>
   <channel site="pluto.tv" site_id="65e977c48b24c8000805b9ef" lang="no" xmltv_id="">Tosh.0</channel>
   <channel site="pluto.tv" site_id="61c1da718a80a4000704013e" lang="no" xmltv_id="">Totally Turtles</channel>
-  <channel site="pluto.tv" site_id="668e60013a4ad20008c878f4" lang="no" xmltv_id="">Triton Poker</channel>
-  <channel site="pluto.tv" site_id="64e770b444fe100009c891b9" lang="no" xmltv_id="">Trucking Hell</channel>
   <channel site="pluto.tv" site_id="679205a13de7c8cf941e7857" lang="no" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="61c1e1c445b45d0007aad03e" lang="no" xmltv_id="">Unga Mammor</channel>
   <channel site="pluto.tv" site_id="61814f38ac1f2100075c8894" lang="no" xmltv_id="">Unsolved Mysteries</channel>
@@ -178,4 +187,5 @@
   <channel site="pluto.tv" site_id="62beb7d7fbf54600076abc7b" lang="no" xmltv_id="">Wildfire</channel>
   <channel site="pluto.tv" site_id="6440f6e25a0cd500083b1ca4" lang="no" xmltv_id="">World of Love Island</channel>
   <channel site="pluto.tv" site_id="61781254560f2e00071b78ce" lang="no" xmltv_id="">World Poker Tour</channel>
+  <channel site="pluto.tv" site_id="6400c228498393000878a9b7" lang="sv" xmltv_id="">Star Trek Movies</channel>
 </channels>

--- a/sites/pluto.tv/pluto.tv_se.channels.xml
+++ b/sites/pluto.tv/pluto.tv_se.channels.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="pluto.tv" site_id="62cd74e38f6f0d000798cd93" lang="en" xmltv_id="">Pluto TV Sport</channel>
+  <channel site="pluto.tv" site_id="62cd74e38f6f0d000798cd93" lang="en" xmltv_id="PlutoTVSport.se@SE">Pluto TV Sport</channel>
   <channel site="pluto.tv" site_id="61c0b627e3ed94000793c18a" lang="en" xmltv_id="">South Park</channel>
   <channel site="pluto.tv" site_id="6728cab6e482950008b76d8c" lang="sv" xmltv_id="">7th Heaven</channel>
+  <channel site="pluto.tv" site_id="699c169077cdde1f05252eb9" lang="sv" xmltv_id="">21 Jump Street</channel>
   <channel site="pluto.tv" site_id="6346935b94aa8c0007c5b7a2" lang="sv" xmltv_id="">48 Hours</channel>
   <channel site="pluto.tv" site_id="68c01954f89c82a68b084a50" lang="sv" xmltv_id="">Afterwork TV</channel>
   <channel site="pluto.tv" site_id="69143e7b0d121b44adfa1ff9" lang="sv" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="pluto.tv" site_id="6464cdcaee6a2f000822a7a8" lang="sv" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="617807a1a3a6160007f615e4" lang="sv" xmltv_id="">Andromeda</channel>
+  <channel site="pluto.tv" site_id="6964b7e007ea70192df28d43" lang="sv" xmltv_id="">Anger Management</channel>
   <channel site="pluto.tv" site_id="6364f6cd308d210007b5eee9" lang="sv" xmltv_id="">Antiques Road Trip</channel>
   <channel site="pluto.tv" site_id="61c0ac242bb0cf0007015f89" lang="sv" xmltv_id="">Are You The One?</channel>
   <channel site="pluto.tv" site_id="62da7380478a5b0007e610d9" lang="sv" xmltv_id="">Auction Hunters</channel>
@@ -16,7 +18,7 @@
   <channel site="pluto.tv" site_id="6512d6a0a1217e00092c1214" lang="sv" xmltv_id="">Beauty and the Beast</channel>
   <channel site="pluto.tv" site_id="6486e8b48e3c0a0008e56914" lang="sv" xmltv_id="">Beavis and Butt-Head</channel>
   <channel site="pluto.tv" site_id="672e16f5daad7f0008929a0d" lang="sv" xmltv_id="">Becker</channel>
-  <channel site="pluto.tv" site_id="62792dbd5e237b0007f84642" lang="sv" xmltv_id="">Bellator MMA</channel>
+  <channel site="pluto.tv" site_id="69d7a0dc805a68fcc92037b7" lang="sv" xmltv_id="">Best of Magnus Midtbø</channel>
   <channel site="pluto.tv" site_id="632afdf820e83e000710ea12" lang="sv" xmltv_id="">Best of MTV</channel>
   <channel site="pluto.tv" site_id="65e97d41f7f0af0008da2543" lang="sv" xmltv_id="">Best of Paradise Hotel: Finalveckan</channel>
   <channel site="pluto.tv" site_id="65b1077e0d9ab40008245b20" lang="sv" xmltv_id="">Best of Paradise Hotel: Kyssar &amp; kärlek</channel>
@@ -28,11 +30,11 @@
   <channel site="pluto.tv" site_id="660d67eec8311c0008b8c3f7" lang="sv" xmltv_id="">Bondi Rescue</channel>
   <channel site="pluto.tv" site_id="67a09e5921af38000808900a" lang="sv" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="65cba7b1ec452d0008acbed8" lang="sv" xmltv_id="">Broad City</channel>
+  <channel site="pluto.tv" site_id="6964b9e19bf57be1537fc7d7" lang="sv" xmltv_id="">Bull</channel>
   <channel site="pluto.tv" site_id="63c6a7544faf1c0007b496d7" lang="sv" xmltv_id="">Buying Blind Denmark</channel>
   <channel site="pluto.tv" site_id="6400bf66dff38e00083f4ee8" lang="sv" xmltv_id="">Camp Kulinaris</channel>
   <channel site="pluto.tv" site_id="65a93be02fac9c00083cbac4" lang="sv" xmltv_id="">Car Chase</channel>
   <channel site="pluto.tv" site_id="66a7ab4dcd0d3100084395b4" lang="sv" xmltv_id="">Caroline in the City</channel>
-  <channel site="pluto.tv" site_id="64e771819c1e39000848df0c" lang="sv" xmltv_id="">Casualty 24/7</channel>
   <channel site="pluto.tv" site_id="6231e9b7f6deff00074674f4" lang="sv" xmltv_id="">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="65788727a620e30008fe4d88" lang="sv" xmltv_id="">Celeb Reality</channel>
   <channel site="pluto.tv" site_id="65e9783b0d456100082d9e05" lang="sv" xmltv_id="">Chappelle&apos;s Show</channel>
@@ -40,11 +42,13 @@
   <channel site="pluto.tv" site_id="65d724a9d8adfa00086c8ae9" lang="sv" xmltv_id="">Come Dine with Me</channel>
   <channel site="pluto.tv" site_id="61c0b550e0d3a700072b6a2a" lang="sv" xmltv_id="">Comedy Central</channel>
   <channel site="pluto.tv" site_id="6400be67219c4c00081755d3" lang="sv" xmltv_id="">COPS</channel>
+  <channel site="pluto.tv" site_id="693ae5b792fad2e93412a2c7" lang="sv" xmltv_id="">Crazy Ex-Girlfriend</channel>
   <channel site="pluto.tv" site_id="6578875614fbe400086e319e" lang="sv" xmltv_id="">Crime 360</channel>
   <channel site="pluto.tv" site_id="64268f52b065d900085eb42b" lang="sv" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="pluto.tv" site_id="64e7715c4c5ed800081230e4" lang="sv" xmltv_id="">Dallas Cowboys Cheerleaders</channel>
   <channel site="pluto.tv" site_id="65788670b9adc40008025500" lang="sv" xmltv_id="">Dance Moms</channel>
-  <channel site="pluto.tv" site_id="64805755536e0c0008a19fa1" lang="sv" xmltv_id="">DAZN Combat</channel>
+  <channel site="pluto.tv" site_id="692edd6bdb8695f63e14f3b9" lang="sv" xmltv_id="">Dating Naked UK</channel>
+  <channel site="pluto.tv" site_id="64805755536e0c0008a19fa1" lang="sv" xmltv_id="">DAZN Ringside</channel>
   <channel site="pluto.tv" site_id="66461f433d173b000805eeeb" lang="sv" xmltv_id="">DFB Play TV</channel>
   <channel site="pluto.tv" site_id="668bf9be0642e5000815102d" lang="sv" xmltv_id="">Diagnosis Murder</channel>
   <channel site="pluto.tv" site_id="62b1e5e77d15410007f798c6" lang="sv" xmltv_id="">Doc Martin</channel>
@@ -54,32 +58,33 @@
   <channel site="pluto.tv" site_id="65788611a620e30008fe36ff" lang="sv" xmltv_id="">Duck Dynasty</channel>
   <channel site="pluto.tv" site_id="68f0fb155d6fb43948165d32" lang="sv" xmltv_id="">Dynastin</channel>
   <channel site="pluto.tv" site_id="646ce0e2e1979c0008983939" lang="sv" xmltv_id="">Efterlyst</channel>
-  <channel site="pluto.tv" site_id="68adafa35190a45dc9c575c9" lang="sv" xmltv_id="">Ernest goes to Pluto TV</channel>
   <channel site="pluto.tv" site_id="66d714d815d2c60008cec6d2" lang="sv" xmltv_id="">Escape to the Country</channel>
   <channel site="pluto.tv" site_id="61de90a47365340007f77c27" lang="sv" xmltv_id="">Euronews</channel>
+  <channel site="pluto.tv" site_id="697b5be36dc3c71eb14d728a" lang="sv" xmltv_id="">Everybody Hates Chris</channel>
   <channel site="pluto.tv" site_id="61c09072a09bbe00078f5692" lang="sv" xmltv_id="">Ex On The Beach</channel>
   <channel site="pluto.tv" site_id="6178037c35922000072a2ff5" lang="sv" xmltv_id="">FailArmy</channel>
   <channel site="pluto.tv" site_id="654a510d986ad20008a45874" lang="sv" xmltv_id="">Family Ties</channel>
+  <channel site="pluto.tv" site_id="699c1c633d27d6da460bbcae" lang="sv" xmltv_id="">Farscape</channel>
   <channel site="pluto.tv" site_id="61814b9a9704450007e52316" lang="sv" xmltv_id="">FBI Files</channel>
   <channel site="pluto.tv" site_id="660bfcd07bcd860008796ae8" lang="sv" xmltv_id="">FIFA+</channel>
+  <channel site="pluto.tv" site_id="698dde7c8b5c1e0795b85739" lang="sv" xmltv_id="">Flipper: The New Adventures</channel>
   <channel site="pluto.tv" site_id="618124b2e53c8d00077b37f8" lang="sv" xmltv_id="">Forensic Files</channel>
-  <channel site="pluto.tv" site_id="65b3d7b7c798e8000852ff0a" lang="sv" xmltv_id="">From South Park with Love</channel>
   <channel site="pluto.tv" site_id="61c19099bf8c520007a93cff" lang="sv" xmltv_id="">Frusna Vägar</channel>
   <channel site="pluto.tv" site_id="64424be3e94c380008d0a66d" lang="sv" xmltv_id="">Geordie Shore</channel>
   <channel site="pluto.tv" site_id="619e4726b9997a00072a4059" lang="sv" xmltv_id="">Ghost Dimension</channel>
-  <channel site="pluto.tv" site_id="65e9b6b58145cb00084d24ee" lang="sv" xmltv_id="">Glory Kickboxing</channel>
   <channel site="pluto.tv" site_id="654a52254d6d8f00084eacfc" lang="sv" xmltv_id="">Happy Days</channel>
   <channel site="pluto.tv" site_id="61c1871dac860c0007684974" lang="sv" xmltv_id="">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="68c015dc6523408b14f54dee" lang="sv" xmltv_id="">Highway to Heaven</channel>
-  <channel site="pluto.tv" site_id="64e771ac9b414d000841080c" lang="sv" xmltv_id="">Hoarders &amp; Dirty Home Rescue</channel>
   <channel site="pluto.tv" site_id="6537abf42cf1310008441686" lang="sv" xmltv_id="">Högspänning</channel>
   <channel site="pluto.tv" site_id="619e4a3518d6970008bebc95" lang="sv" xmltv_id="">Homicide Hunter</channel>
   <channel site="pluto.tv" site_id="671b4e8bc7626f00089b7194" lang="sv" xmltv_id="">Horse &amp; Country</channel>
   <channel site="pluto.tv" site_id="655caa815812e80008884322" lang="sv" xmltv_id="">Hot Ones</channel>
+  <channel site="pluto.tv" site_id="693ae6bf0ddf7d2a40b7fd35" lang="sv" xmltv_id="">House of Lies</channel>
   <channel site="pluto.tv" site_id="657887d9dfed030008ce8aa8" lang="sv" xmltv_id="">I Survived</channel>
   <channel site="pluto.tv" site_id="61c185049e0bde0007820039" lang="sv" xmltv_id="">iCarly</channel>
   <channel site="pluto.tv" site_id="62cdaef300a4b3000739b1bf" lang="sv" xmltv_id="">Ice Pilots</channel>
   <channel site="pluto.tv" site_id="62beb6c0371e6c000775930f" lang="sv" xmltv_id="">Ice Road Truckers</channel>
+  <channel site="pluto.tv" site_id="691ed77b1308fa77bb2d5562" lang="sv" xmltv_id="">Inter 24/7</channel>
   <channel site="pluto.tv" site_id="682b39defaaa60cd7dbfa5c3" lang="sv" xmltv_id="">Iron Chef</channel>
   <channel site="pluto.tv" site_id="660d6b3caec9680008f8debe" lang="sv" xmltv_id="">Jade Fever</channel>
   <channel site="pluto.tv" site_id="654a515f986ad20008a4593b" lang="sv" xmltv_id="">JAG</channel>
@@ -89,11 +94,7 @@
   <channel site="pluto.tv" site_id="6380c4ab81c8d2000790fbf3" lang="sv" xmltv_id="">Judge Judy</channel>
   <channel site="pluto.tv" site_id="61780ce4c215ad0007a66ab2" lang="sv" xmltv_id="">Just for Laughs GAGS</channel>
   <channel site="pluto.tv" site_id="65cba798d77d450008d056e5" lang="sv" xmltv_id="">Key &amp; Peele</channel>
-  <channel site="pluto.tv" site_id="659fbbc4b9adc4000846c57a" lang="sv" xmltv_id="">Kickin&apos;it</channel>
   <channel site="pluto.tv" site_id="65a63ff00d9ab400080b101c" lang="sv" xmltv_id="">Klovn</channel>
-  <channel site="pluto.tv" site_id="63e38ca4c111bc0008ee6023" lang="sv" xmltv_id="">Kungen Av Queens</channel>
-  <channel site="pluto.tv" site_id="670cc67eb2ffb1000823a592" lang="sv" xmltv_id="">Kungen av Queens: På vift</channel>
-  <channel site="pluto.tv" site_id="670cc6a85049580008ecf945" lang="sv" xmltv_id="">Kungen av Queens: Svärfar special</channel>
   <channel site="pluto.tv" site_id="654a517ff91d250008ac2d4a" lang="sv" xmltv_id="">Love Boat</channel>
   <channel site="pluto.tv" site_id="61c18f62f5acaf0007f83135" lang="sv" xmltv_id="">Lyxfällan</channel>
   <channel site="pluto.tv" site_id="61c19165decece0007e9b2f3" lang="sv" xmltv_id="">Lyxfällan Danmark</channel>
@@ -111,7 +112,7 @@
   <channel site="pluto.tv" site_id="65c340983ba51e00083988e8" lang="sv" xmltv_id="">Monster Jam</channel>
   <channel site="pluto.tv" site_id="61780d4267bf4d00077ddd73" lang="sv" xmltv_id="">MTV Catfish</channel>
   <channel site="pluto.tv" site_id="685140f121f49d1b9d178249" lang="sv" xmltv_id="">MTV Dating</channel>
-  <channel site="pluto.tv" site_id="685139b0f7d8b74b62f41c96" lang="sv" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="685139b0f7d8b74b62f41c96" lang="sv" xmltv_id="">MTV Pride</channel>
   <channel site="pluto.tv" site_id="62cda0dfddc1040008fccacc" lang="sv" xmltv_id="">MTV Ridiculousness</channel>
   <channel site="pluto.tv" site_id="61c09342b3a6230007a45119" lang="sv" xmltv_id="">MTV Teen Mom</channel>
   <channel site="pluto.tv" site_id="6728d33f030a2c0008edf4be" lang="sv" xmltv_id="">NonStop Kung Fu</channel>
@@ -120,40 +121,40 @@
   <channel site="pluto.tv" site_id="62cdad7b5c38c00007f566c2" lang="sv" xmltv_id="">On the Case</channel>
   <channel site="pluto.tv" site_id="6380c73f76e43f000721f73b" lang="sv" xmltv_id="">Paradise</channel>
   <channel site="pluto.tv" site_id="61c18e1e0cd4cc00076bc4b3" lang="sv" xmltv_id="">Paradise Hotel</channel>
-  <channel site="pluto.tv" site_id="65b8f9d4d77d450008a3ef8f" lang="sv" xmltv_id="">PFL MMA</channel>
   <channel site="pluto.tv" site_id="66c86fed85e28d0008f8a9ec" lang="sv" xmltv_id="">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="61c09a3894aa450007814aea" lang="sv" xmltv_id="">Pimp My Ride</channel>
   <channel site="pluto.tv" site_id="66bb36e03a4ad200082bb8fe" lang="sv" xmltv_id="">Pixel.tv</channel>
-  <channel site="pluto.tv" site_id="61c0b0688a80a4000703fbcb" lang="sv" xmltv_id="">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="6745b127e40c4a0008ebe16d" lang="sv" xmltv_id="">Pluto TV AIK</channel>
-  <channel site="pluto.tv" site_id="679b94c897bed700080aad4d" lang="sv" xmltv_id="">Pluto TV AIK FollowUs</channel>
-  <channel site="pluto.tv" site_id="679b953715d6eb00081a97a7" lang="sv" xmltv_id="">Pluto TV AIK Matcher vi minns</channel>
-  <channel site="pluto.tv" site_id="65b91b53dc10a40008d54777" lang="sv" xmltv_id="">Pluto TV Brittisk Crime &amp; Drama</channel>
-  <channel site="pluto.tv" site_id="65b917720d9ab4000833f323" lang="sv" xmltv_id="">Pluto TV Bud &amp; Terence</channel>
-  <channel site="pluto.tv" site_id="660d5f2a635c75000828855f" lang="sv" xmltv_id="">Pluto TV Buskis</channel>
-  <channel site="pluto.tv" site_id="62b1e2498261390007f25c98" lang="sv" xmltv_id="">Pluto TV Dokumentär</channel>
-  <channel site="pluto.tv" site_id="61c0afa0a09bbe00078f8378" lang="sv" xmltv_id="">Pluto TV Film</channel>
-  <channel site="pluto.tv" site_id="68dfa3e2cc3c6cd904052c41" lang="sv" xmltv_id="">Pluto TV Handboll Highlights</channel>
-  <channel site="pluto.tv" site_id="686faf533ffa5e0c912688e7" lang="sv" xmltv_id="">Pluto TV Handboll Live</channel>
-  <channel site="pluto.tv" site_id="63a19e1b9ab2df0007bef7a7" lang="sv" xmltv_id="">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="655caaaac0fc8800086f5d99" lang="sv" xmltv_id="">Pluto TV John Wayne</channel>
-  <channel site="pluto.tv" site_id="61c0b7eb8929e40007ff5125" lang="sv" xmltv_id="">Pluto TV Juniorklubben</channel>
-  <channel site="pluto.tv" site_id="61c0b36d18447e000717d686" lang="sv" xmltv_id="">Pluto TV Komedi</channel>
-  <channel site="pluto.tv" site_id="63dbe8c8a9957100087798a3" lang="sv" xmltv_id="">Pluto TV Kultfilmer</channel>
-  <channel site="pluto.tv" site_id="62b1e4189f5db20007ff03be" lang="sv" xmltv_id="">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="63a19da6847a090007f230da" lang="sv" xmltv_id="">Pluto TV Romantik</channel>
-  <channel site="pluto.tv" site_id="61f9597e78607000074f6c2a" lang="sv" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="68ac56363efb41cd979a8005" lang="sv" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="679b98b41e1af8000865530e" lang="sv" xmltv_id="">Pluto TV Studio AIK</channel>
-  <channel site="pluto.tv" site_id="67f5095a3481170e6843d95d" lang="sv" xmltv_id="">Pluto TV Tecknade klassiker</channel>
-  <channel site="pluto.tv" site_id="61c0b6f028e94c000782684a" lang="sv" xmltv_id="">Pluto TV Tecknat</channel>
-  <channel site="pluto.tv" site_id="61c0b438244e50000758083b" lang="sv" xmltv_id="">Pluto TV True Crime</channel>
-  <channel site="pluto.tv" site_id="67f3fc1707d2ba4121bd34a8" lang="sv" xmltv_id="">Pluto TV Ungdomsserier</channel>
-  <channel site="pluto.tv" site_id="677d3ad04bd63600082f7c54" lang="sv" xmltv_id="">Pluto TV Världskrigen</channel>
-  <channel site="pluto.tv" site_id="68c017bf337652ee75db201f" lang="sv" xmltv_id="">Pluto TV Wild West</channel>
+  <channel site="pluto.tv" site_id="61c0b0688a80a4000703fbcb" lang="sv" xmltv_id="PlutoTVAction.se@SE">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="65b91b53dc10a40008d54777" lang="sv" xmltv_id="PlutoTVBrittiskCrimeDrama.se@SE">Pluto TV Brittisk Crime &amp; Drama</channel>
+  <channel site="pluto.tv" site_id="65b917720d9ab4000833f323" lang="sv" xmltv_id="PlutoTVBudTerence.se@SE">Pluto TV Bud &amp; Terence</channel>
+  <channel site="pluto.tv" site_id="660d5f2a635c75000828855f" lang="sv" xmltv_id="PlutoTVBuskis.se@SE">Pluto TV Buskis</channel>
+  <channel site="pluto.tv" site_id="62b1e2498261390007f25c98" lang="sv" xmltv_id="PlutoTVDokumentar.se@SE">Pluto TV Dokumentär</channel>
+  <channel site="pluto.tv" site_id="61c0afa0a09bbe00078f8378" lang="sv" xmltv_id="PlutoTVFilm.se@SE">Pluto TV Film</channel>
+  <channel site="pluto.tv" site_id="68dfa3e2cc3c6cd904052c41" lang="sv" xmltv_id="PlutoTVHandbollHighlights.se@SE">Pluto TV Handboll Highlights</channel>
+  <channel site="pluto.tv" site_id="686faf533ffa5e0c912688e7" lang="sv" xmltv_id="PlutoTVHandbollLive.se@SE">Pluto TV Handboll Live</channel>
+  <channel site="pluto.tv" site_id="68c01bed508ba507f0d0dd60" lang="sv" xmltv_id="PlutoTVHarlequin.se@SE">Pluto TV Harlequin</channel>
+  <channel site="pluto.tv" site_id="63a19e1b9ab2df0007bef7a7" lang="sv" xmltv_id="PlutoTVHorror.se@SE">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="655caaaac0fc8800086f5d99" lang="sv" xmltv_id="PlutoTVJohnWayne.se@SE">Pluto TV John Wayne</channel>
+  <channel site="pluto.tv" site_id="61c0b7eb8929e40007ff5125" lang="sv" xmltv_id="PlutoTVJuniorklubben.se@SE">Pluto TV Juniorklubben</channel>
+  <channel site="pluto.tv" site_id="61c0b36d18447e000717d686" lang="sv" xmltv_id="PlutoTVKomedi.se@SE">Pluto TV Komedi</channel>
+  <channel site="pluto.tv" site_id="63dbe8c8a9957100087798a3" lang="sv" xmltv_id="PlutoTVKultfilmer.se@SE">Pluto TV Kultfilmer</channel>
+  <channel site="pluto.tv" site_id="68ac52fac9b5923e0585578b" lang="sv" xmltv_id="PlutoTVMotor.se@SE">Pluto TV Motor</channel>
+  <channel site="pluto.tv" site_id="62b1e4189f5db20007ff03be" lang="sv" xmltv_id="PlutoTVParanormal.se@SE">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="63a19da6847a090007f230da" lang="sv" xmltv_id="PlutoTVRomantik.se@SE">Pluto TV Romantik</channel>
+  <channel site="pluto.tv" site_id="61f9597e78607000074f6c2a" lang="sv" xmltv_id="PlutoTVSciFi.se@SE">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="68ac56363efb41cd979a8005" lang="sv" xmltv_id="PlutoTVSnooker900.se@SE">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="67f5095a3481170e6843d95d" lang="sv" xmltv_id="PlutoTVTecknadeklassiker.se@SE">Pluto TV Tecknade klassiker</channel>
+  <channel site="pluto.tv" site_id="61c0b6f028e94c000782684a" lang="sv" xmltv_id="PlutoTVTecknat.se@SE">Pluto TV Tecknat</channel>
+  <channel site="pluto.tv" site_id="61c0b438244e50000758083b" lang="sv" xmltv_id="PlutoTVTrueCrime.se@SE">Pluto TV True Crime</channel>
+  <channel site="pluto.tv" site_id="67f3fc1707d2ba4121bd34a8" lang="sv" xmltv_id="PlutoTVUngdomsserier.se@SE">Pluto TV Ungdomsserier</channel>
+  <channel site="pluto.tv" site_id="677d3ad04bd63600082f7c54" lang="sv" xmltv_id="PlutoTVVarldskrigen.se@SE">Pluto TV Världskrigen</channel>
+  <channel site="pluto.tv" site_id="68c017bf337652ee75db201f" lang="sv" xmltv_id="PlutoTVWildWest.se@SE">Pluto TV Wild West</channel>
   <channel site="pluto.tv" site_id="62724c8465731f0007b6cd86" lang="sv" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="6964bb3640c8de392514a0c6" lang="sv" xmltv_id="">Rawhide</channel>
   <channel site="pluto.tv" site_id="660d7232635c75000828c95a" lang="sv" xmltv_id="">Realmadrid TV</channel>
+  <channel site="pluto.tv" site_id="699c1998d5b4d030870ff998" lang="sv" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="65e9781a2873090008b48d8a" lang="sv" xmltv_id="">Reno 911</channel>
+  <channel site="pluto.tv" site_id="69a164f76c0414a7ec68de54" lang="sv" xmltv_id="">Retake E-sport Live</channel>
   <channel site="pluto.tv" site_id="68dfa1e7fae18f8db6218703" lang="sv" xmltv_id="">Ridiculousness - Nya avsnitt</channel>
   <channel site="pluto.tv" site_id="662a26cb5a402e00086b2801" lang="sv" xmltv_id="">River Monsters</channel>
   <channel site="pluto.tv" site_id="65ba4e7bdc10a40008da084a" lang="sv" xmltv_id="">Rock Channel</channel>
@@ -164,35 +165,39 @@
   <channel site="pluto.tv" site_id="61fb9907b1b78d000717ed9f" lang="sv" xmltv_id="">Smithsonian Channel Selects</channel>
   <channel site="pluto.tv" site_id="68adb11bf84960586ad4aae4" lang="sv" xmltv_id="">Smurfarna</channel>
   <channel site="pluto.tv" site_id="660bff7dc8311c0008b4bdb4" lang="sv" xmltv_id="">South Park Armageddon</channel>
-  <channel site="pluto.tv" site_id="6501c86dbd341e000829a1cc" lang="sv" xmltv_id="">South Park Halloween</channel>
   <channel site="pluto.tv" site_id="664f13aff9992200084a3532" lang="sv" xmltv_id="">South Park Rockin&apos; Out</channel>
   <channel site="pluto.tv" site_id="65d881d566eec8000887f6bb" lang="sv" xmltv_id="">South Park: Butters Collection</channel>
   <channel site="pluto.tv" site_id="65d881b1332fec000833a122" lang="sv" xmltv_id="">South Park: Cartman Collection</channel>
-  <channel site="pluto.tv" site_id="66fcee79565d3a00088ac033" lang="sv" xmltv_id="">South Park: Holiday Collection</channel>
   <channel site="pluto.tv" site_id="664f0eea0120f40008bf97d6" lang="sv" xmltv_id="">South Park: Into the Stars</channel>
   <channel site="pluto.tv" site_id="65d880cea25d5e0008315b0a" lang="sv" xmltv_id="">South Park: Kenny Collection</channel>
   <channel site="pluto.tv" site_id="65d882394e01740008a36768" lang="sv" xmltv_id="">South Park: Kyle Collection</channel>
   <channel site="pluto.tv" site_id="65d881914e01740008a36603" lang="sv" xmltv_id="">South Park: Stan Collection</channel>
+  <channel site="pluto.tv" site_id="69b16e2b65c1df7564fc750b" lang="sv" xmltv_id="">Space Live</channel>
   <channel site="pluto.tv" site_id="6400c2a6cb41a40008dbe5bc" lang="sv" xmltv_id="">Star Trek Movies</channel>
+  <channel site="pluto.tv" site_id="693ade4d569386f93f235bb6" lang="sv" xmltv_id="">Star Trek: The Original Series</channel>
   <channel site="pluto.tv" site_id="61c18ec6ac860c0007684981" lang="sv" xmltv_id="">Stugfixarna Norge</channel>
+  <channel site="pluto.tv" site_id="68d66a98508ba507f075c8da" lang="sv" xmltv_id="">SUMO Paris 2026</channel>
   <channel site="pluto.tv" site_id="61c0ba0816e2fd00086cb6b1" lang="sv" xmltv_id="">SvampBob Fyrkant</channel>
   <channel site="pluto.tv" site_id="61c1921610d254000727eebd" lang="sv" xmltv_id="">Svenska Hollywoodfruar</channel>
   <channel site="pluto.tv" site_id="61f128f68a1dfc00086470af" lang="sv" xmltv_id="">Svenska Truckers</channel>
   <channel site="pluto.tv" site_id="63c95491808b740007608a74" lang="sv" xmltv_id="">Tareq Taylor&apos;s Nordic Cookery</channel>
   <channel site="pluto.tv" site_id="66b22c9aa79dea0008cee4a9" lang="sv" xmltv_id="">Taxi</channel>
+  <channel site="pluto.tv" site_id="693ae39cc2fa3abe8ad8208c" lang="sv" xmltv_id="">Teen Wolf</channel>
   <channel site="pluto.tv" site_id="6870c9ca759366af055fe891" lang="sv" xmltv_id="">Tennis Channel</channel>
+  <channel site="pluto.tv" site_id="69afecd4686531d5faac86e2" lang="sv" xmltv_id="">The 4400</channel>
   <channel site="pluto.tv" site_id="65c0978360eb870008bc9d5b" lang="sv" xmltv_id="">The Daily Show</channel>
   <channel site="pluto.tv" site_id="6915de3d74601d957afa4592" lang="sv" xmltv_id="">The Graham Norton Show</channel>
   <channel site="pluto.tv" site_id="61c08d7c73bdb800070eef0a" lang="sv" xmltv_id="">The Hills</channel>
+  <channel site="pluto.tv" site_id="693ae4ee25e9a6646b198fb0" lang="sv" xmltv_id="">The L Word</channel>
+  <channel site="pluto.tv" site_id="69afef4b0306b277744de1e4" lang="sv" xmltv_id="">The Millers</channel>
   <channel site="pluto.tv" site_id="6391df52d146a40007c265f3" lang="sv" xmltv_id="">The Nanny</channel>
   <channel site="pluto.tv" site_id="686d01ad94a028da3aaca6b3" lang="sv" xmltv_id="">The Nanny &amp; Mr Sheffield - A Fine Romance</channel>
   <channel site="pluto.tv" site_id="61814dd68a368d0007d78c53" lang="sv" xmltv_id="">The New Detectives</channel>
   <channel site="pluto.tv" site_id="6512d6c92ce8e40008bd5c81" lang="sv" xmltv_id="">The Twilight Zone</channel>
+  <channel site="pluto.tv" site_id="6964bcf9ae33e24d911d7e1c" lang="sv" xmltv_id="">The Wild Wild West</channel>
   <channel site="pluto.tv" site_id="620239894757070008d4812d" lang="sv" xmltv_id="">Top Gear</channel>
   <channel site="pluto.tv" site_id="65e97856ec9fda0008cb453c" lang="sv" xmltv_id="">Tosh.0</channel>
   <channel site="pluto.tv" site_id="61c185e36faf920007f04b6e" lang="sv" xmltv_id="">Totally Turtles</channel>
-  <channel site="pluto.tv" site_id="668e60bfa4ee270008e3addf" lang="sv" xmltv_id="">Triton Poker</channel>
-  <channel site="pluto.tv" site_id="64e771cc28cec7000889ce39" lang="sv" xmltv_id="">Trucking Hell</channel>
   <channel site="pluto.tv" site_id="645cb7857cb4b1000859c57c" lang="sv" xmltv_id="">True crime från Viaplay</channel>
   <channel site="pluto.tv" site_id="6792066f3de7c8cf941e7ce3" lang="sv" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="61c1900995f417000731a002" lang="sv" xmltv_id="">Unga Mammor</channel>

--- a/sites/pluto.tv/pluto.tv_uk.channels.xml
+++ b/sites/pluto.tv/pluto.tv_uk.channels.xml
@@ -92,9 +92,9 @@
   <channel site="pluto.tv" site_id="68e3c18130ee729844af1fca" lang="en" xmltv_id="">Monkey</channel>
   <channel site="pluto.tv" site_id="639b558c73423d00071ce624" lang="en" xmltv_id="">More TV Crime</channel>
   <channel site="pluto.tv" site_id="645e00d5d3fdde000829463a" lang="en" xmltv_id="">More TV Sci-fi</channel>
-  <channel site="pluto.tv" site_id="6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
+  <channel site="pluto.tv" site_id="6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.uk@UK">Most Haunted</channel>
   <channel site="pluto.tv" site_id="68e3bffe1cfcd7541d59090f" lang="en" xmltv_id="">Most Haunted: Unseen</channel>
-  <channel site="pluto.tv" site_id="6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@SD">Moviesphere</channel>
+  <channel site="pluto.tv" site_id="6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@UK">Moviesphere</channel>
   <channel site="pluto.tv" site_id="624edee2d6394a0007efcac4" lang="en" xmltv_id="MTVPlutoTV.de@UK">MTV Pluto TV</channel>
   <channel site="pluto.tv" site_id="69038c2ee0e0c5f8208c033a" lang="en" xmltv_id="">Murdertown</channel>
   <channel site="pluto.tv" site_id="61c4a09d6c959f0007189c93" lang="en" xmltv_id="">Mystery TV</channel>

--- a/sites/pluto.tv/pluto.tv_uk.channels.xml
+++ b/sites/pluto.tv/pluto.tv_uk.channels.xml
@@ -3,11 +3,10 @@
   <channel site="pluto.tv" site_id="5d2c571faeb3e2738ae27933" lang="en" xmltv_id="5Cops.us@UK">5 Cops</channel>
   <channel site="pluto.tv" site_id="63c1384e829c850007922ca4" lang="en" xmltv_id="">5 Emergency Rescue</channel>
   <channel site="pluto.tv" site_id="5ddf901280e3550009139c86" lang="en" xmltv_id="">5 Exploring Britain</channel>
-  <channel site="pluto.tv" site_id="623c492627cb540007ca55c7" lang="en" xmltv_id="">5 on Pluto TV</channel>
+  <channel site="pluto.tv" site_id="623c492627cb540007ca55c7" lang="en" xmltv_id="5onPlutoTV.de@UK">5 on Pluto TV</channel>
   <channel site="pluto.tv" site_id="656df2849d5ac400083be647" lang="en" xmltv_id="">5 Trucking Hell</channel>
-  <channel site="pluto.tv" site_id="68503cfda1e091e16f000625" lang="en" xmltv_id="">7th Heaven</channel>
-  <channel site="pluto.tv" site_id="5d4af00df345adb154b7a1f4" lang="en" xmltv_id="">21 Jump Street</channel>
   <channel site="pluto.tv" site_id="6299e5afdd5833000727e795" lang="en" xmltv_id="48Hours.us@SD">48 Hours</channel>
+  <channel site="pluto.tv" site_id="68c8203efef6d8a2a6f13906" lang="en" xmltv_id="">60 Days in Jail</channel>
   <channel site="pluto.tv" site_id="64ff1d92d545e9000877fba4" lang="en" xmltv_id="">A Haunting</channel>
   <channel site="pluto.tv" site_id="6852854bce36f0644f37d765" lang="en" xmltv_id="">A New Life in the Sun</channel>
   <channel site="pluto.tv" site_id="62e9184439d80c00076e166d" lang="en" xmltv_id="">Aftershock</channel>
@@ -21,55 +20,45 @@
   <channel site="pluto.tv" site_id="66fd37885049580008d295b6" lang="en" xmltv_id="">AWSN</channel>
   <channel site="pluto.tv" site_id="62ac405b3874370007419b7f" lang="en" xmltv_id="">Barney &amp; Friends</channel>
   <channel site="pluto.tv" site_id="65a7b01907e03a0008913e8f" lang="en" xmltv_id="">Best of Dr. Phil</channel>
-  <channel site="pluto.tv" site_id="604f8f8622166000071a929f" lang="en" xmltv_id="BETPlutoTV.us@UK">BET Pluto TV</channel>
+  <channel site="pluto.tv" site_id="604f8f8622166000071a929f" lang="en" xmltv_id="BETPlutoTV.de@UK">BET Pluto TV</channel>
   <channel site="pluto.tv" site_id="611f85396abc84000738417b" lang="en" xmltv_id="BeyondBeliefFactorFiction.us@UK">Beyond Belief: Fact or Fiction</channel>
   <channel site="pluto.tv" site_id="63d91cc58795f30008678e9d" lang="en" xmltv_id="">Bloodline Detectives</channel>
   <channel site="pluto.tv" site_id="61559552dd585f0007321eca" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg TV+</channel>
   <channel site="pluto.tv" site_id="660be37e7bcd860008793a6a" lang="en" xmltv_id="">Bondi Rescue</channel>
-  <channel site="pluto.tv" site_id="650315163a0d700008bb07f8" lang="en" xmltv_id="">Born to Kill</channel>
-  <channel site="pluto.tv" site_id="686cd7bd8aeeaaa91a153161" lang="en" xmltv_id="">Britain&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="65031534d545e9000881ed10" lang="en" xmltv_id="">British Screen Classics</channel>
   <channel site="pluto.tv" site_id="6960c5a906d76f50db2816dc" lang="en" xmltv_id="">Cagney &amp; Lacey</channel>
-  <channel site="pluto.tv" site_id="65b3895660eb8700089e7f53" lang="en" xmltv_id="">Car Chase</channel>
   <channel site="pluto.tv" site_id="65a7af553af63d000828acca" lang="en" xmltv_id="">Cash In The Attic</channel>
   <channel site="pluto.tv" site_id="625eaebc2a73a00007d3f855" lang="en" xmltv_id="">Catfish</channel>
-  <channel site="pluto.tv" site_id="68e3bf7480f586b45f6fb563" lang="en" xmltv_id="">Catfish UK</channel>
   <channel site="pluto.tv" site_id="6231eb3865be650007f59595" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
   <channel site="pluto.tv" site_id="68c8202f5ec82769fdfcd0a2" lang="en" xmltv_id="">Chaos on Cam</channel>
-  <channel site="pluto.tv" site_id="66dff9d46ad04d0008fda4de" lang="en" xmltv_id="">CNN Headlines</channel>
+  <channel site="pluto.tv" site_id="66dff9d46ad04d0008fda4de" lang="en" xmltv_id="">CNN Headlines International</channel>
   <channel site="pluto.tv" site_id="66c45afaa72e7b0008a2b153" lang="en" xmltv_id="CNNInternational.us@MENA">CNNi</channel>
   <channel site="pluto.tv" site_id="6514346fa76507000887d441" lang="en" xmltv_id="">Confess by Nosey</channel>
   <channel site="pluto.tv" site_id="661cf62d24e1d000087dae0d" lang="en" xmltv_id="Cops.us@SD">COPS</channel>
   <channel site="pluto.tv" site_id="667d664815f35c00089489bf" lang="en" xmltv_id="">Corner Gas</channel>
-  <channel site="pluto.tv" site_id="5ea18cd42ee5410007e349dc" lang="en" xmltv_id="">Crime Investigation</channel>
-  <channel site="pluto.tv" site_id="63fe2ea349839300086d6d3e" lang="en" xmltv_id="">Crime Scene Solvers</channel>
   <channel site="pluto.tv" site_id="66ba1e23d2d50d00084a1e57" lang="en" xmltv_id="">Crimes That Shook Britain</channel>
+  <channel site="pluto.tv" site_id="650315163a0d700008bb07f8" lang="en" xmltv_id="">Criminal Confessions</channel>
   <channel site="pluto.tv" site_id="6304f8d5ffb61000071ab478" lang="en" xmltv_id="">CSI: Crime Scene Investigation</channel>
-  <channel site="pluto.tv" site_id="68b5a7b69ac85c428f54c441" lang="en" xmltv_id="">Curzon Cinema</channel>
+  <channel site="pluto.tv" site_id="68b5a7b69ac85c428f54c441" lang="en" xmltv_id="">Curzon</channel>
   <channel site="pluto.tv" site_id="65b14aae0cb1a100087a216e" lang="en" xmltv_id="">DAZN Ringside</channel>
   <channel site="pluto.tv" site_id="5ca1df0d50be2571e393ad31" lang="en" xmltv_id="DeadlyWomen.us@UK">Deadly Women</channel>
-  <channel site="pluto.tv" site_id="5d765984438d93d01eaf107f" lang="en" xmltv_id="DegrassiTheNextGeneration.us@US">Degrassi Next Gen</channel>
+  <channel site="pluto.tv" site_id="69c6a93486431735d974bc2a" lang="en" xmltv_id="">Deal Masters</channel>
+  <channel site="pluto.tv" site_id="69d51f98fcb9bf5e303ca0c1" lang="en" xmltv_id="">Dinner Date</channel>
   <channel site="pluto.tv" site_id="5f6b535a278bfe000799484a" lang="en" xmltv_id="DogtheBountyHunter.us@UK">Dog The Bounty Hunter</channel>
-  <channel site="pluto.tv" site_id="60e453641239a700071f53a1" lang="en" xmltv_id="DogWhisperer.us@UK">Dog Whisperer</channel>
   <channel site="pluto.tv" site_id="67d45617552472c78d0fd8c0" lang="en" xmltv_id="">Dog Whisperer VIDAA TEST</channel>
   <channel site="pluto.tv" site_id="685aa802fb6023de7cc56357" lang="en" xmltv_id="">Dominance FC TV</channel>
-  <channel site="pluto.tv" site_id="6882521ac258734a42a60ed0" lang="en" xmltv_id="WorldPokerTour.us">DP World Tour</channel>
   <channel site="pluto.tv" site_id="5f6b54b9e67cf60007d4cef1" lang="en" xmltv_id="DuckDynasty.us@UK">Duck Dynasty</channel>
   <channel site="pluto.tv" site_id="622f48de713e510007f85808" lang="en" xmltv_id="">Dynasty</channel>
   <channel site="pluto.tv" site_id="66f1331f9409630008077623" lang="en" xmltv_id="">Earth: Final Conflict</channel>
   <channel site="pluto.tv" site_id="63d91d624e83e7000881ca8c" lang="en" xmltv_id="">Escape to the Country</channel>
   <channel site="pluto.tv" site_id="5ca1da6c593a5d78f0e7edce" lang="en" xmltv_id="EuronewsEnglish.fr@SD">Euronews</channel>
   <channel site="pluto.tv" site_id="64c37e47dac71b000809abab" lang="en" xmltv_id="">Evidence of Evil</channel>
-  <channel site="pluto.tv" site_id="5ad8d883e738977e2c31096b" lang="en" xmltv_id="FailArmy.us@UK">FailArmy</channel>
-  <channel site="pluto.tv" site_id="620bb260821a860007b2d3df" lang="en" xmltv_id="FamilyTies.us@SD">Family Ties</channel>
   <channel site="pluto.tv" site_id="680bb31c56ff83bcd685d64e" lang="en" xmltv_id="Farscape.us@SD">Farscape</channel>
   <channel site="pluto.tv" site_id="5cb6f6f9a461406ffe4022cf" lang="en" xmltv_id="FBIFiles.us@UK">FBI Files</channel>
   <channel site="pluto.tv" site_id="63d91d2560bc8f0008a225e4" lang="en" xmltv_id="FIFAPlus.uk@English">FIFA+</channel>
   <channel site="pluto.tv" site_id="66a10eacfe11e500084c6925" lang="en" xmltv_id="">Flashpoint</channel>
-  <channel site="pluto.tv" site_id="5e78faa05a0e200007a6f487" lang="en" xmltv_id="FullCustomGarage.us@UK">Full Custom Garage</channel>
   <channel site="pluto.tv" site_id="65a6a5e90c7ff50008cb9815" lang="en" xmltv_id="FunnyAF.us@SD">Funny AF</channel>
   <channel site="pluto.tv" site_id="65c4960d11ced7000812c433" lang="en" xmltv_id="GeordieShore.us@Italy">Geordie Shore</channel>
-  <channel site="pluto.tv" site_id="5c45f5a9d40d58066869fa60" lang="en" xmltv_id="GhostDimension.us@UK">Ghost Dimension</channel>
   <channel site="pluto.tv" site_id="5f27bbe4779de70007a6d1c1" lang="en" xmltv_id="GhostHunters.us@UK">Ghost Hunters</channel>
   <channel site="pluto.tv" site_id="66ba1e4446762a000855cd87" lang="en" xmltv_id="GirlfriendsFilms.us@SD">Girlfriends</channel>
   <channel site="pluto.tv" site_id="68503d1736c9361b191e7d89" lang="en" xmltv_id="Gunsmoke.us@SD">Gunsmoke</channel>
@@ -78,139 +67,127 @@
   <channel site="pluto.tv" site_id="5e6f38792075160007d85823" lang="en" xmltv_id="HellsKitchen.us@UK">Hell&apos;s Kitchen</channel>
   <channel site="pluto.tv" site_id="68e38aaf8082ad3760def7bc" lang="en" xmltv_id="">Hercules: The Legendary Journeys</channel>
   <channel site="pluto.tv" site_id="6081738748d3200007afb24b" lang="en" xmltv_id="HighwaytoHeaven.us@UK">Highway to Heaven</channel>
+  <channel site="pluto.tv" site_id="65819fc1b9adc4000813f37d" lang="en" xmltv_id="">History Hunters</channel>
+  <channel site="pluto.tv" site_id="698a040b48d98175cb870fc5" lang="en" xmltv_id="">Hoarders</channel>
   <channel site="pluto.tv" site_id="5c5c2e9d8002db3c3e0b1c72" lang="en" xmltv_id="HomesUnderHammer.us@UK">Homes Under Hammer</channel>
   <channel site="pluto.tv" site_id="60e452730e76f20007598de8" lang="en" xmltv_id="HomicideHunter.us@UK">Homicide Hunter</channel>
-  <channel site="pluto.tv" site_id="64634eb42858cb0008fd92d6" lang="en" xmltv_id="">How To Use Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5c99f5810c95814ff92512f9" lang="en" xmltv_id="Hunter.us@UK">Hunter</channel>
+  <channel site="pluto.tv" site_id="64634eb42858cb0008fd92d6" lang="en" xmltv_id="HowToUsePlutoTV.de@UK">How To Use Pluto TV</channel>
+  <channel site="pluto.tv" site_id="68c82005be767928b4a8ef0c" lang="en" xmltv_id="">I Survived...</channel>
   <channel site="pluto.tv" site_id="68c8201b1e5aaf77c47d9605" lang="en" xmltv_id="">Ice Road Truckers</channel>
   <channel site="pluto.tv" site_id="686fc8fe1889b4ad04604704" lang="en" xmltv_id="">Icons Unearthed+</channel>
   <channel site="pluto.tv" site_id="61c49f1495f417000731cef0" lang="en" xmltv_id="InsideCrime.us@UK">Inside Crime</channel>
-  <channel site="pluto.tv" site_id="5d765786aad587cf4d0e2bf6" lang="en" xmltv_id="InspectorGadget.us@UK">Inspector Gadget</channel>
-  <channel site="pluto.tv" site_id="6193c353d46f7e0007cfb770" lang="en" xmltv_id="IronChef.us@UK">Iron Chef</channel>
   <channel site="pluto.tv" site_id="6900997e043e3df1897d017f" lang="en" xmltv_id="">Ironside</channel>
   <channel site="pluto.tv" site_id="660e5dc60cd4630008f6198a" lang="en" xmltv_id="">JAG</channel>
   <channel site="pluto.tv" site_id="622f498d119b4c000719c0b7" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">Judge Judy</channel>
-  <channel site="pluto.tv" site_id="620f6f9e36a49b000761f0d5" lang="en" xmltv_id="">Location, location, location</channel>
   <channel site="pluto.tv" site_id="68503d585965a2fd49fc2f0b" lang="en" xmltv_id="">MacGyver</channel>
-  <channel site="pluto.tv" site_id="5f6b51af068f49000746e432" lang="en" xmltv_id="">Master Chef Australia</channel>
   <channel site="pluto.tv" site_id="6850426e53d981d1fdb0d966" lang="en" xmltv_id="Matlock.us@SD">Matlock</channel>
   <channel site="pluto.tv" site_id="6852811933a52de120f8b89d" lang="en" xmltv_id="">Mayday Air Disaster</channel>
   <channel site="pluto.tv" site_id="68d113f9184f1a0620c8101c" lang="en" xmltv_id="">Medical Detectives</channel>
-  <channel site="pluto.tv" site_id="66275eed5e23700008f8c8f9" lang="en" xmltv_id="PlutoTVMelrosePlace.us">Melrose Place</channel>
+  <channel site="pluto.tv" site_id="691b453846ca5e6d1665f03b" lang="en" xmltv_id="">Meet, Marry, Murder</channel>
   <channel site="pluto.tv" site_id="67d4548f798df95b8e5e6d5d" lang="en" xmltv_id="">Melrose Place VIDAA TEST</channel>
   <channel site="pluto.tv" site_id="677fb3432952c1163bf1a539" lang="en" xmltv_id="">Million Dollar Listing</channel>
   <channel site="pluto.tv" site_id="62ab579258cb950007811aad" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
   <channel site="pluto.tv" site_id="67063e78b2ffb10008195d08" lang="en" xmltv_id="">MODUS Super Series Darts</channel>
-  <channel site="pluto.tv" site_id="620f6c60b994540007ddd74b" lang="en" xmltv_id="">Moesha</channel>
+  <channel site="pluto.tv" site_id="694178a8026be6e9d3ea7d7a" lang="en" xmltv_id="">Mona The Vampire</channel>
   <channel site="pluto.tv" site_id="68e3c18130ee729844af1fca" lang="en" xmltv_id="">Monkey</channel>
   <channel site="pluto.tv" site_id="639b558c73423d00071ce624" lang="en" xmltv_id="">More TV Crime</channel>
   <channel site="pluto.tv" site_id="645e00d5d3fdde000829463a" lang="en" xmltv_id="">More TV Sci-fi</channel>
   <channel site="pluto.tv" site_id="6081648340382e0007f73d45" lang="en" xmltv_id="MostHaunted.us@UK">Most Haunted</channel>
   <channel site="pluto.tv" site_id="68e3bffe1cfcd7541d59090f" lang="en" xmltv_id="">Most Haunted: Unseen</channel>
   <channel site="pluto.tv" site_id="6401d85a49839300087b116c" lang="en" xmltv_id="MovieSphere.us@SD">Moviesphere</channel>
-  <channel site="pluto.tv" site_id="5ad8d44cfd87eb3a2717afc5" lang="en" xmltv_id="MST3K.us@UK">MST3K</channel>
-  <channel site="pluto.tv" site_id="624edee2d6394a0007efcac4" lang="en" xmltv_id="PlutoTVMTV.us@SD">MTV Pluto TV</channel>
-  <channel site="pluto.tv" site_id="625eb3e245f5bc0007810046" lang="en" xmltv_id="">MTV Reality</channel>
+  <channel site="pluto.tv" site_id="624edee2d6394a0007efcac4" lang="en" xmltv_id="MTVPlutoTV.de@UK">MTV Pluto TV</channel>
   <channel site="pluto.tv" site_id="69038c2ee0e0c5f8208c033a" lang="en" xmltv_id="">Murdertown</channel>
-  <channel site="pluto.tv" site_id="66f12a69913b8e0008cc7365" lang="en" xmltv_id="MutantX.us@UK">Mutant X</channel>
   <channel site="pluto.tv" site_id="61c4a09d6c959f0007189c93" lang="en" xmltv_id="">Mystery TV</channel>
   <channel site="pluto.tv" site_id="5bd833b41843b56328bac189" lang="en" xmltv_id="Mythbusters.us@UK">Mythbusters</channel>
   <channel site="pluto.tv" site_id="63d91c9c8795f30008678e62" lang="en" xmltv_id="">Nature Time</channel>
-  <channel site="pluto.tv" site_id="6627623e307fa3000810b66e" lang="en" xmltv_id="">Ninja Warrior</channel>
   <channel site="pluto.tv" site_id="677fb0e93a225c2d0d8a45bf" lang="en" xmltv_id="">Northern Exposure</channel>
   <channel site="pluto.tv" site_id="5dc2ba1a9c91420009db4858" lang="en" xmltv_id="">Nosey</channel>
-  <channel site="pluto.tv" site_id="64c37e710e086a0009e824ab" lang="en" xmltv_id="">NOW 70&apos;s</channel>
-  <channel site="pluto.tv" site_id="6490254fd2c47c00083a5743" lang="en" xmltv_id="">Now 80&apos;s</channel>
   <channel site="pluto.tv" site_id="660c209e19ca71000846cf38" lang="en" xmltv_id="Now90s00s.uk@Poland">NOW 90s00s</channel>
   <channel site="pluto.tv" site_id="6568a78d635c3c0008765f41" lang="en" xmltv_id="NOWRock.uk@SD">Now Rock</channel>
   <channel site="pluto.tv" site_id="615af74dfe3d8e0007524511" lang="en" xmltv_id="OnTheCase.us@UK">On The Case</channel>
-  <channel site="pluto.tv" site_id="600ad9e56c609c0007e2b6d0" lang="en" xmltv_id="">Operation Repo</channel>
-  <channel site="pluto.tv" site_id="667ac79c15f35c00088a2409" lang="en" xmltv_id="">Outback Truckers</channel>
   <channel site="pluto.tv" site_id="60804d85858bd00007c5d591" lang="en" xmltv_id="ParanormalState.us@UK">Paranormal State</channel>
   <channel site="pluto.tv" site_id="66d885aef0f17500084b6750" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
-  <channel site="pluto.tv" site_id="619243059541940007d1ff86" lang="en" xmltv_id="PimpmyRide.us@UK">Pimp my Ride</channel>
-  <channel site="pluto.tv" site_id="66d717d2abec540008ba7ec4" lang="en" xmltv_id="">Pluto TV 80&apos;s Action</channel>
-  <channel site="pluto.tv" site_id="5dbfeb961b411c00090b52b3" lang="en" xmltv_id="PlutoTVAction.us@UK">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="64b67593798def00088e506e" lang="en" xmltv_id="PlutoTVAction.us@UK">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="62794647e3cbcb000757dc65" lang="en" xmltv_id="">Pluto TV Action+</channel>
-  <channel site="pluto.tv" site_id="6462190b7cb4b1000862dd60" lang="en" xmltv_id="">Pluto TV Alien Invasion</channel>
-  <channel site="pluto.tv" site_id="692ebafce72f03e07e7df985" lang="en" xmltv_id="">Pluto TV American True Crime</channel>
-  <channel site="pluto.tv" site_id="5ddf8ea0d000120009bcad83" lang="en" xmltv_id="PlutoTVAnimals.us@UK">Pluto TV Animals</channel>
-  <channel site="pluto.tv" site_id="612f761008a9e50007984ba0" lang="en" xmltv_id="PlutoTVAnimation.us@UK">Pluto TV Animation</channel>
-  <channel site="pluto.tv" site_id="625e8cb585ef320007806caf" lang="en" xmltv_id="">Pluto TV Britain at War</channel>
-  <channel site="pluto.tv" site_id="5d134a74ca91eedee1630faa" lang="en" xmltv_id="PlutoTVClassicTV.us@UK">Pluto TV Classic TV</channel>
-  <channel site="pluto.tv" site_id="5c363c2411c5ca053f198f97" lang="en" xmltv_id="">Pluto TV Comedy Movies</channel>
-  <channel site="pluto.tv" site_id="5d4ae94ef1a1bbb350ca41bb" lang="en" xmltv_id="PlutoTVConspiracy.us@UK">Pluto TV Conspiracy</channel>
-  <channel site="pluto.tv" site_id="5d767790d0438aceb41d03ae" lang="en" xmltv_id="PlutoTVCrime.us@UK">Pluto TV Crime</channel>
-  <channel site="pluto.tv" site_id="65a6a7a00c7ff50008cba07b" lang="en" xmltv_id="PlutoTVCrimeDrama.us@SD">Pluto TV Crime Drama</channel>
-  <channel site="pluto.tv" site_id="5bd8371b1843b56328bac33d" lang="en" xmltv_id="">Pluto TV Crime+</channel>
-  <channel site="pluto.tv" site_id="5c5c31f2f21b553c1f673fb0" lang="en" xmltv_id="PlutoTVCultFilms.us@UK">Pluto TV Cult Films</channel>
-  <channel site="pluto.tv" site_id="5ddf91149880d60009d35d27" lang="en" xmltv_id="PlutoTVDrama.us@UK">Pluto TV Drama</channel>
-  <channel site="pluto.tv" site_id="65a7ab137bdc8d0008487dfb" lang="en" xmltv_id="">Pluto TV Erotica</channel>
-  <channel site="pluto.tv" site_id="5dc3fc6b9133f500099c7d98" lang="en" xmltv_id="">Pluto TV Family Movie Club</channel>
-  <channel site="pluto.tv" site_id="685041d936c9361b1921c26c" lang="en" xmltv_id="">Pluto TV Fantasy &amp; Horror</channel>
-  <channel site="pluto.tv" site_id="5ddf930548ff9b00090d5686" lang="en" xmltv_id="PlutoTVFood.us@UK">Pluto TV Food</channel>
-  <channel site="pluto.tv" site_id="5d4af1803e7983b391d73b13" lang="en" xmltv_id="PlutoTVHistory.us@UK">Pluto TV History</channel>
-  <channel site="pluto.tv" site_id="612cda102f5f18000705e0bf" lang="en" xmltv_id="PlutoTVHorror.us@UK">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="5bb5c137fd5928058cd3a21f" lang="en" xmltv_id="">Pluto TV Inside+</channel>
-  <channel site="pluto.tv" site_id="63808dc806aa4700075f319a" lang="en" xmltv_id="PlutoTVInvestigation.us@France">Pluto TV Investigation</channel>
-  <channel site="pluto.tv" site_id="5ad8d54be738977e2c310940" lang="en" xmltv_id="PlutoTVKids.us@UK">Pluto TV Kids</channel>
-  <channel site="pluto.tv" site_id="5f3d26ac23a7c800073f128a" lang="en" xmltv_id="">Pluto TV Motor+</channel>
-  <channel site="pluto.tv" site_id="5ad8d3a31b95267e225e4e09" lang="en" xmltv_id="PlutoTVMovies.us@UK">Pluto TV Movies</channel>
-  <channel site="pluto.tv" site_id="5d4af2ffa9506ab29cf38c38" lang="en" xmltv_id="PlutoTVParanormal.us@UK">Pluto TV Paranormal</channel>
-  <channel site="pluto.tv" site_id="5f3d279ab48c0200072df9d0" lang="en" xmltv_id="">Pluto TV Paranormal+</channel>
-  <channel site="pluto.tv" site_id="65a7b0814a10d800085ff2df" lang="en" xmltv_id="">Pluto TV PetrolHeads</channel>
-  <channel site="pluto.tv" site_id="5bd8186d53ed2c6334ea0855" lang="en" xmltv_id="PlutoTVReality.us@UK">Pluto TV Reality</channel>
-  <channel site="pluto.tv" site_id="5c5c2b9d8002db3c3e0b1c6d" lang="en" xmltv_id="PlutoTVRetroToons.us@UK">Pluto TV Retro Toons</channel>
-  <channel site="pluto.tv" site_id="5c45f216e909d90674242965" lang="en" xmltv_id="">Pluto TV Romance+</channel>
-  <channel site="pluto.tv" site_id="5dc02a44a9518600094273ac" lang="en" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="64b676a4798def00088e5150" lang="en" xmltv_id="">Pluto TV Sci-Fi</channel>
-  <channel site="pluto.tv" site_id="619247c34a270700077c8415" lang="en" xmltv_id="">Pluto TV Sci-fi Series</channel>
-  <channel site="pluto.tv" site_id="5d9492c77ea6f99188738ff1" lang="en" xmltv_id="PlutoTVScience.us@UK">Pluto TV Science</channel>
-  <channel site="pluto.tv" site_id="5dc2c00abfed110009d97243" lang="en" xmltv_id="PlutoTVSherlock.us@UK">Pluto TV Sherlock</channel>
-  <channel site="pluto.tv" site_id="62f53dc6ee9a0400071dc22b" lang="en" xmltv_id="PlutoTVSitcoms.us@Germany">Pluto TV Sitcoms</channel>
-  <channel site="pluto.tv" site_id="655b7cbb2c46f300086f0afa" lang="en" xmltv_id="">Pluto TV Snooker 900</channel>
-  <channel site="pluto.tv" site_id="5dbc2f98777f2e0009934ae7" lang="en" xmltv_id="PlutoTVSpace.us@UK">Pluto TV Space</channel>
-  <channel site="pluto.tv" site_id="5dbfedccc563080009b60f4a" lang="en" xmltv_id="PlutoTVThrillers.us@UK">Pluto TV Thrillers</channel>
-  <channel site="pluto.tv" site_id="5d4bdb635ce813b38639e6a3" lang="en" xmltv_id="PlutoTVWesterns.us@UK">Pluto TV Westerns</channel>
-  <channel site="pluto.tv" site_id="65f0166566eec80008b96f7e" lang="en" xmltv_id="">Pluto TV Wildest Adventures</channel>
+  <channel site="pluto.tv" site_id="66d717d2abec540008ba7ec4" lang="en" xmltv_id="PlutoTV80sAction.de@UK">Pluto TV 80&apos;s Action</channel>
+  <channel site="pluto.tv" site_id="5dbfeb961b411c00090b52b3" lang="en" xmltv_id="PlutoTVAction.de@UK">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="64b67593798def00088e506e" lang="en" xmltv_id="PlutoTVAction.de@UKPlus2">Pluto TV Action</channel>
+  <channel site="pluto.tv" site_id="62794647e3cbcb000757dc65" lang="en" xmltv_id="PlutoTVAction.de@UKPlus">Pluto TV Action+</channel>
+  <channel site="pluto.tv" site_id="6462190b7cb4b1000862dd60" lang="en" xmltv_id="PlutoTVAlienInvasion.de@UK">Pluto TV Alien Invasion</channel>
+  <channel site="pluto.tv" site_id="692ebafce72f03e07e7df985" lang="en" xmltv_id="PlutoTVAmericanTrueCrime.de@UK">Pluto TV American True Crime</channel>
+  <channel site="pluto.tv" site_id="5ddf8ea0d000120009bcad83" lang="en" xmltv_id="PlutoTVAnimals.de@UK">Pluto TV Animals</channel>
+  <channel site="pluto.tv" site_id="612f761008a9e50007984ba0" lang="en" xmltv_id="PlutoTVAnimation.de@UK">Pluto TV Animation</channel>
+  <channel site="pluto.tv" site_id="625e8cb585ef320007806caf" lang="en" xmltv_id="PlutoTVBritainatWar.de@UK">Pluto TV Britain at War</channel>
+  <channel site="pluto.tv" site_id="5d134a74ca91eedee1630faa" lang="en" xmltv_id="PlutoTVClassicTV.de@UK">Pluto TV Classic TV</channel>
+  <channel site="pluto.tv" site_id="5c363c2411c5ca053f198f97" lang="en" xmltv_id="PlutoTVComedyMovies.de@UK">Pluto TV Comedy Movies</channel>
+  <channel site="pluto.tv" site_id="5d4ae94ef1a1bbb350ca41bb" lang="en" xmltv_id="PlutoTVConspiracy.de@UK">Pluto TV Conspiracy</channel>
+  <channel site="pluto.tv" site_id="5d767790d0438aceb41d03ae" lang="en" xmltv_id="PlutoTVCrime.de@UK">Pluto TV Crime</channel>
+  <channel site="pluto.tv" site_id="65a6a7a00c7ff50008cba07b" lang="en" xmltv_id="PlutoTVCrimeDrama.de@UK">Pluto TV Crime Drama</channel>
+  <channel site="pluto.tv" site_id="5bd8371b1843b56328bac33d" lang="en" xmltv_id="PlutoTVCrime.de@UKPlus">Pluto TV Crime+</channel>
+  <channel site="pluto.tv" site_id="5c5c31f2f21b553c1f673fb0" lang="en" xmltv_id="PlutoTVCultFilms.de@UK">Pluto TV Cult Films</channel>
+  <channel site="pluto.tv" site_id="5ddf91149880d60009d35d27" lang="en" xmltv_id="PlutoTVDrama.de@UK">Pluto TV Drama</channel>
+  <channel site="pluto.tv" site_id="65a7ab137bdc8d0008487dfb" lang="en" xmltv_id="PlutoTVErotica.de@UK">Pluto TV Erotica</channel>
+  <channel site="pluto.tv" site_id="5dc3fc6b9133f500099c7d98" lang="en" xmltv_id="PlutoTVFamilyMovieClub.de@UK">Pluto TV Family Movie Club</channel>
+  <channel site="pluto.tv" site_id="685041d936c9361b1921c26c" lang="en" xmltv_id="PlutoTVFantasyHorror.de@UK">Pluto TV Fantasy &amp; Horror</channel>
+  <channel site="pluto.tv" site_id="5ddf930548ff9b00090d5686" lang="en" xmltv_id="PlutoTVFood.de@UK">Pluto TV Food</channel>
+  <channel site="pluto.tv" site_id="5d4af1803e7983b391d73b13" lang="en" xmltv_id="PlutoTVHistory.de@UK">Pluto TV History</channel>
+  <channel site="pluto.tv" site_id="612cda102f5f18000705e0bf" lang="en" xmltv_id="PlutoTVHorror.de@UK">Pluto TV Horror</channel>
+  <channel site="pluto.tv" site_id="5bb5c137fd5928058cd3a21f" lang="en" xmltv_id="PlutoTVInside.de@UKPlus">Pluto TV Inside+</channel>
+  <channel site="pluto.tv" site_id="63808dc806aa4700075f319a" lang="en" xmltv_id="PlutoTVInvestigation.de@UK">Pluto TV Investigation</channel>
+  <channel site="pluto.tv" site_id="5ad8d54be738977e2c310940" lang="en" xmltv_id="PlutoTVKids.de@UK">Pluto TV Kids</channel>
+  <channel site="pluto.tv" site_id="5f3d26ac23a7c800073f128a" lang="en" xmltv_id="PlutoTVMotor.de@UKPlus">Pluto TV Motor+</channel>
+  <channel site="pluto.tv" site_id="5ad8d3a31b95267e225e4e09" lang="en" xmltv_id="PlutoTVMovies.de@UK">Pluto TV Movies</channel>
+  <channel site="pluto.tv" site_id="5d4af2ffa9506ab29cf38c38" lang="en" xmltv_id="PlutoTVParanormal.de@UK">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="5f3d279ab48c0200072df9d0" lang="en" xmltv_id="PlutoTVParanormal.de@UKPlus">Pluto TV Paranormal+</channel>
+  <channel site="pluto.tv" site_id="65a7b0814a10d800085ff2df" lang="en" xmltv_id="PlutoTVPetrolHeads.de@UK">Pluto TV PetrolHeads</channel>
+  <channel site="pluto.tv" site_id="5bd8186d53ed2c6334ea0855" lang="en" xmltv_id="PlutoTVReality.de@UK">Pluto TV Reality</channel>
+  <channel site="pluto.tv" site_id="5c5c2b9d8002db3c3e0b1c6d" lang="en" xmltv_id="PlutoTVRetroToons.de@UK">Pluto TV Retro Toons</channel>
+  <channel site="pluto.tv" site_id="5c45f216e909d90674242965" lang="en" xmltv_id="PlutoTVRomance.de@UKPlus">Pluto TV Romance+</channel>
+  <channel site="pluto.tv" site_id="5dc02a44a9518600094273ac" lang="en" xmltv_id="PlutoTVSciFi.de@UK">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="64b676a4798def00088e5150" lang="en" xmltv_id="PlutoTVSciFi.de@UKPlus">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="619247c34a270700077c8415" lang="en" xmltv_id="PlutoTVScifiSeries.de@UK">Pluto TV Sci-fi Series</channel>
+  <channel site="pluto.tv" site_id="5d9492c77ea6f99188738ff1" lang="en" xmltv_id="PlutoTVScience.de@UK">Pluto TV Science</channel>
+  <channel site="pluto.tv" site_id="5dc2c00abfed110009d97243" lang="en" xmltv_id="PlutoTVSherlock.de@UK">Pluto TV Sherlock</channel>
+  <channel site="pluto.tv" site_id="62f53dc6ee9a0400071dc22b" lang="en" xmltv_id="PlutoTVSitcoms.de@UK">Pluto TV Sitcoms</channel>
+  <channel site="pluto.tv" site_id="655b7cbb2c46f300086f0afa" lang="en" xmltv_id="PlutoTVSnooker900.de@UK">Pluto TV Snooker 900</channel>
+  <channel site="pluto.tv" site_id="5dbc2f98777f2e0009934ae7" lang="en" xmltv_id="PlutoTVSpace.de@UK">Pluto TV Space</channel>
+  <channel site="pluto.tv" site_id="5dbfedccc563080009b60f4a" lang="en" xmltv_id="PlutoTVThrillers.de@UK">Pluto TV Thrillers</channel>
+  <channel site="pluto.tv" site_id="600acaff5f2d6e000745effb" lang="en" xmltv_id="PlutoTVToughJobs.de@UK">Pluto TV Tough Jobs</channel>
+  <channel site="pluto.tv" site_id="5d4bdb635ce813b38639e6a3" lang="en" xmltv_id="PlutoTVWesterns.de@UK">Pluto TV Westerns</channel>
   <channel site="pluto.tv" site_id="6683cd71a1d7ad000866ec6a" lang="en" xmltv_id="PlutoTVPokemon.us@UK">Pokémon</channel>
   <channel site="pluto.tv" site_id="664c94e80120f40008b860f0" lang="en" xmltv_id="">POP</channel>
   <channel site="pluto.tv" site_id="66d82143abec540008bd2b1c" lang="en" xmltv_id="">Project Runway</channel>
-  <channel site="pluto.tv" site_id="63fe249f49839300086d4888" lang="en" xmltv_id="">Punk&apos;d</channel>
-  <channel site="pluto.tv" site_id="68503da136c9361b191f9366" lang="en" xmltv_id="">Rawhide</channel>
+  <channel site="pluto.tv" site_id="696e024a7e92438c27a425a8" lang="en" xmltv_id="">Rally TV</channel>
   <channel site="pluto.tv" site_id="68e3b6112baff9f069d02540" lang="en" xmltv_id="">Relic Hunter</channel>
-  <channel site="pluto.tv" site_id="68e3b8c846e8a33b6839e981" lang="en" xmltv_id="">Renegade</channel>
   <channel site="pluto.tv" site_id="682453731295f98347e92da8" lang="en" xmltv_id="">River Monsters</channel>
   <channel site="pluto.tv" site_id="63fe2ec4dff38e000835f786" lang="en" xmltv_id="">Rookie Blue</channel>
   <channel site="pluto.tv" site_id="66f137cb483d460008ece053" lang="en" xmltv_id="RugbyPassTV.uk@SD">Rugby Pass TV</channel>
   <channel site="pluto.tv" site_id="66276091cee0d900085fe053" lang="en" xmltv_id="SabrinaTeenageWitch.us@UK">Sabrina The Teenage Witch</channel>
   <channel site="pluto.tv" site_id="63d000ef4e83e700086e0d6c" lang="en" xmltv_id="">Scorpion</channel>
   <channel site="pluto.tv" site_id="5e9ed47c26ebb000074af566" lang="en" xmltv_id="SensingMurder.us@UK">Sensing Murder</channel>
+  <channel site="pluto.tv" site_id="6981cc6a644861a57c3bd8ad" lang="en" xmltv_id="">Shockwave</channel>
   <channel site="pluto.tv" site_id="6695294632e25300084bb61b" lang="en" xmltv_id="">Sister, Sister</channel>
   <channel site="pluto.tv" site_id="68e38b005c876cf730fcbf0f" lang="en" xmltv_id="">Six Million Dollar Man</channel>
   <channel site="pluto.tv" site_id="64edf6eaa7ec0d000812f58c" lang="en" xmltv_id="SouthPark.us@France">South Park</channel>
-  <channel site="pluto.tv" site_id="5bd81b1053ed2c6334ea0856" lang="en" xmltv_id="Strongman.us@UK">Strongman</channel>
+  <channel site="pluto.tv" site_id="68d67005bdb33359705bbed3" lang="en" xmltv_id="">SUMO Paris 2026</channel>
+  <channel site="pluto.tv" site_id="697a2f8b3991484f03064614" lang="en" xmltv_id="">Super Mario Bros.</channel>
   <channel site="pluto.tv" site_id="6850408053d981d1fdb01696" lang="en" xmltv_id="">Taxi</channel>
   <channel site="pluto.tv" site_id="62d550d81054990007db7798" lang="en" xmltv_id="TeenMom.us@SD">Teen Mom</channel>
-  <channel site="pluto.tv" site_id="68e3bf280989820fd0c7228a" lang="en" xmltv_id="">Teen Mom UK</channel>
   <channel site="pluto.tv" site_id="66a10eeb46762a0008201e85" lang="en" xmltv_id="Teletubbies.uk@SD">Teletubbies</channel>
   <channel site="pluto.tv" site_id="6627621d56fc840008e47c90" lang="en" xmltv_id="TennisChannel.us@SD">Tennis Channel</channel>
+  <channel site="pluto.tv" site_id="64c37e710e086a0009e824ab" lang="en" xmltv_id="">That&apos;s 70s</channel>
+  <channel site="pluto.tv" site_id="6490254fd2c47c00083a5743" lang="en" xmltv_id="">That&apos;s 80s</channel>
   <channel site="pluto.tv" site_id="677fb08f5b68381e2dbfd5af" lang="en" xmltv_id="">The Bionic Woman</channel>
   <channel site="pluto.tv" site_id="66e06576abec540008cc17a9" lang="en" xmltv_id="">The Graham Norton Show</channel>
   <channel site="pluto.tv" site_id="66ebf9bc55567d0008de3b29" lang="en" xmltv_id="">The Hotel Inspector</channel>
   <channel site="pluto.tv" site_id="68e38b6e20115bbaf9c91083" lang="en" xmltv_id="">The Incredible Hulk</channel>
-  <channel site="pluto.tv" site_id="66275e41cee0d900085fde6e" lang="en" xmltv_id="TheLoveBoat.us@SD">The Love Boat</channel>
   <channel site="pluto.tv" site_id="5e393d5c696b3b0009775c8b" lang="en" xmltv_id="TheNewDetectives.us@UK">The New Detectives</channel>
-  <channel site="pluto.tv" site_id="691729bdda5b5095ab1818fd" lang="en" xmltv_id="">The Pink Panther</channel>
+  <channel site="pluto.tv" site_id="69b422590306b277746f48cb" lang="en" xmltv_id="">The Raccoons</channel>
   <channel site="pluto.tv" site_id="677fb115a4af36ad50113e56" lang="en" xmltv_id="">The Real Housewives</channel>
   <channel site="pluto.tv" site_id="68b5a97fc8ef6afa31138718" lang="en" xmltv_id="">The Smurfs</channel>
-  <channel site="pluto.tv" site_id="5f6b5568dfb9ee0007f3a389" lang="en" xmltv_id="">The Wahlburgers</channel>
+  <channel site="pluto.tv" site_id="69b917d632eb9227dd6b427e" lang="en" xmltv_id="">The Therapy Crouch</channel>
   <channel site="pluto.tv" site_id="68e8ffee9d1d49e672fe790f" lang="en" xmltv_id="">The Yellow Couch with Jeremy Lynch</channel>
   <channel site="pluto.tv" site_id="677fb137a5d8215f99b9cc06" lang="en" xmltv_id="">Top Chef</channel>
   <channel site="pluto.tv" site_id="656ef4af4261ca00083c8f37" lang="en" xmltv_id="TotallyTurtles.us@US">Totally Turtles</channel>
   <channel site="pluto.tv" site_id="68504098f212bedacf63a7e1" lang="en" xmltv_id="">Touched by an Angel</channel>
-  <channel site="pluto.tv" site_id="63d8ed19a9957100086f4d33" lang="en" xmltv_id="">Transformers</channel>
   <channel site="pluto.tv" site_id="65a7b04e7bdc8d0008488307" lang="en" xmltv_id="">True Crime Now</channel>
   <channel site="pluto.tv" site_id="6304fb268bd95300072d2198" lang="en" xmltv_id="TrueCrime.uk@SD">True Crime UK</channel>
   <channel site="pluto.tv" site_id="64c0d6f34096290008132d6b" lang="en" xmltv_id="">U&amp;Laughs</channel>
@@ -220,8 +197,8 @@
   <channel site="pluto.tv" site_id="66ed3e9d5e4a6e0008b346e0" lang="en" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="5bd05b4694d45d266bc951f2" lang="en" xmltv_id="UnsolvedMysteries.us@UK">Unsolved Mysteries</channel>
   <channel site="pluto.tv" site_id="68e3c37c19f32ffa27bae948" lang="en" xmltv_id="">Unsolved Mysteries with Dennis Farina</channel>
-  <channel site="pluto.tv" site_id="68e3bfc6c5a50ef76a2393d2" lang="en" xmltv_id="">Wardens</channel>
   <channel site="pluto.tv" site_id="65819f83a620e300080f692a" lang="en" xmltv_id="">Weird or What? With William Shatner</channel>
+  <channel site="pluto.tv" site_id="672cb91149c40600081cbee5" lang="en" xmltv_id="">Whose Line Is It Anyway?</channel>
   <channel site="pluto.tv" site_id="63693fa2bfa0690007ebc880" lang="en" xmltv_id="">Wicked Tuna</channel>
   <channel site="pluto.tv" site_id="60817936fd2d70000763d2b2" lang="en" xmltv_id="WildatHeart.us@UK">Wild at Heart</channel>
   <channel site="pluto.tv" site_id="5ad8d796e738977e2c31094a" lang="en" xmltv_id="WorldPokerTour.us@UK">World Poker Tour</channel>

--- a/sites/pluto.tv/pluto.tv_us.channels.xml
+++ b/sites/pluto.tv/pluto.tv_us.channels.xml
@@ -198,7 +198,7 @@
   <channel site="pluto.tv" site_id="65e23f340d4561000821540d" lang="en" xmltv_id="">Mister Rogers&apos; Neighborhood</channel>
   <channel site="pluto.tv" site_id="5e66968a70f34c0007d050be" lang="en" xmltv_id="MLB.us@SD">MLB</channel>
   <channel site="pluto.tv" site_id="65775d29dfed030008cb3db2" lang="en" xmltv_id="">Modern Marvels by HISTORY</channel>
-  <channel site="pluto.tv" site_id="65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.pl@SD">Monster Jam</channel>
+  <channel site="pluto.tv" site_id="65c69b683ba51e00084534a3" lang="en" xmltv_id="MonsterJam.us@SD">Monster Jam</channel>
   <channel site="pluto.tv" site_id="6532e6a9bdf3cf000887ab29" lang="en" xmltv_id="">More True Crime</channel>
   <channel site="pluto.tv" site_id="613260e4bdb71c00070d63fa" lang="en" xmltv_id="MoreTVDrama.us@SD">More TV Drama</channel>
   <channel site="pluto.tv" site_id="6132619f9ddaa50007e7dd86" lang="en" xmltv_id="MoreTVSitcoms.us@SD">More TV Sitcoms</channel>
@@ -240,7 +240,7 @@
   <channel site="pluto.tv" site_id="640a64bd73e013000893d4e0" lang="en" xmltv_id="PBSNature.us@SD">PBS Nature</channel>
   <channel site="pluto.tv" site_id="5d14fb6c84dd37df3b4290c5" lang="en" xmltv_id="">Peppa Pig</channel>
   <channel site="pluto.tv" site_id="6197086891ddd4000739941a" lang="en" xmltv_id="PerryMason.us@SD">Perry Mason</channel>
-  <channel site="pluto.tv" site_id="6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="pluto.tv" site_id="6334a574605f140007e233c4" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="pluto.tv" site_id="5de94dacb394a300099fa22a" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="6565413e4261ca0008215320" lang="en" xmltv_id="">Pickers &amp; Pawn</channel>
   <channel site="pluto.tv" site_id="561d7d484dc7c8770484914a" lang="en" xmltv_id="PlutoTVAction.us@US">Pluto TV Action</channel>

--- a/sites/pluto.tv/pluto.tv_us.channels.xml
+++ b/sites/pluto.tv/pluto.tv_us.channels.xml
@@ -13,19 +13,22 @@
   <channel site="pluto.tv" site_id="6508be683a0d700008c534e4" lang="en" xmltv_id="ABCNewsLive.us@SD">ABC News Live</channel>
   <channel site="pluto.tv" site_id="5e82530945600e0007ca076c" lang="en" xmltv_id="AllRealitybyWEtv.us@SD">All Reality WE tv</channel>
   <channel site="pluto.tv" site_id="6793ea255225b515b4ba91a7" lang="en" xmltv_id="ALLBLKGems.us@SD">ALLBLK Gems</channel>
+  <channel site="pluto.tv" site_id="69eaa34817801c84fca05d94" lang="en" xmltv_id="">Always Funny</channel>
   <channel site="pluto.tv" site_id="691cf0410a78a9ce61ad2121" lang="en" xmltv_id="">America&apos;s Funniest Home Videos</channel>
   <channel site="pluto.tv" site_id="68757c45759366af05b3b199" lang="en" xmltv_id="">America&apos;s Next Top Model</channel>
   <channel site="pluto.tv" site_id="5e84f54a82f05300080e6746" lang="en" xmltv_id="AmericasTestKitchen.us@SD">America&apos;s Test Kitchen</channel>
   <channel site="pluto.tv" site_id="5e1f7da4bc7d740009831259" lang="en" xmltv_id="AmericasVoiceNews.us@SD">America&apos;s Voice News</channel>
   <channel site="pluto.tv" site_id="65492fc7056b9700088560b5" lang="en" xmltv_id="">American Crimes</channel>
   <channel site="pluto.tv" site_id="6887a8fd8e92b5e0a7244e88" lang="en" xmltv_id="">Ancient Aliens</channel>
-  <channel site="pluto.tv" site_id="6793eaa4bc03978b9bc63db1" lang="en" xmltv_id="">ANIME x HIDIVE</channel>
+  <channel site="pluto.tv" site_id="66c638726838ee00085ac20d" lang="en" xmltv_id="">Andromeda</channel>
+  <channel site="pluto.tv" site_id="6793eaa4bc03978b9bc63db1" lang="en" xmltv_id="AnimexHIDIVE.us@SD">ANIME x HIDIVE</channel>
   <channel site="pluto.tv" site_id="615b8ec39e878900073f419a" lang="en" xmltv_id="AntiquesRoadTrip.us@SD">Antiques Road Trip</channel>
   <channel site="pluto.tv" site_id="5ce44810b421747ae467b7cd" lang="en" xmltv_id="AntiquesRoadshowUK.us@SD">Antiques Roadshow UK</channel>
   <channel site="pluto.tv" site_id="682e43b21295f98347710917" lang="en" xmltv_id="">AWSN</channel>
   <channel site="pluto.tv" site_id="60faffc3fbbc120007fc4376" lang="en" xmltv_id="BabySharkTV.us@SD">Baby Shark TV</channel>
   <channel site="pluto.tv" site_id="654932fa4d6d8f00084c4723" lang="en" xmltv_id="">Bad Girls Club</channel>
   <channel site="pluto.tv" site_id="60a3d889a5b3690008dc7fe8" lang="en" xmltv_id="BarRescue.us@SD">Bar Rescue</channel>
+  <channel site="pluto.tv" site_id="69d7ebff029c431826bd328e" lang="en" xmltv_id="">Battlestar Galactica</channel>
   <channel site="pluto.tv" site_id="656535fc2c46f30008870fae" lang="en" xmltv_id="BBCEarth.uk@US">BBC Earth</channel>
   <channel site="pluto.tv" site_id="65d92a8c8b24c80008e285c0" lang="en" xmltv_id="BBCNews.uk@Africa">BBC News</channel>
   <channel site="pluto.tv" site_id="68bb162bb3900870ec364cbe" lang="en" xmltv_id="">Beach Day</channel>
@@ -50,29 +53,36 @@
   <channel site="pluto.tv" site_id="54ff7ba69222cb1c2624c584" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg TV+</channel>
   <channel site="pluto.tv" site_id="61b3b8c645b45d0007a9bb8d" lang="en" xmltv_id="BlueBloods.us@SD">Blue Bloods</channel>
   <channel site="pluto.tv" site_id="68e9913c4a666b9054849832" lang="en" xmltv_id="">Bonanza</channel>
+  <channel site="pluto.tv" site_id="696997049889f8db34c936c2" lang="en" xmltv_id="">Boruto: Naruto Next Generations</channel>
+  <channel site="pluto.tv" site_id="632b62b3982d0d000755a2be" lang="en" xmltv_id="">Boston 25</channel>
   <channel site="pluto.tv" site_id="6176fd25e83a5f0007a464c9" lang="en" xmltv_id="BounceXL.us@SD">Bounce XL</channel>
   <channel site="pluto.tv" site_id="6549310a53fc97000838fcc9" lang="en" xmltv_id="">Bravo Vault</channel>
   <channel site="pluto.tv" site_id="60f5d389985a0c0007357304" lang="en" xmltv_id="BritBoxMysteries.us@SD">BritBox Mysteries</channel>
   <channel site="pluto.tv" site_id="5812bfbe4ced4f7b601b12e6" lang="en" xmltv_id="Buzzr.us@SD">BUZZR</channel>
   <channel site="pluto.tv" site_id="65244c403fd33c0008ffff31" lang="en" xmltv_id="">Car Chase</channel>
   <channel site="pluto.tv" site_id="5a6b92f6e22a617379789618" lang="en" xmltv_id="CBSNews247.us@SD">CBS News 24/7</channel>
+  <channel site="pluto.tv" site_id="62cdcdf7393d8400076f3df1" lang="en" xmltv_id="">CBS News Baltimore</channel>
   <channel site="pluto.tv" site_id="60f75919718aed0007250d7a" lang="en" xmltv_id="CBSNewsBaltimore.us@SD">CBS News Baltimore</channel>
-  <channel site="pluto.tv" site_id="5eb1afb21486df0007abc57c" lang="en" xmltv_id="CBSNewsBayArea.us@SD">CBS News Bay Area</channel>
   <channel site="pluto.tv" site_id="62cdc6c5a698740007d299b1" lang="en" xmltv_id="">CBS News Bay Area</channel>
+  <channel site="pluto.tv" site_id="5eb1afb21486df0007abc57c" lang="en" xmltv_id="CBSNewsBayArea.us@SD">CBS News Bay Area</channel>
+  <channel site="pluto.tv" site_id="62cdc7c2a3e6270007f3f2f3" lang="en" xmltv_id="">CBS News Boston</channel>
   <channel site="pluto.tv" site_id="5eb1af2ad345340008fccd1e" lang="en" xmltv_id="CBSNewsBoston.us@SD">CBS News Boston</channel>
   <channel site="pluto.tv" site_id="5eb1aeb2fd4b8a00076c2047" lang="en" xmltv_id="CBSNewsChicago.us@SD">CBS News Chicago</channel>
+  <channel site="pluto.tv" site_id="62cdc8709e20de00073045a5" lang="en" xmltv_id="">CBS News Colorado</channel>
   <channel site="pluto.tv" site_id="5eb1b12146cba40007aa7e5d" lang="en" xmltv_id="CBSNewsColorado.us@SD">CBS News Colorado</channel>
   <channel site="pluto.tv" site_id="634f2610d5023700078f7dee" lang="en" xmltv_id="CBSNewsDetroit.us@SD">CBS News Detroit</channel>
-  <channel site="pluto.tv" site_id="5dc481cda1d430000948a1b4" lang="en" xmltv_id="CBSNewsLosAngeles.us@SD">CBS News Los Angeles</channel>
   <channel site="pluto.tv" site_id="5dc9b875e280c80009a8a44a" lang="en" xmltv_id="CBSNewsLosAngeles.us@SD">CBS News Los Angeles</channel>
+  <channel site="pluto.tv" site_id="5dc481cda1d430000948a1b4" lang="en" xmltv_id="CBSNewsLosAngeles.us@SD">CBS News Los Angeles</channel>
   <channel site="pluto.tv" site_id="60fb299b79498900070b29e0" lang="en" xmltv_id="CBSNewsMiami.us@SD">CBS News Miami</channel>
+  <channel site="pluto.tv" site_id="62cdc8fdb05d2b0007ef5035" lang="en" xmltv_id="">CBS News Miami</channel>
   <channel site="pluto.tv" site_id="5eb1b0bf2240d8000732a09c" lang="en" xmltv_id="CBSNewsMinnesota.us@SD">CBS News Minnesota</channel>
-  <channel site="pluto.tv" site_id="62cdc9902466010007383d1a" lang="en" xmltv_id="CBSNewsMinnesota.us@SD">CBS News Minnesota</channel>
   <channel site="pluto.tv" site_id="5dc48170e280c80009a861ab" lang="en" xmltv_id="CBSNewsNewYork.us@SD">CBS News New York</channel>
   <channel site="pluto.tv" site_id="5dc9b8223687ff000936ed79" lang="en" xmltv_id="CBSNewsNewYork.us@SD">CBS News New York</channel>
+  <channel site="pluto.tv" site_id="62cdca1cda044a00077b903d" lang="en" xmltv_id="">CBS News Philadelphia</channel>
   <channel site="pluto.tv" site_id="5eb1b05ea168cc000767ba67" lang="en" xmltv_id="">CBS News Philadelphia</channel>
   <channel site="pluto.tv" site_id="5eb1b17aa5277e00083f6521" lang="en" xmltv_id="CBSNewsPittsburgh.us@SD">CBS News Pittsburgh</channel>
   <channel site="pluto.tv" site_id="60cb6df2b2ad610008cd5bea" lang="en" xmltv_id="CBSNewsSacramento.us@SD">CBS News Sacramento</channel>
+  <channel site="pluto.tv" site_id="62cdc813f5def500070361eb" lang="en" xmltv_id="">CBS News Texas</channel>
   <channel site="pluto.tv" site_id="5eceb0d4065c240007688ec6" lang="en" xmltv_id="">CBS News Texas</channel>
   <channel site="pluto.tv" site_id="5e9f2c05172a0f0007db4786" lang="en" xmltv_id="CBSSportsHQ.us@SD">CBS Sports HQ</channel>
   <channel site="pluto.tv" site_id="627d355aa95efd00077afcc7" lang="en" xmltv_id="">Cheaters</channel>
@@ -84,8 +94,9 @@
   <channel site="pluto.tv" site_id="5f15e32b297f96000768f928" lang="en" xmltv_id="ClassicTVComedy.us@SD">Classic TV Comedy</channel>
   <channel site="pluto.tv" site_id="61325c4f982acd000723287e" lang="en" xmltv_id="">Classic TV Crime Drama</channel>
   <channel site="pluto.tv" site_id="5f15e3cccf49290007053c67" lang="en" xmltv_id="ClassicTVDrama.us@SD">Classic TV Drama</channel>
-  <channel site="pluto.tv" site_id="61325d18f5166c00081b84e0" lang="en" xmltv_id="ClassicTVFamilies.us@SD">Classic TV: Families</channel>
+  <channel site="pluto.tv" site_id="61325d18f5166c00081b84e0" lang="en" xmltv_id="ClassicTVFamilies.us@US">Classic TV: Families</channel>
   <channel site="pluto.tv" site_id="5f779951372da90007fd45e8" lang="en" xmltv_id="Classica.us@SD">Classica</channel>
+  <channel site="pluto.tv" site_id="5f9b017d037a30000730c68e" lang="en" xmltv_id="">Closed Caption Test 3</channel>
   <channel site="pluto.tv" site_id="5f68f53eb1e5800007390bf8" lang="en" xmltv_id="CMTEqualPlay.us@SD">CMT Equal Play</channel>
   <channel site="pluto.tv" site_id="5421f71da6af422839419cb3" lang="en" xmltv_id="">CNN HEADLINES</channel>
   <channel site="pluto.tv" site_id="66e0b4536ad04d0008fff4b2" lang="en" xmltv_id="">CNN Originals</channel>
@@ -115,7 +126,6 @@
   <channel site="pluto.tv" site_id="6675c713fc3a46000863dde7" lang="en" xmltv_id="">Ebony TV Drama</channel>
   <channel site="pluto.tv" site_id="691d1200c2185a44642f5e7c" lang="en" xmltv_id="">El Rey Rebel</channel>
   <channel site="pluto.tv" site_id="5dc0c78281eddb0009a02d5e" lang="en" xmltv_id="EntertainmentTonight.us@SD">ET</channel>
-  <channel site="pluto.tv" site_id="65c69ee3d77d450008c80438" lang="en" xmltv_id="">F1 Channel</channel>
   <channel site="pluto.tv" site_id="554158e864526b29254ff105" lang="en" xmltv_id="FailArmy.us@US">FailArmy</channel>
   <channel site="pluto.tv" site_id="672e4d915534bb0008c50168" lang="en" xmltv_id="">Family Feud</channel>
   <channel site="pluto.tv" site_id="643f03b9d8436e0008edf021" lang="en" xmltv_id="">Family Feud Classic</channel>
@@ -125,18 +135,24 @@
   <channel site="pluto.tv" site_id="58e55b14ad8e9c364d55f717" lang="en" xmltv_id="FlicksofFury.us@SD">Flicks of Fury</channel>
   <channel site="pluto.tv" site_id="5bb1af6a268cae539bcedb0a" lang="en" xmltv_id="ForensicFiles.us@SD">Forensic Files</channel>
   <channel site="pluto.tv" site_id="56171fafada51f8004c4b40f" lang="en" xmltv_id="ForeverKids.us@SD">Forever Kids</channel>
+  <channel site="pluto.tv" site_id="667f2c0aefa2a10008e1a7fa" lang="en" xmltv_id="">FOX LOCAL Dallas - Fort Worth</channel>
+  <channel site="pluto.tv" site_id="667f2d2015f35c00089ace8b" lang="en" xmltv_id="">FOX LOCAL Houston</channel>
+  <channel site="pluto.tv" site_id="667f2c7b22acab0008b7072b" lang="en" xmltv_id="">FOX LOCAL Los Angeles</channel>
+  <channel site="pluto.tv" site_id="667f3696fc3a4600087cd1d6" lang="en" xmltv_id="">FOX LOCAL Phoenix</channel>
+  <channel site="pluto.tv" site_id="667f2b5cca746800086fa029" lang="en" xmltv_id="">FOX LOCAL San Francisco</channel>
   <channel site="pluto.tv" site_id="667f36eda1d7ad00085f588e" lang="en" xmltv_id="">FOX LOCAL Seattle</channel>
+  <channel site="pluto.tv" site_id="667f34fffc3a4600087cb96d" lang="en" xmltv_id="">FOX LOCAL Washington DC</channel>
   <channel site="pluto.tv" site_id="5a74b8e1e22a61737979c6bf" lang="en" xmltv_id="">FOX Sports</channel>
   <channel site="pluto.tv" site_id="640a68880e884c0009979cc2" lang="en" xmltv_id="FoxWeather.us@SD">FOX Weather</channel>
   <channel site="pluto.tv" site_id="580e87ff497c73ba2f321dd3" lang="en" xmltv_id="FunnyAF.us@SD">Funny AF</channel>
   <channel site="pluto.tv" site_id="5e54187aae660e00093561d6" lang="en" xmltv_id="GameShowCentral.us@SD">Game Show Central</channel>
   <channel site="pluto.tv" site_id="60faf9ddfcc1f200070a5932" lang="en" xmltv_id="GarfieldandFriends.us@US">Garfield and Friends</channel>
   <channel site="pluto.tv" site_id="64e561a4354251000823a0e0" lang="en" xmltv_id="GhostHunters.us@UK">Ghost Hunters</channel>
-  <channel site="pluto.tv" site_id="5417a212ff9fba68282fbf5e" lang="en" xmltv_id="GloryKickboxing.us@US">GLORY Kickboxing</channel>
   <channel site="pluto.tv" site_id="667f3852efa2a10008e1e514" lang="en" xmltv_id="">Go Go Gadget!</channel>
   <channel site="pluto.tv" site_id="63a0e33a45264d000850ed7e" lang="en" xmltv_id="CBSSportsGolazoNetwork.us@SD">Golazo Network</channel>
   <channel site="pluto.tv" site_id="65493029ab052400089e9d2f" lang="en" xmltv_id="">GolfPass</channel>
   <channel site="pluto.tv" site_id="5b4e99f4423e067bd6df6903" lang="en" xmltv_id="GordonRamsaysHellsKitchen.us@SD">Gordon Ramsay&apos;s Hell&apos;s Kitchen</channel>
+  <channel site="pluto.tv" site_id="69699ae5d301d54fb3dc1499" lang="en" xmltv_id="">GrowthDay Network</channel>
   <channel site="pluto.tv" site_id="60f75771dfc72a00071fd0e0" lang="en" xmltv_id="Gunsmoke.us@SD">Gunsmoke</channel>
   <channel site="pluto.tv" site_id="628e685ba3811100070551a8" lang="en" xmltv_id="HallmarkMoviesMore.us@SD">Hallmark Movies &amp; More</channel>
   <channel site="pluto.tv" site_id="5f7794162a4559000781fc12" lang="en" xmltv_id="HappyDays.us@SD">Happy Days</channel>
@@ -157,6 +173,7 @@
   <channel site="pluto.tv" site_id="609bfa51fbecc1000733152e" lang="en" xmltv_id="JerseyShore.us@SD">Jersey Shore</channel>
   <channel site="pluto.tv" site_id="5e9decb953e157000752321c" lang="en" xmltv_id="JudgeNosey.us@US">Judge Nosey</channel>
   <channel site="pluto.tv" site_id="60fb040d4795a6000762fe8f" lang="en" xmltv_id="KartoonChannel.us@SD">Kartoon Channel!</channel>
+  <channel site="pluto.tv" site_id="5db0ad56edc89300090d2ebb" lang="en" xmltv_id="">Kids Movie Club</channel>
   <channel site="pluto.tv" site_id="632b619c8d2a6c0007ff534e" lang="en" xmltv_id="">KIRO Seattle</channel>
   <channel site="pluto.tv" site_id="68758038552299d2b08162e3" lang="en" xmltv_id="">Law &amp; Order</channel>
   <channel site="pluto.tv" site_id="60fb01a24795a6000762fe83" lang="en" xmltv_id="LEGOKidsTV.us@SD">LEGO Kids TV</channel>
@@ -174,6 +191,7 @@
   <channel site="pluto.tv" site_id="66df8a29b25d2b0008fc5fe0" lang="en" xmltv_id="LoveNature.ca@SD">Love Nature</channel>
   <channel site="pluto.tv" site_id="6887a86be3703b7d42b3eca3" lang="en" xmltv_id="">Matched Married Meet by Lifetime</channel>
   <channel site="pluto.tv" site_id="60f754f98185580007eb0754" lang="en" xmltv_id="Matlock.us@SD">Matlock</channel>
+  <channel site="pluto.tv" site_id="64d2b6bf9b414d0008187d83" lang="en" xmltv_id="">Mayday: Air Disaster</channel>
   <channel site="pluto.tv" site_id="5cbf6a868a1bce4a3d52a5e9" lang="en" xmltv_id="MidsomerMurders.us@SD">Midsomer Murders</channel>
   <channel site="pluto.tv" site_id="6549322e53fc97000838febc" lang="en" xmltv_id="">Million Dollar Listing Vault</channel>
   <channel site="pluto.tv" site_id="5f77977bd924d80007eee60c" lang="en" xmltv_id="MissionImpossible.us@SD">Mission Impossible</channel>
@@ -197,19 +215,22 @@
   <channel site="pluto.tv" site_id="5da0c85bd2c9c10009370984" lang="en" xmltv_id="Naruto.us@US">Naruto</channel>
   <channel site="pluto.tv" site_id="6675c742ca74680008566b88" lang="en" xmltv_id="">Nash Bridges</channel>
   <channel site="pluto.tv" site_id="5812bd9f249444e05d09cc4e" lang="en" xmltv_id="">Naturescape</channel>
+  <channel site="pluto.tv" site_id="65790d58dfed030008d03051" lang="en" xmltv_id="">NBC Bay Area News</channel>
+  <channel site="pluto.tv" site_id="65790e3532c1b300089c5266" lang="en" xmltv_id="">NBC Boston News</channel>
+  <channel site="pluto.tv" site_id="65790a4914fbe4000870142f" lang="en" xmltv_id="">NBC Dallas News</channel>
+  <channel site="pluto.tv" site_id="65790cda6e4f6a0008768764" lang="en" xmltv_id="">NBC Los Angeles News</channel>
   <channel site="pluto.tv" site_id="5df97894467dfa00091c873c" lang="en" xmltv_id="NBCNewsNOW.us@SD">NBC News NOW</channel>
   <channel site="pluto.tv" site_id="6549306c83595c000815a696" lang="en" xmltv_id="">NBC Sports NOW</channel>
+  <channel site="pluto.tv" site_id="65790bd0dfed030008d02f49" lang="en" xmltv_id="">NBC Washington News</channel>
   <channel site="pluto.tv" site_id="5fff49cfb5cd4f0007c2b0dc" lang="en" xmltv_id="News12NewYork.us@SD">News 12 New York</channel>
   <channel site="pluto.tv" site_id="55b179af994403942f3061d6" lang="en" xmltv_id="Newsmax2.us@SD">Newsmax2</channel>
   <channel site="pluto.tv" site_id="5ced7d5df64be98e07ed47b6" lang="en" xmltv_id="NFLChannel.us@SD">NFL Channel</channel>
-  <channel site="pluto.tv" site_id="5ca6748a37b88b269472dad9" lang="en" xmltv_id="">Nick Jr. Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5ca673e0d0bd6c2689c94ce3" lang="en" xmltv_id="NickPlutoTV.us@US">Nickelodeon Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5ca6748a37b88b269472dad9" lang="en" xmltv_id="NickJrPlutoTV.us@US">Nick Jr. Pluto TV</channel>
+  <channel site="pluto.tv" site_id="5ca673e0d0bd6c2689c94ce3" lang="en" xmltv_id="NickelodeonPlutoTV.us@SD">Nickelodeon Pluto TV</channel>
   <channel site="pluto.tv" site_id="66ff0cf663292d0008320cf8" lang="en" xmltv_id="">No Reservations</channel>
   <channel site="pluto.tv" site_id="5aec96ec5126c2157123c657" lang="en" xmltv_id="">Nosey</channel>
   <channel site="pluto.tv" site_id="5e7cf6c7b156d500078c5f44" lang="en" xmltv_id="OANPlus.us@SD">OAN Plus</channel>
-  <channel site="pluto.tv" site_id="668c5d3bfd9eb2000882bb50" lang="en" xmltv_id="">ONE Championship TV</channel>
   <channel site="pluto.tv" site_id="5f7790b3ed0c88000720b241" lang="en" xmltv_id="OnePiece.us@SD">One Piece</channel>
-  <channel site="pluto.tv" site_id="66c638726838ee00085ac20d" lang="en" xmltv_id="">OuterSphere</channel>
   <channel site="pluto.tv" site_id="654930a8346f420008d3b0b8" lang="en" xmltv_id="">Oxygen True Crime Archives</channel>
   <channel site="pluto.tv" site_id="683f67fde5f82715941c047b" lang="en" xmltv_id="">P+ VLL</channel>
   <channel site="pluto.tv" site_id="5cb0cae7a461406ffe3f5213" lang="en" xmltv_id="ParamountMovieChannel.us@SD">Paramount Movie Channel</channel>
@@ -223,52 +244,59 @@
   <channel site="pluto.tv" site_id="5de94dacb394a300099fa22a" lang="en" xmltv_id="PGATour.us@SD">PGA TOUR</channel>
   <channel site="pluto.tv" site_id="6565413e4261ca0008215320" lang="en" xmltv_id="">Pickers &amp; Pawn</channel>
   <channel site="pluto.tv" site_id="561d7d484dc7c8770484914a" lang="en" xmltv_id="PlutoTVAction.us@US">Pluto TV Action</channel>
-  <channel site="pluto.tv" site_id="5812b7d3249444e05d09cc49" lang="en" xmltv_id="AnimeAllDay.us@US">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="62a2e8d8a1c8650007e95bac" lang="en" xmltv_id="AnimeAllDay.us@US">Pluto TV Anime</channel>
-  <channel site="pluto.tv" site_id="67ed8f7e443f0671bc2b2368" lang="en" xmltv_id="">Pluto TV Anime Movies</channel>
+  <channel site="pluto.tv" site_id="69d7ebb726eeec84158e28cb" lang="en" xmltv_id="PlutoTVAdventure.us@US">Pluto TV Adventure</channel>
+  <channel site="pluto.tv" site_id="62a2e8d8a1c8650007e95bac" lang="en" xmltv_id="PlutoTVAnime.us@USPlus">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="5812b7d3249444e05d09cc49" lang="en" xmltv_id="PlutoTVAnime.us@US">Pluto TV Anime</channel>
+  <channel site="pluto.tv" site_id="67ed8f7e443f0671bc2b2368" lang="en" xmltv_id="PlutoTVAnimeMovies.us@SD">Pluto TV Anime Movies</channel>
   <channel site="pluto.tv" site_id="5cabdf1437b88b26947346b2" lang="en" xmltv_id="PlutoTVBackcountry.us@SD">Pluto TV Backcountry</channel>
   <channel site="pluto.tv" site_id="5812b3a4249444e05d09cc46" lang="en" xmltv_id="PlutoTVCars.us@SD">Pluto TV Cars</channel>
   <channel site="pluto.tv" site_id="5c12ba66eae03059cbdc77f2" lang="en" xmltv_id="PlutoTVCars.us@SD">Pluto TV Cars</channel>
   <channel site="pluto.tv" site_id="5a4d3a00ad95e4718ae8d8db" lang="en" xmltv_id="PlutoTVComedy.us@US">Pluto TV Comedy</channel>
-  <channel site="pluto.tv" site_id="603fde9026ecbf0007752c2c" lang="en" xmltv_id="">Pluto TV Competition</channel>
+  <channel site="pluto.tv" site_id="603fde9026ecbf0007752c2c" lang="en" xmltv_id="PlutoTVCompetition.us@SD">Pluto TV Competition</channel>
   <channel site="pluto.tv" site_id="5f31fd1b4c510e00071c3103" lang="en" xmltv_id="PlutoTVCrimeDrama.us@SD">Pluto TV Crime Drama</channel>
   <channel site="pluto.tv" site_id="5f4d8594eb979c0007706de7" lang="en" xmltv_id="PlutoTVCrimeMovies.us@SD">Pluto TV Crime Movies</channel>
   <channel site="pluto.tv" site_id="5c665db3e6c01b72c4977bc2" lang="en" xmltv_id="PlutoTVCultFilms.us@US">Pluto TV Cult Films</channel>
   <channel site="pluto.tv" site_id="5b4e92e4694c027be6ecece1" lang="en" xmltv_id="PlutoTVDrama.us@US">Pluto TV Drama</channel>
   <channel site="pluto.tv" site_id="5b64a245a202b3337f09e51d" lang="en" xmltv_id="PlutoTVFantastic.us@SD">Pluto TV Fantastic</channel>
+  <channel site="pluto.tv" site_id="68fbf8101d26140175db8b58" lang="en" xmltv_id="">Pluto TV Franchise Favorites</channel>
   <channel site="pluto.tv" site_id="6036e7c385749f00075dbd3b" lang="en" xmltv_id="PlutoTVGameShows.us@SD">Pluto TV Game Shows</channel>
   <channel site="pluto.tv" site_id="5a4d35dfa5c02e717a234f86" lang="en" xmltv_id="PlutoTVHistory.us@US">Pluto TV History</channel>
+  <channel site="pluto.tv" site_id="69d6c7befde57cd5ba0160c3" lang="en" xmltv_id="PlutoTVHometownDrama.us@SD">Pluto TV Hometown Drama</channel>
   <channel site="pluto.tv" site_id="569546031a619b8f07ce6e25" lang="en" xmltv_id="PlutoTVHorror.us@US">Pluto TV Horror</channel>
-  <channel site="pluto.tv" site_id="64b585f84ea480000838e446" lang="en" xmltv_id="">Pluto TV Icons</channel>
+  <channel site="pluto.tv" site_id="64b585f84ea480000838e446" lang="en" xmltv_id="PlutoTVIcons.us@SD">Pluto TV Icons</channel>
   <channel site="pluto.tv" site_id="5d8beeb39b5d5d5f8c672530" lang="en" xmltv_id="PlutoTVLives.us@US">Pluto TV Lives</channel>
   <channel site="pluto.tv" site_id="5bb3fea0f711fd76340eebff" lang="en" xmltv_id="PlutoTVMilitary.us@SD">Pluto TV Military</channel>
   <channel site="pluto.tv" site_id="5adf96e3e738977e2c31cb04" lang="en" xmltv_id="PlutoTVParanormal.us@US">Pluto TV Paranormal</channel>
+  <channel site="pluto.tv" site_id="69fa3faab9c0f0d444e64de3" lang="en" xmltv_id="">Pluto TV Pride</channel>
   <channel site="pluto.tv" site_id="617b37b361e0fd0008cfd8c5" lang="en" xmltv_id="PlutoTVReaction.us@SD">Pluto TV Reaction</channel>
   <channel site="pluto.tv" site_id="5d8bf0b06d2d855ee15115e3" lang="en" xmltv_id="PlutoTVReality.us@US">Pluto TV Reality</channel>
   <channel site="pluto.tv" site_id="5a66795ef91fef2c7031c599" lang="en" xmltv_id="PlutoTVRomance.us@US">Pluto TV Romance</channel>
-  <channel site="pluto.tv" site_id="5b4fc274694c027be6ed3eea" lang="en" xmltv_id="">Pluto TV Sci-Fi</channel>
+  <channel site="pluto.tv" site_id="5b4fc274694c027be6ed3eea" lang="en" xmltv_id="PlutoTVSciFi.us@US">Pluto TV Sci-Fi</channel>
   <channel site="pluto.tv" site_id="563a970aa1a1f7fe7c9daad7" lang="en" xmltv_id="PlutoTVScience.us@US">Pluto TV Science</channel>
   <channel site="pluto.tv" site_id="5ba3fb9c4b078e0f37ad34e8" lang="en" xmltv_id="PlutoTVSpotlight.us@SD">Pluto TV Spotlight</channel>
   <channel site="pluto.tv" site_id="5f4d863b98b41000076cd061" lang="en" xmltv_id="PlutoTVStaffPicks.us@SD">Pluto TV Staff Picks</channel>
   <channel site="pluto.tv" site_id="5c6dc88fcd232425a6e0f06e" lang="en" xmltv_id="PlutoTVTerror.us@SD">Pluto TV Terror</channel>
   <channel site="pluto.tv" site_id="5b4e69e08291147bd04a9fd7" lang="en" xmltv_id="PlutoTVThrillers.us@US">Pluto TV Thrillers</channel>
-  <channel site="pluto.tv" site_id="673247127d5da5000817b4d6" lang="en" xmltv_id="">Pluto TV Trending Now</channel>
+  <channel site="pluto.tv" site_id="673247127d5da5000817b4d6" lang="en" xmltv_id="PlutoTVTrendingNow.us@SD">Pluto TV Trending Now</channel>
   <channel site="pluto.tv" site_id="5812be1c249444e05d09cc50" lang="en" xmltv_id="PlutoTVTrueCrime.us@US">Pluto TV True Crime</channel>
   <channel site="pluto.tv" site_id="5b4e94282d4ec87bdcbb87cd" lang="en" xmltv_id="PlutoTVWesterns.us@US">Pluto TV Westerns</channel>
   <channel site="pluto.tv" site_id="6675c7868768aa0008d7f1c7" lang="en" xmltv_id="PlutoTVPokemon.us@US">Pokémon</channel>
   <channel site="pluto.tv" site_id="5fc54366b04b2300072e31af" lang="en" xmltv_id="PokerGo.us@US">PokerGO</channel>
   <channel site="pluto.tv" site_id="63b48016d9dd51000828fa37" lang="en" xmltv_id="PowerNationTV.us@SD">POWERNATION</channel>
   <channel site="pluto.tv" site_id="68757c60552299d2b080eab6" lang="en" xmltv_id="">Project Runway</channel>
+  <channel site="pluto.tv" site_id="698384cb7230043f21f4a3f4" lang="en" xmltv_id="">Property Brothers</channel>
+  <channel site="pluto.tv" site_id="696998915a0ae9e1b563f0c6" lang="en" xmltv_id="">Qello Concerts</channel>
   <channel site="pluto.tv" site_id="5bdcdf1e851dd5632e2c11d1" lang="en" xmltv_id="">QVC</channel>
   <channel site="pluto.tv" site_id="67817323dd7846fe546940dd" lang="en" xmltv_id="">QVC2</channel>
   <channel site="pluto.tv" site_id="634f307c7a068e00072c9982" lang="en" xmltv_id="">Rawhide</channel>
-  <channel site="pluto.tv" site_id="64d2b6bf9b414d0008187d83" lang="en" xmltv_id="">Real Disaster Channel</channel>
   <channel site="pluto.tv" site_id="6549316d2c1d330008631496" lang="en" xmltv_id="">Real Housewives Vault</channel>
   <channel site="pluto.tv" site_id="674f735a2fb8a100087bf253" lang="en" xmltv_id="Revry.us@SD">Revry</channel>
+  <channel site="pluto.tv" site_id="6996296087742204bff43147" lang="en" xmltv_id="">Ridiculousness</channel>
   <channel site="pluto.tv" site_id="58d947b9e420d8656ee101ab" lang="en" xmltv_id="RiffTrax.us@US">RiffTrax</channel>
-  <channel site="pluto.tv" site_id="677d672ef090ab00085b8e9b" lang="en" xmltv_id="">Robot Wars by MECH+</channel>
+  <channel site="pluto.tv" site_id="6a037119f6ac24413f849d5b" lang="en" xmltv_id="">Road to UFC at the White House</channel>
   <channel site="pluto.tv" site_id="6565430c9d5ac4000822f508" lang="en" xmltv_id="">Rustic Retreats</channel>
   <channel site="pluto.tv" site_id="5fb584b7613a31000789de5a" lang="en" xmltv_id="RyanandFriends.us@SD">Ryan and Friends</channel>
+  <channel site="pluto.tv" site_id="65033c4b98020f0008547124" lang="en" xmltv_id="">S.W.A.T.</channel>
   <channel site="pluto.tv" site_id="637e55347427a40007fac703" lang="en" xmltv_id="">Sailor Moon</channel>
   <channel site="pluto.tv" site_id="66a7f0a78561260008c177f2" lang="en" xmltv_id="">Salem News Channel</channel>
   <channel site="pluto.tv" site_id="5459795fc9f133a519bc0bef" lang="en" xmltv_id="ScrippsNews.us@SD">Scripps News</channel>
@@ -279,12 +307,12 @@
   <channel site="pluto.tv" site_id="5f21ea08007a49000762d349" lang="en" xmltv_id="SmithsonianChannelSelects.us@SD">Smithsonian Channel Selects</channel>
   <channel site="pluto.tv" site_id="5c393cad2de254456f7ef8c2" lang="en" xmltv_id="SpikeOutdoors.us@SD">Spike Outdoors</channel>
   <channel site="pluto.tv" site_id="5812bcc8237a6ff45d16c407" lang="en" xmltv_id="SpikePlutoTV.us@SD">Spike Pluto TV</channel>
-  <channel site="pluto.tv" site_id="5efbd39f8c4ce900075d7698" lang="en" xmltv_id="StarTrek.us@SD">Star Trek</channel>
+  <channel site="pluto.tv" site_id="5efbd39f8c4ce900075d7698" lang="en" xmltv_id="StarTrek.us@US">Star Trek</channel>
   <channel site="pluto.tv" site_id="65c69bbfd77d450008c7ffee" lang="en" xmltv_id="">Star Trek: Deep Space Nine</channel>
-  <channel site="pluto.tv" site_id="695c32671ca20bb8ca7fd8f7" lang="en" xmltv_id="">Star Trek: Enterprise</channel>
   <channel site="pluto.tv" site_id="695c32e61ca20bb8ca802eb9" lang="en" xmltv_id="">Star Trek: The Next Generation</channel>
   <channel site="pluto.tv" site_id="634dacf51d90320007fcd5fa" lang="en" xmltv_id="">Star Trek: Voyager</channel>
   <channel site="pluto.tv" site_id="620bfa7df72827000703ddb1" lang="en" xmltv_id="">Stargate</channel>
+  <channel site="pluto.tv" site_id="696689d13b9ce349c9be3a18" lang="en" xmltv_id="">Stingray DJAZZ</channel>
   <channel site="pluto.tv" site_id="6887aaf4e3703b7d42b71a1e" lang="en" xmltv_id="">Storage Wars by A&amp;E</channel>
   <channel site="pluto.tv" site_id="5e8254118601b80007b4b7ae" lang="en" xmltv_id="StoriesbyAMC.us@SD">Stories by AMC</channel>
   <channel site="pluto.tv" site_id="667f393836a2f90008fd17c0" lang="en" xmltv_id="">Strawberry Shortcake and Friends</channel>
@@ -299,10 +327,11 @@
   <channel site="pluto.tv" site_id="5f21e8a6e2f12b000755afdb" lang="en" xmltv_id="TheAmazingRace.us@SD">The Amazing Race</channel>
   <channel site="pluto.tv" site_id="60f75178e7f8aa0007e9c259" lang="en" xmltv_id="TheAndyGriffithShow.us@SD">The Andy Griffith Show</channel>
   <channel site="pluto.tv" site_id="5f36d726234ce10007784f2a" lang="en" xmltv_id="TheBobRossChannel.us@SD">The Bob Ross Channel</channel>
+  <channel site="pluto.tv" site_id="68e40b54cba140ddfe5fb3b5" lang="en" xmltv_id="">The Brady Bunch</channel>
   <channel site="pluto.tv" site_id="5d48685da7e9f476aa8a1888" lang="en" xmltv_id="TheChallenge.us@SD">The Challenge</channel>
-  <channel site="pluto.tv" site_id="67d07b7b798df95b8e9484b5" lang="en" xmltv_id="">The Emeril Lagasse Channel</channel>
   <channel site="pluto.tv" site_id="5d486acc34ceb37d3c458a64" lang="en" xmltv_id="TheFirstTV.us@SD">The First</channel>
   <channel site="pluto.tv" site_id="6887aaade3703b7d42b64be8" lang="en" xmltv_id="">The First 48 by A&amp;E</channel>
+  <channel site="pluto.tv" site_id="68e40bc9a1646a6c555a7e85" lang="en" xmltv_id="">The Hills / Laguna Beach</channel>
   <channel site="pluto.tv" site_id="64dab9df3d48f40008868091" lang="en" xmltv_id="TheJamieOliverChannel.us@SD">The Jamie Oliver Channel</channel>
   <channel site="pluto.tv" site_id="6283d51144ad8f0007fa382d" lang="en" xmltv_id="TheJudgeJudyChannel.us@SD">The Judge Judy Channel</channel>
   <channel site="pluto.tv" site_id="65a6dafb7bdc8d0008473c85" lang="en" xmltv_id="">The Lone Ranger</channel>
@@ -320,6 +349,7 @@
   <channel site="pluto.tv" site_id="6913e381b6bf26bb6e798c13" lang="en" xmltv_id="">The X-Files</channel>
   <channel site="pluto.tv" site_id="5d51e791b7dba3b2ae990ab2" lang="en" xmltv_id="ThisOldHouse.us@SD">This Old House</channel>
   <channel site="pluto.tv" site_id="5ef3977e5d773400077de284" lang="en" xmltv_id="ThreesCompany.us@SD">Three&apos;s Company</channel>
+  <channel site="pluto.tv" site_id="69445a9a78c0c45b6c9aa8b9" lang="en" xmltv_id="">TikTok Radio</channel>
   <channel site="pluto.tv" site_id="601a0342dcf4370007566891" lang="en" xmltv_id="TinyHouseNation.us@SD">Tiny House Nation</channel>
   <channel site="pluto.tv" site_id="59b722526996084038c01e1b" lang="en" xmltv_id="TNAWrestlingChannel.pl@SD">TNA Wrestling</channel>
   <channel site="pluto.tv" site_id="5d695f7db53adf96b78e7ce3" lang="en" xmltv_id="TODAYAllDay.us@SD">TODAY All Day</channel>
@@ -330,11 +360,10 @@
   <channel site="pluto.tv" site_id="5d0c16d686454ead733d08f8" lang="en" xmltv_id="TotallyTurtles.us@US">TOTALLY TURTLES</channel>
   <channel site="pluto.tv" site_id="65c69bf23ef47d0008583967" lang="en" xmltv_id="">Tough Jobs</channel>
   <channel site="pluto.tv" site_id="60fb053712f22a0007ff14d2" lang="en" xmltv_id="">Transformers TV</channel>
-  <channel site="pluto.tv" site_id="661827ffe8fba800086b217d" lang="en" xmltv_id="">Triton Poker</channel>
   <channel site="pluto.tv" site_id="5d40bebc5e3d2750a2239d7e" lang="en" xmltv_id="TVLandDrama.us@SD">TV Land Drama</channel>
   <channel site="pluto.tv" site_id="612fea0e970e6f00083be56b" lang="en" xmltv_id="TVLandDrama.us@SD">TV Land Drama</channel>
-  <channel site="pluto.tv" site_id="5c2d64ffbdf11b71587184b8" lang="en" xmltv_id="TVLandSitcoms.us@SD">TV Land Sitcoms</channel>
   <channel site="pluto.tv" site_id="61bd0b57872c650008ed2e38" lang="en" xmltv_id="TVLandSitcoms.us@SD">TV Land Sitcoms</channel>
+  <channel site="pluto.tv" site_id="5c2d64ffbdf11b71587184b8" lang="en" xmltv_id="TVLandSitcoms.us@SD">TV Land Sitcoms</channel>
   <channel site="pluto.tv" site_id="65ea8b928145cb0008509426" lang="en" xmltv_id="">UEFA Champions League</channel>
   <channel site="pluto.tv" site_id="677d9adfa9a51b0008497fa0" lang="en" xmltv_id="">UFC</channel>
   <channel site="pluto.tv" site_id="656542ae4261ca00082154a8" lang="en" xmltv_id="">Ultimate Builds</channel>
@@ -355,33 +384,45 @@
   <channel site="pluto.tv" site_id="66abefe5d2d50d00082c7d12" lang="en" xmltv_id="">VH1 Queens of Reality</channel>
   <channel site="pluto.tv" site_id="6532e8342cf13100083b404c" lang="en" xmltv_id="">Warner Bros. TV Say Yes to the Dress</channel>
   <channel site="pluto.tv" site_id="6532e7fa045c3d0008514ca7" lang="en" xmltv_id="">Warner Bros. TV Sweet Escapes</channel>
+  <channel site="pluto.tv" site_id="5bdce04659ee03633e758130" lang="en" xmltv_id="">WeatherNation</channel>
   <channel site="pluto.tv" site_id="5d2cb7ac552e3773bc48982e" lang="en" xmltv_id="WeatherNation.us@SD">WeatherNation</channel>
+  <channel site="pluto.tv" site_id="61ea266adde9d0000738970d" lang="en" xmltv_id="">WeatherNation Boston</channel>
+  <channel site="pluto.tv" site_id="628c20c0097ef20007607938" lang="en" xmltv_id="">WeatherNation Charlotte</channel>
+  <channel site="pluto.tv" site_id="61ea24de7371e20007c027f4" lang="en" xmltv_id="">WeatherNation Dallas/Ft. Worth</channel>
+  <channel site="pluto.tv" site_id="61ea25c5d17f0200075934f1" lang="en" xmltv_id="">WeatherNation Houston</channel>
+  <channel site="pluto.tv" site_id="61e9af6bfbbcc6000700119b" lang="en" xmltv_id="">WeatherNation Los Angeles</channel>
+  <channel site="pluto.tv" site_id="628bedd5b45e1c00070572da" lang="en" xmltv_id="">WeatherNation Phoenix</channel>
+  <channel site="pluto.tv" site_id="628c2d8a3067b30007ac2901" lang="en" xmltv_id="">WeatherNation Salt Lake City</channel>
+  <channel site="pluto.tv" site_id="61ea261c8874280007b4865f" lang="en" xmltv_id="">WeatherNation San Francisco</channel>
   <channel site="pluto.tv" site_id="628bf0057007a30007e99af9" lang="en" xmltv_id="">WeatherNation Seattle</channel>
+  <channel site="pluto.tv" site_id="61ea25686fd777000739a272" lang="en" xmltv_id="">WeatherNation Washington D.C.</channel>
   <channel site="pluto.tv" site_id="5e8df4bc16e34700077e77d3" lang="en" xmltv_id="">Western TV</channel>
+  <channel site="pluto.tv" site_id="632b6233822bbc000748fd81" lang="en" xmltv_id="">WFTV Orlando</channel>
   <channel site="pluto.tv" site_id="686c2677ed17cf4c900a496d" lang="en" xmltv_id="">Wicked Tuna</channel>
   <channel site="pluto.tv" site_id="5d48678d34ceb37d3c458a55" lang="en" xmltv_id="WildNOut.us@SD">Wild &apos;N Out</channel>
   <channel site="pluto.tv" site_id="686d8dd294a028da3ac59566" lang="en" xmltv_id="WomensSportsNetwork.us@SD">Women&apos;s Sports Network</channel>
+  <channel site="pluto.tv" site_id="69699b6d23ea437206f4a036" lang="en" xmltv_id="">World of Love Island</channel>
   <channel site="pluto.tv" site_id="5616f9c0ada51f8004c4b091" lang="en" xmltv_id="WorldPokerTour.us@US">World Poker Tour</channel>
-  <channel site="pluto.tv" site_id="68c85164b7af374ee483210f" lang="en" xmltv_id="">Wrestling Central</channel>
+  <channel site="pluto.tv" site_id="632b642933a6280007aaf265" lang="en" xmltv_id="">WSB Atlanta</channel>
+  <channel site="pluto.tv" site_id="632b648c08cd050007d94114" lang="en" xmltv_id="">WSOC Charlotte</channel>
   <channel site="pluto.tv" site_id="623b92a2ccefed0007b1db48" lang="en" xmltv_id="">XITE Classic Country</channel>
   <channel site="pluto.tv" site_id="623b93628e6ded0007337d4d" lang="en" xmltv_id="">XITE Gospel</channel>
   <channel site="pluto.tv" site_id="623a1b5188ecdc0007c9ef5a" lang="en" xmltv_id="">XITE Rock x Metal</channel>
   <channel site="pluto.tv" site_id="6000a6f4c3f8550008fc9b91" lang="en" xmltv_id="">Xtreme Outdoor by HISTORY</channel>
   <channel site="pluto.tv" site_id="5d14fc31252d35decbc4080b" lang="en" xmltv_id="YoMTV.us@SD">Yo! MTV</channel>
   <channel site="pluto.tv" site_id="5f4ec10ed9636f00089b8c89" lang="en" xmltv_id="YuGiOh.us@SD">Yu-Gi-Oh!</channel>
-  <channel site="pluto.tv" site_id="64dab1f835425100080e1e7b" lang="es" xmltv_id="AcapulcoShore.us@SD">Acapulco Shore</channel>
+  <channel site="pluto.tv" site_id="696998dfa2b623e8b20125a3" lang="en" xmltv_id="">ZenLIFE by Stingray</channel>
+  <channel site="pluto.tv" site_id="64dab1f835425100080e1e7b" lang="es" xmltv_id="AcapulcoShore.us@US">Acapulco Shore</channel>
   <channel site="pluto.tv" site_id="60d393e5579a420007ee553c" lang="es" xmltv_id="">Casos de la Dra. Polo</channel>
   <channel site="pluto.tv" site_id="668c5cb4f01dbe0008dd4082" lang="es" xmltv_id="">CBS en español</channel>
   <channel site="pluto.tv" site_id="5d8d164d92e97a5e107638d2" lang="es" xmltv_id="CineAdrenalina.us@SD">Cine adrenalina</channel>
   <channel site="pluto.tv" site_id="5f5136317aedfb0007016f93" lang="es" xmltv_id="">Cine Amor</channel>
   <channel site="pluto.tv" site_id="60fb2f47c133270007327375" lang="es" xmltv_id="">Cine aventura</channel>
-  <channel site="pluto.tv" site_id="64b9671cdac71b0008f371df" lang="es" xmltv_id="PlutoTVCineClasico.us@US">Cine Clásico</channel>
-  <channel site="pluto.tv" site_id="5f513564e4622a0007c578c0" lang="es" xmltv_id="PlutoTVCineComedia.us@Spain">Cine comedia</channel>
-  <channel site="pluto.tv" site_id="686c1c873ffa5e0c91a85938" lang="es" xmltv_id="">Cine Crimen</channel>
+  <channel site="pluto.tv" site_id="5f513564e4622a0007c578c0" lang="es" xmltv_id="PlutoTVCineComedia.us@US">Cine comedia</channel>
   <channel site="pluto.tv" site_id="5cf96b1c4f1ca3f0629f4bf0" lang="es" xmltv_id="">Cine en español</channel>
   <channel site="pluto.tv" site_id="5cf968040ab7d8f181e6a68b" lang="es" xmltv_id="CinePremiere.us@SD">Cine Premiere</channel>
-  <channel site="pluto.tv" site_id="5d8d180092e97a5e107638d3" lang="es" xmltv_id="CineTerror.us@SD">Cine terror</channel>
-  <channel site="pluto.tv" site_id="673248f9030a2c0008033af8" lang="es" xmltv_id="">CNN XPRESS</channel>
+  <channel site="pluto.tv" site_id="5d8d180092e97a5e107638d3" lang="es" xmltv_id="CineTerror.us@US">Cine terror</channel>
+  <channel site="pluto.tv" site_id="673248f9030a2c0008033af8" lang="es" xmltv_id="">CNN Noticias</channel>
   <channel site="pluto.tv" site_id="5cf96dad1652631e36d43320" lang="es" xmltv_id="ComedyCentralenEspanol.us@SD">Comedy Central en español</channel>
   <channel site="pluto.tv" site_id="673249433a61d400087a51ed" lang="es" xmltv_id="">Construcciones Asombrosas</channel>
   <channel site="pluto.tv" site_id="6732499ce40c4a0008bb9894" lang="es" xmltv_id="">Crimen</channel>
@@ -392,18 +433,19 @@
   <channel site="pluto.tv" site_id="66fedd65d7de140008dccd66" lang="es" xmltv_id="PlutoTVElReinoInfantil.us@SD">El Reino Infantil</channel>
   <channel site="pluto.tv" site_id="60492e6d7f3f560007ab0f62" lang="es" xmltv_id="EstrellaNews.us@SD">Estrella News</channel>
   <channel site="pluto.tv" site_id="5cf0622da00ca1e2f6fac712" lang="es" xmltv_id="EstrellaTV.us@SD">EstrellaTV</channel>
-  <channel site="pluto.tv" site_id="63d0269d60bc8f000890facc" lang="es" xmltv_id="FoxDeportes.us@SD">FOX Deportes</channel>
   <channel site="pluto.tv" site_id="5cf96b8f4f1ca3f0629f4bf1" lang="es" xmltv_id="">Investiga</channel>
   <channel site="pluto.tv" site_id="668c566d08d5490008075948" lang="es" xmltv_id="">La Familia del Barrio</channel>
   <channel site="pluto.tv" site_id="60493283ffc52f000710edae" lang="es" xmltv_id="">Little Angel&apos;s Playroom en Español</channel>
-  <channel site="pluto.tv" site_id="5c01df1759ee03633e7b272c" lang="es" xmltv_id="LuchaLibreAAA.us@SD">Lucha Libre AAA</channel>
   <channel site="pluto.tv" site_id="687fea9a4fa995eff284a1c8" lang="es" xmltv_id="">Más adrenalina</channel>
   <channel site="pluto.tv" site_id="5f4d882d5233170007ee880e" lang="es" xmltv_id="Misteriossinresolver.us@SD">Misterios sin resolver</channel>
   <channel site="pluto.tv" site_id="5cf96d351652631e36d4331f" lang="es" xmltv_id="MTVenEspanol.us@SD">MTV en español</channel>
   <channel site="pluto.tv" site_id="5d8d08395f39465da6fb3ec4" lang="es" xmltv_id="NickenEspanol.us@SD">Nickelodeon en español</channel>
-  <channel site="pluto.tv" site_id="5cf96c0222df39f1a338d163" lang="es" xmltv_id="PlutoTVNovelas.us@SD">Pluto TV Novelas</channel>
+  <channel site="pluto.tv" site_id="5cf96c0222df39f1a338d163" lang="es" xmltv_id="PlutoTVNovelas.us@US">Pluto TV Novelas</channel>
+  <channel site="pluto.tv" site_id="69e6be40fde57cd5ba562b29" lang="es" xmltv_id="">Pokémon en español</channel>
   <channel site="pluto.tv" site_id="66ba53cda4ee2700083fac09" lang="es" xmltv_id="">Sala de Emergencias: Historias Inéditas</channel>
-  <channel site="pluto.tv" site_id="605e479d5b8229000763e697" lang="es" xmltv_id="SonyCanalEscapePerfecto.us@SD">Sony Canal Escape Perfecto</channel>
+  <channel site="pluto.tv" site_id="65790feacbd0d60008fac87a" lang="es" xmltv_id="">Telemundo Noticias California</channel>
+  <channel site="pluto.tv" site_id="65791199dfed030008d031d3" lang="es" xmltv_id="">Telemundo Noticias Noreste</channel>
+  <channel site="pluto.tv" site_id="657910d9b228b700084620c1" lang="es" xmltv_id="">Telemundo Noticias Texas</channel>
   <channel site="pluto.tv" site_id="5cf96cc422df39f1a338d165" lang="es" xmltv_id="TelemundoTelenovelasClasicas.us@SD">Telemundo telenovelas clásicas</channel>
   <channel site="pluto.tv" site_id="5e82bb378601b80007b4bd78" lang="es" xmltv_id="TheWalkingDeadenEspanol.us@SD">The Walking Dead en español</channel>
   <channel site="pluto.tv" site_id="64d161c93c785e0008df575e" lang="es" xmltv_id="">Vevo Íconos Latinos</channel>

--- a/sites/tataplay.com/tataplay.com.channels.xml
+++ b/sites/tataplay.com/tataplay.com.channels.xml
@@ -1,403 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="tataplay.com" site_id="15" lang="en" xmltv_id="">SET HD</channel>
-  <channel site="tataplay.com" site_id="32" lang="en" xmltv_id="">SONY PIX HD</channel>
-  <channel site="tataplay.com" site_id="34" lang="en" xmltv_id="">SONY AATH</channel>
-  <channel site="tataplay.com" site_id="35" lang="en" xmltv_id="">SONY SPORTS TEN 5 HD</channel>
-  <channel site="tataplay.com" site_id="45" lang="en" xmltv_id="">SONY YAY!</channel>
-  <channel site="tataplay.com" site_id="48" lang="en" xmltv_id="">SONY SAB HD</channel>
-  <channel site="tataplay.com" site_id="56" lang="en" xmltv_id="">Sony Wah</channel>
-  <channel site="tataplay.com" site_id="71" lang="en" xmltv_id="">Tata Play English in Hindi</channel>
-  <channel site="tataplay.com" site_id="76" lang="en" xmltv_id="">Udaya TV</channel>
-  <channel site="tataplay.com" site_id="80" lang="en" xmltv_id="">SONY MAX HD</channel>
-  <channel site="tataplay.com" site_id="81" lang="en" xmltv_id="">SONY SPORTS TEN 1 HD</channel>
-  <channel site="tataplay.com" site_id="93" lang="en" xmltv_id="">NDTV Profit Prime</channel>
-  <channel site="tataplay.com" site_id="95" lang="en" xmltv_id="">Tata Play Javed Akhtar</channel>
-  <channel site="tataplay.com" site_id="98" lang="en" xmltv_id="">Russia Today</channel>
-  <channel site="tataplay.com" site_id="100" lang="en" xmltv_id="">Action Cinema</channel>
-  <channel site="tataplay.com" site_id="101" lang="en" xmltv_id="">Rang</channel>
-  <channel site="tataplay.com" site_id="111" lang="en" xmltv_id="">Tata Play Smart Manager</channel>
-  <channel site="tataplay.com" site_id="114" lang="en" xmltv_id="">Disney</channel>
-  <channel site="tataplay.com" site_id="120" lang="en" xmltv_id="">SONY MAX 2</channel>
-  <channel site="tataplay.com" site_id="121" lang="en" xmltv_id="">Tata Play Fitness</channel>
-  <channel site="tataplay.com" site_id="123" lang="en" xmltv_id="">Zee Cinema</channel>
-  <channel site="tataplay.com" site_id="132" lang="en" xmltv_id="">SONY MAX</channel>
-  <channel site="tataplay.com" site_id="144" lang="en" xmltv_id="">Disney Junior</channel>
-  <channel site="tataplay.com" site_id="147" lang="en" xmltv_id="">KTV</channel>
-  <channel site="tataplay.com" site_id="150" lang="en" xmltv_id="">SONY SPORTS TEN 1</channel>
-  <channel site="tataplay.com" site_id="151" lang="en" xmltv_id="">Tata Play Devotion</channel>
-  <channel site="tataplay.com" site_id="152" lang="en" xmltv_id="">TV9 Kannada</channel>
-  <channel site="tataplay.com" site_id="157" lang="en" xmltv_id="">Channel News Asia</channel>
-  <channel site="tataplay.com" site_id="158" lang="en" xmltv_id="">SONY BBC Earth</channel>
-  <channel site="tataplay.com" site_id="165" lang="en" xmltv_id="">Sun TV</channel>
-  <channel site="tataplay.com" site_id="167" lang="en" xmltv_id="">Tata Play Vedic Maths</channel>
-  <channel site="tataplay.com" site_id="170" lang="en" xmltv_id="">SONY SPORTS TEN 2</channel>
-  <channel site="tataplay.com" site_id="171" lang="en" xmltv_id="">SONY SPORTS TEN 3 Hindi</channel>
-  <channel site="tataplay.com" site_id="194" lang="en" xmltv_id="">Dangal 2</channel>
-  <channel site="tataplay.com" site_id="210" lang="en" xmltv_id="">MN+ HD</channel>
-  <channel site="tataplay.com" site_id="212" lang="en" xmltv_id="">Sansad TV 2</channel>
-  <channel site="tataplay.com" site_id="213" lang="en" xmltv_id="">Sansad TV 1</channel>
-  <channel site="tataplay.com" site_id="234" lang="en" xmltv_id="">MNX</channel>
-  <channel site="tataplay.com" site_id="250" lang="en" xmltv_id="">Zee Telugu</channel>
-  <channel site="tataplay.com" site_id="251" lang="en" xmltv_id="">Zee Marathi</channel>
-  <channel site="tataplay.com" site_id="252" lang="en" xmltv_id="">Zee Cinemalu</channel>
-  <channel site="tataplay.com" site_id="253" lang="en" xmltv_id="">Zee Bangla</channel>
-  <channel site="tataplay.com" site_id="256" lang="en" xmltv_id="">Zee Kannada</channel>
-  <channel site="tataplay.com" site_id="257" lang="en" xmltv_id="">Zee Tamil</channel>
-  <channel site="tataplay.com" site_id="259" lang="en" xmltv_id="">Zee News</channel>
-  <channel site="tataplay.com" site_id="288" lang="en" xmltv_id="">Dharma Sandesh</channel>
-  <channel site="tataplay.com" site_id="319" lang="en" xmltv_id="">Tata Play Bollywood Premiere HD</channel>
-  <channel site="tataplay.com" site_id="331" lang="en" xmltv_id="">DD North East</channel>
-  <channel site="tataplay.com" site_id="341" lang="en" xmltv_id="">Discovery HD World</channel>
-  <channel site="tataplay.com" site_id="356" lang="en" xmltv_id="">God TV</channel>
-  <channel site="tataplay.com" site_id="368" lang="en" xmltv_id="">News Live Bangla</channel>
-  <channel site="tataplay.com" site_id="384" lang="en" xmltv_id="">Khabarain Abhi Tak</channel>
-  <channel site="tataplay.com" site_id="385" lang="en" xmltv_id="">Sharnam TV</channel>
-  <channel site="tataplay.com" site_id="391" lang="en" xmltv_id="">MalaiMurasu Seithigal</channel>
-  <channel site="tataplay.com" site_id="406" lang="en" xmltv_id="">MTV HD</channel>
-  <channel site="tataplay.com" site_id="413" lang="en" xmltv_id="">Nat Geo Wild HD</channel>
-  <channel site="tataplay.com" site_id="418" lang="en" xmltv_id="">Colors Tamil</channel>
-  <channel site="tataplay.com" site_id="435" lang="en" xmltv_id="">SAI TV</channel>
-  <channel site="tataplay.com" site_id="446" lang="en" xmltv_id="">Paras Gold One</channel>
-  <channel site="tataplay.com" site_id="450" lang="en" xmltv_id="">SVBC Telugu</channel>
-  <channel site="tataplay.com" site_id="460" lang="en" xmltv_id="">SONY BBC Earth HD</channel>
-  <channel site="tataplay.com" site_id="462" lang="en" xmltv_id="">SONY SPORTS TEN 2 HD</channel>
-  <channel site="tataplay.com" site_id="464" lang="en" xmltv_id="">SONY SPORTS TEN 3 Hindi HD</channel>
-  <channel site="tataplay.com" site_id="480" lang="en" xmltv_id="">TLC HD</channel>
-  <channel site="tataplay.com" site_id="486" lang="en" xmltv_id="">Tata Play Bollywood Premiere</channel>
-  <channel site="tataplay.com" site_id="503" lang="en" xmltv_id="">Zee Cinema HD</channel>
-  <channel site="tataplay.com" site_id="515" lang="en" xmltv_id="">Zee Talkies HD</channel>
-  <channel site="tataplay.com" site_id="516" lang="en" xmltv_id="">STAR Maa HD</channel>
-  <channel site="tataplay.com" site_id="543" lang="en" xmltv_id="">Colors</channel>
-  <channel site="tataplay.com" site_id="544" lang="en" xmltv_id="">Colors Infinity</channel>
-  <channel site="tataplay.com" site_id="552" lang="en" xmltv_id="">Gujarat Samachar TV</channel>
-  <channel site="tataplay.com" site_id="554" lang="en" xmltv_id="">Sony Pal</channel>
-  <channel site="tataplay.com" site_id="556" lang="en" xmltv_id="">SET</channel>
-  <channel site="tataplay.com" site_id="557" lang="en" xmltv_id="">Zee TV</channel>
-  <channel site="tataplay.com" site_id="558" lang="en" xmltv_id="">SONY PIX</channel>
-  <channel site="tataplay.com" site_id="559" lang="en" xmltv_id="">SONY SAB</channel>
-  <channel site="tataplay.com" site_id="568" lang="en" xmltv_id="">Prarthana Life</channel>
-  <channel site="tataplay.com" site_id="571" lang="en" xmltv_id="">Tata Play Punjab De Rang</channel>
-  <channel site="tataplay.com" site_id="578" lang="en" xmltv_id="">&amp;TV</channel>
-  <channel site="tataplay.com" site_id="587" lang="en" xmltv_id="">Super Hungama</channel>
-  <channel site="tataplay.com" site_id="594" lang="en" xmltv_id="">Ishwar TV</channel>
-  <channel site="tataplay.com" site_id="614" lang="en" xmltv_id="">Tata Play Bangla Cinema</channel>
-  <channel site="tataplay.com" site_id="616" lang="en" xmltv_id="">History TV18 HD</channel>
-  <channel site="tataplay.com" site_id="622" lang="en" xmltv_id="">Tata Play Marathi Cinema</channel>
-  <channel site="tataplay.com" site_id="626" lang="en" xmltv_id="">Tata Play Fun Learn Rhymes</channel>
-  <channel site="tataplay.com" site_id="627" lang="en" xmltv_id="">Tata Play Fun Learn Junior</channel>
-  <channel site="tataplay.com" site_id="641" lang="en" xmltv_id="">Tata Play Cooking</channel>
-  <channel site="tataplay.com" site_id="643" lang="en" xmltv_id="">News State MP CG</channel>
-  <channel site="tataplay.com" site_id="645" lang="en" xmltv_id="">Tata Play English in Telugu</channel>
-  <channel site="tataplay.com" site_id="646" lang="en" xmltv_id="">DD Gyan Darshan</channel>
-  <channel site="tataplay.com" site_id="657" lang="en" xmltv_id="">Tata Play Telugu Cinema</channel>
-  <channel site="tataplay.com" site_id="658" lang="en" xmltv_id="">Sony Marathi</channel>
-  <channel site="tataplay.com" site_id="663" lang="en" xmltv_id="">Tata Play Tamil Cinema</channel>
-  <channel site="tataplay.com" site_id="664" lang="en" xmltv_id="">Star Sports 3</channel>
-  <channel site="tataplay.com" site_id="666" lang="en" xmltv_id="">Tata Play Theatre HD</channel>
-  <channel site="tataplay.com" site_id="677" lang="en" xmltv_id="">Tata Play ShortsTV</channel>
-  <channel site="tataplay.com" site_id="735" lang="en" xmltv_id="">Tata Play Ibaadat</channel>
-  <channel site="tataplay.com" site_id="737" lang="en" xmltv_id="">Tata Play Music</channel>
-  <channel site="tataplay.com" site_id="741" lang="en" xmltv_id="">Tata Play Classic Cinema</channel>
-  <channel site="tataplay.com" site_id="744" lang="en" xmltv_id="">Tata Play Comedy</channel>
-  <channel site="tataplay.com" site_id="772" lang="en" xmltv_id="">Tata Play Gujarati Cinema</channel>
-  <channel site="tataplay.com" site_id="773" lang="en" xmltv_id="">PTC Simran</channel>
-  <channel site="tataplay.com" site_id="781" lang="en" xmltv_id="">Prudent</channel>
-  <channel site="tataplay.com" site_id="782" lang="en" xmltv_id="">Namma TV</channel>
-  <channel site="tataplay.com" site_id="783" lang="en" xmltv_id="">Tata Play Seniors</channel>
-  <channel site="tataplay.com" site_id="785" lang="en" xmltv_id="">Tata Play Kannada Cinema</channel>
-  <channel site="tataplay.com" site_id="789" lang="en" xmltv_id="">Tata Play Hollywood Local</channel>
-  <channel site="tataplay.com" site_id="797" lang="en" xmltv_id="">Zee Thirai</channel>
-  <channel site="tataplay.com" site_id="807" lang="en" xmltv_id="">In Goa 24x7</channel>
-  <channel site="tataplay.com" site_id="811" lang="en" xmltv_id="">Tata Play Adbhut Kahaniyan</channel>
-  <channel site="tataplay.com" site_id="812" lang="en" xmltv_id="">Eurosport HD</channel>
-  <channel site="tataplay.com" site_id="814" lang="en" xmltv_id="">Zee Biskope</channel>
-  <channel site="tataplay.com" site_id="818" lang="en" xmltv_id="">Shemaroo TV</channel>
-  <channel site="tataplay.com" site_id="819" lang="en" xmltv_id="">RDX Goa</channel>
-  <channel site="tataplay.com" site_id="821" lang="en" xmltv_id="">Headlines Tripura</channel>
-  <channel site="tataplay.com" site_id="833" lang="en" xmltv_id="">DD Port Blair</channel>
-  <channel site="tataplay.com" site_id="840" lang="en" xmltv_id="">Shirdi Sai Baba</channel>
-  <channel site="tataplay.com" site_id="842" lang="en" xmltv_id="">Somnath Temple</channel>
-  <channel site="tataplay.com" site_id="849" lang="en" xmltv_id="">Kashi Vishwanath Temple, Varanasi</channel>
-  <channel site="tataplay.com" site_id="865" lang="en" xmltv_id="">Bangla Bhakti</channel>
-  <channel site="tataplay.com" site_id="866" lang="en" xmltv_id="">Tara News</channel>
-  <channel site="tataplay.com" site_id="868" lang="en" xmltv_id="">Tata Play Malayalam Cinema</channel>
-  <channel site="tataplay.com" site_id="872" lang="en" xmltv_id="">Tata Play Astro Duniya</channel>
-  <channel site="tataplay.com" site_id="873" lang="en" xmltv_id="">TV9 Bangla</channel>
-  <channel site="tataplay.com" site_id="883" lang="en" xmltv_id="">Swar Shree</channel>
-  <channel site="tataplay.com" site_id="887" lang="en" xmltv_id="">Garv Gurbani</channel>
-  <channel site="tataplay.com" site_id="892" lang="en" xmltv_id="">Samara News</channel>
-  <channel site="tataplay.com" site_id="893" lang="en" xmltv_id="">Tata Play Valam TV</channel>
-  <channel site="tataplay.com" site_id="908" lang="en" xmltv_id="">Nimbark TV</channel>
-  <channel site="tataplay.com" site_id="911" lang="en" xmltv_id="">Santwani</channel>
-  <channel site="tataplay.com" site_id="912" lang="en" xmltv_id="">Haryana Beats</channel>
-  <channel site="tataplay.com" site_id="928" lang="en" xmltv_id="">Tata Play NEET Prep</channel>
-  <channel site="tataplay.com" site_id="929" lang="en" xmltv_id="">Tata Play JEE Prep</channel>
-  <channel site="tataplay.com" site_id="930" lang="en" xmltv_id="">Buletin India</channel>
-  <channel site="tataplay.com" site_id="931" lang="en" xmltv_id="">Green Chillies TV</channel>
-  <channel site="tataplay.com" site_id="933" lang="en" xmltv_id="">Asianet Movies</channel>
-  <channel site="tataplay.com" site_id="940" lang="en" xmltv_id="">SIRIKANNADA Alltime</channel>
-  <channel site="tataplay.com" site_id="943" lang="en" xmltv_id="">Tata Play K-Dramas</channel>
-  <channel site="tataplay.com" site_id="944" lang="en" xmltv_id="">Live Iskcon Vrindavan</channel>
-  <channel site="tataplay.com" site_id="947" lang="en" xmltv_id="">Live Patna Sahib Patna</channel>
-  <channel site="tataplay.com" site_id="948" lang="en" xmltv_id="">Live Naina Devi Himachal Pradesh</channel>
-  <channel site="tataplay.com" site_id="959" lang="en" xmltv_id="">Tata Play Romance</channel>
-  <channel site="tataplay.com" site_id="960" lang="en" xmltv_id="">Atmadarshan</channel>
-  <channel site="tataplay.com" site_id="964" lang="en" xmltv_id="">Tata Play Classic TV</channel>
   <channel site="tataplay.com" site_id="974" lang="en" xmltv_id="">1st Gujarat</channel>
-  <channel site="tataplay.com" site_id="978" lang="en" xmltv_id="">Sidharth TV</channel>
-  <channel site="tataplay.com" site_id="986" lang="en" xmltv_id="">Tata Play Zindagi</channel>
-  <channel site="tataplay.com" site_id="994" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="995" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="996" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="997" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="998" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="999" lang="en" xmltv_id="">Tata Play Toons+</channel>
-  <channel site="tataplay.com" site_id="1002" lang="en" xmltv_id="">Saileela TV</channel>
-  <channel site="tataplay.com" site_id="1003" lang="en" xmltv_id="">Tata Play South Talkies</channel>
-  <channel site="tataplay.com" site_id="1004" lang="en" xmltv_id="">Mahavir Temple, Patna</channel>
-  <channel site="tataplay.com" site_id="1007" lang="en" xmltv_id="">Shri Ashtavinayak Mahaganpati, Ranjangaon</channel>
-  <channel site="tataplay.com" site_id="1008" lang="en" xmltv_id="">Naga Sai Temple</channel>
-  <channel site="tataplay.com" site_id="1009" lang="en" xmltv_id="">TV27 News</channel>
-  <channel site="tataplay.com" site_id="1018" lang="en" xmltv_id="">Real News Kerala</channel>
-  <channel site="tataplay.com" site_id="1019" lang="en" xmltv_id="">7x Music</channel>
-  <channel site="tataplay.com" site_id="1026" lang="en" xmltv_id="">Sidharth UTSAV</channel>
-  <channel site="tataplay.com" site_id="1032" lang="en" xmltv_id="">Sansad TV 2 HD</channel>
-  <channel site="tataplay.com" site_id="1035" lang="en" xmltv_id="">Khandoba Temple, Jejuri</channel>
-  <channel site="tataplay.com" site_id="1044" lang="en" xmltv_id="">Global India</channel>
-  <channel site="tataplay.com" site_id="1045" lang="en" xmltv_id="">Shemaroo UMANG</channel>
-  <channel site="tataplay.com" site_id="1053" lang="en" xmltv_id="">Asian News</channel>
-  <channel site="tataplay.com" site_id="1058" lang="en" xmltv_id="">Aaj Ki Khabar</channel>
-  <channel site="tataplay.com" site_id="1059" lang="en" xmltv_id="">Indian News</channel>
-  <channel site="tataplay.com" site_id="1066" lang="en" xmltv_id="">Disney Channel HD</channel>
-  <channel site="tataplay.com" site_id="1067" lang="en" xmltv_id="">Star Sports 1 Tamil HD</channel>
-  <channel site="tataplay.com" site_id="1068" lang="en" xmltv_id="">Star Sports 1 Telugu HD</channel>
-  <channel site="tataplay.com" site_id="1069" lang="en" xmltv_id="">Star Movies Select</channel>
-  <channel site="tataplay.com" site_id="1070" lang="en" xmltv_id="">MEDIA 9</channel>
-  <channel site="tataplay.com" site_id="1072" lang="en" xmltv_id="">Star Gold 2 HD</channel>
-  <channel site="tataplay.com" site_id="1073" lang="en" xmltv_id="">Tata Play Telugu Classics</channel>
-  <channel site="tataplay.com" site_id="1076" lang="en" xmltv_id="">Asom Live 24</channel>
-  <channel site="tataplay.com" site_id="1078" lang="en" xmltv_id="">Daily Post Punjab Haryana Himachal</channel>
-  <channel site="tataplay.com" site_id="1079" lang="en" xmltv_id="">TTN 24</channel>
-  <channel site="tataplay.com" site_id="1080" lang="en" xmltv_id="">U Bangla TV</channel>
-  <channel site="tataplay.com" site_id="1082" lang="en" xmltv_id="">Tata Play Asomiya Monoronjan</channel>
-  <channel site="tataplay.com" site_id="1092" lang="en" xmltv_id="">Test Service 4101</channel>
-  <channel site="tataplay.com" site_id="1130" lang="en" xmltv_id="">Tata Play Bollywood Masala</channel>
-  <channel site="tataplay.com" site_id="1164" lang="en" xmltv_id="">Unique TV</channel>
-  <channel site="tataplay.com" site_id="1167" lang="en" xmltv_id="">Tata Play Hollywood Local Tamil</channel>
-  <channel site="tataplay.com" site_id="1168" lang="en" xmltv_id="">Tata Play Hollywood Local Telugu</channel>
-  <channel site="tataplay.com" site_id="1169" lang="en" xmltv_id="">Jay Jagannath.</channel>
-  <channel site="tataplay.com" site_id="1170" lang="en" xmltv_id="">Sidharth GOLD</channel>
-  <channel site="tataplay.com" site_id="1171" lang="en" xmltv_id="">Shree Ichchhapuran Balaji Mandir</channel>
-  <channel site="tataplay.com" site_id="1181" lang="en" xmltv_id="">Zee Power HD</channel>
-  <channel site="tataplay.com" site_id="1191" lang="en" xmltv_id="">DD Sports HD</channel>
-  <channel site="tataplay.com" site_id="1192" lang="en" xmltv_id="">SONY SPORTS TEN 4 Telugu</channel>
-  <channel site="tataplay.com" site_id="1194" lang="en" xmltv_id="">BRK News</channel>
-  <channel site="tataplay.com" site_id="1196" lang="en" xmltv_id="">Ekamra Bharat Odia</channel>
-  <channel site="tataplay.com" site_id="1197" lang="en" xmltv_id="">Ekamra Nilachakra</channel>
-  <channel site="tataplay.com" site_id="1198" lang="en" xmltv_id="">Ekamra Cynema</channel>
-  <channel site="tataplay.com" site_id="1199" lang="en" xmltv_id="">Ekamra Music</channel>
-  <channel site="tataplay.com" site_id="1200" lang="en" xmltv_id="">Ekamra Jatra</channel>
-  <channel site="tataplay.com" site_id="1201" lang="en" xmltv_id="">Ekamra Paramatma</channel>
-  <channel site="tataplay.com" site_id="1202" lang="en" xmltv_id="">Ekamra One paschima</channel>
-  <channel site="tataplay.com" site_id="1205" lang="en" xmltv_id="">Lokmanch</channel>
-  <channel site="tataplay.com" site_id="1206" lang="en" xmltv_id="">LNI</channel>
-  <channel site="tataplay.com" site_id="1207" lang="en" xmltv_id="">Ekamra Manoranjan</channel>
-  <channel site="tataplay.com" site_id="1209" lang="en" xmltv_id="">Samrat News</channel>
-  <channel site="tataplay.com" site_id="1222" lang="en" xmltv_id="">Sun Bangla HD</channel>
-  <channel site="tataplay.com" site_id="1242" lang="en" xmltv_id="">In24 News</channel>
-  <channel site="tataplay.com" site_id="1245" lang="en" xmltv_id="">National Today 24x7</channel>
-  <channel site="tataplay.com" site_id="1246" lang="en" xmltv_id="">Vande Bharat News</channel>
-  <channel site="tataplay.com" site_id="1247" lang="en" xmltv_id="">35 MM</channel>
-  <channel site="tataplay.com" site_id="1253" lang="en" xmltv_id="">Jeewan Bhakti</channel>
-  <channel site="tataplay.com" site_id="1254" lang="en" xmltv_id="">National News Live</channel>
-  <channel site="tataplay.com" site_id="1255" lang="en" xmltv_id="">Update India</channel>
-  <channel site="tataplay.com" site_id="1256" lang="en" xmltv_id="">Oye Music</channel>
-  <channel site="tataplay.com" site_id="1257" lang="en" xmltv_id="">Sangam TV</channel>
-  <channel site="tataplay.com" site_id="1258" lang="en" xmltv_id="">Tata Play Filmy Safar</channel>
-  <channel site="tataplay.com" site_id="1260" lang="en" xmltv_id="">Tata Play Tamil Classics</channel>
-  <channel site="tataplay.com" site_id="1266" lang="en" xmltv_id="">Gemini Music HD</channel>
-  <channel site="tataplay.com" site_id="1286" lang="en" xmltv_id="">News Capital</channel>
-  <channel site="tataplay.com" site_id="1301" lang="en" xmltv_id="">Tata Play 4K</channel>
-  <channel site="tataplay.com" site_id="1309" lang="en" xmltv_id="">SS1 HD Hindi Geo</channel>
-  <channel site="tataplay.com" site_id="1311" lang="en" xmltv_id="">SS 1 Hindi Geo</channel>
-  <channel site="tataplay.com" site_id="1312" lang="en" xmltv_id="">SS 1 Geo</channel>
-  <channel site="tataplay.com" site_id="1317" lang="en" xmltv_id="">Tamil Janam</channel>
-  <channel site="tataplay.com" site_id="1321" lang="en" xmltv_id="">ALL Time MOVIES</channel>
-  <channel site="tataplay.com" site_id="1324" lang="en" xmltv_id="">Raj Nagaichuvai</channel>
-  <channel site="tataplay.com" site_id="1332" lang="en" xmltv_id="">AB STAR News</channel>
-  <channel site="tataplay.com" site_id="1333" lang="en" xmltv_id="">ABC News</channel>
-  <channel site="tataplay.com" site_id="1334" lang="en" xmltv_id="">KBC News</channel>
-  <channel site="tataplay.com" site_id="1335" lang="en" xmltv_id="">Shiksha TV</channel>
-  <channel site="tataplay.com" site_id="1337" lang="en" xmltv_id="">Sristi TV</channel>
-  <channel site="tataplay.com" site_id="1338" lang="en" xmltv_id="">TV 45 News</channel>
-  <channel site="tataplay.com" site_id="1339" lang="en" xmltv_id="">TNP News</channel>
-  <channel site="tataplay.com" site_id="1340" lang="en" xmltv_id="">ETV Bal Bharat HD</channel>
-  <channel site="tataplay.com" site_id="1343" lang="en" xmltv_id="">NDTV MARATHI</channel>
-  <channel site="tataplay.com" site_id="1350" lang="en" xmltv_id="">Tata Play Lakshya TV</channel>
-  <channel site="tataplay.com" site_id="1352" lang="en" xmltv_id="">Pear TV</channel>
-  <channel site="tataplay.com" site_id="1363" lang="en" xmltv_id="">Tata Play Anime Local</channel>
-  <channel site="tataplay.com" site_id="1370" lang="en" xmltv_id="">Sun Neo HD</channel>
-  <channel site="tataplay.com" site_id="1371" lang="en" xmltv_id="">BVG</channel>
-  <channel site="tataplay.com" site_id="1372" lang="en" xmltv_id="">Bhaktisagar</channel>
-  <channel site="tataplay.com" site_id="1380" lang="en" xmltv_id="">News 21</channel>
-  <channel site="tataplay.com" site_id="1382" lang="en" xmltv_id="">DHARSAN TV</channel>
-  <channel site="tataplay.com" site_id="1383" lang="en" xmltv_id="">NIJAM TV</channel>
-  <channel site="tataplay.com" site_id="1389" lang="en" xmltv_id="">Mahaa Max</channel>
-  <channel site="tataplay.com" site_id="1390" lang="en" xmltv_id="">Tata Play Superhits Serials</channel>
-  <channel site="tataplay.com" site_id="1391" lang="en" xmltv_id="">Bhakthi Siri</channel>
-  <channel site="tataplay.com" site_id="1392" lang="en" xmltv_id="">Sadvidya</channel>
-  <channel site="tataplay.com" site_id="1393" lang="en" xmltv_id="">In24 Live News</channel>
-  <channel site="tataplay.com" site_id="1395" lang="en" xmltv_id="">Live Times</channel>
-  <channel site="tataplay.com" site_id="1400" lang="en" xmltv_id="">Sadhna Prime News</channel>
-  <channel site="tataplay.com" site_id="1407" lang="en" xmltv_id="">India TV Speed News HD</channel>
-  <channel site="tataplay.com" site_id="1411" lang="en" xmltv_id="">News State Punjab Haryana Himachal</channel>
-  <channel site="tataplay.com" site_id="1413" lang="en" xmltv_id="">HIFF Movies</channel>
-  <channel site="tataplay.com" site_id="1444" lang="en" xmltv_id="">Tata Play Marathi Classics</channel>
-  <channel site="tataplay.com" site_id="1445" lang="en" xmltv_id="">Tar TV</channel>
-  <channel site="tataplay.com" site_id="1447" lang="en" xmltv_id="">Garvi Gujarat Gujarati</channel>
-  <channel site="tataplay.com" site_id="1448" lang="en" xmltv_id="">24Hrs TV</channel>
-  <channel site="tataplay.com" site_id="1450" lang="en" xmltv_id="">OSD Binge 1</channel>
-  <channel site="tataplay.com" site_id="1451" lang="en" xmltv_id="">OSD Binge 2</channel>
-  <channel site="tataplay.com" site_id="1452" lang="en" xmltv_id="">OSD Binge 3</channel>
-  <channel site="tataplay.com" site_id="1453" lang="en" xmltv_id="">OSD Binge 4</channel>
-  <channel site="tataplay.com" site_id="1454" lang="en" xmltv_id="">OSD Binge 5</channel>
-  <channel site="tataplay.com" site_id="1459" lang="en" xmltv_id="">Tata Play Deiveegam</channel>
-  <channel site="tataplay.com" site_id="1460" lang="en" xmltv_id="">BHI Channel</channel>
-  <channel site="tataplay.com" site_id="1461" lang="en" xmltv_id="">News Ground 24x7</channel>
-  <channel site="tataplay.com" site_id="1462" lang="en" xmltv_id="">22 Scope</channel>
-  <channel site="tataplay.com" site_id="1463" lang="en" xmltv_id="">Express News Bharat</channel>
-  <channel site="tataplay.com" site_id="1464" lang="en" xmltv_id="">ABC Australia</channel>
-  <channel site="tataplay.com" site_id="1468" lang="en" xmltv_id="">NAVSARJAN SANSKRUTI GUJARATI</channel>
-  <channel site="tataplay.com" site_id="1470" lang="en" xmltv_id="">News Nation 81</channel>
-  <channel site="tataplay.com" site_id="1485" lang="en" xmltv_id="">Village TV</channel>
-  <channel site="tataplay.com" site_id="1488" lang="en" xmltv_id="">Guarantee News</channel>
-  <channel site="tataplay.com" site_id="1489" lang="en" xmltv_id="">Tata Play Fancode Sports</channel>
-  <channel site="tataplay.com" site_id="1495" lang="en" xmltv_id="">Star Sports 2 Tamil HD</channel>
-  <channel site="tataplay.com" site_id="1496" lang="en" xmltv_id="">Star Sports 2 Telugu HD</channel>
-  <channel site="tataplay.com" site_id="1717" lang="en" xmltv_id="">SONY MAX 1</channel>
-  <channel site="tataplay.com" site_id="1731" lang="en" xmltv_id="">Alias-3 of 2725</channel>
-  <channel site="tataplay.com" site_id="1732" lang="en" xmltv_id="">Alias-2 of 2725</channel>
-  <channel site="tataplay.com" site_id="1733" lang="en" xmltv_id="">Alias-1 of 2725</channel>
-  <channel site="tataplay.com" site_id="1734" lang="en" xmltv_id="">OSD - 3</channel>
-  <channel site="tataplay.com" site_id="1735" lang="en" xmltv_id="">Alias-3 of 2715</channel>
-  <channel site="tataplay.com" site_id="1736" lang="en" xmltv_id="">Alias-2 of 2715</channel>
-  <channel site="tataplay.com" site_id="1737" lang="en" xmltv_id="">Alias-1 of 2715</channel>
-  <channel site="tataplay.com" site_id="1738" lang="en" xmltv_id="">OSD - 2</channel>
-  <channel site="tataplay.com" site_id="1739" lang="en" xmltv_id="">Alias-3 of 2714</channel>
-  <channel site="tataplay.com" site_id="1740" lang="en" xmltv_id="">Alias-2 of 2714</channel>
-  <channel site="tataplay.com" site_id="1741" lang="en" xmltv_id="">Alias-1 of 2714</channel>
-  <channel site="tataplay.com" site_id="1742" lang="en" xmltv_id="">OSD - 1</channel>
-  <channel site="tataplay.com" site_id="1744" lang="en" xmltv_id="">Zee Cinema Geo</channel>
-  <channel site="tataplay.com" site_id="1747" lang="en" xmltv_id="">Alias Service 1543</channel>
-  <channel site="tataplay.com" site_id="1752" lang="en" xmltv_id="">Delta 140823_21.0</channel>
-  <channel site="tataplay.com" site_id="1753" lang="en" xmltv_id="">Zee Cinema Geo</channel>
-  <channel site="tataplay.com" site_id="1754" lang="en" xmltv_id="">Dagdusheth Pune</channel>
-  <channel site="tataplay.com" site_id="1785" lang="en" xmltv_id="">Tata Play Bhakti Sangeet</channel>
-  <channel site="tataplay.com" site_id="1786" lang="en" xmltv_id="">Tata Play Fancode Sports +1</channel>
-  <channel site="tataplay.com" site_id="1787" lang="en" xmltv_id="">Tata Play Cartoon Network Forever</channel>
-  <channel site="tataplay.com" site_id="1788" lang="en" xmltv_id="">S India News</channel>
-  <channel site="tataplay.com" site_id="1789" lang="en" xmltv_id="">KM News</channel>
-  <channel site="tataplay.com" site_id="1790" lang="en" xmltv_id="">National TV India</channel>
-  <channel site="tataplay.com" site_id="1795" lang="en" xmltv_id="">Aagaaz Times</channel>
-  <channel site="tataplay.com" site_id="1796" lang="en" xmltv_id="">Voice TV Urdu</channel>
-  <channel site="tataplay.com" site_id="1797" lang="en" xmltv_id="">Smriti Patra</channel>
-  <channel site="tataplay.com" site_id="1799" lang="en" xmltv_id="">Public First</channel>
-  <channel site="tataplay.com" site_id="1800" lang="en" xmltv_id="">Test Service 3701</channel>
-  <channel site="tataplay.com" site_id="1818" lang="en" xmltv_id="">Mirror Media</channel>
-  <channel site="tataplay.com" site_id="1821" lang="en" xmltv_id="">Top News Marathi</channel>
-  <channel site="tataplay.com" site_id="1822" lang="en" xmltv_id="">NE Bharat 24</channel>
-  <channel site="tataplay.com" site_id="1823" lang="en" xmltv_id="">Prime Asia</channel>
-  <channel site="tataplay.com" site_id="1824" lang="en" xmltv_id="">NSC9</channel>
-  <channel site="tataplay.com" site_id="1825" lang="en" xmltv_id="">A ONE NEWS</channel>
-  <channel site="tataplay.com" site_id="1826" lang="en" xmltv_id="">INDIA 24X7 LIVE TV</channel>
-  <channel site="tataplay.com" site_id="1827" lang="en" xmltv_id="">Nation Update</channel>
-  <channel site="tataplay.com" site_id="1834" lang="en" xmltv_id="">Hingulambika Devi, Solapur</channel>
-  <channel site="tataplay.com" site_id="1835" lang="en" xmltv_id="">Tata Play Odia Manoranjan</channel>
-  <channel site="tataplay.com" site_id="1836" lang="en" xmltv_id="">GTC Punjabi</channel>
-  <channel site="tataplay.com" site_id="1850" lang="en" xmltv_id="">GTC News</channel>
-  <channel site="tataplay.com" site_id="1851" lang="en" xmltv_id="">Bharat A to Z News</channel>
-  <channel site="tataplay.com" site_id="1859" lang="en" xmltv_id="">Gangaur TV</channel>
-  <channel site="tataplay.com" site_id="1861" lang="en" xmltv_id="">Freedom TV</channel>
-  <channel site="tataplay.com" site_id="1862" lang="en" xmltv_id="">F Plus</channel>
-  <channel site="tataplay.com" site_id="1864" lang="en" xmltv_id="">SAMACHAR TODAY</channel>
-  <channel site="tataplay.com" site_id="1865" lang="en" xmltv_id="">Shree Sanatan TV</channel>
-  <channel site="tataplay.com" site_id="1866" lang="en" xmltv_id="">Valam TV Dayro</channel>
-  <channel site="tataplay.com" site_id="1867" lang="en" xmltv_id="">Roja TV</channel>
-  <channel site="tataplay.com" site_id="1868" lang="en" xmltv_id="">Roja Movies</channel>
-  <channel site="tataplay.com" site_id="1869" lang="en" xmltv_id="">News Plus24x7</channel>
-  <channel site="tataplay.com" site_id="1870" lang="en" xmltv_id="">Mahotsav TV</channel>
-  <channel site="tataplay.com" site_id="1871" lang="en" xmltv_id="">SONY SPORTS TEN 4 KANNADA</channel>
   <channel site="tataplay.com" site_id="774" lang="en" xmltv_id="4TVNews.in@SD">4tv News</channel>
+  <channel site="tataplay.com" site_id="1019" lang="en" xmltv_id="">7x Music</channel>
   <channel site="tataplay.com" site_id="139" lang="en" xmltv_id="9XM.in@SD">9XM</channel>
   <channel site="tataplay.com" site_id="266" lang="en" xmltv_id="10TV.in@SD">10 TV</channel>
+  <channel site="tataplay.com" site_id="1462" lang="en" xmltv_id="">22 Scope</channel>
+  <channel site="tataplay.com" site_id="1448" lang="en" xmltv_id="">24Hrs TV</channel>
+  <channel site="tataplay.com" site_id="1247" lang="en" xmltv_id="">35 MM</channel>
+  <channel site="tataplay.com" site_id="148" lang="en" xmltv_id="Andpictures.in@SD">&amp;pictures</channel>
+  <channel site="tataplay.com" site_id="267" lang="en" xmltv_id="Andpictures.in@HD">&amp;pictures HD</channel>
+  <channel site="tataplay.com" site_id="578" lang="en" xmltv_id="AndTV.in@SD">&amp;TV</channel>
+  <channel site="tataplay.com" site_id="40" lang="en" xmltv_id="AndTV.in@HD">&amp;tv HD</channel>
+  <channel site="tataplay.com" site_id="1183" lang="en" xmltv_id="AndxplorHD.in@HD">&amp;Xplor HD</channel>
   <channel site="tataplay.com" site_id="969" lang="en" xmltv_id="AadinathTV.in@SD">Aadinath TV</channel>
+  <channel site="tataplay.com" site_id="1795" lang="en" xmltv_id="">Aagaaz Times</channel>
+  <channel site="tataplay.com" site_id="1058" lang="en" xmltv_id="">Aaj Ki Khabar</channel>
   <channel site="tataplay.com" site_id="153" lang="en" xmltv_id="AajTak.in@SD">Aaj Tak</channel>
-  <channel site="tataplay.com" site_id="689" lang="en" xmltv_id="AajTak.in@SD">Aaj Tak HD</channel>
+  <channel site="tataplay.com" site_id="689" lang="en" xmltv_id="AajTak.in@HD">Aaj Tak HD</channel>
   <channel site="tataplay.com" site_id="129" lang="en" xmltv_id="AakaashAath.in@SD">Aakaash Aath</channel>
   <channel site="tataplay.com" site_id="38" lang="en" xmltv_id="Aastha.in@SD">Aastha</channel>
   <channel site="tataplay.com" site_id="283" lang="en" xmltv_id="AasthaBhajan.in@SD">Aastha Bhajan</channel>
+  <channel site="tataplay.com" site_id="1332" lang="en" xmltv_id="">AB STAR News</channel>
+  <channel site="tataplay.com" site_id="1464" lang="en" xmltv_id="ABCAustralia.au@SD">ABC Australia</channel>
+  <channel site="tataplay.com" site_id="1333" lang="en" xmltv_id="">ABC News</channel>
   <channel site="tataplay.com" site_id="225" lang="en" xmltv_id="ABNAndhraJyoti.in@SD">ABN Andhra Jyothy</channel>
   <channel site="tataplay.com" site_id="102" lang="en" xmltv_id="ABPAnanda.in@SD">ABP Ananda</channel>
   <channel site="tataplay.com" site_id="73" lang="en" xmltv_id="ABPAsmita.in@SD">ABP Asmita</channel>
   <channel site="tataplay.com" site_id="155" lang="en" xmltv_id="ABPMajha.in@SD">ABP Majha</channel>
   <channel site="tataplay.com" site_id="177" lang="en" xmltv_id="ABPNews.in@SD">ABP News</channel>
+  <channel site="tataplay.com" site_id="100" lang="en" xmltv_id="">Action Cinema</channel>
   <channel site="tataplay.com" site_id="284" lang="en" xmltv_id="AdithyaTV.in@SD">Adithya TV</channel>
-  <channel site="tataplay.com" site_id="648" lang="en" xmltv_id="AKDCalcuttaNews.in@SD">Calcutta News</channel>
-  <channel site="tataplay.com" site_id="28" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
   <channel site="tataplay.com" site_id="190" lang="en" xmltv_id="AlJazeera.qa@English">Al Jazeera</channel>
+  <channel site="tataplay.com" site_id="28" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
+  <channel site="tataplay.com" site_id="1747" lang="en" xmltv_id="">Alias Service 1543</channel>
+  <channel site="tataplay.com" site_id="1741" lang="en" xmltv_id="">Alias-1 of 2714</channel>
+  <channel site="tataplay.com" site_id="1737" lang="en" xmltv_id="">Alias-1 of 2715</channel>
+  <channel site="tataplay.com" site_id="1733" lang="en" xmltv_id="">Alias-1 of 2725</channel>
+  <channel site="tataplay.com" site_id="1740" lang="en" xmltv_id="">Alias-2 of 2714</channel>
+  <channel site="tataplay.com" site_id="1736" lang="en" xmltv_id="">Alias-2 of 2715</channel>
+  <channel site="tataplay.com" site_id="1732" lang="en" xmltv_id="">Alias-2 of 2725</channel>
+  <channel site="tataplay.com" site_id="1739" lang="en" xmltv_id="">Alias-3 of 2714</channel>
+  <channel site="tataplay.com" site_id="1735" lang="en" xmltv_id="">Alias-3 of 2715</channel>
+  <channel site="tataplay.com" site_id="1731" lang="en" xmltv_id="">Alias-3 of 2725</channel>
+  <channel site="tataplay.com" site_id="1321" lang="en" xmltv_id="AllTimeMovies.in@SD">ALL Time MOVIES</channel>
   <channel site="tataplay.com" site_id="178" lang="en" xmltv_id="AmritaTV.in@SD">Amrita TV</channel>
   <channel site="tataplay.com" site_id="937" lang="en" xmltv_id="AnaadiTV.in@SD">Anaadi TV</channel>
-  <channel site="tataplay.com" site_id="1486" lang="en" xmltv_id="AnandTV.uk@SD">Anand TV</channel>
+  <channel site="tataplay.com" site_id="1486" lang="en" xmltv_id="AnandTV.in@SD">Anand TV</channel>
   <channel site="tataplay.com" site_id="787" lang="en" xmltv_id="ANBNews.in@SD">ANB NEWS</channel>
-  <channel site="tataplay.com" site_id="506" lang="en" xmltv_id="Andflix.in@SD">&amp;Flix HD</channel>
-  <channel site="tataplay.com" site_id="592" lang="en" xmltv_id="Andflix.in@SD">&amp;flix</channel>
-  <channel site="tataplay.com" site_id="267" lang="en" xmltv_id="Andpictures.in@HD">&amp;pictures HD</channel>
-  <channel site="tataplay.com" site_id="148" lang="en" xmltv_id="Andpictures.in@SD">&amp;pictures</channel>
-  <channel site="tataplay.com" site_id="40" lang="en" xmltv_id="AndTV.in@SD">&amp;tv HD</channel>
-  <channel site="tataplay.com" site_id="1183" lang="en" xmltv_id="AndxplorHD.in@SD">&amp;Xplor HD</channel>
   <channel site="tataplay.com" site_id="282" lang="en" xmltv_id="AngelTV.gh@SD">Angel TV</channel>
-  <channel site="tataplay.com" site_id="287" lang="en" xmltv_id="AnimalPlanet.in@HD">Animal Planet HD</channel>
   <channel site="tataplay.com" site_id="130" lang="en" xmltv_id="AnimalPlanet.in@SD">Animal Planet</channel>
+  <channel site="tataplay.com" site_id="287" lang="en" xmltv_id="AnimalPlanet.in@HD">Animal Planet HD</channel>
   <channel site="tataplay.com" site_id="180" lang="en" xmltv_id="AnjanTV.in@SD">Anjan TV</channel>
-  <channel site="tataplay.com" site_id="12" lang="en" xmltv_id="AnmolCinema2.in@SD">Anmol Cinema 2</channel>
   <channel site="tataplay.com" site_id="64" lang="en" xmltv_id="AnmolCinema.in@SD">Anmol Cinema</channel>
+  <channel site="tataplay.com" site_id="12" lang="en" xmltv_id="AnmolCinema2.in@SD">Anmol Cinema 2</channel>
   <channel site="tataplay.com" site_id="523" lang="en" xmltv_id="AnmolCinema.in@SD">Anmol TV</channel>
-  <channel site="tataplay.com" site_id="962" lang="en" xmltv_id="ANNNews.in@HD">ANN News</channel>
   <channel site="tataplay.com" site_id="286" lang="en" xmltv_id="APN.in@SD">APN News</channel>
   <channel site="tataplay.com" site_id="285" lang="en" xmltv_id="AradanaTV.in@SD">Aradana TV</channel>
   <channel site="tataplay.com" site_id="907" lang="en" xmltv_id="ArgusNews.in@SD">Argus News</channel>
-  <channel site="tataplay.com" site_id="292" lang="en" xmltv_id="Asianet.in@HD">Asianet HD</channel>
+  <channel site="tataplay.com" site_id="1053" lang="en" xmltv_id="">Asian News</channel>
   <channel site="tataplay.com" site_id="289" lang="en" xmltv_id="Asianet.in@SD">Asianet</channel>
-  <channel site="tataplay.com" site_id="1173" lang="en" xmltv_id="AsianetMovies.in@HD">Asianet Movies HD</channel>
+  <channel site="tataplay.com" site_id="292" lang="en" xmltv_id="Asianet.in@HD">Asianet HD</channel>
   <channel site="tataplay.com" site_id="293" lang="en" xmltv_id="AsianetMovies.in@SD">Asianet Movies</channel>
+  <channel site="tataplay.com" site_id="933" lang="en" xmltv_id="AsianetMovies.in@SD">Asianet Movies</channel>
+  <channel site="tataplay.com" site_id="1173" lang="en" xmltv_id="AsianetMovies.in@HD">Asianet Movies HD</channel>
   <channel site="tataplay.com" site_id="532" lang="en" xmltv_id="AsianetNews.in@SD">Asianet News</channel>
   <channel site="tataplay.com" site_id="953" lang="en" xmltv_id="AsianetPlus.in@SD">Asianet Plus</channel>
   <channel site="tataplay.com" site_id="555" lang="en" xmltv_id="AsianetSuvarnaNews.in@SD">Asianet Suvarna News</channel>
+  <channel site="tataplay.com" site_id="1076" lang="en" xmltv_id="">Asom Live 24</channel>
   <channel site="tataplay.com" site_id="29" lang="en" xmltv_id="AssamTalks.in@SD">Assam Talks</channel>
   <channel site="tataplay.com" site_id="1484" lang="en" xmltv_id="AssamTalks.in@SD">Assam Talks</channel>
+  <channel site="tataplay.com" site_id="960" lang="en" xmltv_id="">Atmadarshan</channel>
   <channel site="tataplay.com" site_id="935" lang="en" xmltv_id="AwakeningTV.in@SD">Awakening</channel>
   <channel site="tataplay.com" site_id="660" lang="en" xmltv_id="AyushTV.in@SD">Ayush TV</channel>
   <channel site="tataplay.com" site_id="729" lang="en" xmltv_id="B4UBhojpuri.in@SD">B4U Bhojpuri</channel>
   <channel site="tataplay.com" site_id="730" lang="en" xmltv_id="B4UKadak.in@SD">B4U Kadak</channel>
   <channel site="tataplay.com" site_id="7" lang="en" xmltv_id="B4UMovies.in@India">B4U Movies</channel>
   <channel site="tataplay.com" site_id="9" lang="en" xmltv_id="B4UMusic.in@India">B4U Music</channel>
+  <channel site="tataplay.com" site_id="865" lang="en" xmltv_id="">Bangla Bhakti</channel>
   <channel site="tataplay.com" site_id="652" lang="en" xmltv_id="BansalNews.in@SD">Bansal News</channel>
   <channel site="tataplay.com" site_id="188" lang="en" xmltv_id="BBCNews.uk@SouthAsia">BBC News</channel>
-  <channel site="tataplay.com" site_id="290" lang="en" xmltv_id="BhaktiTV.tt@SD">Bhakti TV</channel>
+  <channel site="tataplay.com" site_id="290" lang="en" xmltv_id="BhakthiTV.in@SD">Bhakti TV</channel>
+  <channel site="tataplay.com" site_id="1372" lang="en" xmltv_id="">Bhaktisagar</channel>
   <channel site="tataplay.com" site_id="1010" lang="en" xmltv_id="Bharat24.in@SD">Bharat 24</channel>
   <channel site="tataplay.com" site_id="1051" lang="en" xmltv_id="BharatExpress.in@SD">Bharat Express</channel>
   <channel site="tataplay.com" site_id="291" lang="en" xmltv_id="BharatSamachar.in@SD">Bharat Samachar</channel>
+  <channel site="tataplay.com" site_id="1872" lang="en" xmltv_id="">Bharat Update</channel>
+  <channel site="tataplay.com" site_id="1460" lang="en" xmltv_id="">BHI Channel</channel>
   <channel site="tataplay.com" site_id="181" lang="en" xmltv_id="BhojpuriCinema.in@SD">Bhojpuri Cinema</channel>
   <channel site="tataplay.com" site_id="297" lang="en" xmltv_id="BigMagic.in@SD">Big Magic</channel>
-  <channel site="tataplay.com" site_id="1100" lang="en" xmltv_id="BIGTV.in@SD">BIG TV Telugu</channel>
   <channel site="tataplay.com" site_id="1136" lang="en" xmltv_id="BloombergTV.us@Plus">Bloomberg Television</channel>
-  <channel site="tataplay.com" site_id="1376" lang="en" xmltv_id="BSTV.bg@SD">BS TV</channel>
+  <channel site="tataplay.com" site_id="1194" lang="en" xmltv_id="BRKNews.in@SD">BRK News</channel>
+  <channel site="tataplay.com" site_id="1376" lang="en" xmltv_id="">BS TV</channel>
+  <channel site="tataplay.com" site_id="930" lang="en" xmltv_id="">Buletin India</channel>
+  <channel site="tataplay.com" site_id="1371" lang="en" xmltv_id="">BVG</channel>
+  <channel site="tataplay.com" site_id="910" lang="en" xmltv_id="CnewsBharat.in@SD">C News Bharat</channel>
+  <channel site="tataplay.com" site_id="648" lang="en" xmltv_id="AKDCalcuttaNews.in@SD">Calcutta News</channel>
   <channel site="tataplay.com" site_id="1318" lang="en" xmltv_id="CalvaryTV.in@SD">Calvary TV</channel>
   <channel site="tataplay.com" site_id="238" lang="en" xmltv_id="CartoonNetwork.in@SD">Cartoon Network</channel>
   <channel site="tataplay.com" site_id="681" lang="en" xmltv_id="CartoonNetworkHDPlus.in@SD">Cartoon Network HD+</channel>
   <channel site="tataplay.com" site_id="816" lang="en" xmltv_id="CBeebies.au@SD">CBeeBies</channel>
-  <channel site="tataplay.com" site_id="775" lang="en" xmltv_id="ChannelDivya.in@SD">DIVYA</channel>
+  <channel site="tataplay.com" site_id="157" lang="en" xmltv_id="">Channel News Asia</channel>
   <channel site="tataplay.com" site_id="161" lang="en" xmltv_id="ChannelWIN.in@SD">Channel WIN</channel>
   <channel site="tataplay.com" site_id="193" lang="en" xmltv_id="ChardiklaTimeTV.in@SD">Chardikla Time TV</channel>
   <channel site="tataplay.com" site_id="561" lang="en" xmltv_id="ChintuTV.in@SD">Chintu TV</channel>
@@ -407,30 +110,36 @@
   <channel site="tataplay.com" site_id="303" lang="en" xmltv_id="CNBCBajar.in@SD">CNBC Bajaar</channel>
   <channel site="tataplay.com" site_id="168" lang="en" xmltv_id="CNBCTV18.in@SD">CNBC TV18</channel>
   <channel site="tataplay.com" site_id="304" lang="en" xmltv_id="CNBCTV18PrimeHD.in@SD">CNBC TV18 Prime HD</channel>
-  <channel site="tataplay.com" site_id="910" lang="en" xmltv_id="CnewsBharat.in@SD">C News Bharat</channel>
   <channel site="tataplay.com" site_id="243" lang="en" xmltv_id="CNNInternational.us@SouthAsia">CNN International</channel>
   <channel site="tataplay.com" site_id="206" lang="en" xmltv_id="CNNNews18.in@SD">CNN News18</channel>
-  <channel site="tataplay.com" site_id="52" lang="en" xmltv_id="Colors.in@SD">Colors HD</channel>
+  <channel site="tataplay.com" site_id="543" lang="en" xmltv_id="Colors.in@SD">Colors</channel>
   <channel site="tataplay.com" site_id="26" lang="en" xmltv_id="ColorsBangla.in@SD">Colors Bangla</channel>
-  <channel site="tataplay.com" site_id="305" lang="en" xmltv_id="ColorsBangla.in@SD">Colors Bangla HD</channel>
   <channel site="tataplay.com" site_id="896" lang="en" xmltv_id="ColorsBanglaCinema.in@SD">Colors Bangla Cinema</channel>
+  <channel site="tataplay.com" site_id="305" lang="en" xmltv_id="ColorsBangla.in@HD">Colors Bangla HD</channel>
   <channel site="tataplay.com" site_id="53" lang="en" xmltv_id="ColorsCineplex.in@SD">Colors Cineplex</channel>
-  <channel site="tataplay.com" site_id="61" lang="en" xmltv_id="ColorsCineplex.in@SD">Colors Cineplex HD</channel>
   <channel site="tataplay.com" site_id="1000" lang="en" xmltv_id="ColorsCineplexBollywood.in@SD">Colors Cineplex Bollywood</channel>
+  <channel site="tataplay.com" site_id="61" lang="en" xmltv_id="ColorsCineplex.in@HD">Colors Cineplex HD</channel>
   <channel site="tataplay.com" site_id="1025" lang="en" xmltv_id="ColorsCineplexSuperhits.in@SD">Colors Cineplex Superhits</channel>
   <channel site="tataplay.com" site_id="107" lang="en" xmltv_id="ColorsGujarati.in@SD">Colors Gujarati</channel>
   <channel site="tataplay.com" site_id="692" lang="en" xmltv_id="ColorsGujaratiCinema.in@SD">Colors Gujarati Cinema</channel>
-  <channel site="tataplay.com" site_id="187" lang="en" xmltv_id="ColorsInfinity.in@SD">Colors Infinity HD</channel>
+  <channel site="tataplay.com" site_id="52" lang="en" xmltv_id="Colors.in@SD">Colors HD</channel>
+  <channel site="tataplay.com" site_id="544" lang="en" xmltv_id="ColorsInfinity.in@SD">Colors Infinity</channel>
+  <channel site="tataplay.com" site_id="187" lang="en" xmltv_id="ColorsInfinity.in@HD">Colors Infinity HD</channel>
   <channel site="tataplay.com" site_id="108" lang="en" xmltv_id="ColorsKannada.in@SD">Colors Kannada</channel>
-  <channel site="tataplay.com" site_id="612" lang="en" xmltv_id="ColorsKannada.in@SD">Colors Kannada HD</channel>
   <channel site="tataplay.com" site_id="667" lang="en" xmltv_id="ColorsKannadaCinema.in@SD">Colors Kannada Cinema</channel>
+  <channel site="tataplay.com" site_id="612" lang="en" xmltv_id="ColorsKannada.in@HD">Colors Kannada HD</channel>
   <channel site="tataplay.com" site_id="134" lang="en" xmltv_id="ColorsMarathi.in@SD">Colors Marathi</channel>
-  <channel site="tataplay.com" site_id="308" lang="en" xmltv_id="ColorsMarathi.in@SD">Colors Marathi HD</channel>
+  <channel site="tataplay.com" site_id="308" lang="en" xmltv_id="ColorsMarathi.in@HD">Colors Marathi HD</channel>
   <channel site="tataplay.com" site_id="438" lang="en" xmltv_id="ColorsRishteyAsia.in@SD">Colors Rishtey</channel>
   <channel site="tataplay.com" site_id="533" lang="en" xmltv_id="ColorsSuper.in@SD">Colors SUPER</channel>
-  <channel site="tataplay.com" site_id="674" lang="en" xmltv_id="ColorsTamil.in@SD">Colors Tamil HD</channel>
+  <channel site="tataplay.com" site_id="418" lang="en" xmltv_id="ColorsTamil.in@SD">Colors Tamil</channel>
+  <channel site="tataplay.com" site_id="674" lang="en" xmltv_id="ColorsTamil.in@HD">Colors Tamil HD</channel>
   <channel site="tataplay.com" site_id="311" lang="en" xmltv_id="CTVNAKDPlus.in@SD">CTVN AKD Plus</channel>
+  <channel site="tataplay.com" site_id="99" lang="en" xmltv_id="DTamil.in@SD">D Tamil</channel>
+  <channel site="tataplay.com" site_id="1754" lang="en" xmltv_id="">Dagdusheth Pune</channel>
+  <channel site="tataplay.com" site_id="1078" lang="en" xmltv_id="">Daily Post Punjab Haryana Himachal</channel>
   <channel site="tataplay.com" site_id="51" lang="en" xmltv_id="DangalTV.in@SD">Dangal</channel>
+  <channel site="tataplay.com" site_id="194" lang="en" xmltv_id="Dangal2.in@SD">Dangal 2</channel>
   <channel site="tataplay.com" site_id="758" lang="en" xmltv_id="DDArunPrabha.in@SD">DD Arunprabha</channel>
   <channel site="tataplay.com" site_id="314" lang="en" xmltv_id="DDBangla.in@SD">DD Bangla</channel>
   <channel site="tataplay.com" site_id="316" lang="en" xmltv_id="DDBharati.in@SD">DD Bharati</channel>
@@ -439,10 +148,11 @@
   <channel site="tataplay.com" site_id="1216" lang="en" xmltv_id="DDChhattisgarh.in@SD">DD Chhattisgarh</channel>
   <channel site="tataplay.com" site_id="323" lang="en" xmltv_id="DDGirnar.in@SD">DD Girnar</channel>
   <channel site="tataplay.com" site_id="1215" lang="en" xmltv_id="DDGoa.in@SD">DD Goa</channel>
+  <channel site="tataplay.com" site_id="646" lang="en" xmltv_id="">DD Gyan Darshan</channel>
   <channel site="tataplay.com" site_id="1212" lang="en" xmltv_id="DDHaryana.in@SD">DD Haryana</channel>
   <channel site="tataplay.com" site_id="1217" lang="en" xmltv_id="DDHimachalPradesh.in@SD">DD Himachal</channel>
   <channel site="tataplay.com" site_id="324" lang="en" xmltv_id="DDIndia.in@SD">DD India</channel>
-  <channel site="tataplay.com" site_id="1219" lang="en" xmltv_id="DDIndia.in@SD">DD India HD</channel>
+  <channel site="tataplay.com" site_id="1219" lang="en" xmltv_id="DDIndia.in@HD">DD India HD</channel>
   <channel site="tataplay.com" site_id="1188" lang="en" xmltv_id="DDJharkhand.in@SD">DD Jharkhand</channel>
   <channel site="tataplay.com" site_id="325" lang="en" xmltv_id="DDKashir.in@SD">DD Kashir</channel>
   <channel site="tataplay.com" site_id="326" lang="en" xmltv_id="DDKisan.in@SD">DD Kisan</channel>
@@ -452,80 +162,117 @@
   <channel site="tataplay.com" site_id="991" lang="en" xmltv_id="DDMeghalaya.in@SD">DD Meghalaya</channel>
   <channel site="tataplay.com" site_id="1211" lang="en" xmltv_id="DDMizoram.in@SD">DD Mizoram</channel>
   <channel site="tataplay.com" site_id="1214" lang="en" xmltv_id="DDNagaland.in@SD">DD Nagaland</channel>
-  <channel site="tataplay.com" site_id="1218" lang="en" xmltv_id="DDNational.in@HD">DD National HD</channel>
   <channel site="tataplay.com" site_id="191" lang="en" xmltv_id="DDNational.in@SD">DD National</channel>
+  <channel site="tataplay.com" site_id="1218" lang="en" xmltv_id="DDNational.in@HD">DD National HD</channel>
   <channel site="tataplay.com" site_id="322" lang="en" xmltv_id="DDNews.in@SD">DD News</channel>
-  <channel site="tataplay.com" site_id="691" lang="en" xmltv_id="DDNews.in@SD">DD News HD</channel>
+  <channel site="tataplay.com" site_id="691" lang="en" xmltv_id="DDNews.in@HD">DD News HD</channel>
+  <channel site="tataplay.com" site_id="331" lang="en" xmltv_id="">DD North East</channel>
   <channel site="tataplay.com" site_id="333" lang="en" xmltv_id="DDOdia.in@SD">DD Odia</channel>
+  <channel site="tataplay.com" site_id="833" lang="en" xmltv_id="">DD Port Blair</channel>
   <channel site="tataplay.com" site_id="335" lang="en" xmltv_id="DDPunjabi.in@SD">DD Punjabi</channel>
   <channel site="tataplay.com" site_id="332" lang="en" xmltv_id="DDRajasthan.in@SD">DD Rajasthan</channel>
   <channel site="tataplay.com" site_id="336" lang="en" xmltv_id="DDSahyadri.in@SD">DD Sahyadri</channel>
   <channel site="tataplay.com" site_id="337" lang="en" xmltv_id="DDSaptagiri.in@SD">DD Saptagiri</channel>
   <channel site="tataplay.com" site_id="223" lang="en" xmltv_id="DDSports.in@SD">DD Sports</channel>
+  <channel site="tataplay.com" site_id="1191" lang="en" xmltv_id="DDSports.in@HD">DD Sports HD</channel>
   <channel site="tataplay.com" site_id="334" lang="en" xmltv_id="DDTamil.in@SD">DD Tamil</channel>
   <channel site="tataplay.com" site_id="1210" lang="en" xmltv_id="DDTripura.in@SD">DD Tripura</channel>
   <channel site="tataplay.com" site_id="338" lang="en" xmltv_id="DDUrdu.in@SD">DD Urdu</channel>
-  <channel site="tataplay.com" site_id="1213" lang="en" xmltv_id="DDUttarakhand.in@SD">DD Uttarakhand</channel>
   <channel site="tataplay.com" site_id="339" lang="en" xmltv_id="DDUttarPradesh.in@SD">DD Uttar Pradesh</channel>
+  <channel site="tataplay.com" site_id="1213" lang="en" xmltv_id="DDUttarakhand.in@SD">DD Uttarakhand</channel>
   <channel site="tataplay.com" site_id="548" lang="en" xmltv_id="DDYadagiri.in@SD">DD Yadagiri</channel>
-  <channel site="tataplay.com" site_id="823" lang="en" xmltv_id="Dhinchaak2.in@SD">Goldmines</channel>
-  <channel site="tataplay.com" site_id="1499" lang="en" xmltv_id="Dhinchaak2.in@SD">Goldmines Movies</channel>
-  <channel site="tataplay.com" site_id="1050" lang="en" xmltv_id="Dhinchaak.in@SD">Goldmines Bollywood</channel>
+  <channel site="tataplay.com" site_id="1752" lang="en" xmltv_id="">Delta 140823_21.0</channel>
+  <channel site="tataplay.com" site_id="288" lang="en" xmltv_id="">Dharma Sandesh</channel>
+  <channel site="tataplay.com" site_id="1382" lang="en" xmltv_id="">DHARSAN TV</channel>
   <channel site="tataplay.com" site_id="219" lang="en" xmltv_id="DiscoveryChannel.in@SD">Discovery Channel</channel>
+  <channel site="tataplay.com" site_id="341" lang="en" xmltv_id="">Discovery HD World</channel>
   <channel site="tataplay.com" site_id="119" lang="en" xmltv_id="DiscoveryKids.in@SD">Discovery Kids</channel>
   <channel site="tataplay.com" site_id="113" lang="en" xmltv_id="DiscoveryScience.in@SD">Discovery Science</channel>
   <channel site="tataplay.com" site_id="228" lang="en" xmltv_id="DiscoveryTurbo.in@SD">Discovery Turbo</channel>
+  <channel site="tataplay.com" site_id="114" lang="en" xmltv_id="">Disney</channel>
+  <channel site="tataplay.com" site_id="1066" lang="en" xmltv_id="DisneyChannel.in@HD">Disney Channel HD</channel>
   <channel site="tataplay.com" site_id="265" lang="en" xmltv_id="DisneyInternationalHD.in@SD">Disney International HD</channel>
-  <channel site="tataplay.com" site_id="99" lang="en" xmltv_id="DTamil.in@SD">D Tamil</channel>
+  <channel site="tataplay.com" site_id="144" lang="en" xmltv_id="DisneyJunior.in@SD">Disney Junior</channel>
+  <channel site="tataplay.com" site_id="775" lang="en" xmltv_id="ChannelDivya.in@SD">DIVYA</channel>
+  <channel site="tataplay.com" site_id="351" lang="en" xmltv_id="SwaraSagar.in@SD">Divyavani TV</channel>
   <channel site="tataplay.com" site_id="60" lang="en" xmltv_id="DW.de@English">DW</channel>
   <channel site="tataplay.com" site_id="353" lang="en" xmltv_id="DY365.in@SD">DY 365</channel>
-  <channel site="tataplay.com" site_id="224" lang="en" xmltv_id="E24.in@SD">E24</channel>
+  <channel site="tataplay.com" site_id="1196" lang="en" xmltv_id="">Ekamra Bharat Odia</channel>
+  <channel site="tataplay.com" site_id="1198" lang="en" xmltv_id="">Ekamra Cynema</channel>
+  <channel site="tataplay.com" site_id="1200" lang="en" xmltv_id="">Ekamra Jatra</channel>
+  <channel site="tataplay.com" site_id="1207" lang="en" xmltv_id="">Ekamra Manoranjan</channel>
+  <channel site="tataplay.com" site_id="1199" lang="en" xmltv_id="">Ekamra Music</channel>
+  <channel site="tataplay.com" site_id="1197" lang="en" xmltv_id="">Ekamra Nilachakra</channel>
+  <channel site="tataplay.com" site_id="1202" lang="en" xmltv_id="">Ekamra One paschima</channel>
+  <channel site="tataplay.com" site_id="1201" lang="en" xmltv_id="">Ekamra Paramatma</channel>
   <channel site="tataplay.com" site_id="788" lang="en" xmltv_id="Enterr10Bangla.in@SD">Enterr10 Bangla</channel>
   <channel site="tataplay.com" site_id="126" lang="en" xmltv_id="EpicTV.in@SD">EPIC</channel>
+  <channel site="tataplay.com" site_id="830" lang="en" xmltv_id="EpicBhojpuri.in@SD">EPIC Bhojpuri</channel>
+  <channel site="tataplay.com" site_id="867" lang="en" xmltv_id="EpicKids.in@SD">EPIC Kids</channel>
+  <channel site="tataplay.com" site_id="733" lang="en" xmltv_id="EpicMusic.in@SD">EPIC Music</channel>
+  <channel site="tataplay.com" site_id="888" lang="en" xmltv_id="EpicParivar.in@SD">EPIC Parivar</channel>
   <channel site="tataplay.com" site_id="88" lang="en" xmltv_id="ETNow.in@SD">ET NOW</channel>
   <channel site="tataplay.com" site_id="950" lang="en" xmltv_id="ETNowSwadesh.in@SD">ET Now Swadesh</channel>
   <channel site="tataplay.com" site_id="358" lang="en" xmltv_id="ETVAbhiruchi.in@SD">ETV Abhiruchi</channel>
   <channel site="tataplay.com" site_id="146" lang="en" xmltv_id="ETVAndhraPradesh.in@SD">ETV Andhra Pradesh</channel>
-  <channel site="tataplay.com" site_id="905" lang="en" xmltv_id="ETVBalBharatTelugu.in@SD">ETV Bal Bharat</channel>
-  <channel site="tataplay.com" site_id="1341" lang="en" xmltv_id="ETVCinema.in@HD">ETV Cinema HD</channel>
+  <channel site="tataplay.com" site_id="905" lang="en" xmltv_id="ETVBalBharat.in@SD">ETV Bal Bharat</channel>
+  <channel site="tataplay.com" site_id="1340" lang="en" xmltv_id="ETVBalBharat.in@HD">ETV Bal Bharat HD</channel>
   <channel site="tataplay.com" site_id="128" lang="en" xmltv_id="ETVCinema.in@SD">ETV Cinema</channel>
-  <channel site="tataplay.com" site_id="268" lang="en" xmltv_id="ETVLife.in@SD">ETV Life</channel>
-  <channel site="tataplay.com" site_id="1342" lang="en" xmltv_id="ETVPlus.in@HD">ETV Plus HD</channel>
-  <channel site="tataplay.com" site_id="352" lang="en" xmltv_id="ETVPlus.in@SD">ETV Plus</channel>
-  <channel site="tataplay.com" site_id="83" lang="en" xmltv_id="ETVTelangana.in@SD">ETV Telangana</channel>
+  <channel site="tataplay.com" site_id="1341" lang="en" xmltv_id="ETVCinema.in@HD">ETV Cinema HD</channel>
   <channel site="tataplay.com" site_id="359" lang="en" xmltv_id="ETVTelugu.in@HD">ETV HD</channel>
+  <channel site="tataplay.com" site_id="268" lang="en" xmltv_id="ETVLife.in@SD">ETV Life</channel>
+  <channel site="tataplay.com" site_id="352" lang="en" xmltv_id="ETVPlus.in@SD">ETV Plus</channel>
+  <channel site="tataplay.com" site_id="1342" lang="en" xmltv_id="ETVPlus.in@HD">ETV Plus HD</channel>
+  <channel site="tataplay.com" site_id="83" lang="en" xmltv_id="ETVTelangana.in@SD">ETV Telangana</channel>
   <channel site="tataplay.com" site_id="145" lang="en" xmltv_id="ETVTelugu.in@SD">ETV Telugu</channel>
-  <channel site="tataplay.com" site_id="693" lang="en" xmltv_id="Eurosport.fr@Asia">Eurosport</channel>
+  <channel site="tataplay.com" site_id="693" lang="en" xmltv_id="Eurosport.in@SD">Eurosport</channel>
+  <channel site="tataplay.com" site_id="812" lang="en" xmltv_id="Eurosport.in@HD">Eurosport HD</channel>
+  <channel site="tataplay.com" site_id="1463" lang="en" xmltv_id="">Express News Bharat</channel>
+  <channel site="tataplay.com" site_id="1862" lang="en" xmltv_id="">F Plus</channel>
   <channel site="tataplay.com" site_id="192" lang="en" xmltv_id="FaktMarathi.in@SD">Fakt Marathi</channel>
   <channel site="tataplay.com" site_id="227" lang="en" xmltv_id="FashionTV.in@SD">Fashion TV</channel>
   <channel site="tataplay.com" site_id="791" lang="en" xmltv_id="FatehTV.in@SD">Fateh TV</channel>
-  <channel site="tataplay.com" site_id="830" lang="en" xmltv_id="FilamchiBhojpuri.in@SD">Filamchi Bhojpuri</channel>
   <channel site="tataplay.com" site_id="650" lang="en" xmltv_id="FirstIndiaNews.in@SD">First India Rajasthan</channel>
   <channel site="tataplay.com" site_id="10" lang="en" xmltv_id="FlowersTV.in@SD">Flowers</channel>
   <channel site="tataplay.com" site_id="117" lang="en" xmltv_id="FoodFood.in@SD">Food Food</channel>
   <channel site="tataplay.com" site_id="1030" lang="en" xmltv_id="Foodxp.uk@SD">Food XP</channel>
   <channel site="tataplay.com" site_id="131" lang="en" xmltv_id="France24.fr@English">France 24</channel>
-  <channel site="tataplay.com" site_id="360" lang="en" xmltv_id="GeminiComedy.in@SD">Gemini Comedy</channel>
-  <channel site="tataplay.com" site_id="361" lang="en" xmltv_id="GeminiLife.in@SD">Gemini Life</channel>
-  <channel site="tataplay.com" site_id="162" lang="en" xmltv_id="GeminiMovies.in@SD">Gemini Movies</channel>
-  <channel site="tataplay.com" site_id="362" lang="en" xmltv_id="GeminiMovies.in@SD">Gemini Movies HD</channel>
-  <channel site="tataplay.com" site_id="363" lang="en" xmltv_id="GeminiMusic.in@SD">Gemini Music</channel>
-  <channel site="tataplay.com" site_id="195" lang="en" xmltv_id="GeminiTV.in@SD">Gemini TV</channel>
-  <channel site="tataplay.com" site_id="355" lang="en" xmltv_id="GeminiTV.in@SD">Gemini TV HD</channel>
-  <channel site="tataplay.com" site_id="269" lang="en" xmltv_id="GoodnessTV.in@SD">Goodness</channel>
+  <channel site="tataplay.com" site_id="1861" lang="en" xmltv_id="">Freedom TV</channel>
+  <channel site="tataplay.com" site_id="1859" lang="en" xmltv_id="">Gangaur TV</channel>
+  <channel site="tataplay.com" site_id="887" lang="en" xmltv_id="">Garv Gurbani</channel>
+  <channel site="tataplay.com" site_id="1044" lang="en" xmltv_id="">Global India</channel>
+  <channel site="tataplay.com" site_id="356" lang="en" xmltv_id="">God TV</channel>
+  <channel site="tataplay.com" site_id="823" lang="en" xmltv_id="Goldmines.in@SD">Goldmines</channel>
+  <channel site="tataplay.com" site_id="1050" lang="en" xmltv_id="GoldminesBollywood.in@SD">Goldmines Bollywood</channel>
+  <channel site="tataplay.com" site_id="1499" lang="en" xmltv_id="GoldminesMovies.in@SD">Goldmines Movies</channel>
   <channel site="tataplay.com" site_id="278" lang="en" xmltv_id="GoodNewsToday.in@SD">Good News Today</channel>
-  <channel site="tataplay.com" site_id="867" lang="en" xmltv_id="Gubbare.in@SD">Gubbare</channel>
+  <channel site="tataplay.com" site_id="136" lang="en" xmltv_id="NDTVGoodTimes.in@SD">GOOD TiMES</channel>
+  <channel site="tataplay.com" site_id="269" lang="en" xmltv_id="GoodnessTV.in@SD">Goodness</channel>
+  <channel site="tataplay.com" site_id="931" lang="en" xmltv_id="">Green Chillies TV</channel>
+  <channel site="tataplay.com" site_id="1850" lang="en" xmltv_id="GTCNews.in@SD">GTC News</channel>
+  <channel site="tataplay.com" site_id="1836" lang="en" xmltv_id="GTCPunjabi.in@SD">GTC Punjabi</channel>
+  <channel site="tataplay.com" site_id="1488" lang="en" xmltv_id="">Guarantee News</channel>
+  <channel site="tataplay.com" site_id="552" lang="en" xmltv_id="">Gujarat Samachar TV</channel>
   <channel site="tataplay.com" site_id="365" lang="en" xmltv_id="GulistanNews.in@SD">Gulistan News</channel>
   <channel site="tataplay.com" site_id="837" lang="en" xmltv_id="HareKrsnaTV.in@SD">Hare Krsna</channel>
   <channel site="tataplay.com" site_id="348" lang="en" xmltv_id="HarvestTV.in@SD">Harvest TV 24x7</channel>
+  <channel site="tataplay.com" site_id="912" lang="en" xmltv_id="">Haryana Beats</channel>
+  <channel site="tataplay.com" site_id="821" lang="en" xmltv_id="">Headlines Tripura</channel>
+  <channel site="tataplay.com" site_id="1413" lang="en" xmltv_id="">HIFF Movies</channel>
   <channel site="tataplay.com" site_id="344" lang="en" xmltv_id="HindiKhabar.in@SD">Hindi Khabar</channel>
   <channel site="tataplay.com" site_id="630" lang="en" xmltv_id="HinduDharmam.in@SD">Hindu Dharmam</channel>
+  <channel site="tataplay.com" site_id="1834" lang="en" xmltv_id="">Hingulambika Devi, Solapur</channel>
   <channel site="tataplay.com" site_id="172" lang="en" xmltv_id="HistoryTV18.in@SD">History TV18</channel>
+  <channel site="tataplay.com" site_id="616" lang="en" xmltv_id="HistoryTV18.in@HD">History TV18 HD</channel>
   <channel site="tataplay.com" site_id="349" lang="en" xmltv_id="HMTV.in@SD">HM TV</channel>
   <channel site="tataplay.com" site_id="1267" lang="en" xmltv_id="HNN24x7.in@SD">HNN News</channel>
   <channel site="tataplay.com" site_id="898" lang="en" xmltv_id="HornbillTV.in@SD">Hornbill TV</channel>
   <channel site="tataplay.com" site_id="345" lang="en" xmltv_id="HungamaTV.in@SD">Hungama</channel>
   <channel site="tataplay.com" site_id="27" lang="en" xmltv_id="IBC24.in@SD">IBC 24</channel>
+  <channel site="tataplay.com" site_id="1393" lang="en" xmltv_id="">In24 Live News</channel>
+  <channel site="tataplay.com" site_id="1242" lang="en" xmltv_id="">In24 News</channel>
+  <channel site="tataplay.com" site_id="807" lang="en" xmltv_id="">In Goa 24x7</channel>
+  <channel site="tataplay.com" site_id="1826" lang="en" xmltv_id="">INDIA 24X7 LIVE TV</channel>
   <channel site="tataplay.com" site_id="1084" lang="en" xmltv_id="IndiaDailyLive.in@SD">India Daily 24x7</channel>
   <channel site="tataplay.com" site_id="183" lang="en" xmltv_id="IndiaNews.in@SD">India News</channel>
   <channel site="tataplay.com" site_id="654" lang="en" xmltv_id="IndiaNewsGujarati.in@SD">India News Gujarat</channel>
@@ -534,57 +281,74 @@
   <channel site="tataplay.com" site_id="366" lang="en" xmltv_id="IndiaNewsPunjabHimachal.in@SD">India News Punjab</channel>
   <channel site="tataplay.com" site_id="14" lang="en" xmltv_id="IndiaNewsRajasthan.in@SD">India News Rajasthan</channel>
   <channel site="tataplay.com" site_id="30" lang="en" xmltv_id="IndiaNewsUttarPradesh.in@SD">India News UP UK</channel>
+  <channel site="tataplay.com" site_id="1873" lang="en" xmltv_id="">India Superfast TV</channel>
   <channel site="tataplay.com" site_id="1" lang="en" xmltv_id="IndiaToday.in@SD">INDIA TODAY</channel>
   <channel site="tataplay.com" site_id="104" lang="en" xmltv_id="IndiaTV.in@SD">India TV</channel>
+  <channel site="tataplay.com" site_id="1407" lang="en" xmltv_id="IndiaTVSpeedNews.in@HD">India TV Speed News HD</channel>
   <channel site="tataplay.com" site_id="685" lang="en" xmltv_id="IndiaVoice.in@SD">India Voice</channel>
+  <channel site="tataplay.com" site_id="1059" lang="en" xmltv_id="">Indian News</channel>
   <channel site="tataplay.com" site_id="698" lang="en" xmltv_id="INH24x7.in@SD">INH 24X7</channel>
   <channel site="tataplay.com" site_id="633" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery</channel>
-  <channel site="tataplay.com" site_id="1276" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery HD</channel>
+  <channel site="tataplay.com" site_id="1276" lang="en" xmltv_id="InvestigationDiscovery.in@HD">Investigation Discovery HD</channel>
   <channel site="tataplay.com" site_id="647" lang="en" xmltv_id="IsaiAruvi.in@SD">Isaiaruvi</channel>
-  <channel site="tataplay.com" site_id="888" lang="en" xmltv_id="IsharaTV.in@SD">Ishara</channel>
-  <channel site="tataplay.com" site_id="370" lang="en" xmltv_id="JaihindTV.in@SD">Jaihind TV</channel>
+  <channel site="tataplay.com" site_id="594" lang="en" xmltv_id="IshwarBhaktiTV.in@SD">Ishwar TV</channel>
+  <channel site="tataplay.com" site_id="201" lang="en" xmltv_id="JMovie.in@SD">J Movies</channel>
   <channel site="tataplay.com" site_id="233" lang="en" xmltv_id="JaiMaharashtra.in@SD">Jai Maharashtra</channel>
-  <channel site="tataplay.com" site_id="537" lang="en" xmltv_id="JalshaMovies.in@HD">Jalsha Movies HD</channel>
+  <channel site="tataplay.com" site_id="370" lang="en" xmltv_id="JaihindTV.in@SD">Jaihind TV</channel>
   <channel site="tataplay.com" site_id="572" lang="en" xmltv_id="JalshaMovies.in@SD">Jalsha Movies</channel>
-  <channel site="tataplay.com" site_id="270" lang="en" xmltv_id="JanamTV.in@SD">Janam TV</channel>
-  <channel site="tataplay.com" site_id="701" lang="en" xmltv_id="JantantraTV.in@SD">Jantantra TV</channel>
-  <channel site="tataplay.com" site_id="371" lang="en" xmltv_id="JantaTV.in@SD">Janta TV</channel>
+  <channel site="tataplay.com" site_id="537" lang="en" xmltv_id="JalshaMovies.in@HD">Jalsha Movies HD</channel>
   <channel site="tataplay.com" site_id="870" lang="en" xmltv_id="JanTV.in@SD">Jan TV</channel>
+  <channel site="tataplay.com" site_id="270" lang="en" xmltv_id="JanamTV.in@SD">Janam TV</channel>
+  <channel site="tataplay.com" site_id="371" lang="en" xmltv_id="JantaTV.in@SD">Janta TV</channel>
+  <channel site="tataplay.com" site_id="701" lang="en" xmltv_id="JantantraTV.in@SD">Jantantra TV</channel>
+  <channel site="tataplay.com" site_id="1169" lang="en" xmltv_id="">Jay Jagannath.</channel>
   <channel site="tataplay.com" site_id="199" lang="en" xmltv_id="JayaMax.in@SD">Jaya Max</channel>
   <channel site="tataplay.com" site_id="198" lang="en" xmltv_id="JayaPlus.in@SD">Jaya Plus</channel>
-  <channel site="tataplay.com" site_id="708" lang="en" xmltv_id="JayaTV.in@SD">Jaya TV HD</channel>
+  <channel site="tataplay.com" site_id="708" lang="en" xmltv_id="JayaTV.in@HD">Jaya TV HD</channel>
   <channel site="tataplay.com" site_id="372" lang="en" xmltv_id="JeevanTV.in@SD">Jeevan TV</channel>
+  <channel site="tataplay.com" site_id="1253" lang="en" xmltv_id="">Jeewan Bhakti</channel>
   <channel site="tataplay.com" site_id="373" lang="en" xmltv_id="JinvaniChannel.in@SD">Jinvani Channel</channel>
-  <channel site="tataplay.com" site_id="201" lang="en" xmltv_id="JMovie.in@SD">J Movies</channel>
   <channel site="tataplay.com" site_id="434" lang="en" xmltv_id="JothiTV.in@SD">Jothi TV</channel>
   <channel site="tataplay.com" site_id="211" lang="en" xmltv_id="KairaliNews.in@SD">Kairali News</channel>
   <channel site="tataplay.com" site_id="25" lang="en" xmltv_id="KairaliTV.in@SD">Kairali TV</channel>
-  <channel site="tataplay.com" site_id="411" lang="en" xmltv_id="KalaignarMurasu.in@SD">Murasu TV</channel>
-  <channel site="tataplay.com" site_id="44" lang="en" xmltv_id="KalaignarSeithigal.in@SD">Seithigal TV</channel>
   <channel site="tataplay.com" site_id="200" lang="en" xmltv_id="KalaignarTV.in@SD">Kalaignar TV</channel>
   <channel site="tataplay.com" site_id="375" lang="en" xmltv_id="KalingaTV.in@SD">Kalinga TV</channel>
-  <channel site="tataplay.com" site_id="1204" lang="en" xmltv_id="KalingaTV.in@SD">Kalinga Bharat</channel>
   <channel site="tataplay.com" site_id="376" lang="en" xmltv_id="KanakNews.in@SD">Kanak News</channel>
   <channel site="tataplay.com" site_id="377" lang="en" xmltv_id="KappaTV.in@SD">Kappa TV</channel>
+  <channel site="tataplay.com" site_id="849" lang="en" xmltv_id="">Kashi Vishwanath Temple, Varanasi</channel>
   <channel site="tataplay.com" site_id="838" lang="en" xmltv_id="KashishNews.in@SD">Kashish News</channel>
   <channel site="tataplay.com" site_id="378" lang="en" xmltv_id="KaumudyTV.in@SD">Kaumudy TV</channel>
+  <channel site="tataplay.com" site_id="1334" lang="en" xmltv_id="">KBC News</channel>
   <channel site="tataplay.com" site_id="972" lang="en" xmltv_id="KhabarFast.in@SD">Khabar Fast</channel>
+  <channel site="tataplay.com" site_id="384" lang="en" xmltv_id="">Khabarain Abhi Tak</channel>
+  <channel site="tataplay.com" site_id="1035" lang="en" xmltv_id="">Khandoba Temple, Jejuri</channel>
   <channel site="tataplay.com" site_id="379" lang="en" xmltv_id="KhushbooBangla.in@SD">Khushboo Bangla</channel>
+  <channel site="tataplay.com" site_id="1789" lang="en" xmltv_id="">KM News</channel>
   <channel site="tataplay.com" site_id="82" lang="en" xmltv_id="KochuTV.in@SD">Kochu TV</channel>
   <channel site="tataplay.com" site_id="381" lang="en" xmltv_id="KolkataTV.in@SD">Kolkata TV</channel>
-  <channel site="tataplay.com" site_id="380" lang="en" xmltv_id="KTV.in@SD">KTV HD</channel>
+  <channel site="tataplay.com" site_id="147" lang="en" xmltv_id="KTV.in@SD">KTV</channel>
+  <channel site="tataplay.com" site_id="380" lang="en" xmltv_id="KTV.in@HD">KTV HD</channel>
   <channel site="tataplay.com" site_id="383" lang="en" xmltv_id="KushiTV.in@SD">Kushi TV</channel>
+  <channel site="tataplay.com" site_id="944" lang="en" xmltv_id="">Live Iskcon Vrindavan</channel>
+  <channel site="tataplay.com" site_id="948" lang="en" xmltv_id="">Live Naina Devi Himachal Pradesh</channel>
+  <channel site="tataplay.com" site_id="947" lang="en" xmltv_id="">Live Patna Sahib Patna</channel>
+  <channel site="tataplay.com" site_id="1395" lang="en" xmltv_id="">Live Times</channel>
   <channel site="tataplay.com" site_id="793" lang="en" xmltv_id="LivingIndiaNews.in@SD">Living India News</channel>
+  <channel site="tataplay.com" site_id="1206" lang="en" xmltv_id="">LNI</channel>
+  <channel site="tataplay.com" site_id="1205" lang="en" xmltv_id="">Lokmanch</channel>
   <channel site="tataplay.com" site_id="826" lang="en" xmltv_id="LokshahiNews.in@SD">Lokshahi Marathi</channel>
   <channel site="tataplay.com" site_id="390" lang="en" xmltv_id="MadhaTV.in@SD">Madha TV</channel>
-  <channel site="tataplay.com" site_id="1151" lang="en" xmltv_id="MahaaNews.in@SD">MAHAA NEWS</channel>
+  <channel site="tataplay.com" site_id="1004" lang="en" xmltv_id="">Mahavir Temple, Patna.</channel>
+  <channel site="tataplay.com" site_id="1870" lang="en" xmltv_id="">Mahotsav TV</channel>
   <channel site="tataplay.com" site_id="392" lang="en" xmltv_id="MakkalTV.in@SD">Makkal TV</channel>
+  <channel site="tataplay.com" site_id="391" lang="en" xmltv_id="MalaiMurasuTV.in@SD">MalaiMurasu Seithigal</channel>
   <channel site="tataplay.com" site_id="87" lang="en" xmltv_id="ManoramaNews.in@SD">Manorama News</channel>
   <channel site="tataplay.com" site_id="965" lang="en" xmltv_id="ManoranjanGrand.in@SD">Manoranjan Grand</channel>
   <channel site="tataplay.com" site_id="731" lang="en" xmltv_id="ManoranjanTV.in@SD">Manoranjan TV</channel>
   <channel site="tataplay.com" site_id="394" lang="en" xmltv_id="MathrubhumiNews.in@SD">Mathrubhumi News</channel>
-  <channel site="tataplay.com" site_id="395" lang="en" xmltv_id="MazhavilManorama.in@HD">Mazhavil Manorama HD</channel>
   <channel site="tataplay.com" site_id="31" lang="en" xmltv_id="MazhavilManorama.in@SD">Mazhavil Manorama</channel>
+  <channel site="tataplay.com" site_id="395" lang="en" xmltv_id="MazhavilManorama.in@HD">Mazhavil Manorama HD</channel>
+  <channel site="tataplay.com" site_id="1070" lang="en" xmltv_id="">MEDIA 9</channel>
   <channel site="tataplay.com" site_id="576" lang="en" xmltv_id="MediaOne.in@SD">Media One</channel>
   <channel site="tataplay.com" site_id="396" lang="en" xmltv_id="Mega24.in@SD">Mega 24</channel>
   <channel site="tataplay.com" site_id="400" lang="en" xmltv_id="MegaMusiq.in@SD">Mega Musiq</channel>
@@ -592,295 +356,517 @@
   <channel site="tataplay.com" site_id="399" lang="en" xmltv_id="Mh1Music.in@SD">MH One</channel>
   <channel site="tataplay.com" site_id="401" lang="en" xmltv_id="Mh1News.in@SD">MH One News</channel>
   <channel site="tataplay.com" site_id="397" lang="en" xmltv_id="MHOneShraddha.in@SD">MH One Shraddha</channel>
+  <channel site="tataplay.com" site_id="1818" lang="en" xmltv_id="">Mirror Media</channel>
   <channel site="tataplay.com" site_id="591" lang="en" xmltv_id="MirrorNow.in@SD">Mirror Now</channel>
-  <channel site="tataplay.com" site_id="599" lang="en" xmltv_id="MNX.in@SD">MNX HD</channel>
+  <channel site="tataplay.com" site_id="210" lang="en" xmltv_id="MoviesNowPlus.in@SD">MN+ HD</channel>
+  <channel site="tataplay.com" site_id="234" lang="en" xmltv_id="MNX.in@SD">MNX</channel>
+  <channel site="tataplay.com" site_id="599" lang="en" xmltv_id="MNX.in@HD">MNX HD</channel>
   <channel site="tataplay.com" site_id="173" lang="en" xmltv_id="MoviesNow.in@SD">Movies Now</channel>
-  <channel site="tataplay.com" site_id="562" lang="en" xmltv_id="MoviesNow.in@SD">Movies Now HD</channel>
+  <channel site="tataplay.com" site_id="562" lang="en" xmltv_id="MoviesNow.in@HD">Movies Now HD</channel>
   <channel site="tataplay.com" site_id="103" lang="en" xmltv_id="MTV.in@SD">MTV</channel>
+  <channel site="tataplay.com" site_id="406" lang="en" xmltv_id="MTV.in@HD">MTV HD</channel>
+  <channel site="tataplay.com" site_id="411" lang="en" xmltv_id="KalaignarMurasu.in@SD">Murasu TV</channel>
+  <channel site="tataplay.com" site_id="1008" lang="en" xmltv_id="">Naga Sai Temple</channel>
   <channel site="tataplay.com" site_id="408" lang="en" xmltv_id="NambikkaiTV.in@SD">Nambikkai TV</channel>
+  <channel site="tataplay.com" site_id="782" lang="en" xmltv_id="">Namma TV</channel>
   <channel site="tataplay.com" site_id="805" lang="en" xmltv_id="NandighoshaTV.in@SD">Nandighosha TV</channel>
-  <channel site="tataplay.com" site_id="605" lang="en" xmltv_id="NationalGeographic.in@HD">National Geographic HD</channel>
+  <channel site="tataplay.com" site_id="184" lang="en" xmltv_id="NationalGeographicWild.in@SD">Nat Geo Wild</channel>
+  <channel site="tataplay.com" site_id="413" lang="en" xmltv_id="NationalGeographicWild.in@HD">Nat Geo Wild HD</channel>
+  <channel site="tataplay.com" site_id="1827" lang="en" xmltv_id="">Nation Update</channel>
   <channel site="tataplay.com" site_id="137" lang="en" xmltv_id="NationalGeographic.in@SD">National Geographic</channel>
-  <channel site="tataplay.com" site_id="184" lang="en" xmltv_id="NationalGeographicWild.in@HD">Nat Geo Wild</channel>
-  <channel site="tataplay.com" site_id="1344" lang="en" xmltv_id="NaxatraNews.in@SD">Naxatra News</channel>
+  <channel site="tataplay.com" site_id="605" lang="en" xmltv_id="NationalGeographic.in@HD">National Geographic HD</channel>
+  <channel site="tataplay.com" site_id="1254" lang="en" xmltv_id="">National News Live</channel>
+  <channel site="tataplay.com" site_id="1245" lang="en" xmltv_id="">National Today 24x7</channel>
+  <channel site="tataplay.com" site_id="1790" lang="en" xmltv_id="">National TV India</channel>
   <channel site="tataplay.com" site_id="208" lang="en" xmltv_id="NDTV24x7.in@SD">NDTV 24x7</channel>
-  <channel site="tataplay.com" site_id="136" lang="en" xmltv_id="NDTVGoodTimes.in@SD">GOOD TiMES</channel>
   <channel site="tataplay.com" site_id="179" lang="en" xmltv_id="NDTVIndia.in@SD">NDTV India</channel>
+  <channel site="tataplay.com" site_id="1343" lang="en" xmltv_id="NDTVMarathi.in@SD">NDTV MARATHI</channel>
   <channel site="tataplay.com" site_id="1159" lang="en" xmltv_id="NDTVMadhyaPradeshChhattisgarh.in@SD">NDTV MPCG</channel>
+  <channel site="tataplay.com" site_id="93" lang="en" xmltv_id="NDTVProfit.in@SD">NDTV Profit Prime</channel>
   <channel site="tataplay.com" site_id="1152" lang="en" xmltv_id="NDTVRajasthan.in@SD">NDTV Rajasthan</channel>
+  <channel site="tataplay.com" site_id="1822" lang="en" xmltv_id="">NE Bharat 24</channel>
   <channel site="tataplay.com" site_id="567" lang="en" xmltv_id="Nepal1.in@SD">Nepal 1</channel>
   <channel site="tataplay.com" site_id="848" lang="en" xmltv_id="Network10.in@SD">Network 10</channel>
   <channel site="tataplay.com" site_id="414" lang="en" xmltv_id="News1India.in@SD">News 1 India</channel>
   <channel site="tataplay.com" site_id="913" lang="en" xmltv_id="News1st.in@SD">News 1st Kannada</channel>
   <channel site="tataplay.com" site_id="448" lang="en" xmltv_id="News7Tamil.in@SD">News7</channel>
-  <channel site="tataplay.com" site_id="1458" lang="en" xmltv_id="News9Live.in@SD">News 9</channel>
   <channel site="tataplay.com" site_id="415" lang="en" xmltv_id="News11.in@SD">News 11 Bharat</channel>
   <channel site="tataplay.com" site_id="68" lang="en" xmltv_id="News18AssamNorthEast.in@SD">News18 Assam North East</channel>
   <channel site="tataplay.com" site_id="23" lang="en" xmltv_id="News18Bangla.in@SD">News18 Bangla</channel>
   <channel site="tataplay.com" site_id="166" lang="en" xmltv_id="News18BiharJharkhand.in@SD">News18 Bihar Jharkhand</channel>
+  <channel site="tataplay.com" site_id="354" lang="en" xmltv_id="News18DelhiNCRJK.in@SD">News18 Delhi NCR Jammu Kashmir</channel>
   <channel site="tataplay.com" site_id="6" lang="en" xmltv_id="News18Gujarati.in@SD">News18 Gujarati</channel>
   <channel site="tataplay.com" site_id="106" lang="en" xmltv_id="News18India.in@SD">News18 India</channel>
-  <channel site="tataplay.com" site_id="354" lang="en" xmltv_id="News18JKLH.in@SD">News18 Jammu Kashmir Ladakh Himachal</channel>
   <channel site="tataplay.com" site_id="85" lang="en" xmltv_id="News18Kannada.in@SD">News18 Kannada</channel>
   <channel site="tataplay.com" site_id="66" lang="en" xmltv_id="News18Kerala.in@SD">News18 Kerala</channel>
-  <channel site="tataplay.com" site_id="140" lang="en" xmltv_id="News18Lokmat.in@SD">NEWS18 MARATHI</channel>
   <channel site="tataplay.com" site_id="203" lang="en" xmltv_id="News18MadhyaPradeshChhattisgarh.in@SD">News18 Madhya Pradesh Chhattisgarh</channel>
+  <channel site="tataplay.com" site_id="140" lang="en" xmltv_id="News18Marathi.in@SD">NEWS18 MARATHI</channel>
   <channel site="tataplay.com" site_id="41" lang="en" xmltv_id="News18Odia.in@SD">News18 Odia</channel>
-  <channel site="tataplay.com" site_id="1208" lang="en" xmltv_id="News18Odia.in@SD">Rajya 24</channel>
   <channel site="tataplay.com" site_id="232" lang="en" xmltv_id="News18PunjabHaryanaHimachal.in@SD">News18 Punjab Haryana</channel>
   <channel site="tataplay.com" site_id="205" lang="en" xmltv_id="News18Rajasthan.in@SD">News18 Rajasthan</channel>
   <channel site="tataplay.com" site_id="58" lang="en" xmltv_id="News18TamilNadu.in@SD">News18 Tamil Nadu</channel>
   <channel site="tataplay.com" site_id="79" lang="en" xmltv_id="News18UttarPradeshUttarakhand.in@SD">News18 Uttar Pradesh Uttarakhand</channel>
+  <channel site="tataplay.com" site_id="1380" lang="en" xmltv_id="">News 21</channel>
   <channel site="tataplay.com" site_id="209" lang="en" xmltv_id="News24.in@SD">News 24</channel>
   <channel site="tataplay.com" site_id="902" lang="en" xmltv_id="News24MPChhattisgarh.in@SD">News 24 Madhyapradesh Chattisgarh</channel>
+  <channel site="tataplay.com" site_id="1286" lang="en" xmltv_id="">News Capital</channel>
   <channel site="tataplay.com" site_id="702" lang="en" xmltv_id="NewsJ.in@SD">News J</channel>
   <channel site="tataplay.com" site_id="226" lang="en" xmltv_id="NewsLive.in@SD">NEWS LIVE</channel>
+  <channel site="tataplay.com" site_id="368" lang="en" xmltv_id="">News Live Bangla</channel>
   <channel site="tataplay.com" site_id="1367" lang="en" xmltv_id="NewsMalayalam24x7.in@SD">News Malayalam 24x7</channel>
   <channel site="tataplay.com" site_id="36" lang="en" xmltv_id="NewsNation.in@SD">News Nation</channel>
+  <channel site="tataplay.com" site_id="1470" lang="en" xmltv_id="">News Nation 81</channel>
+  <channel site="tataplay.com" site_id="1869" lang="en" xmltv_id="">News Plus24x7</channel>
+  <channel site="tataplay.com" site_id="643" lang="en" xmltv_id="NewsStateMPCHG.in@SD">News State MP CG</channel>
+  <channel site="tataplay.com" site_id="1411" lang="en" xmltv_id="">News State Punjab Haryana Himachal</channel>
   <channel site="tataplay.com" site_id="613" lang="en" xmltv_id="NewsStateUPUK.in@SD">News State UP Uttarakhand</channel>
   <channel site="tataplay.com" site_id="968" lang="en" xmltv_id="NewsTamil24x7.in@SD">News Tamil 24x7</channel>
   <channel site="tataplay.com" site_id="207" lang="en" xmltv_id="NewsTimeBangla.in@SD">News Time Bangla</channel>
+  <channel site="tataplay.com" site_id="1874" lang="en" xmltv_id="">News TV India</channel>
   <channel site="tataplay.com" site_id="189" lang="en" xmltv_id="NewsX.in@SD">NewsX</channel>
   <channel site="tataplay.com" site_id="1487" lang="en" xmltv_id="NewsXWorld.in@HD">NewsX World</channel>
   <channel site="tataplay.com" site_id="976" lang="en" xmltv_id="NHKWorldJapan.jp@SD">NHK World Japan</channel>
   <channel site="tataplay.com" site_id="138" lang="en" xmltv_id="Nickelodeon.in@SD">Nick</channel>
-  <channel site="tataplay.com" site_id="433" lang="en" xmltv_id="NickHDPlus.in@SD">Nick HD+</channel>
+  <channel site="tataplay.com" site_id="433" lang="en" xmltv_id="NickHDPlus.in@HD">Nick HD+</channel>
   <channel site="tataplay.com" site_id="118" lang="en" xmltv_id="NickJr.in@SD">Nick Jr</channel>
+  <channel site="tataplay.com" site_id="1383" lang="en" xmltv_id="">NIJAM TV</channel>
+  <channel site="tataplay.com" site_id="908" lang="en" xmltv_id="">Nimbark TV</channel>
   <channel site="tataplay.com" site_id="1378" lang="en" xmltv_id="NireekshanaTV.in@SD">Nireekshana TV</channel>
   <channel site="tataplay.com" site_id="894" lang="en" xmltv_id="NKTV24x7.in@SD">NKTV PLUS</channel>
-  <channel site="tataplay.com" site_id="417" lang="en" xmltv_id="NortheastLive.in@SD">North East Live</channel>
-  <channel site="tataplay.com" site_id="1386" lang="en" xmltv_id="NTV.ae@SD">NTV</channel>
+  <channel site="tataplay.com" site_id="417" lang="en" xmltv_id="NortheastLive.in@HD">North East Live</channel>
+  <channel site="tataplay.com" site_id="1824" lang="en" xmltv_id="">NSC9</channel>
+  <channel site="tataplay.com" site_id="1386" lang="en" xmltv_id="">NTV</channel>
   <channel site="tataplay.com" site_id="160" lang="en" xmltv_id="NTVTelugu.in@SD">NTV Telugu</channel>
   <channel site="tataplay.com" site_id="431" lang="en" xmltv_id="OscarMoviesBhojpuri.in@SD">Oscar Movies Bhojpuri</channel>
+  <channel site="tataplay.com" site_id="1742" lang="en" xmltv_id="">OSD - 1</channel>
+  <channel site="tataplay.com" site_id="1738" lang="en" xmltv_id="">OSD - 2</channel>
+  <channel site="tataplay.com" site_id="1734" lang="en" xmltv_id="">OSD - 3</channel>
+  <channel site="tataplay.com" site_id="1450" lang="en" xmltv_id="">OSD Binge 1</channel>
+  <channel site="tataplay.com" site_id="1451" lang="en" xmltv_id="">OSD Binge 2</channel>
+  <channel site="tataplay.com" site_id="1452" lang="en" xmltv_id="">OSD Binge 3</channel>
+  <channel site="tataplay.com" site_id="1453" lang="en" xmltv_id="">OSD Binge 4</channel>
+  <channel site="tataplay.com" site_id="1454" lang="en" xmltv_id="">OSD Binge 5</channel>
+  <channel site="tataplay.com" site_id="1256" lang="en" xmltv_id="">Oye Music</channel>
+  <channel site="tataplay.com" site_id="446" lang="en" xmltv_id="">Paras Gold One</channel>
   <channel site="tataplay.com" site_id="899" lang="en" xmltv_id="PasandTV.in@SD">Pasand</channel>
   <channel site="tataplay.com" site_id="420" lang="en" xmltv_id="PeaceofMindTV.in@SD">Peace of Mind</channel>
+  <channel site="tataplay.com" site_id="1352" lang="en" xmltv_id="PearTV.in@SD">Pear TV</channel>
   <channel site="tataplay.com" site_id="421" lang="en" xmltv_id="PeppersTV.in@SD">Peppers TV</channel>
   <channel site="tataplay.com" site_id="624" lang="en" xmltv_id="Pitaara.in@SD">Pitaara Movies</channel>
   <channel site="tataplay.com" site_id="239" lang="en" xmltv_id="Pogo.in@SD">Pogo</channel>
   <channel site="tataplay.com" site_id="509" lang="en" xmltv_id="PolimerNews.in@SD">Polimer News</channel>
   <channel site="tataplay.com" site_id="272" lang="en" xmltv_id="PolimerTV.in@SD">Polimer TV</channel>
-  <channel site="tataplay.com" site_id="824" lang="en" xmltv_id="PowerTV.bj@SD">Power TV</channel>
+  <channel site="tataplay.com" site_id="824" lang="en" xmltv_id="PowerTV.in@SD">Power TV</channel>
   <channel site="tataplay.com" site_id="1364" lang="en" xmltv_id="PowervisionTV.in@SD">Powervision</channel>
   <channel site="tataplay.com" site_id="423" lang="en" xmltv_id="PragNews.in@SD">Prag News</channel>
-  <channel site="tataplay.com" site_id="221" lang="en" xmltv_id="PratidinTime.in@SD">Protidin Time</channel>
-  <channel site="tataplay.com" site_id="1175" lang="en" xmltv_id="PravahPicture.in@HD">Star Pravah Pictures HD</channel>
-  <channel site="tataplay.com" site_id="985" lang="en" xmltv_id="PravahPicture.in@SD">STAR Pravah Picture</channel>
+  <channel site="tataplay.com" site_id="568" lang="en" xmltv_id="">Prarthana Life</channel>
   <channel site="tataplay.com" site_id="1099" lang="en" xmltv_id="Prime9News.in@SD">Prime9 Plus</channel>
-  <channel site="tataplay.com" site_id="1278" lang="en" xmltv_id="PrimeTV.ge@SD">Prime TV</channel>
+  <channel site="tataplay.com" site_id="1823" lang="en" xmltv_id="PrimeAsiaTV.ca@SD">Prime Asia</channel>
+  <channel site="tataplay.com" site_id="1278" lang="en" xmltv_id="PrimeTVGoa.in@SD">Prime TV</channel>
+  <channel site="tataplay.com" site_id="221" lang="en" xmltv_id="PratidinTime.in@SD">Protidin Time</channel>
   <channel site="tataplay.com" site_id="92" lang="en" xmltv_id="PTCChakde.in@SD">PTC Chak De</channel>
   <channel site="tataplay.com" site_id="922" lang="en" xmltv_id="PTCMusic.in@SD">PTC Music</channel>
   <channel site="tataplay.com" site_id="91" lang="en" xmltv_id="PTCNews.in@SD">PTC News</channel>
   <channel site="tataplay.com" site_id="122" lang="en" xmltv_id="PTCPunjabi.in@SD">PTC Punjabi</channel>
   <channel site="tataplay.com" site_id="794" lang="en" xmltv_id="PTCPunjabiGold.in@SD">PTC Punjabi Gold</channel>
+  <channel site="tataplay.com" site_id="773" lang="en" xmltv_id="PTCSimran.in@SD">PTC Simran</channel>
+  <channel site="tataplay.com" site_id="1799" lang="en" xmltv_id="">Public First</channel>
   <channel site="tataplay.com" site_id="661" lang="en" xmltv_id="PublicMovies.in@SD">Public Movies</channel>
   <channel site="tataplay.com" site_id="424" lang="en" xmltv_id="PublicMusic.in@SD">Public Music</channel>
   <channel site="tataplay.com" site_id="33" lang="en" xmltv_id="PublicTV.in@SD">Public TV</channel>
   <channel site="tataplay.com" site_id="1102" lang="en" xmltv_id="PudhariNews.in@SD">Pudhari News</channel>
   <channel site="tataplay.com" site_id="220" lang="en" xmltv_id="PuthiyaThalaimurai.in@SD">Puthiya Thalaimurai</channel>
+  <channel site="tataplay.com" site_id="696" lang="en" xmltv_id="RepublicBharat.in@SD">R Bharat</channel>
+  <channel site="tataplay.com" site_id="342" lang="en" xmltv_id="RepublicKannada.in@SD">R Kannada</channel>
   <channel site="tataplay.com" site_id="426" lang="en" xmltv_id="RajDigitalPlus.in@SD">Raj Digital Plus</channel>
+  <channel site="tataplay.com" site_id="425" lang="en" xmltv_id="RajMusixTamil.in@SD">Raj Musix</channel>
   <channel site="tataplay.com" site_id="427" lang="en" xmltv_id="RajMusixKannada.in@SD">Raj Musix Kannada</channel>
   <channel site="tataplay.com" site_id="541" lang="en" xmltv_id="RajMusixMalayalam.in@SD">Raj Musix Malayalam</channel>
-  <channel site="tataplay.com" site_id="425" lang="en" xmltv_id="RajMusixTamil.in@SD">Raj Musix</channel>
   <channel site="tataplay.com" site_id="429" lang="en" xmltv_id="RajMusixTelugu.in@SD">Raj Musix Telugu</channel>
-  <channel site="tataplay.com" site_id="525" lang="en" xmltv_id="RajNews.in@SD">Raj News Tamil.</channel>
+  <channel site="tataplay.com" site_id="1324" lang="en" xmltv_id="RajAsia.in@SD">Raj Nagaichuvai</channel>
   <channel site="tataplay.com" site_id="510" lang="en" xmltv_id="RajNewsKannada.in@SD">Raj News Kannada</channel>
   <channel site="tataplay.com" site_id="428" lang="en" xmltv_id="RajNewsMalayalam.in@SD">Raj News Malayalam</channel>
+  <channel site="tataplay.com" site_id="525" lang="en" xmltv_id="RajNews.in@SD">Raj News Tamil.</channel>
   <channel site="tataplay.com" site_id="430" lang="en" xmltv_id="RajNewsTelugu.in@SD">Raj News Telugu</channel>
   <channel site="tataplay.com" site_id="1330" lang="en" xmltv_id="RajPariwar.in@SD">Raj Pariwar</channel>
   <channel site="tataplay.com" site_id="439" lang="en" xmltv_id="RajTV.in@SD">Raj TV</channel>
+  <channel site="tataplay.com" site_id="1208" lang="en" xmltv_id="News18Odia.in@SD">Rajya 24</channel>
   <channel site="tataplay.com" site_id="449" lang="en" xmltv_id="Ramdhenu.in@SD">Ramdhenu</channel>
+  <channel site="tataplay.com" site_id="101" lang="en" xmltv_id="Rang.in@SD">Rang</channel>
+  <channel site="tataplay.com" site_id="819" lang="en" xmltv_id="RDXGoa.in@SD">RDX Goa</channel>
+  <channel site="tataplay.com" site_id="1018" lang="en" xmltv_id="RealNewsKerala.in@SD">Real News Kerala</channel>
   <channel site="tataplay.com" site_id="214" lang="en" xmltv_id="Rengoni.in@SD">Rengoni TV</channel>
   <channel site="tataplay.com" site_id="1124" lang="en" xmltv_id="ReporterTV.in@SD">Reporter TV</channel>
   <channel site="tataplay.com" site_id="890" lang="en" xmltv_id="RepublicBangla.in@SD">Republic Bangla</channel>
-  <channel site="tataplay.com" site_id="696" lang="en" xmltv_id="RepublicBharat.in@SD">R Bharat</channel>
-  <channel site="tataplay.com" site_id="342" lang="en" xmltv_id="RepublicKannada.in@SD">R Kannada</channel>
   <channel site="tataplay.com" site_id="72" lang="en" xmltv_id="RepublicTV.in@SD">REPUBLIC TV</channel>
+  <channel site="tataplay.com" site_id="1868" lang="en" xmltv_id="RojaMovies.in@SD">Roja Movies</channel>
+  <channel site="tataplay.com" site_id="1867" lang="en" xmltv_id="RojaTV.in@SD">Roja TV</channel>
   <channel site="tataplay.com" site_id="174" lang="en" xmltv_id="RomedyNow.in@SD">Romedy Now</channel>
   <channel site="tataplay.com" site_id="1132" lang="en" xmltv_id="RongeenTV.in@SD">Rongeen TV</channel>
   <channel site="tataplay.com" site_id="3" lang="en" xmltv_id="RupasiBangla.in@SD">Ruposhi Bangla</channel>
+  <channel site="tataplay.com" site_id="98" lang="en" xmltv_id="RTIndia.in@HD">Russia Today</channel>
+  <channel site="tataplay.com" site_id="1788" lang="en" xmltv_id="">S India News</channel>
   <channel site="tataplay.com" site_id="546" lang="en" xmltv_id="SaamTV.in@SD">Saam TV</channel>
   <channel site="tataplay.com" site_id="829" lang="en" xmltv_id="SadhnaNewsMadhyaPradeshChhattisgarh.in@SD">Sadhna News MP CG</channel>
   <channel site="tataplay.com" site_id="827" lang="en" xmltv_id="SadhnaPlusNews.in@SD">Sadhna Plus News</channel>
+  <channel site="tataplay.com" site_id="1400" lang="en" xmltv_id="">Sadhna Prime News</channel>
   <channel site="tataplay.com" site_id="447" lang="en" xmltv_id="SadhnaTV.in@SD">Sadhna TV</channel>
+  <channel site="tataplay.com" site_id="1392" lang="en" xmltv_id="SadvidyaTV.in@SD">Sadvidya</channel>
   <channel site="tataplay.com" site_id="436" lang="en" xmltv_id="SafariTV.in@SD">Safari TV</channel>
+  <channel site="tataplay.com" site_id="435" lang="en" xmltv_id="">SAI TV</channel>
+  <channel site="tataplay.com" site_id="1002" lang="en" xmltv_id="">Saileela TV</channel>
   <channel site="tataplay.com" site_id="596" lang="en" xmltv_id="SakshiTV.in@SD">Sakshi TV</channel>
-  <channel site="tataplay.com" site_id="518" lang="en" xmltv_id="SalaamTV.us@SD">Salaam TV</channel>
+  <channel site="tataplay.com" site_id="518" lang="en" xmltv_id="SalaamTV.in@SD">Salaam TV</channel>
   <channel site="tataplay.com" site_id="1281" lang="en" xmltv_id="SamacharPlus24x7.in@SD">Samachar 24 News</channel>
+  <channel site="tataplay.com" site_id="1877" lang="en" xmltv_id="">Samachar Plus 24x7</channel>
+  <channel site="tataplay.com" site_id="1864" lang="en" xmltv_id="">SAMACHAR TODAY</channel>
+  <channel site="tataplay.com" site_id="1209" lang="en" xmltv_id="">Samrat News</channel>
   <channel site="tataplay.com" site_id="1284" lang="en" xmltv_id="SanaPlus.in@SD">Sana Plus TV</channel>
   <channel site="tataplay.com" site_id="1285" lang="en" xmltv_id="SanaTV.in@SD">Sana TV</channel>
   <channel site="tataplay.com" site_id="586" lang="en" xmltv_id="SandeshNews.in@SD">Sandesh News</channel>
+  <channel site="tataplay.com" site_id="1257" lang="en" xmltv_id="">Sangam TV</channel>
   <channel site="tataplay.com" site_id="215" lang="en" xmltv_id="SangeetBangla.in@SD">Sangeet Bangla</channel>
   <channel site="tataplay.com" site_id="217" lang="en" xmltv_id="SangeetMarathi.in@SD">Sangeet Marathi</channel>
-  <channel site="tataplay.com" site_id="477" lang="en" xmltv_id="SankaraTV.in@SD">Sri Sankara TV</channel>
-  <channel site="tataplay.com" site_id="1368" lang="en" xmltv_id="SansadTV.in@SD">Sansad TV 1 HD</channel>
+  <channel site="tataplay.com" site_id="213" lang="en" xmltv_id="SansadTV1.in@SD">Sansad TV 1</channel>
+  <channel site="tataplay.com" site_id="1368" lang="en" xmltv_id="SansadTV1.in@HD">Sansad TV 1 HD</channel>
+  <channel site="tataplay.com" site_id="212" lang="en" xmltv_id="SansadTV2.in@SD">Sansad TV 2</channel>
+  <channel site="tataplay.com" site_id="1032" lang="en" xmltv_id="SansadTV2.in@HD">Sansad TV 2 HD</channel>
   <channel site="tataplay.com" site_id="43" lang="en" xmltv_id="SanskarTV.in@SD">Sanskar</channel>
+  <channel site="tataplay.com" site_id="911" lang="en" xmltv_id="">Santwani</channel>
   <channel site="tataplay.com" site_id="455" lang="en" xmltv_id="SathiyamTV.in@SD">Sathiyam TV</channel>
   <channel site="tataplay.com" site_id="456" lang="en" xmltv_id="SatsangTV.in@SD">Satsang TV</channel>
+  <channel site="tataplay.com" site_id="44" lang="en" xmltv_id="KalaignarSeithigal.in@SD">Seithigal TV</channel>
+  <channel site="tataplay.com" site_id="556" lang="en" xmltv_id="SonyEntertainmentTelevision.in@SD">SET</channel>
+  <channel site="tataplay.com" site_id="15" lang="en" xmltv_id="SonyEntertainmentTelevision.in@HD">SET HD</channel>
   <channel site="tataplay.com" site_id="457" lang="en" xmltv_id="Shalom.in@SD">Shalom TV</channel>
+  <channel site="tataplay.com" site_id="385" lang="en" xmltv_id="">Sharnam TV</channel>
   <channel site="tataplay.com" site_id="1313" lang="en" xmltv_id="ShekinahTV.in@SD">SHEKINAH</channel>
   <channel site="tataplay.com" site_id="1269" lang="en" xmltv_id="ShemarooJosh.in@SD">Shemaroo Josh</channel>
   <channel site="tataplay.com" site_id="800" lang="en" xmltv_id="ShemarooMarathiBana.in@SD">Shemaroo MarathiBana</channel>
-  <channel site="tataplay.com" site_id="733" lang="en" xmltv_id="ShowBox.in@SD">Showbox</channel>
+  <channel site="tataplay.com" site_id="818" lang="en" xmltv_id="ShemarooTV.in@SD">Shemaroo TV</channel>
+  <channel site="tataplay.com" site_id="1045" lang="en" xmltv_id="ShemarooUmang.in@SD">Shemaroo UMANG</channel>
+  <channel site="tataplay.com" site_id="1335" lang="en" xmltv_id="ShikshaTV.in@SD">Shiksha TV</channel>
+  <channel site="tataplay.com" site_id="840" lang="en" xmltv_id="">Shirdi Sai Baba</channel>
+  <channel site="tataplay.com" site_id="1171" lang="en" xmltv_id="">Shree Ichchhapuran Balaji Mandir</channel>
+  <channel site="tataplay.com" site_id="1865" lang="en" xmltv_id="">Shree Sanatan TV</channel>
+  <channel site="tataplay.com" site_id="1007" lang="en" xmltv_id="">Shri Ashtavinayak Mahaganpati, Ranjangaon</channel>
   <channel site="tataplay.com" site_id="458" lang="en" xmltv_id="ShubhTV.in@SD">Shubh TV</channel>
-  <channel site="tataplay.com" site_id="611" lang="en" xmltv_id="Sirippoli.in@SD">Sirippoli</channel>
+  <channel site="tataplay.com" site_id="1170" lang="en" xmltv_id="">Sidharth GOLD</channel>
+  <channel site="tataplay.com" site_id="978" lang="en" xmltv_id="">Sidharth TV</channel>
+  <channel site="tataplay.com" site_id="1026" lang="en" xmltv_id="">Sidharth UTSAV</channel>
+  <channel site="tataplay.com" site_id="940" lang="en" xmltv_id="">SIRIKANNADA Alltime</channel>
+  <channel site="tataplay.com" site_id="611" lang="en" xmltv_id="SirippoliTV.in@SD">Sirippoli</channel>
+  <channel site="tataplay.com" site_id="1797" lang="en" xmltv_id="">Smriti Patra</channel>
+  <channel site="tataplay.com" site_id="842" lang="en" xmltv_id="">Somnath Temple</channel>
   <channel site="tataplay.com" site_id="127" lang="en" xmltv_id="Sonic.in@SD">Sonic</channel>
-  <channel site="tataplay.com" site_id="914" lang="en" xmltv_id="SonySportsTen4.in@SD">SONY SPORTS TEN 4 Tamil</channel>
+  <channel site="tataplay.com" site_id="34" lang="en" xmltv_id="SonyAath.in@SD">SONY AATH</channel>
+  <channel site="tataplay.com" site_id="158" lang="en" xmltv_id="SonyBBCEarth.in@SD">SONY BBC Earth</channel>
+  <channel site="tataplay.com" site_id="460" lang="en" xmltv_id="SonyBBCEarth.in@HD">SONY BBC Earth HD</channel>
+  <channel site="tataplay.com" site_id="658" lang="en" xmltv_id="SonyMarathi.in@SD">Sony Marathi</channel>
+  <channel site="tataplay.com" site_id="132" lang="en" xmltv_id="SonyMax.in@SD">SONY MAX</channel>
+  <channel site="tataplay.com" site_id="1717" lang="en" xmltv_id="SonyMax1.in@SD">SONY MAX 1</channel>
+  <channel site="tataplay.com" site_id="120" lang="en" xmltv_id="SonyMax2.in@SD">SONY MAX 2</channel>
+  <channel site="tataplay.com" site_id="80" lang="en" xmltv_id="SonyMax.in@HD">SONY MAX HD</channel>
+  <channel site="tataplay.com" site_id="554" lang="en" xmltv_id="SonyPal.in@SD">Sony Pal</channel>
+  <channel site="tataplay.com" site_id="558" lang="en" xmltv_id="SonyPix.in@SD">SONY PIX</channel>
+  <channel site="tataplay.com" site_id="32" lang="en" xmltv_id="SonyPix.in@HD">SONY PIX HD</channel>
+  <channel site="tataplay.com" site_id="559" lang="en" xmltv_id="SonySAB.in@SD">SONY SAB</channel>
+  <channel site="tataplay.com" site_id="48" lang="en" xmltv_id="SonySAB.in@HD">SONY SAB HD</channel>
+  <channel site="tataplay.com" site_id="150" lang="en" xmltv_id="SonySportsTen1.in@SD">SONY SPORTS TEN 1</channel>
+  <channel site="tataplay.com" site_id="81" lang="en" xmltv_id="SonySportsTen1.in@HD">SONY SPORTS TEN 1 HD</channel>
+  <channel site="tataplay.com" site_id="170" lang="en" xmltv_id="SonySportsTen2.in@SD">SONY SPORTS TEN 2</channel>
+  <channel site="tataplay.com" site_id="462" lang="en" xmltv_id="SonySportsTen2.in@HD">SONY SPORTS TEN 2 HD</channel>
+  <channel site="tataplay.com" site_id="171" lang="en" xmltv_id="SonySportsTen3Hindi.in@SD">SONY SPORTS TEN 3 Hindi</channel>
+  <channel site="tataplay.com" site_id="464" lang="en" xmltv_id="SonySportsTen3Hindi.in@HD">SONY SPORTS TEN 3 Hindi HD</channel>
+  <channel site="tataplay.com" site_id="1871" lang="en" xmltv_id="">SONY SPORTS TEN 4 KANNADA</channel>
+  <channel site="tataplay.com" site_id="914" lang="en" xmltv_id="">SONY SPORTS TEN 4 Tamil</channel>
+  <channel site="tataplay.com" site_id="1192" lang="en" xmltv_id="">SONY SPORTS TEN 4 Telugu</channel>
   <channel site="tataplay.com" site_id="610" lang="en" xmltv_id="SonySportsTen5.in@SD">SONY SPORTS TEN 5</channel>
-  <channel site="tataplay.com" site_id="244" lang="en" xmltv_id="StarBharat.in@HD">Star Bharat HD</channel>
+  <channel site="tataplay.com" site_id="35" lang="en" xmltv_id="SonySportsTen5.in@HD">SONY SPORTS TEN 5 HD</channel>
+  <channel site="tataplay.com" site_id="56" lang="en" xmltv_id="SonyWah.in@SD">Sony Wah</channel>
+  <channel site="tataplay.com" site_id="45" lang="en" xmltv_id="SonyYay.in@SD">SONY YAY!</channel>
+  <channel site="tataplay.com" site_id="477" lang="en" xmltv_id="SankaraTV.in@SD">Sri Sankara TV</channel>
+  <channel site="tataplay.com" site_id="1337" lang="en" xmltv_id="">Sristi TV</channel>
+  <channel site="tataplay.com" site_id="1312" lang="en" xmltv_id="">SS 1 Geo</channel>
+  <channel site="tataplay.com" site_id="1309" lang="en" xmltv_id="">SS1 HD Hindi Geo</channel>
+  <channel site="tataplay.com" site_id="1311" lang="en" xmltv_id="">SS 1 Hindi Geo</channel>
   <channel site="tataplay.com" site_id="86" lang="en" xmltv_id="StarBharat.in@SD">Star Bharat</channel>
-  <channel site="tataplay.com" site_id="163" lang="en" xmltv_id="StarGold2.in@SD">Star Gold 2</channel>
-  <channel site="tataplay.com" site_id="632" lang="en" xmltv_id="StarGold.in@HD">Star GOLD HD</channel>
+  <channel site="tataplay.com" site_id="244" lang="en" xmltv_id="StarBharat.in@HD">Star Bharat HD</channel>
   <channel site="tataplay.com" site_id="164" lang="en" xmltv_id="StarGold.in@SD">STAR Gold</channel>
+  <channel site="tataplay.com" site_id="163" lang="en" xmltv_id="StarGold2.in@SD">Star Gold 2</channel>
+  <channel site="tataplay.com" site_id="1072" lang="en" xmltv_id="StarGold2.in@HD">Star Gold 2 HD</channel>
+  <channel site="tataplay.com" site_id="632" lang="en" xmltv_id="StarGold.in@HD">Star GOLD HD</channel>
   <channel site="tataplay.com" site_id="493" lang="en" xmltv_id="StarGoldRomance.in@SD">Star Gold Romance</channel>
-  <channel site="tataplay.com" site_id="595" lang="en" xmltv_id="StarGoldSelect.in@HD">Star Gold Select HD</channel>
   <channel site="tataplay.com" site_id="461" lang="en" xmltv_id="StarGoldSelect.in@SD">Star Gold Select</channel>
+  <channel site="tataplay.com" site_id="595" lang="en" xmltv_id="StarGoldSelect.in@HD">Star Gold Select HD</channel>
   <channel site="tataplay.com" site_id="494" lang="en" xmltv_id="StarGoldThrills.in@SD">Star Gold Thrills</channel>
-  <channel site="tataplay.com" site_id="468" lang="en" xmltv_id="StarJalsha.in@HD">Star Jalsha HD</channel>
   <channel site="tataplay.com" site_id="465" lang="en" xmltv_id="StarJalsha.in@SD">STAR Jalsha</channel>
+  <channel site="tataplay.com" site_id="468" lang="en" xmltv_id="StarJalsha.in@HD">Star Jalsha HD</channel>
   <channel site="tataplay.com" site_id="987" lang="en" xmltv_id="StarKiran.in@SD">Star Kiran</channel>
-  <channel site="tataplay.com" site_id="956" lang="en" xmltv_id="StarMaa.in@HD">STAR Maa HD</channel>
   <channel site="tataplay.com" site_id="538" lang="en" xmltv_id="StarMaa.in@SD">STAR Maa</channel>
   <channel site="tataplay.com" site_id="954" lang="en" xmltv_id="StarMaaGold.in@SD">Star Maa Gold</channel>
-  <channel site="tataplay.com" site_id="957" lang="en" xmltv_id="StarMaaMovies.in@HD">Star Maa Movies HD</channel>
+  <channel site="tataplay.com" site_id="516" lang="en" xmltv_id="StarMaa.in@HD">STAR Maa HD</channel>
+  <channel site="tataplay.com" site_id="956" lang="en" xmltv_id="StarMaa.in@HD">STAR Maa HD</channel>
   <channel site="tataplay.com" site_id="277" lang="en" xmltv_id="StarMaaMovies.in@SD">Star Maa Movies</channel>
+  <channel site="tataplay.com" site_id="957" lang="en" xmltv_id="StarMaaMovies.in@HD">Star Maa Movies HD</channel>
   <channel site="tataplay.com" site_id="389" lang="en" xmltv_id="StarMaaMusic.in@SD">Star Maa Music</channel>
-  <channel site="tataplay.com" site_id="560" lang="en" xmltv_id="StarMovies.in@HD">STAR Movies HD</channel>
   <channel site="tataplay.com" site_id="273" lang="en" xmltv_id="StarMovies.in@SD">STAR Movies</channel>
+  <channel site="tataplay.com" site_id="560" lang="en" xmltv_id="StarMovies.in@HD">STAR Movies HD</channel>
+  <channel site="tataplay.com" site_id="1069" lang="en" xmltv_id="StarMoviesSelect.in@SD">Star Movies Select</channel>
   <channel site="tataplay.com" site_id="593" lang="en" xmltv_id="StarMoviesSelect.in@HD">STAR Movies Select HD</channel>
-  <channel site="tataplay.com" site_id="8" lang="en" xmltv_id="StarPlus.in@HD">STAR Plus HD</channel>
   <channel site="tataplay.com" site_id="550" lang="en" xmltv_id="StarPlus.in@SD">STAR Plus</channel>
-  <channel site="tataplay.com" site_id="469" lang="en" xmltv_id="StarPravah.in@HD">Star Pravah HD</channel>
+  <channel site="tataplay.com" site_id="8" lang="en" xmltv_id="StarPlus.in@HD">STAR Plus HD</channel>
   <channel site="tataplay.com" site_id="466" lang="en" xmltv_id="StarPravah.in@SD">STAR Pravah</channel>
-  <channel site="tataplay.com" site_id="78" lang="en" xmltv_id="StarSports1.in@HD">Star Sports 1 HD</channel>
+  <channel site="tataplay.com" site_id="469" lang="en" xmltv_id="StarPravah.in@HD">Star Pravah HD</channel>
+  <channel site="tataplay.com" site_id="985" lang="en" xmltv_id="PravahPicture.in@SD">STAR Pravah Picture</channel>
+  <channel site="tataplay.com" site_id="1175" lang="en" xmltv_id="PravahPicture.in@HD">Star Pravah Pictures HD</channel>
   <channel site="tataplay.com" site_id="600" lang="en" xmltv_id="StarSports1.in@SD">STAR Sports 1</channel>
-  <channel site="tataplay.com" site_id="24" lang="en" xmltv_id="StarSports1Hindi.in@HD">Star Sports 1 Hindi HD</channel>
+  <channel site="tataplay.com" site_id="78" lang="en" xmltv_id="StarSports1.in@HD">Star Sports 1 HD</channel>
   <channel site="tataplay.com" site_id="601" lang="en" xmltv_id="StarSports1Hindi.in@SD">Star Sports 1 Hindi</channel>
+  <channel site="tataplay.com" site_id="24" lang="en" xmltv_id="StarSports1Hindi.in@HD">Star Sports 1 Hindi HD</channel>
   <channel site="tataplay.com" site_id="690" lang="en" xmltv_id="StarSports1Kannada.in@SD">Star Sports 1 Kannada</channel>
   <channel site="tataplay.com" site_id="77" lang="en" xmltv_id="StarSports1Tamil.in@SD">Star Sports 1 Tamil</channel>
+  <channel site="tataplay.com" site_id="1067" lang="en" xmltv_id="StarSports1Tamil.in@HD">Star Sports 1 Tamil HD</channel>
   <channel site="tataplay.com" site_id="688" lang="en" xmltv_id="StarSports1Telugu.in@SD">Star Sports 1 Telugu</channel>
-  <channel site="tataplay.com" site_id="235" lang="en" xmltv_id="StarSports2.in@HD">Star Sports 2 HD</channel>
+  <channel site="tataplay.com" site_id="1068" lang="en" xmltv_id="StarSports1Telugu.in@HD">Star Sports 1 Telugu HD</channel>
   <channel site="tataplay.com" site_id="609" lang="en" xmltv_id="StarSports2.in@SD">STAR Sports 2</channel>
+  <channel site="tataplay.com" site_id="235" lang="en" xmltv_id="StarSports2.in@HD">Star Sports 2 HD</channel>
   <channel site="tataplay.com" site_id="980" lang="en" xmltv_id="StarSports2Hindi.in@SD">Star Sports 2 Hindi</channel>
-  <channel site="tataplay.com" site_id="1033" lang="en" xmltv_id="StarSports2Hindi.in@SD">Star Sports 2 Hindi HD</channel>
+  <channel site="tataplay.com" site_id="1033" lang="en" xmltv_id="StarSports2Hindi.in@HD">Star Sports 2 Hindi HD</channel>
   <channel site="tataplay.com" site_id="683" lang="en" xmltv_id="StarSports2Kannada.in@SD">Star Sports 2 Kannada</channel>
   <channel site="tataplay.com" site_id="1187" lang="en" xmltv_id="StarSports2Tamil.in@SD">Star Sports 2 Tamil</channel>
+  <channel site="tataplay.com" site_id="1495" lang="en" xmltv_id="">Star Sports 2 Tamil HD</channel>
   <channel site="tataplay.com" site_id="1186" lang="en" xmltv_id="StarSports2Telugu.in@SD">Star Sports 2 Telugu</channel>
+  <channel site="tataplay.com" site_id="1496" lang="en" xmltv_id="">Star Sports 2 Telugu HD</channel>
+  <channel site="tataplay.com" site_id="664" lang="en" xmltv_id="StarSports3.in@SD">Star Sports 3</channel>
   <channel site="tataplay.com" site_id="1494" lang="en" xmltv_id="StarSportsKhel.in@SD">Star Sports Khel</channel>
-  <channel site="tataplay.com" site_id="246" lang="en" xmltv_id="StarSportsSelect1.in@HD">Star Sports Select 1 HD</channel>
   <channel site="tataplay.com" site_id="141" lang="en" xmltv_id="StarSportsSelect1.in@SD">Star Sports Select 1</channel>
-  <channel site="tataplay.com" site_id="463" lang="en" xmltv_id="StarSportsSelect2.in@HD">Star Sports Select 2 HD</channel>
+  <channel site="tataplay.com" site_id="246" lang="en" xmltv_id="StarSportsSelect1.in@HD">Star Sports Select 1 HD</channel>
   <channel site="tataplay.com" site_id="603" lang="en" xmltv_id="StarSportsSelect2.in@SD">Star Sports Select 2</channel>
-  <channel site="tataplay.com" site_id="467" lang="en" xmltv_id="StarSuvarna.in@HD">Star Suvarna HD</channel>
+  <channel site="tataplay.com" site_id="463" lang="en" xmltv_id="StarSportsSelect2.in@HD">Star Sports Select 2 HD</channel>
   <channel site="tataplay.com" site_id="579" lang="en" xmltv_id="StarSuvarna.in@SD">Star Suvarna</channel>
+  <channel site="tataplay.com" site_id="467" lang="en" xmltv_id="StarSuvarna.in@HD">Star Suvarna HD</channel>
   <channel site="tataplay.com" site_id="540" lang="en" xmltv_id="StarSuvarnaPlus.in@SD">Star Suvarna Plus</channel>
   <channel site="tataplay.com" site_id="551" lang="en" xmltv_id="StarUtsav.in@SD">STAR Utsav</channel>
   <channel site="tataplay.com" site_id="470" lang="en" xmltv_id="StarUtsavMovies.in@SD">STAR Utsav Movies</channel>
-  <channel site="tataplay.com" site_id="496" lang="en" xmltv_id="StarVijay.in@HD">Star Vijay HD</channel>
   <channel site="tataplay.com" site_id="527" lang="en" xmltv_id="StarVijay.in@SD">STAR Vijay</channel>
+  <channel site="tataplay.com" site_id="496" lang="en" xmltv_id="StarVijay.in@HD">Star Vijay HD</channel>
+  <channel site="tataplay.com" site_id="989" lang="en" xmltv_id="">STV Haryana News</channel>
   <channel site="tataplay.com" site_id="445" lang="en" xmltv_id="SubhavaarthaTV.in@SD">Subhavaarta TV</channel>
   <channel site="tataplay.com" site_id="1385" lang="en" xmltv_id="SubinTV.in@SD">SUBIN TV</channel>
   <channel site="tataplay.com" site_id="475" lang="en" xmltv_id="SudarshanNews.in@SD">Sudarshan News</channel>
   <channel site="tataplay.com" site_id="697" lang="en" xmltv_id="SunBangla.in@SD">Sun Bangla</channel>
+  <channel site="tataplay.com" site_id="1222" lang="en" xmltv_id="SunBangla.in@HD">Sun Bangla HD</channel>
+  <channel site="tataplay.com" site_id="195" lang="en" xmltv_id="SunGemini.in@SD">Sun Gemini</channel>
+  <channel site="tataplay.com" site_id="360" lang="en" xmltv_id="SunGeminiComedy.in@SD">Sun Gemini Comedy</channel>
+  <channel site="tataplay.com" site_id="355" lang="en" xmltv_id="SunGemini.in@HD">Sun Gemini HD</channel>
+  <channel site="tataplay.com" site_id="361" lang="en" xmltv_id="SunGeminiLife.in@SD">Sun Gemini Life</channel>
+  <channel site="tataplay.com" site_id="162" lang="en" xmltv_id="SunGeminiMovies.in@SD">Sun Gemini Movies</channel>
+  <channel site="tataplay.com" site_id="362" lang="en" xmltv_id="SunGeminiMovies.in@HD">Sun Gemini Movies HD</channel>
+  <channel site="tataplay.com" site_id="363" lang="en" xmltv_id="SunGeminiMusic.in@SD">Sun Gemini Music</channel>
+  <channel site="tataplay.com" site_id="1266" lang="en" xmltv_id="GeminiMusic.in@HD">Sun Gemini Music HD</channel>
   <channel site="tataplay.com" site_id="474" lang="en" xmltv_id="SunLife.in@SD">Sun Life</channel>
   <channel site="tataplay.com" site_id="955" lang="en" xmltv_id="SunMarathi.in@SD">Sun Marathi</channel>
-  <channel site="tataplay.com" site_id="1221" lang="en" xmltv_id="SunMarathi.in@SD">Sun Marathi HD</channel>
+  <channel site="tataplay.com" site_id="1221" lang="en" xmltv_id="SunMarathi.in@HD">Sun Marathi HD</channel>
   <channel site="tataplay.com" site_id="511" lang="en" xmltv_id="SunMusic.in@SD">Sun Music</channel>
-  <channel site="tataplay.com" site_id="520" lang="en" xmltv_id="SunMusic.in@SD">Sun Music HD</channel>
+  <channel site="tataplay.com" site_id="520" lang="en" xmltv_id="SunMusic.in@HD">Sun Music HD</channel>
   <channel site="tataplay.com" site_id="1369" lang="en" xmltv_id="SunNeo.in@SD">Sun Neo</channel>
+  <channel site="tataplay.com" site_id="1370" lang="en" xmltv_id="SunNeo.in@HD">Sun Neo HD</channel>
   <channel site="tataplay.com" site_id="443" lang="en" xmltv_id="SunNews.in@SD">Sun News</channel>
-  <channel site="tataplay.com" site_id="521" lang="en" xmltv_id="SunTV.in@SD">Sun TV HD</channel>
+  <channel site="tataplay.com" site_id="230" lang="en" xmltv_id="SunSurya.in@SD">Sun Surya</channel>
+  <channel site="tataplay.com" site_id="481" lang="en" xmltv_id="SunSuryaComedy.in@SD">Sun Surya Comedy</channel>
+  <channel site="tataplay.com" site_id="479" lang="en" xmltv_id="SunSurya.in@HD">Sun Surya HD</channel>
+  <channel site="tataplay.com" site_id="229" lang="en" xmltv_id="SunSuryaMovies.in@SD">Sun Surya Movies</channel>
+  <channel site="tataplay.com" site_id="483" lang="en" xmltv_id="SunSuryaMusic.in@SD">Sun Surya Music</channel>
+  <channel site="tataplay.com" site_id="165" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
+  <channel site="tataplay.com" site_id="521" lang="en" xmltv_id="SunTV.in@HD">Sun TV HD</channel>
+  <channel site="tataplay.com" site_id="76" lang="en" xmltv_id="SunUdaya.in@SD">Sun Udaya</channel>
+  <channel site="tataplay.com" site_id="491" lang="en" xmltv_id="SunUdayaComedy.in@SD">Sun Udaya Comedy</channel>
+  <channel site="tataplay.com" site_id="492" lang="en" xmltv_id="SunUdaya.in@HD">Sun Udaya HD</channel>
+  <channel site="tataplay.com" site_id="231" lang="en" xmltv_id="SunUdayaMovies.in@SD">Sun Udaya Movies</channel>
+  <channel site="tataplay.com" site_id="442" lang="en" xmltv_id="SunUdayaMusic.in@SD">Sun Udaya Music</channel>
+  <channel site="tataplay.com" site_id="587" lang="en" xmltv_id="SuperHungama.in@SD">Super Hungama</channel>
   <channel site="tataplay.com" site_id="1384" lang="en" xmltv_id="SuriyanTV.in@SD">SURIYAN TV</channel>
-  <channel site="tataplay.com" site_id="481" lang="en" xmltv_id="SuryaComedy.in@SD">Surya Comedy</channel>
-  <channel site="tataplay.com" site_id="229" lang="en" xmltv_id="SuryaMovies.in@SD">Surya Movies</channel>
-  <channel site="tataplay.com" site_id="483" lang="en" xmltv_id="SuryaMusic.in@SD">Surya Music</channel>
-  <channel site="tataplay.com" site_id="230" lang="en" xmltv_id="SuryaTV.in@SD">Surya TV</channel>
-  <channel site="tataplay.com" site_id="479" lang="en" xmltv_id="SuryaTV.in@SD">Surya HD</channel>
-  <channel site="tataplay.com" site_id="490" lang="en" xmltv_id="SVBC2.in@SD">SVBC 2</channel>
-  <channel site="tataplay.com" site_id="569" lang="en" xmltv_id="SVBC3.in@SD">SVBC Kannada</channel>
-  <channel site="tataplay.com" site_id="971" lang="en" xmltv_id="SVBC3.in@SD">SVBC 3</channel>
   <channel site="tataplay.com" site_id="218" lang="en" xmltv_id="SVBC.in@SD">SVBC</channel>
+  <channel site="tataplay.com" site_id="490" lang="en" xmltv_id="SVBC2.in@SD">SVBC 2</channel>
+  <channel site="tataplay.com" site_id="971" lang="en" xmltv_id="SVBC3.in@SD">SVBC 3</channel>
+  <channel site="tataplay.com" site_id="569" lang="en" xmltv_id="SVBC3.in@SD">SVBC Kannada</channel>
+  <channel site="tataplay.com" site_id="450" lang="en" xmltv_id="SVBC.in@SD">SVBC Telugu</channel>
   <channel site="tataplay.com" site_id="1274" lang="en" xmltv_id="SwadeshNews.in@SD">Swadesh News</channel>
+  <channel site="tataplay.com" site_id="883" lang="en" xmltv_id="">Swar Shree</channel>
   <channel site="tataplay.com" site_id="577" lang="en" xmltv_id="SwarajExpressSMBC.in@SD">Swaraj Express SMBC</channel>
-  <channel site="tataplay.com" site_id="351" lang="en" xmltv_id="SwaraSagar.in@SD">Divyavani TV</channel>
+  <channel site="tataplay.com" site_id="49" lang="en" xmltv_id="TNews.in@SD">T News</channel>
+  <channel site="tataplay.com" site_id="1317" lang="en" xmltv_id="TamilJanam.in@SD">Tamil Janam</channel>
+  <channel site="tataplay.com" site_id="1445" lang="en" xmltv_id="">Tar TV</channel>
+  <channel site="tataplay.com" site_id="866" lang="en" xmltv_id="">Tara News</channel>
   <channel site="tataplay.com" site_id="50" lang="en" xmltv_id="TarangMusic.in@SD">Tarang Music</channel>
   <channel site="tataplay.com" site_id="237" lang="en" xmltv_id="TarangTV.in@SD">Tarang TV</channel>
+  <channel site="tataplay.com" site_id="1301" lang="en" xmltv_id="TataSky4K.in@SD">Tata Play 4K</channel>
+  <channel site="tataplay.com" site_id="811" lang="en" xmltv_id="">Tata Play Adbhut Kahaniyan</channel>
+  <channel site="tataplay.com" site_id="1363" lang="en" xmltv_id="">Tata Play Anime Local</channel>
   <channel site="tataplay.com" site_id="742" lang="en" xmltv_id="TataSkyAradhana.in@SD">Tata Play Aradhana</channel>
+  <channel site="tataplay.com" site_id="1082" lang="en" xmltv_id="">Tata Play Asomiya Monoronjan</channel>
+  <channel site="tataplay.com" site_id="872" lang="en" xmltv_id="">Tata Play Astro Duniya</channel>
+  <channel site="tataplay.com" site_id="614" lang="en" xmltv_id="">Tata Play Bangla Cinema</channel>
   <channel site="tataplay.com" site_id="618" lang="en" xmltv_id="TataSkyBeauty.in@SD">Tata Play Beauty</channel>
-  <channel site="tataplay.com" site_id="1322" lang="en" xmltv_id="ThanthiOne.in@SD">Thanthi One</channel>
-  <channel site="tataplay.com" site_id="524" lang="en" xmltv_id="ThanthiTV.in@SD">Thanthi TV</channel>
+  <channel site="tataplay.com" site_id="1785" lang="en" xmltv_id="">Tata Play Bhakti Sangeet</channel>
+  <channel site="tataplay.com" site_id="1130" lang="en" xmltv_id="">Tata Play Bollywood Masala</channel>
+  <channel site="tataplay.com" site_id="486" lang="en" xmltv_id="TataPlayBollywoodPremiere.in@SD">Tata Play Bollywood Premiere</channel>
+  <channel site="tataplay.com" site_id="319" lang="en" xmltv_id="">Tata Play Bollywood Premiere HD</channel>
+  <channel site="tataplay.com" site_id="1787" lang="en" xmltv_id="">Tata Play Cartoon Network Forever</channel>
+  <channel site="tataplay.com" site_id="741" lang="en" xmltv_id="">Tata Play Classic Cinema</channel>
+  <channel site="tataplay.com" site_id="964" lang="en" xmltv_id="">Tata Play Classic TV</channel>
+  <channel site="tataplay.com" site_id="744" lang="en" xmltv_id="">Tata Play Comedy</channel>
+  <channel site="tataplay.com" site_id="641" lang="en" xmltv_id="">Tata Play Cooking</channel>
+  <channel site="tataplay.com" site_id="1459" lang="en" xmltv_id="">Tata Play Deiveegam</channel>
+  <channel site="tataplay.com" site_id="151" lang="en" xmltv_id="">Tata Play Devotion</channel>
+  <channel site="tataplay.com" site_id="71" lang="en" xmltv_id="">Tata Play English in Hindi</channel>
+  <channel site="tataplay.com" site_id="645" lang="en" xmltv_id="">Tata Play English in Telugu</channel>
+  <channel site="tataplay.com" site_id="1489" lang="en" xmltv_id="">Tata Play Fancode Sports</channel>
+  <channel site="tataplay.com" site_id="1786" lang="en" xmltv_id="">Tata Play Fancode Sports +1</channel>
+  <channel site="tataplay.com" site_id="1258" lang="en" xmltv_id="">Tata Play Filmy Safar</channel>
+  <channel site="tataplay.com" site_id="121" lang="en" xmltv_id="">Tata Play Fitness</channel>
+  <channel site="tataplay.com" site_id="627" lang="en" xmltv_id="">Tata Play Fun Learn Junior</channel>
+  <channel site="tataplay.com" site_id="626" lang="en" xmltv_id="">Tata Play Fun Learn Rhymes</channel>
+  <channel site="tataplay.com" site_id="772" lang="en" xmltv_id="">Tata Play Gujarati Cinema</channel>
+  <channel site="tataplay.com" site_id="789" lang="en" xmltv_id="">Tata Play Hollywood Local</channel>
+  <channel site="tataplay.com" site_id="1167" lang="en" xmltv_id="">Tata Play Hollywood Local Tamil</channel>
+  <channel site="tataplay.com" site_id="1168" lang="en" xmltv_id="">Tata Play Hollywood Local Telugu</channel>
+  <channel site="tataplay.com" site_id="735" lang="en" xmltv_id="TataSkyIbaadat.in@SD">Tata Play Ibaadat</channel>
+  <channel site="tataplay.com" site_id="95" lang="en" xmltv_id="">Tata Play Javed Akhtar</channel>
+  <channel site="tataplay.com" site_id="929" lang="en" xmltv_id="">Tata Play JEE Prep</channel>
+  <channel site="tataplay.com" site_id="943" lang="en" xmltv_id="">Tata Play K-Dramas</channel>
+  <channel site="tataplay.com" site_id="785" lang="en" xmltv_id="">Tata Play Kannada Cinema</channel>
+  <channel site="tataplay.com" site_id="1350" lang="en" xmltv_id="">Tata Play Lakshya TV</channel>
+  <channel site="tataplay.com" site_id="868" lang="en" xmltv_id="">Tata Play Malayalam Cinema</channel>
+  <channel site="tataplay.com" site_id="622" lang="en" xmltv_id="">Tata Play Marathi Cinema</channel>
+  <channel site="tataplay.com" site_id="1444" lang="en" xmltv_id="">Tata Play Marathi Classics</channel>
+  <channel site="tataplay.com" site_id="737" lang="en" xmltv_id="">Tata Play Music</channel>
+  <channel site="tataplay.com" site_id="928" lang="en" xmltv_id="">Tata Play NEET Prep</channel>
+  <channel site="tataplay.com" site_id="1835" lang="en" xmltv_id="">Tata Play Odia Manoranjan</channel>
+  <channel site="tataplay.com" site_id="571" lang="en" xmltv_id="">Tata Play Punjab De Rang</channel>
+  <channel site="tataplay.com" site_id="959" lang="en" xmltv_id="">Tata Play Romance</channel>
+  <channel site="tataplay.com" site_id="783" lang="en" xmltv_id="">Tata Play Seniors</channel>
+  <channel site="tataplay.com" site_id="677" lang="en" xmltv_id="TataSkyShortsTV.in@SD">Tata Play ShortsTV</channel>
+  <channel site="tataplay.com" site_id="111" lang="en" xmltv_id="">Tata Play Smart Manager</channel>
+  <channel site="tataplay.com" site_id="1003" lang="en" xmltv_id="">Tata Play South Talkies</channel>
+  <channel site="tataplay.com" site_id="1390" lang="en" xmltv_id="">Tata Play Superhits Serials</channel>
+  <channel site="tataplay.com" site_id="663" lang="en" xmltv_id="">Tata Play Tamil Cinema</channel>
+  <channel site="tataplay.com" site_id="1260" lang="en" xmltv_id="">Tata Play Tamil Classics</channel>
+  <channel site="tataplay.com" site_id="657" lang="en" xmltv_id="">Tata Play Telugu Cinema</channel>
+  <channel site="tataplay.com" site_id="1073" lang="en" xmltv_id="">Tata Play Telugu Classics</channel>
+  <channel site="tataplay.com" site_id="666" lang="en" xmltv_id="">Tata Play Theatre HD</channel>
+  <channel site="tataplay.com" site_id="994" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="995" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="996" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="997" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="998" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="999" lang="en" xmltv_id="">Tata Play Toons+</channel>
+  <channel site="tataplay.com" site_id="893" lang="en" xmltv_id="">Tata Play Valam TV</channel>
+  <channel site="tataplay.com" site_id="167" lang="en" xmltv_id="">Tata Play Vedic Maths</channel>
+  <channel site="tataplay.com" site_id="986" lang="en" xmltv_id="">Tata Play Zindagi</channel>
+  <channel site="tataplay.com" site_id="1800" lang="en" xmltv_id="">Test Service 3701</channel>
+  <channel site="tataplay.com" site_id="1092" lang="en" xmltv_id="">Test Service 4101</channel>
   <channel site="tataplay.com" site_id="90" lang="en" xmltv_id="TimesNow.in@SD">TIMES NOW</channel>
-  <channel site="tataplay.com" site_id="932" lang="en" xmltv_id="TimesNowNavbharat.in@SD">Times Now Navbharat HD</channel>
   <channel site="tataplay.com" site_id="966" lang="en" xmltv_id="TimesNowNavbharat.in@SD">Times Now Navbharat</channel>
+  <channel site="tataplay.com" site_id="932" lang="en" xmltv_id="TimesNowNavbharat.in@HD">Times Now Navbharat HD</channel>
   <channel site="tataplay.com" site_id="547" lang="en" xmltv_id="TimesNowWorld.in@SD">Times Now World</channel>
   <channel site="tataplay.com" site_id="135" lang="en" xmltv_id="TLC.in@SD">TLC</channel>
-  <channel site="tataplay.com" site_id="49" lang="en" xmltv_id="TNews.in@SD">T News</channel>
+  <channel site="tataplay.com" site_id="480" lang="en" xmltv_id="TLC.in@HD">TLC HD</channel>
+  <channel site="tataplay.com" site_id="1339" lang="en" xmltv_id="">TNP News</channel>
+  <channel site="tataplay.com" site_id="1821" lang="en" xmltv_id="">Top News Marathi</channel>
   <channel site="tataplay.com" site_id="485" lang="en" xmltv_id="TotalTVHaryana.in@SD">TOTAL TV</channel>
   <channel site="tataplay.com" site_id="55" lang="en" xmltv_id="Travelxp.in@SD">Travelxp</channel>
-  <channel site="tataplay.com" site_id="484" lang="en" xmltv_id="Travelxp.in@SD">Travelxp HD</channel>
+  <channel site="tataplay.com" site_id="484" lang="en" xmltv_id="Travelxp.in@HD">Travelxp HD</channel>
   <channel site="tataplay.com" site_id="444" lang="en" xmltv_id="TravelxpTamil.in@SD">Travelxp Tamil</channel>
+  <channel site="tataplay.com" site_id="1079" lang="en" xmltv_id="">TTN 24</channel>
   <channel site="tataplay.com" site_id="629" lang="en" xmltv_id="TV5Kannada.in@SD">TV5 Kannada</channel>
   <channel site="tataplay.com" site_id="65" lang="en" xmltv_id="TV5MondeAsia.fr@SD">TV5 Monde Asie</channel>
   <channel site="tataplay.com" site_id="320" lang="en" xmltv_id="TV5News.in@SD">TV5 News</channel>
+  <channel site="tataplay.com" site_id="873" lang="en" xmltv_id="TV9Bangla.in@SD">TV9 Bangla</channel>
   <channel site="tataplay.com" site_id="706" lang="en" xmltv_id="TV9Bharatvarsh.in@SD">TV9 Bharatvarsh</channel>
   <channel site="tataplay.com" site_id="489" lang="en" xmltv_id="TV9Gujarati.in@SD">TV9 Gujarati</channel>
+  <channel site="tataplay.com" site_id="152" lang="en" xmltv_id="TV9Kannada.in@SD">TV9 Kannada</channel>
   <channel site="tataplay.com" site_id="97" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
   <channel site="tataplay.com" site_id="11" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu</channel>
+  <channel site="tataplay.com" site_id="1876" lang="en" xmltv_id="">TV13 Gujarati</channel>
+  <channel site="tataplay.com" site_id="1009" lang="en" xmltv_id="">TV27 News</channel>
+  <channel site="tataplay.com" site_id="1338" lang="en" xmltv_id="">TV 45 News</channel>
   <channel site="tataplay.com" site_id="1290" lang="en" xmltv_id="TVRIWorld.id@SD">TVRI World</channel>
   <channel site="tataplay.com" site_id="799" lang="en" xmltv_id="TwentyFourNews.in@SD">Twenty Four</channel>
-  <channel site="tataplay.com" site_id="491" lang="en" xmltv_id="UdayaComedy.in@SD">Udaya Comedy</channel>
-  <channel site="tataplay.com" site_id="231" lang="en" xmltv_id="UdayaMovies.in@SD">Udaya Movies</channel>
-  <channel site="tataplay.com" site_id="442" lang="en" xmltv_id="UdayaMusic.in@SD">Udaya Music</channel>
-  <channel site="tataplay.com" site_id="492" lang="en" xmltv_id="UdayaTV.in@SD">Udaya TV HD</channel>
-  <channel site="tataplay.com" site_id="1388" lang="en" xmltv_id="UTV.cl@SD">UTV</channel>
+  <channel site="tataplay.com" site_id="1080" lang="en" xmltv_id="">U Bangla TV</channel>
+  <channel site="tataplay.com" site_id="1164" lang="en" xmltv_id="UniqueTV.in@SD">Unique TV</channel>
+  <channel site="tataplay.com" site_id="602" lang="en" xmltv_id="Unite8Sports1.in@SD">Unite8 Sports 1</channel>
+  <channel site="tataplay.com" site_id="502" lang="en" xmltv_id="Unite8Sports1.in@HD">Unite8 Sports 1 HD</channel>
+  <channel site="tataplay.com" site_id="592" lang="en" xmltv_id="Unite8Sports2.in@SD">Unite8 Sports 2</channel>
+  <channel site="tataplay.com" site_id="506" lang="en" xmltv_id="Unite8Sports2.in@HD">Unite8 Sports 2 HD</channel>
+  <channel site="tataplay.com" site_id="1255" lang="en" xmltv_id="">Update India</channel>
+  <channel site="tataplay.com" site_id="1388" lang="en" xmltv_id="UltimateTV.in@SD">UTV</channel>
   <channel site="tataplay.com" site_id="274" lang="en" xmltv_id="V6News.in@SD">V6 Telugu</channel>
+  <channel site="tataplay.com" site_id="1246" lang="en" xmltv_id="">Vande Bharat News</channel>
   <channel site="tataplay.com" site_id="1135" lang="en" xmltv_id="VanithaTV.in@SD">Vanitha</channel>
   <channel site="tataplay.com" site_id="499" lang="en" xmltv_id="VasanthTV.in@SD">Vasanth TV</channel>
   <channel site="tataplay.com" site_id="500" lang="en" xmltv_id="Vedic.in@SD">Vedic</channel>
   <channel site="tataplay.com" site_id="659" lang="en" xmltv_id="VendharTV.in@SD">Vendhar TV</channel>
-  <channel site="tataplay.com" site_id="1176" lang="en" xmltv_id="VijaySuper.in@HD">Vijay Super HD</channel>
   <channel site="tataplay.com" site_id="275" lang="en" xmltv_id="VijaySuper.in@SD">Vijay Super</channel>
+  <channel site="tataplay.com" site_id="1176" lang="en" xmltv_id="VijaySuper.in@HD">Vijay Super HD</channel>
   <channel site="tataplay.com" site_id="906" lang="en" xmltv_id="VijayTakkar.in@SD">Vijay Takkar</channel>
   <channel site="tataplay.com" site_id="585" lang="en" xmltv_id="VissaTV.in@SD">Vissa TV</channel>
   <channel site="tataplay.com" site_id="1315" lang="en" xmltv_id="VistaarNews.in@SD">Vistaar News</channel>
+  <channel site="tataplay.com" site_id="1796" lang="en" xmltv_id="">Voice TV Urdu</channel>
   <channel site="tataplay.com" site_id="497" lang="en" xmltv_id="VTVNews.in@SD">VTV News</channel>
-  <channel site="tataplay.com" site_id="553" lang="en" xmltv_id="We.in@SD">We TV</channel>
+  <channel site="tataplay.com" site_id="553" lang="en" xmltv_id="KairaliWe.in@SD">We TV</channel>
   <channel site="tataplay.com" site_id="255" lang="en" xmltv_id="WION.in@SD">WION</channel>
   <channel site="tataplay.com" site_id="258" lang="en" xmltv_id="Zee24Ghanta.in@SD">Zee 24 Ghanta</channel>
   <channel site="tataplay.com" site_id="507" lang="en" xmltv_id="Zee24Kalak.in@SD">Zee 24 Kalak</channel>
   <channel site="tataplay.com" site_id="261" lang="en" xmltv_id="Zee24Taas.in@SD">Zee 24 Taas</channel>
-  <channel site="tataplay.com" site_id="522" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla HD</channel>
+  <channel site="tataplay.com" site_id="253" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla</channel>
+  <channel site="tataplay.com" site_id="522" lang="en" xmltv_id="ZeeBangla.in@HD">Zee Bangla HD</channel>
   <channel site="tataplay.com" site_id="254" lang="en" xmltv_id="ZeeBanglaCinema.in@SD">Zee Bangla Sonar</channel>
   <channel site="tataplay.com" site_id="514" lang="en" xmltv_id="ZeeBharat.in@SD">Zee Bharat</channel>
   <channel site="tataplay.com" site_id="20" lang="en" xmltv_id="ZeeBiharJharkhand.in@SD">Zee Bihar Jharkhand</channel>
+  <channel site="tataplay.com" site_id="814" lang="en" xmltv_id="ZeeBiskope.in@SD">Zee Biskope</channel>
   <channel site="tataplay.com" site_id="175" lang="en" xmltv_id="ZeeBollywood.in@SD">Zee Bollywood</channel>
   <channel site="tataplay.com" site_id="260" lang="en" xmltv_id="ZeeBusiness.in@SD">Zee Business</channel>
-  <channel site="tataplay.com" site_id="502" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe HD</channel>
-  <channel site="tataplay.com" site_id="602" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe</channel>
-  <channel site="tataplay.com" site_id="636" lang="en" xmltv_id="ZeeCinemalu.in@SD">Zee Cinemalu HD</channel>
+  <channel site="tataplay.com" site_id="123" lang="en" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
+  <channel site="tataplay.com" site_id="1744" lang="en" xmltv_id="">Zee Cinema Geo</channel>
+  <channel site="tataplay.com" site_id="1753" lang="en" xmltv_id="">Zee Cinema Geo</channel>
+  <channel site="tataplay.com" site_id="503" lang="en" xmltv_id="ZeeCinema.in@HD">Zee Cinema HD</channel>
+  <channel site="tataplay.com" site_id="252" lang="en" xmltv_id="ZeeCinemalu.in@SD">Zee Cinemalu</channel>
+  <channel site="tataplay.com" site_id="636" lang="en" xmltv_id="ZeeCinemalu.in@HD">Zee Cinemalu HD</channel>
   <channel site="tataplay.com" site_id="727" lang="en" xmltv_id="ZeeClassic.in@SD">Zee Classic</channel>
   <channel site="tataplay.com" site_id="262" lang="en" xmltv_id="ZeeDelhiNCRHaryana.in@SD">Zee Delhi NCR Haryana</channel>
-  <channel site="tataplay.com" site_id="675" lang="en" xmltv_id="ZeeKannada.in@SD">Zee Kannada HD</channel>
+  <channel site="tataplay.com" site_id="256" lang="en" xmltv_id="ZeeKannada.in@SD">Zee Kannada</channel>
+  <channel site="tataplay.com" site_id="675" lang="en" xmltv_id="ZeeKannada.in@HD">Zee Kannada HD</channel>
   <channel site="tataplay.com" site_id="1287" lang="en" xmltv_id="ZeeKannadaNews.in@SD">Zee Kannada News</channel>
   <channel site="tataplay.com" site_id="684" lang="en" xmltv_id="ZeeKeralam.in@SD">Zee Keralam</channel>
-  <channel site="tataplay.com" site_id="694" lang="en" xmltv_id="ZeeKeralam.in@SD">Zee Keralam HD</channel>
+  <channel site="tataplay.com" site_id="694" lang="en" xmltv_id="ZeeKeralam.in@HD">Zee Keralam HD</channel>
   <channel site="tataplay.com" site_id="512" lang="en" xmltv_id="ZeeMadhyaPradeshChhattisgarh.in@SD">Zee Madhya Pradesh Chattisgarh</channel>
-  <channel site="tataplay.com" site_id="501" lang="en" xmltv_id="ZeeMarathi.in@SD">Zee Marathi HD</channel>
-  <channel site="tataplay.com" site_id="1497" lang="en" xmltv_id="ZeeNews.in@SD">Zee News HD</channel>
+  <channel site="tataplay.com" site_id="251" lang="en" xmltv_id="ZeeMarathi.in@SD">Zee Marathi</channel>
+  <channel site="tataplay.com" site_id="501" lang="en" xmltv_id="ZeeMarathi.in@HD">Zee Marathi HD</channel>
+  <channel site="tataplay.com" site_id="259" lang="en" xmltv_id="ZeeNews.in@SD">Zee News</channel>
+  <channel site="tataplay.com" site_id="1497" lang="en" xmltv_id="ZeeNews.in@HD">Zee News HD</channel>
   <channel site="tataplay.com" site_id="810" lang="en" xmltv_id="ZeePower.in@SD">Zee Power</channel>
+  <channel site="tataplay.com" site_id="1181" lang="en" xmltv_id="ZeePower.in@HD">Zee Power HD</channel>
   <channel site="tataplay.com" site_id="580" lang="en" xmltv_id="ZeePunjabHaryanaHimachal.in@SD">Zee Punjab Haryana Himachal Pradesh</channel>
   <channel site="tataplay.com" site_id="796" lang="en" xmltv_id="ZeePunjabi.in@SD">Zee Punjabi</channel>
   <channel site="tataplay.com" site_id="583" lang="en" xmltv_id="ZeeRajasthan.in@SD">Zee Rajasthan News</channel>
   <channel site="tataplay.com" site_id="597" lang="en" xmltv_id="ZeeSarthak.in@SD">Zee Sarthak</channel>
   <channel site="tataplay.com" site_id="249" lang="en" xmltv_id="ZeeTalkies.in@SD">Zee Talkies</channel>
-  <channel site="tataplay.com" site_id="608" lang="en" xmltv_id="ZeeTamil.in@SD">Zee Tamil HD</channel>
-  <channel site="tataplay.com" site_id="635" lang="en" xmltv_id="ZeeTelugu.in@SD">Zee Telugu HD</channel>
+  <channel site="tataplay.com" site_id="515" lang="en" xmltv_id="ZeeTalkies.in@HD">Zee Talkies HD</channel>
+  <channel site="tataplay.com" site_id="257" lang="en" xmltv_id="ZeeTamil.in@SD">Zee Tamil</channel>
+  <channel site="tataplay.com" site_id="608" lang="en" xmltv_id="ZeeTamil.in@HD">Zee Tamil HD</channel>
+  <channel site="tataplay.com" site_id="250" lang="en" xmltv_id="ZeeTelugu.in@SD">Zee Telugu</channel>
+  <channel site="tataplay.com" site_id="635" lang="en" xmltv_id="ZeeTelugu.in@HD">Zee Telugu HD</channel>
   <channel site="tataplay.com" site_id="1288" lang="en" xmltv_id="ZeeTeluguNews.in@SD">Zee Telugu News</channel>
-  <channel site="tataplay.com" site_id="1182" lang="en" xmltv_id="ZeeThirai.in@SD">Zee Thirai HD</channel>
-  <channel site="tataplay.com" site_id="63" lang="en" xmltv_id="ZeeTV.in@SD">Zee TV HD</channel>
+  <channel site="tataplay.com" site_id="797" lang="en" xmltv_id="ZeeThirai.in@SD">Zee Thirai</channel>
+  <channel site="tataplay.com" site_id="1182" lang="en" xmltv_id="ZeeThirai.in@HD">Zee Thirai HD</channel>
+  <channel site="tataplay.com" site_id="557" lang="en" xmltv_id="ZeeTV.in@SD">Zee TV</channel>
+  <channel site="tataplay.com" site_id="63" lang="en" xmltv_id="ZeeTV.in@HD">Zee TV HD</channel>
   <channel site="tataplay.com" site_id="637" lang="en" xmltv_id="ZeeUttarPradeshUttarakhand.in@SD">Zee Uttar Pradesh Uttarakhand</channel>
   <channel site="tataplay.com" site_id="248" lang="en" xmltv_id="ZeeYuva.in@SD">Zee YUVA</channel>
-  <channel site="tataplay.com" site_id="382" lang="en" xmltv_id="ZeeZest.in@SD">Zee Zest HD</channel>
   <channel site="tataplay.com" site_id="504" lang="en" xmltv_id="ZeeZest.in@SD">Zee Zest</channel>
+  <channel site="tataplay.com" site_id="382" lang="en" xmltv_id="ZeeZest.in@HD">Zee Zest HD</channel>
   <channel site="tataplay.com" site_id="517" lang="en" xmltv_id="Zing.in@SD">Zing</channel>
   <channel site="tataplay.com" site_id="96" lang="en" xmltv_id="Zoom.in@SD">Zoom</channel>
 </channels>

--- a/sites/tataplay.com/tataplay.com_dth.channels.xml
+++ b/sites/tataplay.com/tataplay.com_dth.channels.xml
@@ -1,217 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="tataplay.com" site_id="15" lang="en" xmltv_id="SonyEntertainmentTelevision.in@HD">SET HD</channel>
-  <channel site="tataplay.com" site_id="28" lang="en" xmltv_id="AlankarTV.in@SD">Alankar</channel>
-  <channel site="tataplay.com" site_id="30" lang="en" xmltv_id="IndiaNewsUttarPradesh.in@SD">India News UP UK</channel>
-  <channel site="tataplay.com" site_id="32" lang="en" xmltv_id="SonyPix.in@HD">SONY PIX HD</channel>
-  <channel site="tataplay.com" site_id="34" lang="en" xmltv_id="SonyAath.in@SD">SONY AATH</channel>
-  <channel site="tataplay.com" site_id="35" lang="en" xmltv_id="SonySportsTen5.in@HD">SONY SPORTS TEN 5 HD</channel>
-  <channel site="tataplay.com" site_id="45" lang="en" xmltv_id="SonyYay.in@SD">SONY YAY!</channel>
-  <channel site="tataplay.com" site_id="48" lang="en" xmltv_id="SonySAB.in@HD">SONY SAB HD</channel>
-  <channel site="tataplay.com" site_id="50" lang="en" xmltv_id="TarangMusic.in@SD">Tarang Music</channel>
-  <channel site="tataplay.com" site_id="56" lang="en" xmltv_id="SonyWah.in@SD">Sony Wah</channel>
-  <channel site="tataplay.com" site_id="76" lang="en" xmltv_id="UdayaTV.in@SD">Udaya TV</channel>
-  <channel site="tataplay.com" site_id="77" lang="en" xmltv_id="StarSports1Tamil.in@SD">Star Sports 1 Tamil</channel>
-  <channel site="tataplay.com" site_id="80" lang="en" xmltv_id="SonyMax.in@HD">SONY MAX HD..</channel>
-  <channel site="tataplay.com" site_id="81" lang="en" xmltv_id="SonySportsTen1.in@HD">SONY SPORTS TEN 1 HD</channel>
-  <channel site="tataplay.com" site_id="82" lang="en" xmltv_id="KochuTV.in@SD">Kochu TV</channel>
-  <channel site="tataplay.com" site_id="86" lang="en" xmltv_id="StarBharat.in@SD">Star Bharat</channel>
-  <channel site="tataplay.com" site_id="120" lang="en" xmltv_id="SonyMax2.in@SD">SONY MAX 2</channel>
-  <channel site="tataplay.com" site_id="128" lang="en" xmltv_id="ETVCinema.in@SD">ETV Cinema</channel>
-  <channel site="tataplay.com" site_id="130" lang="en" xmltv_id="AnimalPlanet.in@SD">Animal Planet</channel>
-  <channel site="tataplay.com" site_id="132" lang="en" xmltv_id="SonyMax.in@SD">SONY MAX</channel>
-  <channel site="tataplay.com" site_id="135" lang="en" xmltv_id="TLC.in@SD">TLC</channel>
-  <channel site="tataplay.com" site_id="137" lang="en" xmltv_id="NationalGeographic.in@SD">National Geographic</channel>
-  <channel site="tataplay.com" site_id="141" lang="en" xmltv_id="StarSportsSelect1.in@SD">Star Sports Select 1</channel>
-  <channel site="tataplay.com" site_id="144" lang="en" xmltv_id="DisneyJunior.in@SD">Disney Junior</channel>
-  <channel site="tataplay.com" site_id="145" lang="en" xmltv_id="ETVTelugu.in@SD">ETV Telugu</channel>
-  <channel site="tataplay.com" site_id="147" lang="en" xmltv_id="KTV.in@SD">KTV</channel>
-  <channel site="tataplay.com" site_id="150" lang="en" xmltv_id="SonySportsTen1.in@SD">SONY SPORTS TEN 1</channel>
-  <channel site="tataplay.com" site_id="158" lang="en" xmltv_id="SonyBBCEarth.in@SD">SONY BBC Earth</channel>
-  <channel site="tataplay.com" site_id="162" lang="en" xmltv_id="GeminiMovies.in@SD">Gemini Movies</channel>
-  <channel site="tataplay.com" site_id="163" lang="en" xmltv_id="StarGold2.in@SD">Star Gold 2</channel>
-  <channel site="tataplay.com" site_id="164" lang="en" xmltv_id="StarGold.in@SD">STAR Gold</channel>
-  <channel site="tataplay.com" site_id="165" lang="en" xmltv_id="SunTV.in@SD">Sun TV</channel>
-  <channel site="tataplay.com" site_id="170" lang="en" xmltv_id="SonySportsTen2.in@SD">SONY SPORTS TEN 2</channel>
-  <channel site="tataplay.com" site_id="171" lang="en" xmltv_id="SonySportsTen3Hindi.in@SD">SONY SPORTS TEN 3 Hindi</channel>
-  <channel site="tataplay.com" site_id="172" lang="en" xmltv_id="HistoryTV18.in@SD">History TV18</channel>
-  <channel site="tataplay.com" site_id="173" lang="en" xmltv_id="MoviesNow.in@SD">Movies Now</channel>
-  <channel site="tataplay.com" site_id="184" lang="en" xmltv_id="NationalGeographicWild.in@HD">Nat Geo Wild</channel>
-  <channel site="tataplay.com" site_id="195" lang="en" xmltv_id="GeminiTV.in@SD">Gemini TV</channel>
-  <channel site="tataplay.com" site_id="218" lang="en" xmltv_id="SVBC.in@SD">SVBC</channel>
-  <channel site="tataplay.com" site_id="219" lang="en" xmltv_id="DiscoveryChannel.in@SD">Discovery Channel</channel>
-  <channel site="tataplay.com" site_id="234" lang="en" xmltv_id="MNX.in@SD">MNX</channel>
-  <channel site="tataplay.com" site_id="237" lang="en" xmltv_id="TarangTV.in@SD">Tarang TV</channel>
-  <channel site="tataplay.com" site_id="245" lang="en" xmltv_id="StarGold.in@HD">STAR GOLD HD</channel>
-  <channel site="tataplay.com" site_id="253" lang="en" xmltv_id="ZeeBangla.in@SD">Zee Bangla</channel>
-  <channel site="tataplay.com" site_id="265" lang="en" xmltv_id="DisneyInternationalHD.in@SD">Disney International HD</channel>
-  <channel site="tataplay.com" site_id="273" lang="en" xmltv_id="StarMovies.in@SD">STAR Movies</channel>
-  <channel site="tataplay.com" site_id="275" lang="en" xmltv_id="VijaySuper.in@SD">Vijay Super</channel>
-  <channel site="tataplay.com" site_id="277" lang="en" xmltv_id="StarMaaMovies.in@SD">Star Maa Movies</channel>
-  <channel site="tataplay.com" site_id="284" lang="en" xmltv_id="AdithyaTV.in@SD">Adithya TV</channel>
-  <channel site="tataplay.com" site_id="289" lang="en" xmltv_id="Asianet.in@SD">Asianet</channel>
-  <channel site="tataplay.com" site_id="294" lang="en" xmltv_id="AsianetPlus.in@SD">Asianet Plus</channel>
-  <channel site="tataplay.com" site_id="302" lang="en" xmltv_id="ChuttiTV.in@SD">Chutti TV</channel>
-  <channel site="tataplay.com" site_id="304" lang="en" xmltv_id="CNBCTV18PrimeHD.in@SD">CNBC TV18 Prime HD</channel>
-  <channel site="tataplay.com" site_id="317" lang="en" xmltv_id="DDBihar.in@SD">DD Bihar</channel>
-  <channel site="tataplay.com" site_id="319" lang="en" xmltv_id="">Tata Play Bollywood Premiere HD</channel>
-  <channel site="tataplay.com" site_id="338" lang="en" xmltv_id="DDUrdu.in@SD">DD Urdu</channel>
-  <channel site="tataplay.com" site_id="339" lang="en" xmltv_id="DDUttarPradesh.in@SD">DD Uttar Pradesh</channel>
-  <channel site="tataplay.com" site_id="345" lang="en" xmltv_id="HungamaTV.in@SD">Hungama</channel>
-  <channel site="tataplay.com" site_id="352" lang="en" xmltv_id="ETVPlus.in@SD">ETV Plus</channel>
-  <channel site="tataplay.com" site_id="360" lang="en" xmltv_id="GeminiComedy.in@SD">Gemini Comedy</channel>
-  <channel site="tataplay.com" site_id="363" lang="en" xmltv_id="GeminiMusic.in@SD">Gemini Music</channel>
-  <channel site="tataplay.com" site_id="382" lang="en" xmltv_id="ZeeZest.in@SD">Zee Zest HD</channel>
-  <channel site="tataplay.com" site_id="383" lang="en" xmltv_id="KushiTV.in@SD">Kushi TV</channel>
-  <channel site="tataplay.com" site_id="387" lang="en" xmltv_id="StarMaaMovies.in@HD">Star Maa Movies HD</channel>
-  <channel site="tataplay.com" site_id="388" lang="en" xmltv_id="StarMaaGold.in@SD">MAA Gold</channel>
-  <channel site="tataplay.com" site_id="389" lang="en" xmltv_id="StarMaaMusic.in@SD">Star Maa Music</channel>
-  <channel site="tataplay.com" site_id="393" lang="en" xmltv_id="ManoranjanMovies.in@SD">Manoranjan Movies</channel>
-  <channel site="tataplay.com" site_id="396" lang="en" xmltv_id="Mega24.in@SD">Mega 24</channel>
-  <channel site="tataplay.com" site_id="399" lang="en" xmltv_id="Mh1Music.in@SD">MH One</channel>
-  <channel site="tataplay.com" site_id="413" lang="en" xmltv_id="NationalGeographicWild.in@HD">Nat Geo Wild HD..</channel>
-  <channel site="tataplay.com" site_id="419" lang="en" xmltv_id="OdishaTV.in@SD">OTV</channel>
-  <channel site="tataplay.com" site_id="442" lang="en" xmltv_id="UdayaMusic.in@SD">Udaya Music</channel>
-  <channel site="tataplay.com" site_id="443" lang="en" xmltv_id="SunNews.in@SD">Sun News</channel>
-  <channel site="tataplay.com" site_id="450" lang="en" xmltv_id="SVBC.in@SD">SVBC Telugu</channel>
-  <channel site="tataplay.com" site_id="460" lang="en" xmltv_id="SonyBBCEarth.in@HD">SONY BBC Earth HD</channel>
-  <channel site="tataplay.com" site_id="461" lang="en" xmltv_id="StarGoldSelect.in@SD">Star Gold Select</channel>
-  <channel site="tataplay.com" site_id="462" lang="en" xmltv_id="SonySportsTen2.in@HD">SONY SPORTS TEN 2 HD</channel>
-  <channel site="tataplay.com" site_id="464" lang="en" xmltv_id="SonySportsTen3Hindi.in@HD">SONY SPORTS TEN 3 Hindi HD</channel>
-  <channel site="tataplay.com" site_id="465" lang="en" xmltv_id="StarJalsha.in@SD">STAR Jalsha</channel>
-  <channel site="tataplay.com" site_id="466" lang="en" xmltv_id="StarPravah.in@SD">STAR Pravah</channel>
-  <channel site="tataplay.com" site_id="470" lang="en" xmltv_id="StarUtsavMovies.in@SD">STAR Utsav Movies</channel>
-  <channel site="tataplay.com" site_id="479" lang="en" xmltv_id="SuryaTV.in@HD">Surya HD</channel>
-  <channel site="tataplay.com" site_id="481" lang="en" xmltv_id="SuryaComedy.in@SD">Surya Comedy</channel>
-  <channel site="tataplay.com" site_id="483" lang="en" xmltv_id="SuryaMusic.in@SD">Surya Music</channel>
-  <channel site="tataplay.com" site_id="491" lang="en" xmltv_id="UdayaComedy.in@SD">Udaya Comedy</channel>
-  <channel site="tataplay.com" site_id="493" lang="en" xmltv_id="StarGoldRomance.in@SD">Star Gold Romance</channel>
-  <channel site="tataplay.com" site_id="494" lang="en" xmltv_id="StarGoldThrills.in@SD">Star Gold Thrills</channel>
-  <channel site="tataplay.com" site_id="497" lang="en" xmltv_id="VTVNews.in@SD">VTV News</channel>
-  <channel site="tataplay.com" site_id="502" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe HD</channel>
-  <channel site="tataplay.com" site_id="504" lang="en" xmltv_id="ZeeZest.in@SD">Zee Zest</channel>
-  <channel site="tataplay.com" site_id="506" lang="en" xmltv_id="Andflix.in@SD">&amp;Flix HD</channel>
-  <channel site="tataplay.com" site_id="511" lang="en" xmltv_id="SunMusic.in@SD">Sun Music</channel>
-  <channel site="tataplay.com" site_id="520" lang="en" xmltv_id="SunMusic.in@HD">Sun Music HD</channel>
-  <channel site="tataplay.com" site_id="527" lang="en" xmltv_id="StarVijay.in@SD">STAR Vijay</channel>
-  <channel site="tataplay.com" site_id="530" lang="en" xmltv_id="AndpriveHD.in@SD">&amp;Prive HD</channel>
-  <channel site="tataplay.com" site_id="532" lang="en" xmltv_id="AsianetNews.in@SD">Asianet News</channel>
-  <channel site="tataplay.com" site_id="538" lang="en" xmltv_id="StarMaa.in@SD">STAR Maa</channel>
-  <channel site="tataplay.com" site_id="541" lang="en" xmltv_id="RajMusixMalayalam.in@SD">Raj Musix Malayalam</channel>
-  <channel site="tataplay.com" site_id="550" lang="en" xmltv_id="StarPlus.in@SD">STAR Plus</channel>
-  <channel site="tataplay.com" site_id="554" lang="en" xmltv_id="SonyPal.in@SD">Sony Pal</channel>
-  <channel site="tataplay.com" site_id="556" lang="en" xmltv_id="SonyEntertainmentTelevision.in@SD">SET</channel>
-  <channel site="tataplay.com" site_id="558" lang="en" xmltv_id="SonyPix.in@SD">SONY PIX</channel>
-  <channel site="tataplay.com" site_id="559" lang="en" xmltv_id="SonySAB.in@SD">SONY SAB</channel>
-  <channel site="tataplay.com" site_id="560" lang="en" xmltv_id="StarMovies.in@HD">STAR Movies HD</channel>
-  <channel site="tataplay.com" site_id="561" lang="en" xmltv_id="ChintuTV.in@SD">Chintu TV</channel>
-  <channel site="tataplay.com" site_id="568" lang="en" xmltv_id="">Prarthana Life</channel>
-  <channel site="tataplay.com" site_id="572" lang="en" xmltv_id="JalshaMovies.in@SD">Jalsha Movies</channel>
-  <channel site="tataplay.com" site_id="579" lang="en" xmltv_id="StarSuvarna.in@SD">Star Suvarna</channel>
-  <channel site="tataplay.com" site_id="587" lang="en" xmltv_id="SuperHungama.in@SD">Super Hungama</channel>
-  <channel site="tataplay.com" site_id="592" lang="en" xmltv_id="Andflix.in@SD">&amp;flix</channel>
-  <channel site="tataplay.com" site_id="593" lang="en" xmltv_id="StarMoviesSelect.in@HD">STAR Movies Select HD</channel>
-  <channel site="tataplay.com" site_id="595" lang="en" xmltv_id="StarGoldSelect.in@HD">Star Gold Select HD</channel>
-  <channel site="tataplay.com" site_id="600" lang="en" xmltv_id="StarSports1.in@SD">STAR Sports 1</channel>
-  <channel site="tataplay.com" site_id="601" lang="en" xmltv_id="StarSports1Hindi.in@SD">Star Sports 1 Hindi</channel>
-  <channel site="tataplay.com" site_id="602" lang="en" xmltv_id="ZeeCafe.in@SD">Zee Cafe</channel>
-  <channel site="tataplay.com" site_id="603" lang="en" xmltv_id="StarSportsSelect2.in@SD">Star Sports Select 2</channel>
-  <channel site="tataplay.com" site_id="605" lang="en" xmltv_id="NationalGeographic.in@HD">National Geographic HD</channel>
-  <channel site="tataplay.com" site_id="609" lang="en" xmltv_id="StarSports2.in@SD">STAR Sports 2</channel>
-  <channel site="tataplay.com" site_id="610" lang="en" xmltv_id="SonySportsTen5.in@SD">SONY SPORTS TEN 5</channel>
-  <channel site="tataplay.com" site_id="616" lang="en" xmltv_id="HistoryTV18.in@HD">History TV18 HD</channel>
-  <channel site="tataplay.com" site_id="633" lang="en" xmltv_id="InvestigationDiscovery.in@SD">Investigation Discovery</channel>
-  <channel site="tataplay.com" site_id="643" lang="en" xmltv_id="NewsStateMPCHG.in@SD">News State MP CG</channel>
-  <channel site="tataplay.com" site_id="657" lang="en" xmltv_id="">Tata Play Telugu Cinema</channel>
-  <channel site="tataplay.com" site_id="658" lang="en" xmltv_id="SonyMarathi.in@SD">Sony Marathi</channel>
-  <channel site="tataplay.com" site_id="663" lang="en" xmltv_id="">Tata Play Tamil Cinema</channel>
-  <channel site="tataplay.com" site_id="664" lang="en" xmltv_id="StarSports3.in@SD">Star Sports 3</channel>
-  <channel site="tataplay.com" site_id="683" lang="en" xmltv_id="StarSports2Kannada.in@SD">Star Sports 2 Kannada</channel>
-  <channel site="tataplay.com" site_id="688" lang="en" xmltv_id="StarSports1Telugu.in@SD">Star Sports 1 Telugu</channel>
-  <channel site="tataplay.com" site_id="690" lang="en" xmltv_id="StarSports1Kannada.in@SD">Star Sports 1 Kannada</channel>
-  <channel site="tataplay.com" site_id="693" lang="en" xmltv_id="Eurosport.in@SD">Eurosport</channel>
-  <channel site="tataplay.com" site_id="697" lang="en" xmltv_id="SunBangla.in@SD">Sun Bangla</channel>
-  <channel site="tataplay.com" site_id="706" lang="en" xmltv_id="TV9Bharatvarsh.in@SD">TV9 Bharatvarsh</channel>
-  <channel site="tataplay.com" site_id="737" lang="en" xmltv_id="">Tata Play Music</channel>
-  <channel site="tataplay.com" site_id="738" lang="en" xmltv_id="">Smart Games</channel>
-  <channel site="tataplay.com" site_id="745" lang="en" xmltv_id="">Theatre</channel>
-  <channel site="tataplay.com" site_id="750" lang="en" xmltv_id="">TRAI Tariff Order</channel>
-  <channel site="tataplay.com" site_id="785" lang="en" xmltv_id="">Tata Play Kannada Cinema</channel>
-  <channel site="tataplay.com" site_id="797" lang="en" xmltv_id="ZeeThirai.in@SD">Zee Thirai</channel>
-  <channel site="tataplay.com" site_id="868" lang="en" xmltv_id="">Tata Play Malayalam Cinema</channel>
-  <channel site="tataplay.com" site_id="892" lang="en" xmltv_id="">Samara News</channel>
-  <channel site="tataplay.com" site_id="905" lang="en" xmltv_id="ETVBalBharatTelugu.in@SD">ETV Bal Bharat</channel>
-  <channel site="tataplay.com" site_id="906" lang="en" xmltv_id="VijayTakkar.in@SD">Vijay Takkar</channel>
-  <channel site="tataplay.com" site_id="914" lang="en" xmltv_id="SonySportsTen4.in">SONY SPORTS TEN 4</channel>
-  <channel site="tataplay.com" site_id="923" lang="en" xmltv_id="Travelxp.in@4KHDR">TravelXP 4K HDR</channel>
-  <channel site="tataplay.com" site_id="955" lang="en" xmltv_id="SunMarathi.in@SD">Sun Marathi</channel>
-  <channel site="tataplay.com" site_id="967" lang="en" xmltv_id="">TCh 100 Binge</channel>
-  <channel site="tataplay.com" site_id="985" lang="en" xmltv_id="PravahPicture.in@SD">STAR Pravah Picture</channel>
-  <channel site="tataplay.com" site_id="987" lang="en" xmltv_id="StarKiran.in@SD">Star Kiran</channel>
-  <channel site="tataplay.com" site_id="1025" lang="en" xmltv_id="ColorsCineplexSuperhits.in@SD">Colors Cineplex Superhits</channel>
-  <channel site="tataplay.com" site_id="1026" lang="en" xmltv_id="">Sidharth UTSAV</channel>
-  <channel site="tataplay.com" site_id="1032" lang="en" xmltv_id="SansadTV2.in@HD">Sansad TV 2 HD</channel>
-  <channel site="tataplay.com" site_id="1035" lang="en" xmltv_id="">Khandoba Temple Jejuri</channel>
   <channel site="tataplay.com" site_id="1060" lang="en" xmltv_id="">Live Punjabi</channel>
-  <channel site="tataplay.com" site_id="1066" lang="en" xmltv_id="DisneyChannel.in@HD">Disney Channel HD</channel>
-  <channel site="tataplay.com" site_id="1067" lang="en" xmltv_id="StarSports1Tamil.in@HD">Star Sports 1 Tamil HD</channel>
-  <channel site="tataplay.com" site_id="1068" lang="en" xmltv_id="StarSports1Telugu.in@HD">Star Sports 1 Telugu HD</channel>
-  <channel site="tataplay.com" site_id="1069" lang="en" xmltv_id="StarMoviesSelect.in@SD">Star Movies Select</channel>
-  <channel site="tataplay.com" site_id="1072" lang="en" xmltv_id="StarGold2.in@HD">Star Gold 2 HD</channel>
-  <channel site="tataplay.com" site_id="1173" lang="en" xmltv_id="AsianetMovies.in@HD">Asianet Movies HD</channel>
-  <channel site="tataplay.com" site_id="1175" lang="en" xmltv_id="PravahPicture.in@HD">Star Pravah Pictures HD</channel>
-  <channel site="tataplay.com" site_id="1176" lang="en" xmltv_id="VijaySuper.in@HD">Vijay Super HD</channel>
-  <channel site="tataplay.com" site_id="1184" lang="en" xmltv_id="Nazara.in@SD">NAZARA</channel>
-  <channel site="tataplay.com" site_id="1188" lang="en" xmltv_id="DDJharkhand.in@SD">DD Jharkhand</channel>
-  <channel site="tataplay.com" site_id="1191" lang="en" xmltv_id="DDSports.in@HD">DD Sports HD</channel>
-  <channel site="tataplay.com" site_id="1192" lang="en" xmltv_id="SonySportsTen4.in">Sony Sports Ten 4 HD</channel>
-  <channel site="tataplay.com" site_id="1214" lang="en" xmltv_id="DDNagaland.in@SD">DD Nagaland</channel>
-  <channel site="tataplay.com" site_id="1216" lang="en" xmltv_id="DDChhattisgarh.in@SD">DD Chhattisgarh</channel>
-  <channel site="tataplay.com" site_id="1218" lang="en" xmltv_id="DDNational.in@HD">DD National HD</channel>
-  <channel site="tataplay.com" site_id="1219" lang="en" xmltv_id="DDIndia.in@SD">DD India HD</channel>
-  <channel site="tataplay.com" site_id="1221" lang="en" xmltv_id="SunMarathi.in@HD">Sun Marathi HD</channel>
-  <channel site="tataplay.com" site_id="1222" lang="en" xmltv_id="SunBangla.in@HD">Sun Bangla HD</channel>
-  <channel site="tataplay.com" site_id="1226" lang="en" xmltv_id="Channel100.in@SD">Ch 100 4003</channel>
-  <channel site="tataplay.com" site_id="1227" lang="en" xmltv_id="">Ch 100 4005</channel>
-  <channel site="tataplay.com" site_id="1228" lang="en" xmltv_id="">Ch 100 4006</channel>
-  <channel site="tataplay.com" site_id="1229" lang="en" xmltv_id="">Ch 100 4007</channel>
-  <channel site="tataplay.com" site_id="1230" lang="en" xmltv_id="">Ch 100 4008</channel>
-  <channel site="tataplay.com" site_id="1231" lang="en" xmltv_id="">Ch 100 4009</channel>
-  <channel site="tataplay.com" site_id="1232" lang="en" xmltv_id="">Ch 100 4010</channel>
-  <channel site="tataplay.com" site_id="1233" lang="en" xmltv_id="">Ch 100 4011</channel>
-  <channel site="tataplay.com" site_id="1234" lang="en" xmltv_id="">Ch 100 4012</channel>
-  <channel site="tataplay.com" site_id="1235" lang="en" xmltv_id="">Ch 100 4013</channel>
-  <channel site="tataplay.com" site_id="1236" lang="en" xmltv_id="">Ch 100 4014</channel>
-  <channel site="tataplay.com" site_id="1237" lang="en" xmltv_id="">Ch 100 4015</channel>
-  <channel site="tataplay.com" site_id="1238" lang="en" xmltv_id="">Ch 100 4016</channel>
-  <channel site="tataplay.com" site_id="1239" lang="en" xmltv_id="">Ch 100 4018</channel>
-  <channel site="tataplay.com" site_id="1240" lang="en" xmltv_id="">Ch 100 4004</channel>
-  <channel site="tataplay.com" site_id="1241" lang="en" xmltv_id="">Ch 100 4017</channel>
-  <channel site="tataplay.com" site_id="1266" lang="en" xmltv_id="GeminiMusic.in@HD">Gemini Music HD</channel>
-  <channel site="tataplay.com" site_id="1301" lang="en" xmltv_id="TataSky4K.in@SD">Tata Play 4K</channel>
-  <channel site="tataplay.com" site_id="1318" lang="en" xmltv_id="CalvaryTV.in@SD">Calvary TV</channel>
-  <channel site="tataplay.com" site_id="1324" lang="en" xmltv_id="RajAsia.in@SD">Raj Nagaichuvai</channel>
-  <channel site="tataplay.com" site_id="1363" lang="en" xmltv_id="">Tata Play Anime Local</channel>
-  <channel site="tataplay.com" site_id="1368" lang="en" xmltv_id="SansadTV1.in@HD">Sansad TV 1 HD</channel>
-  <channel site="tataplay.com" site_id="1369" lang="en" xmltv_id="SunNeo.in@SD">Sun Neo</channel>
-  <channel site="tataplay.com" site_id="1370" lang="en" xmltv_id="SunNeo.in@HD">Sun Neo HD</channel>
-  <channel site="tataplay.com" site_id="1378" lang="en" xmltv_id="NireekshanaTV.in@SD">Nireekshana TV</channel>
-  <channel site="tataplay.com" site_id="1390" lang="en" xmltv_id="">Tata Play Superhits Serials</channel>
-  <channel site="tataplay.com" site_id="1407" lang="en" xmltv_id="IndiaTVSpeedNews.in@HD">India TV Speed News HD</channel>
-  <channel site="tataplay.com" site_id="1464" lang="en" xmltv_id="ABCAustralia.au@SD">ABC Australia</channel>
-  <channel site="tataplay.com" site_id="1484" lang="en" xmltv_id="AssamTalks.in@SD">Assam Talks</channel>
-  <channel site="tataplay.com" site_id="1485" lang="en" xmltv_id="">Village TV</channel>
-  <channel site="tataplay.com" site_id="1488" lang="en" xmltv_id="">Guarantee News</channel>
-  <channel site="tataplay.com" site_id="1494" lang="en" xmltv_id="StarSportsKhel.in@SD">Star Sports Khel</channel>
-  <channel site="tataplay.com" site_id="1495" lang="en" xmltv_id="">Star Sports 2 Tamil HD</channel>
-  <channel site="tataplay.com" site_id="1496" lang="en" xmltv_id="">Star Sports 2 Telugu HD</channel>
-  <channel site="tataplay.com" site_id="1497" lang="en" xmltv_id="ZeeNews.in@SD">Zee News HD</channel>
-  <channel site="tataplay.com" site_id="1717" lang="en" xmltv_id="">SONY MAX 1</channel>
+  <channel site="tataplay.com" site_id="750" lang="en" xmltv_id="">TRAI Tariff Order</channel>
   <channel site="tataplay.com" site_id="1718" lang="en" xmltv_id="">Darshan Linear</channel>
-  <channel site="tataplay.com" site_id="1727" lang="en" xmltv_id="">Star Maa HD Geo2</channel>
-  <channel site="tataplay.com" site_id="1753" lang="en" xmltv_id="">Zee Cinema Geo</channel>
-  <channel site="tataplay.com" site_id="1783" lang="en" xmltv_id="">Colors HD Geo</channel>
+  <channel site="tataplay.com" site_id="1234" lang="en" xmltv_id="">Ch 100 4012</channel>
   <channel site="tataplay.com" site_id="1798" lang="en" xmltv_id="">Tata Play Music Binge</channel>
-  <channel site="tataplay.com" site_id="1836" lang="en" xmltv_id="GTCPunjabi.in@SD">GTC Punjabi</channel>
-  <channel site="tataplay.com" site_id="1850" lang="en" xmltv_id="GTCNews.in@SD">GTC News</channel>
+  <channel site="tataplay.com" site_id="1229" lang="en" xmltv_id="">Ch 100 4007</channel>
+  <channel site="tataplay.com" site_id="1236" lang="en" xmltv_id="">Ch 100 4014</channel>
+  <channel site="tataplay.com" site_id="1240" lang="en" xmltv_id="">Ch 100 4004</channel>
+  <channel site="tataplay.com" site_id="1184" lang="en" xmltv_id="EpicBharat.in@SD">NAZARA</channel>
+  <channel site="tataplay.com" site_id="1239" lang="en" xmltv_id="">Ch 100 4018</channel>
+  <channel site="tataplay.com" site_id="1226" lang="en" xmltv_id="Channel100.in@SD">Ch 100 4003</channel>
+  <channel site="tataplay.com" site_id="245" lang="en" xmltv_id="StarGold.in@HD">STAR GOLD HD</channel>
+  <channel site="tataplay.com" site_id="1232" lang="en" xmltv_id="">Ch 100 4010</channel>
+  <channel site="tataplay.com" site_id="387" lang="en" xmltv_id="StarMaaMovies.in@HD">Star Maa Movies HD</channel>
+  <channel site="tataplay.com" site_id="1227" lang="en" xmltv_id="">Ch 100 4005</channel>
+  <channel site="tataplay.com" site_id="1485" lang="en" xmltv_id="">Village TV</channel>
+  <channel site="tataplay.com" site_id="1727" lang="en" xmltv_id="">Star Maa HD Geo2</channel>
+  <channel site="tataplay.com" site_id="1237" lang="en" xmltv_id="">Ch 100 4015</channel>
+  <channel site="tataplay.com" site_id="1231" lang="en" xmltv_id="">Ch 100 4009</channel>
+  <channel site="tataplay.com" site_id="419" lang="en" xmltv_id="OdishaTV.in@SD">OTV</channel>
+  <channel site="tataplay.com" site_id="1228" lang="en" xmltv_id="">Ch 100 4006</channel>
+  <channel site="tataplay.com" site_id="1238" lang="en" xmltv_id="">Ch 100 4016</channel>
+  <channel site="tataplay.com" site_id="1233" lang="en" xmltv_id="">Ch 100 4011</channel>
+  <channel site="tataplay.com" site_id="1235" lang="en" xmltv_id="">Ch 100 4013</channel>
+  <channel site="tataplay.com" site_id="892" lang="en" xmltv_id="">Samara News</channel>
+  <channel site="tataplay.com" site_id="745" lang="en" xmltv_id="">Theatre</channel>
+  <channel site="tataplay.com" site_id="294" lang="en" xmltv_id="AsianetPlus.in@SD">Asianet Plus</channel>
+  <channel site="tataplay.com" site_id="1241" lang="en" xmltv_id="">Ch 100 4017</channel>
+  <channel site="tataplay.com" site_id="967" lang="en" xmltv_id="">TCh 100 Binge</channel>
+  <channel site="tataplay.com" site_id="388" lang="en" xmltv_id="StarMaaGold.in@SD">MAA Gold</channel>
+  <channel site="tataplay.com" site_id="1230" lang="en" xmltv_id="">Ch 100 4008</channel>
+  <channel site="tataplay.com" site_id="1783" lang="en" xmltv_id="">Colors HD Geo</channel>
+  <channel site="tataplay.com" site_id="923" lang="en" xmltv_id="Travelxp.in@4KHDR">TravelXP 4K HDR</channel>
+  <channel site="tataplay.com" site_id="530" lang="en" xmltv_id="AndpriveHD.in@SD">&amp;Prive HD</channel>
+  <channel site="tataplay.com" site_id="393" lang="en" xmltv_id="ManoranjanMovies.in@SD">Manoranjan Movies</channel>
+  <channel site="tataplay.com" site_id="738" lang="en" xmltv_id="">Smart Games</channel>
 </channels>

--- a/sites/vantagetv.ee/vantagetv.ee.channels.xml
+++ b/sites/vantagetv.ee/vantagetv.ee.channels.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="vantagetv.ee" site_id="vmusic" lang="en" xmltv_id="VantageMusic.ee@SD">Vantage Music</channel>
-  <channel site="vantagetv.ee" site_id="vdance" lang="en" xmltv_id="">Vantage Dance</channel>
-  <channel site="vantagetv.ee" site_id="vrock" lang="en" xmltv_id="">Vantage Rock</channel>
+  <channel site="vantagetv.ee" site_id="vmusic" lang="en" xmltv_id="VantageMusic.ee@HD">Vantage Music</channel>
+  <channel site="vantagetv.ee" site_id="vdance" lang="en" xmltv_id="VantageDance.ee@HD">Vantage Dance</channel>
+  <channel site="vantagetv.ee" site_id="vrock" lang="en" xmltv_id="VantageRock.ee@HD">Vantage Rock</channel>
+  <channel site="vantagetv.ee" site_id="vclassic" lang="en" xmltv_id="VantageClassic.ee@HD">Vantage Classic</channel>
 </channels>

--- a/sites/xumo.tv/xumo.tv.channels.xml
+++ b/sites/xumo.tv/xumo.tv.channels.xml
@@ -53,8 +53,8 @@
   <channel site="xumo.tv" site_id="50#9999615" lang="en" xmltv_id="DarkMatterTV.us@SD">Dark Matter TV</channel>
   <channel site="xumo.tv" site_id="50#99951134" lang="en" xmltv_id="">UFC</channel>
   <channel site="xumo.tv" site_id="50#99951158" lang="en" xmltv_id="">ION</channel>
-  <channel site="xumo.tv" site_id="50#99951180" lang="en" xmltv_id="StrongmanChampionsLeague.pl@SD">Strongman Champions League</channel>
-  <channel site="xumo.tv" site_id="50#99951203" lang="en" xmltv_id="PFLMMA.pl@SD">PFL MMA</channel>
+  <channel site="xumo.tv" site_id="50#99951180" lang="en" xmltv_id="StrongmanChampionsLeague.uk@SD">Strongman Champions League</channel>
+  <channel site="xumo.tv" site_id="50#99951203" lang="en" xmltv_id="PFLMMA.us@SD">PFL MMA</channel>
   <channel site="xumo.tv" site_id="50#99951248" lang="en" xmltv_id="ClassicDoctorWho.us@SD">Classic Doctor Who</channel>
   <channel site="xumo.tv" site_id="50#99951250" lang="en" xmltv_id="OuterSphere.us@SD">OuterSphere by Lionsgate</channel>
   <channel site="xumo.tv" site_id="50#99951253" lang="en" xmltv_id="NBCSportsNOW.us@SD">NBC Sports NOW</channel>

--- a/sites/zee5.com/zee5.com.channels.xml
+++ b/sites/zee5.com/zee5.com.channels.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="zee5.com" site_id="0-9-channel_2105335046" lang="en" xmltv_id="Andflix.in@SD">&amp;flix HD</channel>
   <channel site="zee5.com" site_id="0-9-pictures" lang="en" xmltv_id="Andpictures.in@SD">&amp;Pictures</channel>
   <channel site="zee5.com" site_id="0-9-tvpictureshd" lang="en" xmltv_id="Andpictures.in@HD">&amp;Pictures HD</channel>
   <channel site="zee5.com" site_id="0-9-channel_122044711" lang="en" xmltv_id="AndTV.in@International">&amp;TV HD</channel>
@@ -19,7 +18,7 @@
   <channel site="zee5.com" site_id="0-9-9z5910523" lang="en" xmltv_id="GREATmystery.uk@SD">Great! Mystery</channel>
   <channel site="zee5.com" site_id="0-9-9z5910524" lang="en" xmltv_id="GREATromance.uk@UK">Great! Romance</channel>
   <channel site="zee5.com" site_id="0-9-indiatoday" lang="en" xmltv_id="IndiaToday.in@SD">India Today</channel>
-  <channel site="zee5.com" site_id="0-9-9z5938346" lang="en" xmltv_id="">Iskon Vrindavan</channel>
+  <channel site="zee5.com" site_id="0-9-9z5938346" lang="en" xmltv_id="">Iskcon Vrindavan</channel>
   <channel site="zee5.com" site_id="0-9-9z5938349" lang="en" xmltv_id="">Kashi Vishwanath</channel>
   <channel site="zee5.com" site_id="0-9-9z5938347" lang="en" xmltv_id="">Ma Naina Devi</channel>
   <channel site="zee5.com" site_id="0-9-9z5938351" lang="en" xmltv_id="">Mahavir Mandir Patna</channel>
@@ -44,6 +43,8 @@
   <channel site="zee5.com" site_id="0-9-259" lang="en" xmltv_id="TV9Kannada.in@SD">TV9 Kannada</channel>
   <channel site="zee5.com" site_id="0-9-257" lang="en" xmltv_id="TV9Marathi.in@SD">TV9 Marathi</channel>
   <channel site="zee5.com" site_id="0-9-258" lang="en" xmltv_id="TV9Telugu.in@SD">TV9 Telugu</channel>
+  <channel site="zee5.com" site_id="0-9-zeecafehd" lang="en" xmltv_id="Unite8Sports1.in@HD">Unite8 Sports 1 HD</channel>
+  <channel site="zee5.com" site_id="0-9-channel_2105335046" lang="en" xmltv_id="Unite8Sports2.in@HD">Unite8 Sports 2 HD</channel>
   <channel site="zee5.com" site_id="0-9-wion" lang="en" xmltv_id="WION.in@SD">WION</channel>
   <channel site="zee5.com" site_id="0-9-24ghantatv" lang="en" xmltv_id="Zee24Ghanta.in@SD">Zee 24 Ghanta</channel>
   <channel site="zee5.com" site_id="0-9-zee24kalak" lang="en" xmltv_id="Zee24Kalak.in@SD">Zee 24 Kalak</channel>
@@ -63,7 +64,6 @@
   <channel site="zee5.com" site_id="0-9-216" lang="en" xmltv_id="ZeeBiskope.in@SD">Zee Biskope</channel>
   <channel site="zee5.com" site_id="0-9-zeeclassic" lang="en" xmltv_id="ZeeBollywood.in@SD">Zee Bollywood</channel>
   <channel site="zee5.com" site_id="0-9-zeebusiness" lang="en" xmltv_id="ZeeBusiness.in@SD">Zee Business</channel>
-  <channel site="zee5.com" site_id="0-9-zeecafehd" lang="en" xmltv_id="ZeeCafe.in@HD">Zee Café HD</channel>
   <channel site="zee5.com" site_id="0-9-zeecinema" lang="en" xmltv_id="ZeeCinema.in@SD">Zee Cinema</channel>
   <channel site="zee5.com" site_id="0-9-zeecinemahd" lang="en" xmltv_id="ZeeCinema.in@HD">Zee Cinema HD</channel>
   <channel site="zee5.com" site_id="0-9-zeecinemaintl" lang="en" xmltv_id="ZeeCinema.in@ME">Zee Cinema ME</channel>
@@ -92,6 +92,7 @@
   <channel site="zee5.com" site_id="0-9-241" lang="en" xmltv_id="ZeePower.in@HD">Zee Power HD</channel>
   <channel site="zee5.com" site_id="0-9-zeepunjabharyanahima" lang="en" xmltv_id="ZeePunjabHaryanaHimachal.in@SD">Zee Punjab Haryana Himachal Pradesh</channel>
   <channel site="zee5.com" site_id="0-9-215" lang="en" xmltv_id="ZeePunjabi.in@SD">Zee Punjabi</channel>
+  <channel site="zee5.com" site_id="0-9-9z5950417" lang="en" xmltv_id="">Zee Punjabi HD UK</channel>
   <channel site="zee5.com" site_id="0-9-zeerajasthannews" lang="en" xmltv_id="ZeeRajasthan.in@SD">Zee Rajasthan News</channel>
   <channel site="zee5.com" site_id="0-9-sarthaktv" lang="en" xmltv_id="ZeeSarthak.in@SD">Zee Sarthak</channel>
   <channel site="zee5.com" site_id="0-9-9z5383489" lang="en" xmltv_id="ZeeTalkies.in@SD">Zee Talkies</channel>


### PR DESCRIPTION
- `pluto.tv`, `i.mjh.nz/pluto` - https://github.com/iptv-org/database/pull/28409
- Indian `channels.xml` update- `airtelxstream.in`, `dishtv.in`, `tataplay.com`, `zee5.com`
- `distro.tv` - majority channels seem to be down at the source
- `vantagetv.ee` - add channels
- validate fixes based on database edit.