### PR TITLE
Fix mi.tv time parsing and modifying Cheerio to use .find() instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,9 +3119,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3137,9 +3134,6 @@
       "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3157,9 +3151,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3175,9 +3166,6 @@
       "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3195,9 +3183,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3213,9 +3198,6 @@
       "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3959,9 +3941,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3974,9 +3953,6 @@
       "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3991,9 +3967,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4006,9 +3979,6 @@
       "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4023,9 +3993,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4038,9 +4005,6 @@
       "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4055,9 +4019,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4070,9 +4031,6 @@
       "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4087,9 +4045,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4102,9 +4057,6 @@
       "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,6 +3119,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3134,6 +3137,9 @@
       "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3151,6 +3157,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3166,6 +3175,9 @@
       "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3183,6 +3195,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3198,6 +3213,9 @@
       "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3941,6 +3959,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3953,6 +3974,9 @@
       "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3967,6 +3991,9 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3979,6 +4006,9 @@
       "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
       "cpu": [
         "loong64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3993,6 +4023,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4005,6 +4038,9 @@
       "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4019,6 +4055,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4031,6 +4070,9 @@
       "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4045,6 +4087,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4057,6 +4102,9 @@
       "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/sites/mi.tv/mi.tv.config.js
+++ b/sites/mi.tv/mi.tv.config.js
@@ -23,14 +23,22 @@ module.exports = {
     const [country, id] = channel.site_id.split('#')
     return `https://mi.tv/${country}/async/channel/${id}/${date.format('YYYY-MM-DD')}/0`
   },
-  parser({ content, date }) {
+  parser({ content, date, channel }) { 
+    const country = channel?.site_id?.split('#')?.[0] || null
+    let hourformat
+    if (country === 'co') { // Colombia uses h:mma instead of HH:mm 
+      hourformat = 'h:mma'
+    } else {
+      hourformat = 'HH:mm'
+    } 
     const programs = []
-    const items = parseItems(content)
-    items.forEach(item => {
+    const $ = cheerio.load(content)
+    const items = parseItems($)
+    for (const item of items) { 
       const prev = programs[programs.length - 1]
-      const $item = cheerio.load(item)
-      let start = parseStart($item, date)
-      if (!start) return
+      const $item = $(item) 
+      let start = parseStart($item, date, hourformat)
+      if (!start) continue
       if (prev) {
         if (start.isBefore(prev.start)) {
           start = start.add(1, 'd')
@@ -47,7 +55,7 @@ module.exports = {
         start,
         stop
       })
-    })
+    } 
 
     return programs
   },
@@ -82,29 +90,29 @@ module.exports = {
   }
 }
 
-function parseStart($item, date) {
-  const timeString = $item('a > div.content > span.time').text()
+function parseStart($item, date, hourformat) {
+  const timeString = $item.find('a > div.content > span.time').text()
   if (!timeString) return null
   const dateString = `${date.format('MM/DD/YYYY')} ${timeString}`
 
-  return dayjs.utc(dateString, 'MM/DD/YYYY HH:mm')
+  return dayjs.utc(dateString, `MM/DD/YYYY ${hourformat}`)
 }
 
 function parseTitle($item) {
-  return $item('a > div.content > h2').text().trim()
+  return $item.find('a > div.content > h2').text().trim()
 }
 
 function parseCategory($item) {
-  return $item('a > div.content > span.sub-title').text().trim()
+  return $item.find('a > div.content > span.sub-title').text().trim()
 }
 
 function parseDescription($item) {
-  return $item('a > div.content > p.synopsis').text().trim()
+  return $item.find('a > div.content > p.synopsis').text().trim()
 }
 
 
 function parseImage($item) {
-  const styleAttr = $item('a > div.image-parent > div.image').attr('style')
+  const styleAttr = $item.find('a > div.image-parent > div.image').attr('style')
   
   if (styleAttr) {
     const match = styleAttr.match(/background-image:\s*url\(['"]?(.*?)['"]?\)/)
@@ -113,7 +121,7 @@ function parseImage($item) {
     }
   }
   
-  const backgroundImage = $item('a > div.image-parent > div.image').css('background-image')
+  const backgroundImage = $item.find('a > div.image-parent > div.image').css('background-image')
   
   if (backgroundImage && backgroundImage !== 'none') {
     const match = backgroundImage.match(/url\(['"]?(.*?)['"]?\)/)
@@ -137,8 +145,6 @@ function cleanUrl(url) {
 }
 
 
-function parseItems(content) {
-  const $ = cheerio.load(content)
-
+function parseItems($) { 
   return $('#listings > ul > li').toArray()
 }

--- a/sites/mi.tv/mi.tv.test.js
+++ b/sites/mi.tv/mi.tv.test.js
@@ -21,7 +21,7 @@ it('can generate valid url', () => {
 
 it('can parse response', () => {
   const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.html'), 'utf8')
-  const result = parser({ content, date }).map(p => {
+  const result = parser({ content, date, channel }).map(p => {
     p.start = p.start.toJSON()
     p.stop = p.stop.toJSON()
     return p


### PR DESCRIPTION
Changes: 
- The colombian version of mi.tv uses the AM/PM 12-hour format instead of 24 hours (like the another countries), so it grabs the country code from the channel site ID and changes the hour parsing format from it. 
- Now cheerio.load() is called only when parsing the programming page and not in any program.
Works perfectly fine for me, it correctly lists each program with its actual date and time and passes the tests too.

PD: The package-lock.json file was automatically modified when setting up this project so I reverted it to its previous version before this fork. 