### PR TITLE
Fix dna.fi guide: full-day results, hard errors on bad responses

### DIFF
--- a/sites/dna.fi/dna.fi.config.js
+++ b/sites/dna.fi/dna.fi.config.js
@@ -1,20 +1,35 @@
 const axios = require('axios')
 const dayjs = require('dayjs')
+const utc = require('dayjs/plugin/utc')
+const timezone = require('dayjs/plugin/timezone')
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+// The API groups programmes into broadcast days that start at 04:00
+// Europe/Helsinki. Requesting exactly that window (instead of a fixed
+// UTC+2 offset) keeps the interval aligned year-round; a misaligned
+// interval gets answered with a "303 See Other" to a widened window.
+// Without an explicit `limit` the API paginates 20 items per response,
+// so only the first ~20 programmes of each day would be returned.
+const dayStart = date => dayjs.tz(date.format('YYYY-MM-DD'), 'Europe/Helsinki').add(4, 'h')
 
 module.exports = {
   site: 'dna.fi',
   days: 2,
   url({ date, channel }) {
-    const beginTimestamp = date.add(2, 'h').valueOf()
-    const endTimestamp = date.add(1, 'd').add(2, 'h').subtract(1, 's').valueOf()
+    const beginTimestamp = dayStart(date).valueOf()
+    const endTimestamp = dayStart(date.add(1, 'd')).subtract(1, 's').valueOf()
 
-    return `https://mts-pro-envoy-vip.dna.fi/hbx/api/pub/xrtv/g/media?q=channel:${channel.site_id}&q=profile:pr&q=start-interval:${beginTimestamp}/${endTimestamp}`
+    return `https://mts-pro-envoy-vip.dna.fi/hbx/api/pub/xrtv/g/media?q=channel:${channel.site_id}&q=profile:pr&q=start-interval:${beginTimestamp}/${endTimestamp}&limit=1000`
   },
-  parser({ content, date }) {
+  parser({ content }) {
     let programs = []
-    let items = parseItems(content, date)
+    let items = parseItems(content)
     items.forEach(item => {
       const data = item?._embedded?.['xrtv:meta']?.data
+      if (!data?.start) return
+
       programs.push({
         title: data?.title,
         subtitle: data?.episode_title,
@@ -27,8 +42,8 @@ module.exports = {
         images: parseImages(item),
         directors: parseCast(data, 'director'),
         actors: parseCast(data, 'actors'),
-        start: dayjs(data?.start),
-        stop: dayjs(data?.end)
+        start: dayjs(data.start),
+        stop: dayjs(data.end)
       })
     })
 
@@ -80,20 +95,17 @@ function parseImages(item) {
   return Array.isArray(images) ? images.map(image => image.src) : []
 }
 
-function parseItems(content, date) {
-  try {
-    const data = JSON.parse(content)
-    let items = data?._embedded?.['xrtv:media-item']
-    items = Array.isArray(items) ? items : []
-    items = items.filter(item => {
-      const start = item?._embedded?.['xrtv:meta']?.data?.start
-      if (!start) return false
+function parseItems(content) {
+  if (!content) return []
 
-      return date.isSame(dayjs(start), 'day')
-    })
-
-    return items
-  } catch {
-    return []
+  // Let malformed content (e.g. an HTML error page) throw, so the grab
+  // is reported as an error instead of silently producing no programmes.
+  const data = JSON.parse(content)
+  if (!data?.page) {
+    throw new Error('Unexpected response structure')
   }
+
+  const items = data?._embedded?.['xrtv:media-item']
+
+  return Array.isArray(items) ? items : []
 }

--- a/sites/dna.fi/dna.fi.test.js
+++ b/sites/dna.fi/dna.fi.test.js
@@ -15,7 +15,14 @@ const channel = {
 
 it('can generate valid url', async () => {
   expect(url({ date, channel })).toBe(
-    'https://mts-pro-envoy-vip.dna.fi/hbx/api/pub/xrtv/g/media?q=channel:ch-216356&q=profile:pr&q=start-interval:1736906400000/1736992799000'
+    'https://mts-pro-envoy-vip.dna.fi/hbx/api/pub/xrtv/g/media?q=channel:ch-216356&q=profile:pr&q=start-interval:1736906400000/1736992799000&limit=1000'
+  )
+})
+
+it('can generate valid url during daylight saving time', async () => {
+  const dstDate = dayjs.utc('2025-07-15', 'YYYY-MM-DD').startOf('d')
+  expect(url({ date: dstDate, channel })).toBe(
+    'https://mts-pro-envoy-vip.dna.fi/hbx/api/pub/xrtv/g/media?q=channel:ch-216356&q=profile:pr&q=start-interval:1752541200000/1752627599000&limit=1000'
   )
 })
 
@@ -135,4 +142,11 @@ it('can handle empty guide', () => {
   })
 
   expect(results).toMatchObject([])
+})
+
+it('throws on unexpected response', () => {
+  expect(() => parser({ date, content: '<html>Error</html>' })).toThrow()
+  expect(() => parser({ date, content: '{"message":"Internal Server Error"}' })).toThrow(
+    'Unexpected response structure'
+  )
 })


### PR DESCRIPTION
### What broke

The dna.fi grabber was returning heavily truncated guides (and, when the API misbehaves, empty ones) while still reporting success:

1. **Misaligned request window.** The config computed each day as a fixed UTC+2 interval, but the API groups programmes into broadcast days starting at **04:00 Europe/Helsinki**. During daylight saving time (UTC+3) every request was off by an hour, and the API answers misaligned intervals with a `303 See Other` redirect to a widened two-day window.
2. **Pagination.** The endpoint returns **20 items per page** by default (`"page":{"size":20,...}`). The grabber never requested more, so each day was cut to the first ~20 programmes (mornings only). The existing test fixture already shows this: `"totalElements": 36` with only 20 items in the response.
3. **Silent failures.** `parseItems()` wrapped everything in `try { ... } catch { return [] }`, so any malformed response (HTML error page, API error JSON) produced an empty guide with a green status.

### The fix

- Request the exact broadcast-day window in Europe/Helsinki time (`dayjs.tz`), which stays aligned year-round and avoids the redirect. Verified against the live API: aligned intervals return `200` directly in both EET (winter) and EEST (summer); misaligned ones get `303`.
- Add `limit=1000` (one of the limits the API itself advertises in `_links["xrtv:limits"]`) so a full day fits in one response.
- Drop the local-timezone `date.isSame(..., 'day')` filter. The requested interval already bounds the results, and the filter discarded late-night programmes depending on the timezone the grab happens to run in.
- Make `parseItems()` throw on unparseable or unrecognized responses (a valid response always carries a `page` object, even for empty days) so failures surface as `ERR:` in the grab log instead of a silently empty guide. Empty content still returns `[]`.

### Test evidence

`npm test --- dna.fi` — 5/5 passing (added a DST url test and a malformed-response test).

Live grab, 4 channels x 2 days (before: exactly 20 programmes per channel/day):

```
[1/8] dna.fi (fi) - YleTV1.fi  - Jul 10, 2026 (43 programs)
[2/8] dna.fi (fi) - YleTV1.fi  - Jul 11, 2026 (48 programs)
[3/8] dna.fi (fi) - YleTV2.fi  - Jul 10, 2026 (44 programs)
[4/8] dna.fi (fi) - YleTV2.fi  - Jul 11, 2026 (38 programs)
[5/8] dna.fi (fi) - MTV3.fi    - Jul 10, 2026 (29 programs)
[6/8] dna.fi (fi) - MTV3.fi    - Jul 11, 2026 (33 programs)
[7/8] dna.fi (fi) - Nelonen.fi - Jul 10, 2026 (31 programs)
[8/8] dna.fi (fi) - Nelonen.fi - Jul 11, 2026 (32 programs)
```

The 91 programmes for Yle TV1 match the API's own `totalElements: 91` for that two-day span exactly (no duplicates, no gaps; coverage runs 04:09 local on day 1 to 03:50 local after day 2).
