### PR TITLE
feat: derive MagentaTV XMLTV IDs from database and provider metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,9 +3119,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3137,9 +3134,6 @@
       "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3157,9 +3151,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3175,9 +3166,6 @@
       "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3195,9 +3183,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3213,9 +3198,6 @@
       "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3959,9 +3941,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3974,9 +3953,6 @@
       "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3991,9 +3967,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4006,9 +3979,6 @@
       "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4023,9 +3993,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4038,9 +4005,6 @@
       "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4055,9 +4019,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4070,9 +4031,6 @@
       "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4087,9 +4045,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4102,9 +4057,6 @@
       "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/scripts/commands/channels/parse.ts
+++ b/scripts/commands/channels/parse.ts
@@ -96,8 +96,8 @@ async function main() {
     )
 
     if (found) {
-      channel.xmltv_id = found.xmltv_id
-      channel.lang = found.lang
+      channel.xmltv_id = found.xmltv_id || channel.xmltv_id
+      channel.lang = found.lang || channel.lang
     }
 
     newChannelList.add(channel)

--- a/sites/www.magenta.tv/www.magenta.tv.channels.xml
+++ b/sites/www.magenta.tv/www.magenta.tv.channels.xml
@@ -1,407 +1,413 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="www.magenta.tv" site_id="259549736358" lang="de" xmltv_id="">RTL</channel>
-  <channel site="www.magenta.tv" site_id="259549736360" lang="de" xmltv_id="">Das Erste</channel>
-  <channel site="www.magenta.tv" site_id="259728423995" lang="de" xmltv_id="">RTL</channel>
-  <channel site="www.magenta.tv" site_id="262264872014" lang="de" xmltv_id="">ZDF</channel>
-  <channel site="www.magenta.tv" site_id="262269992391" lang="de" xmltv_id="">SAT.1</channel>
-  <channel site="www.magenta.tv" site_id="262270504164" lang="de" xmltv_id="">SAT.1</channel>
-  <channel site="www.magenta.tv" site_id="262270504165" lang="de" xmltv_id="">ProSieben</channel>
-  <channel site="www.magenta.tv" site_id="262277160057" lang="de" xmltv_id="">RTLZWEI</channel>
-  <channel site="www.magenta.tv" site_id="262277160060" lang="de" xmltv_id="">Super RTL</channel>
-  <channel site="www.magenta.tv" site_id="262280744415" lang="de" xmltv_id="">Kabel Eins</channel>
-  <channel site="www.magenta.tv" site_id="262281768126" lang="de" xmltv_id="">KiKA</channel>
-  <channel site="www.magenta.tv" site_id="262282280173" lang="de" xmltv_id="">VOX</channel>
-  <channel site="www.magenta.tv" site_id="262729768194" lang="de" xmltv_id="">ZDFneo</channel>
-  <channel site="www.magenta.tv" site_id="262729768197" lang="de" xmltv_id="">Sport 1 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="262729768198" lang="de" xmltv_id="">Warner TV Serie</channel>
-  <channel site="www.magenta.tv" site_id="262729768199" lang="de" xmltv_id="">phoenix</channel>
-  <channel site="www.magenta.tv" site_id="262729768201" lang="de" xmltv_id="">13TH STREET</channel>
-  <channel site="www.magenta.tv" site_id="262729768202" lang="de" xmltv_id="">WDR Fernsehen Köln</channel>
-  <channel site="www.magenta.tv" site_id="262730280151" lang="de" xmltv_id="">Warner TV Film</channel>
-  <channel site="www.magenta.tv" site_id="262730280155" lang="de" xmltv_id="">3sat</channel>
-  <channel site="www.magenta.tv" site_id="262730280165" lang="de" xmltv_id="">Warner TV Comedy</channel>
-  <channel site="www.magenta.tv" site_id="262730792005" lang="de" xmltv_id="">BR Fernsehen Süd</channel>
-  <channel site="www.magenta.tv" site_id="262731304141" lang="de" xmltv_id="">Eurosport 1</channel>
-  <channel site="www.magenta.tv" site_id="262731304143" lang="de" xmltv_id="">ntv</channel>
-  <channel site="www.magenta.tv" site_id="262731304145" lang="de" xmltv_id="">WELT</channel>
-  <channel site="www.magenta.tv" site_id="274350120287" lang="de" xmltv_id="">VOX</channel>
-  <channel site="www.magenta.tv" site_id="274350120288" lang="de" xmltv_id="">hr-fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="274350120289" lang="de" xmltv_id="">Kabel Eins</channel>
-  <channel site="www.magenta.tv" site_id="274350120290" lang="de" xmltv_id="">RTL Crime</channel>
-  <channel site="www.magenta.tv" site_id="274350120291" lang="de" xmltv_id="">SWR Fernsehen BW</channel>
-  <channel site="www.magenta.tv" site_id="274351656120" lang="de" xmltv_id="">DMAX</channel>
-  <channel site="www.magenta.tv" site_id="274351656121" lang="de" xmltv_id="">ProSieben FUN</channel>
-  <channel site="www.magenta.tv" site_id="274351656122" lang="de" xmltv_id="">NITRO</channel>
-  <channel site="www.magenta.tv" site_id="274351656123" lang="de" xmltv_id="">rbb fernsehen Berlin</channel>
-  <channel site="www.magenta.tv" site_id="274351656124" lang="de" xmltv_id="">WELT</channel>
-  <channel site="www.magenta.tv" site_id="274351656125" lang="de" xmltv_id="">Eurosport 1</channel>
-  <channel site="www.magenta.tv" site_id="274351656126" lang="de" xmltv_id="">RTLup</channel>
-  <channel site="www.magenta.tv" site_id="274351656127" lang="de" xmltv_id="">National Geographic</channel>
-  <channel site="www.magenta.tv" site_id="274351656128" lang="de" xmltv_id="">Eurosport 2</channel>
-  <channel site="www.magenta.tv" site_id="274352168016" lang="de" xmltv_id="">ntv</channel>
-  <channel site="www.magenta.tv" site_id="274352168017" lang="de" xmltv_id="">SAT.1 GOLD</channel>
-  <channel site="www.magenta.tv" site_id="274352168018" lang="de" xmltv_id="">MDR-Fernsehen Sachsen</channel>
-  <channel site="www.magenta.tv" site_id="274352679970" lang="de" xmltv_id="">ProSieben</channel>
-  <channel site="www.magenta.tv" site_id="274352679971" lang="de" xmltv_id="">Radio Bremen TV</channel>
-  <channel site="www.magenta.tv" site_id="274352679972" lang="de" xmltv_id="">ARTE</channel>
-  <channel site="www.magenta.tv" site_id="274352679973" lang="de" xmltv_id="">RTLZWEI</channel>
-  <channel site="www.magenta.tv" site_id="274352679974" lang="de" xmltv_id="">SAT.1 emotions</channel>
-  <channel site="www.magenta.tv" site_id="274352679975" lang="de" xmltv_id="">NDR Fernsehen Niedersachsen</channel>
-  <channel site="www.magenta.tv" site_id="274352679976" lang="de" xmltv_id="">SR Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="274352679977" lang="de" xmltv_id="">Super RTL</channel>
-  <channel site="www.magenta.tv" site_id="389263912216" lang="de" xmltv_id="">CHANNEL21</channel>
-  <channel site="www.magenta.tv" site_id="389263912217" lang="de" xmltv_id="">NITRO</channel>
-  <channel site="www.magenta.tv" site_id="389263912218" lang="de" xmltv_id="">ÜLKE TV</channel>
-  <channel site="www.magenta.tv" site_id="389263912219" lang="de" xmltv_id="">Schlagerparadies.TV</channel>
-  <channel site="www.magenta.tv" site_id="389263912220" lang="de" xmltv_id="">Magenta Musik 1</channel>
-  <channel site="www.magenta.tv" site_id="389263912221" lang="de" xmltv_id="">Sky Sport 5</channel>
-  <channel site="www.magenta.tv" site_id="389263912222" lang="de" xmltv_id="">Sport 5 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389263912223" lang="de" xmltv_id="">KinoweltTV</channel>
-  <channel site="www.magenta.tv" site_id="389263912224" lang="de" xmltv_id="">Sky Sport Bundesliga 7</channel>
-  <channel site="www.magenta.tv" site_id="389263912226" lang="de" xmltv_id="">sixx</channel>
-  <channel site="www.magenta.tv" site_id="389263912227" lang="de" xmltv_id="">MagentaSport</channel>
-  <channel site="www.magenta.tv" site_id="389263912228" lang="de" xmltv_id="">Heimatkanal</channel>
-  <channel site="www.magenta.tv" site_id="389263912229" lang="de" xmltv_id="">TLC</channel>
-  <channel site="www.magenta.tv" site_id="389263912230" lang="de" xmltv_id="">Cartoon Network (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389263912231" lang="de" xmltv_id="">Sky Sport Golf</channel>
-  <channel site="www.magenta.tv" site_id="389263912232" lang="de" xmltv_id="">Sky Sport Premier League</channel>
-  <channel site="www.magenta.tv" site_id="389263912233" lang="de" xmltv_id="">Bibel TV</channel>
-  <channel site="www.magenta.tv" site_id="389263912234" lang="de" xmltv_id="">More Than Sports TV</channel>
-  <channel site="www.magenta.tv" site_id="389263912235" lang="de" xmltv_id="">SAT.1 GOLD</channel>
-  <channel site="www.magenta.tv" site_id="389263912236" lang="de" xmltv_id="">Sky Sport F1</channel>
-  <channel site="www.magenta.tv" site_id="389263912237" lang="de" xmltv_id="">Sky Sport Bundesliga 1</channel>
-  <channel site="www.magenta.tv" site_id="389263912238" lang="de" xmltv_id="">Kabel Eins Doku</channel>
-  <channel site="www.magenta.tv" site_id="389263912240" lang="de" xmltv_id="">Sport 18 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389263912242" lang="de" xmltv_id="">Sky Sport 1</channel>
-  <channel site="www.magenta.tv" site_id="389263912243" lang="de" xmltv_id="">Warner TV Comedy (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389263912244" lang="de" xmltv_id="">National Geographic Wild</channel>
-  <channel site="www.magenta.tv" site_id="389263912245" lang="de" xmltv_id="">DF1</channel>
-  <channel site="www.magenta.tv" site_id="389263912247" lang="de" xmltv_id="">TV8 Int</channel>
-  <channel site="www.magenta.tv" site_id="389263912248" lang="de" xmltv_id="">Jukebox</channel>
-  <channel site="www.magenta.tv" site_id="389263912249" lang="de" xmltv_id="">Shop LC</channel>
-  <channel site="www.magenta.tv" site_id="389263912250" lang="de" xmltv_id="">Sky Sport Mix</channel>
-  <channel site="www.magenta.tv" site_id="389264424226" lang="de" xmltv_id="">TV5MONDE Europe</channel>
-  <channel site="www.magenta.tv" site_id="389264424227" lang="de" xmltv_id="">QVC</channel>
-  <channel site="www.magenta.tv" site_id="389264424228" lang="de" xmltv_id="">Sky Sci-Fi</channel>
-  <channel site="www.magenta.tv" site_id="389264424230" lang="de" xmltv_id="">Sport 3 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389264424231" lang="de" xmltv_id="">Kabel Eins CLASSICS</channel>
-  <channel site="www.magenta.tv" site_id="389264424232" lang="de" xmltv_id="">VOXup</channel>
-  <channel site="www.magenta.tv" site_id="389264424233" lang="de" xmltv_id="">ARD-alpha</channel>
-  <channel site="www.magenta.tv" site_id="389264424234" lang="de" xmltv_id="">Welt der Wunder</channel>
-  <channel site="www.magenta.tv" site_id="389264424235" lang="de" xmltv_id="">Warner TV Film (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389264424236" lang="de" xmltv_id="">Magenta Musik 2</channel>
-  <channel site="www.magenta.tv" site_id="389264424237" lang="de" xmltv_id="">Sky Sport Bundesliga</channel>
-  <channel site="www.magenta.tv" site_id="389264424238" lang="de" xmltv_id="">ProSieben MAXX</channel>
-  <channel site="www.magenta.tv" site_id="389264424239" lang="de" xmltv_id="">Stingray Classica</channel>
-  <channel site="www.magenta.tv" site_id="389264424240" lang="de" xmltv_id="">Sky Sport Bundesliga 4</channel>
-  <channel site="www.magenta.tv" site_id="389264424241" lang="de" xmltv_id="">SPORTDIGITAL FUSSBALL</channel>
-  <channel site="www.magenta.tv" site_id="389264424242" lang="de" xmltv_id="">Sky Sport Bundesliga 6</channel>
-  <channel site="www.magenta.tv" site_id="389264424243" lang="de" xmltv_id="">beIN Movies Turk</channel>
-  <channel site="www.magenta.tv" site_id="389264424244" lang="de" xmltv_id="">Sport 17 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389264424245" lang="de" xmltv_id="">TOGGO plus</channel>
-  <channel site="www.magenta.tv" site_id="389264424246" lang="de" xmltv_id="">ONE</channel>
-  <channel site="www.magenta.tv" site_id="389264424248" lang="de" xmltv_id="">ONE MUSIC TELEVISION</channel>
-  <channel site="www.magenta.tv" site_id="389264424249" lang="de" xmltv_id="">wedotv Movies</channel>
-  <channel site="www.magenta.tv" site_id="389264424250" lang="de" xmltv_id="">Discovery Channel</channel>
-  <channel site="www.magenta.tv" site_id="389264424252" lang="de" xmltv_id="">Habertürk TV</channel>
-  <channel site="www.magenta.tv" site_id="389264424253" lang="de" xmltv_id="">RTLup</channel>
-  <channel site="www.magenta.tv" site_id="389264424254" lang="de" xmltv_id="">RiC</channel>
-  <channel site="www.magenta.tv" site_id="389264424255" lang="de" xmltv_id="">Sky Sport News</channel>
-  <channel site="www.magenta.tv" site_id="389264424256" lang="de" xmltv_id="">Universal TV</channel>
-  <channel site="www.magenta.tv" site_id="389264424257" lang="de" xmltv_id="">RTL Passion</channel>
-  <channel site="www.magenta.tv" site_id="389264424258" lang="de" xmltv_id="">Warner TV Serie (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389264424259" lang="de" xmltv_id="">Sky Cinema Classics</channel>
-  <channel site="www.magenta.tv" site_id="389264424261" lang="de" xmltv_id="">TeleBom/TeleDom</channel>
-  <channel site="www.magenta.tv" site_id="389264424262" lang="de" xmltv_id="">Romance TV</channel>
-  <channel site="www.magenta.tv" site_id="389264424263" lang="de" xmltv_id="">The HISTORY Channel</channel>
-  <channel site="www.magenta.tv" site_id="389264424264" lang="de" xmltv_id="">Sky Atlantic</channel>
-  <channel site="www.magenta.tv" site_id="389264424268" lang="de" xmltv_id="">OUTtv</channel>
-  <channel site="www.magenta.tv" site_id="389264424269" lang="de" xmltv_id="">Sport 4 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389264424271" lang="de" xmltv_id="">Sky Sport 3</channel>
-  <channel site="www.magenta.tv" site_id="389264424272" lang="de" xmltv_id="">Sky Krimi</channel>
-  <channel site="www.magenta.tv" site_id="389264424273" lang="de" xmltv_id="">Espreso</channel>
-  <channel site="www.magenta.tv" site_id="389264424274" lang="de" xmltv_id="">Stingray iConcerts</channel>
-  <channel site="www.magenta.tv" site_id="389264936243" lang="de" xmltv_id="">Sky Sport Tennis</channel>
-  <channel site="www.magenta.tv" site_id="389264936244" lang="de" xmltv_id="">13TH STREET (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389264936247" lang="de" xmltv_id="">Sky Sport 9</channel>
-  <channel site="www.magenta.tv" site_id="389264936248" lang="de" xmltv_id="">Sky Cinema Action</channel>
-  <channel site="www.magenta.tv" site_id="389264936249" lang="de" xmltv_id="">Sport 8 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389264936251" lang="de" xmltv_id="">Sport 2 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389264936252" lang="de" xmltv_id="">Sky Sport 2</channel>
-  <channel site="www.magenta.tv" site_id="389264936253" lang="de" xmltv_id="">AXN Black</channel>
-  <channel site="www.magenta.tv" site_id="389264936254" lang="de" xmltv_id="">Ballermann TV</channel>
-  <channel site="www.magenta.tv" site_id="389264936255" lang="de" xmltv_id="">Cartoon Network</channel>
-  <channel site="www.magenta.tv" site_id="389264936256" lang="de" xmltv_id="">Sky Sport Bundesliga 10</channel>
-  <channel site="www.magenta.tv" site_id="389264936257" lang="de" xmltv_id="">Show Turk</channel>
-  <channel site="www.magenta.tv" site_id="389264936258" lang="de" xmltv_id="">Sky Sport 6</channel>
-  <channel site="www.magenta.tv" site_id="389264936259" lang="de" xmltv_id="">BonGusto</channel>
-  <channel site="www.magenta.tv" site_id="389264936260" lang="de" xmltv_id="">Sky Sport Bundesliga 8</channel>
-  <channel site="www.magenta.tv" site_id="389264936261" lang="de" xmltv_id="">ANIXE HD Serie</channel>
-  <channel site="www.magenta.tv" site_id="389264936262" lang="de" xmltv_id="">Red Bull TV Motorsport</channel>
-  <channel site="www.magenta.tv" site_id="389264936263" lang="de" xmltv_id="">eSportsONE</channel>
-  <channel site="www.magenta.tv" site_id="389264936264" lang="de" xmltv_id="">Animal Planet</channel>
-  <channel site="www.magenta.tv" site_id="389264936266" lang="de" xmltv_id="">Sky Cinema Premiere</channel>
-  <channel site="www.magenta.tv" site_id="389264936267" lang="de" xmltv_id="">Rai 3</channel>
-  <channel site="www.magenta.tv" site_id="389264936269" lang="de" xmltv_id="">Stingray DJAZZ</channel>
-  <channel site="www.magenta.tv" site_id="389264936270" lang="de" xmltv_id="">Bergblick</channel>
-  <channel site="www.magenta.tv" site_id="389264936271" lang="de" xmltv_id="">Playboy Europe</channel>
-  <channel site="www.magenta.tv" site_id="389264936272" lang="de" xmltv_id="">OstWest</channel>
-  <channel site="www.magenta.tv" site_id="389264936273" lang="de" xmltv_id="">Sky One</channel>
-  <channel site="www.magenta.tv" site_id="389264936278" lang="de" xmltv_id="">iTVN</channel>
-  <channel site="www.magenta.tv" site_id="389264936279" lang="de" xmltv_id="">Kabel Eins Doku</channel>
-  <channel site="www.magenta.tv" site_id="389264936281" lang="de" xmltv_id="">N24 Doku</channel>
-  <channel site="www.magenta.tv" site_id="389265448044" lang="de" xmltv_id="">MagentaTV Info</channel>
-  <channel site="www.magenta.tv" site_id="389265448045" lang="de" xmltv_id="">Comedy Central</channel>
-  <channel site="www.magenta.tv" site_id="389265448046" lang="de" xmltv_id="">Sky Sport Kompakt 1</channel>
-  <channel site="www.magenta.tv" site_id="389265448047" lang="de" xmltv_id="">Motorvision+</channel>
-  <channel site="www.magenta.tv" site_id="389265448048" lang="de" xmltv_id="">tagesschau24</channel>
-  <channel site="www.magenta.tv" site_id="389265448049" lang="de" xmltv_id="">Marco Polo TV</channel>
-  <channel site="www.magenta.tv" site_id="389265448050" lang="de" xmltv_id="">ANIXE+</channel>
-  <channel site="www.magenta.tv" site_id="389265448051" lang="de" xmltv_id="">CNN International</channel>
-  <channel site="www.magenta.tv" site_id="389265448052" lang="de" xmltv_id="">SPORT1</channel>
-  <channel site="www.magenta.tv" site_id="389265448053" lang="de" xmltv_id="">HGTV</channel>
-  <channel site="www.magenta.tv" site_id="389265448054" lang="de" xmltv_id="">FREEDOM</channel>
-  <channel site="www.magenta.tv" site_id="389265448055" lang="de" xmltv_id="">TLC</channel>
-  <channel site="www.magenta.tv" site_id="389265448056" lang="de" xmltv_id="">SCHLAGER DELUXE</channel>
-  <channel site="www.magenta.tv" site_id="389265448057" lang="de" xmltv_id="">DMF</channel>
-  <channel site="www.magenta.tv" site_id="389265448058" lang="de" xmltv_id="">Sky Sport Bundesliga 9</channel>
-  <channel site="www.magenta.tv" site_id="389265448059" lang="de" xmltv_id="">ProSieben MAXX</channel>
-  <channel site="www.magenta.tv" site_id="389265448060" lang="de" xmltv_id="">MTV</channel>
-  <channel site="www.magenta.tv" site_id="389265448061" lang="de" xmltv_id="">Volksmusik.TV</channel>
-  <channel site="www.magenta.tv" site_id="389265448062" lang="de" xmltv_id="">Sky Sport Bundesliga 5</channel>
-  <channel site="www.magenta.tv" site_id="389265448063" lang="de" xmltv_id="">Sport 11 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389265448065" lang="de" xmltv_id="">123.live</channel>
-  <channel site="www.magenta.tv" site_id="389265448066" lang="de" xmltv_id="">SPORT1</channel>
-  <channel site="www.magenta.tv" site_id="389265448067" lang="de" xmltv_id="">Sport 14 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389265448068" lang="de" xmltv_id="">Sky Sport Bundesliga 3</channel>
-  <channel site="www.magenta.tv" site_id="389265448069" lang="de" xmltv_id="">Kinomir</channel>
-  <channel site="www.magenta.tv" site_id="389265448071" lang="de" xmltv_id="">Crime+Investigation</channel>
-  <channel site="www.magenta.tv" site_id="389265448072" lang="de" xmltv_id="">Sky Sport Top Event</channel>
-  <channel site="www.magenta.tv" site_id="389265448073" lang="de" xmltv_id="">Sport 16 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389265448075" lang="de" xmltv_id="">Nicktoons (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389265960191" lang="de" xmltv_id="">Euro D</channel>
-  <channel site="www.magenta.tv" site_id="389265960192" lang="de" xmltv_id="">Sky Sport Bundesliga 2</channel>
-  <channel site="www.magenta.tv" site_id="389265960194" lang="de" xmltv_id="">ZWEI MUSIC TELEVISION</channel>
-  <channel site="www.magenta.tv" site_id="389265960195" lang="de" xmltv_id="">Rai 2</channel>
-  <channel site="www.magenta.tv" site_id="389265960196" lang="de" xmltv_id="">SWR Fernsehen RP</channel>
-  <channel site="www.magenta.tv" site_id="389265960197" lang="de" xmltv_id="">Show Max</channel>
-  <channel site="www.magenta.tv" site_id="389265960198" lang="de" xmltv_id="">Nick Jr. (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389265960199" lang="de" xmltv_id="">Penthouse Passion</channel>
-  <channel site="www.magenta.tv" site_id="389265960200" lang="de" xmltv_id="">Sport 7 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389265960201" lang="de" xmltv_id="">Euronews Deutsch</channel>
-  <channel site="www.magenta.tv" site_id="389265960204" lang="de" xmltv_id="">RTL Living</channel>
-  <channel site="www.magenta.tv" site_id="389265960205" lang="de" xmltv_id="">FOLX MUSIC TELEVISION</channel>
-  <channel site="www.magenta.tv" site_id="389265960207" lang="de" xmltv_id="">France 24 francais</channel>
-  <channel site="www.magenta.tv" site_id="389265960208" lang="de" xmltv_id="">Comedy Central</channel>
-  <channel site="www.magenta.tv" site_id="389265960209" lang="de" xmltv_id="">Sport 12 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389265960210" lang="de" xmltv_id="">TELE 5</channel>
-  <channel site="www.magenta.tv" site_id="389265960211" lang="de" xmltv_id="">Blue Hustler</channel>
-  <channel site="www.magenta.tv" site_id="389265960212" lang="de" xmltv_id="">beIN iZ</channel>
-  <channel site="www.magenta.tv" site_id="389265960213" lang="de" xmltv_id="">TOP SERIEN</channel>
-  <channel site="www.magenta.tv" site_id="389265960214" lang="de" xmltv_id="">Rai 1</channel>
-  <channel site="www.magenta.tv" site_id="389265960215" lang="de" xmltv_id="">Al Jazeera English</channel>
-  <channel site="www.magenta.tv" site_id="389265960216" lang="de" xmltv_id="">Nick Jr.</channel>
-  <channel site="www.magenta.tv" site_id="389265960218" lang="de" xmltv_id="">Asharq News</channel>
-  <channel site="www.magenta.tv" site_id="389265960219" lang="de" xmltv_id="">sonnenklar.TV</channel>
-  <channel site="www.magenta.tv" site_id="389265960220" lang="de" xmltv_id="">N24 Doku</channel>
-  <channel site="www.magenta.tv" site_id="389265960221" lang="de" xmltv_id="">MTV</channel>
-  <channel site="www.magenta.tv" site_id="389265960222" lang="de" xmltv_id="">Nick/Comedy Central+1</channel>
-  <channel site="www.magenta.tv" site_id="389265960223" lang="de" xmltv_id="">CNN International</channel>
-  <channel site="www.magenta.tv" site_id="389265960224" lang="de" xmltv_id="">Euronews Russki</channel>
-  <channel site="www.magenta.tv" site_id="389265960225" lang="de" xmltv_id="">Red Bull TV</channel>
-  <channel site="www.magenta.tv" site_id="389265960226" lang="de" xmltv_id="">Sky Sport 8</channel>
-  <channel site="www.magenta.tv" site_id="389265960227" lang="de" xmltv_id="">Spiegel Geschichte</channel>
-  <channel site="www.magenta.tv" site_id="389265960229" lang="de" xmltv_id="">K-TV</channel>
-  <channel site="www.magenta.tv" site_id="389265960231" lang="de" xmltv_id="">Cartoonito</channel>
-  <channel site="www.magenta.tv" site_id="389265960232" lang="de" xmltv_id="">Sky Documentaries</channel>
-  <channel site="www.magenta.tv" site_id="389265960233" lang="de" xmltv_id="">DMAX</channel>
-  <channel site="www.magenta.tv" site_id="389265960236" lang="de" xmltv_id="">Sportdigital1+</channel>
-  <channel site="www.magenta.tv" site_id="389265960237" lang="de" xmltv_id="">France 24 english</channel>
-  <channel site="www.magenta.tv" site_id="389265960239" lang="de" xmltv_id="">Sky Crime</channel>
-  <channel site="www.magenta.tv" site_id="389265960241" lang="de" xmltv_id="">DELUXE MUSIC</channel>
-  <channel site="www.magenta.tv" site_id="389265960242" lang="de" xmltv_id="">Lust pur</channel>
-  <channel site="www.magenta.tv" site_id="389266472146" lang="de" xmltv_id="">TOGGO plus</channel>
-  <channel site="www.magenta.tv" site_id="389266472147" lang="de" xmltv_id="">VOXup</channel>
-  <channel site="www.magenta.tv" site_id="389266472148" lang="de" xmltv_id="">Sky Sci-Fi (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389266472149" lang="de" xmltv_id="">Sky Nature</channel>
-  <channel site="www.magenta.tv" site_id="389266472150" lang="de" xmltv_id="">Sky Showcase</channel>
-  <channel site="www.magenta.tv" site_id="389266472151" lang="de" xmltv_id="">wetter.com TV</channel>
-  <channel site="www.magenta.tv" site_id="389266472152" lang="de" xmltv_id="">Sport 9 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389266472153" lang="de" xmltv_id="">The HISTORY Channel (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389266472154" lang="de" xmltv_id="">Universal TV (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389266472155" lang="de" xmltv_id="">AXN White</channel>
-  <channel site="www.magenta.tv" site_id="389266472157" lang="de" xmltv_id="">Sport 13 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389266472159" lang="de" xmltv_id="">Sky Cinema Family</channel>
-  <channel site="www.magenta.tv" site_id="389266472161" lang="de" xmltv_id="">Sport 15 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389266472162" lang="de" xmltv_id="">Sport 10 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389266472163" lang="de" xmltv_id="">Travelxp</channel>
-  <channel site="www.magenta.tv" site_id="389266472164" lang="de" xmltv_id="">sixx</channel>
-  <channel site="www.magenta.tv" site_id="389266472165" lang="de" xmltv_id="">MS Sport</channel>
-  <channel site="www.magenta.tv" site_id="389266472166" lang="de" xmltv_id="">Euronews Italiano</channel>
-  <channel site="www.magenta.tv" site_id="389266472167" lang="de" xmltv_id="">Sport 6 - myTeamTV</channel>
-  <channel site="www.magenta.tv" site_id="389266472168" lang="de" xmltv_id="">TELE 5</channel>
-  <channel site="www.magenta.tv" site_id="389266472169" lang="de" xmltv_id="">Sky Sport 4</channel>
-  <channel site="www.magenta.tv" site_id="389266472171" lang="de" xmltv_id="">Sky Sport 7</channel>
-  <channel site="www.magenta.tv" site_id="389266472172" lang="de" xmltv_id="">Fashion TV</channel>
-  <channel site="www.magenta.tv" site_id="389266472173" lang="de" xmltv_id="">GEO Television</channel>
-  <channel site="www.magenta.tv" site_id="389266472174" lang="de" xmltv_id="">HSE</channel>
-  <channel site="www.magenta.tv" site_id="389266472175" lang="de" xmltv_id="">Nick/Comedy Central+1</channel>
-  <channel site="www.magenta.tv" site_id="389266472176" lang="de" xmltv_id="">Kanal 7</channel>
-  <channel site="www.magenta.tv" site_id="389266472177" lang="de" xmltv_id="">auto motor und sport</channel>
-  <channel site="www.magenta.tv" site_id="389266472178" lang="de" xmltv_id="">Curiosity Channel</channel>
-  <channel site="www.magenta.tv" site_id="389266472179" lang="de" xmltv_id="">Eurostar TV</channel>
-  <channel site="www.magenta.tv" site_id="389266472181" lang="de" xmltv_id="">Cartoonito (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389266472182" lang="de" xmltv_id="">Crime+Investigation (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="389266472183" lang="de" xmltv_id="">Sky Sport 10</channel>
-  <channel site="www.magenta.tv" site_id="389266472185" lang="de" xmltv_id="">MOMENTS</channel>
-  <channel site="www.magenta.tv" site_id="389266472186" lang="de" xmltv_id="">ZDFinfo</channel>
-  <channel site="www.magenta.tv" site_id="415147560391" lang="de" xmltv_id="">WDR Fernsehen Duisburg</channel>
-  <channel site="www.magenta.tv" site_id="415147560392" lang="de" xmltv_id="">SAT.1 Bayern</channel>
-  <channel site="www.magenta.tv" site_id="415147560393" lang="de" xmltv_id="">SAT.1 Bayern</channel>
-  <channel site="www.magenta.tv" site_id="415148584245" lang="de" xmltv_id="">CNBC International</channel>
-  <channel site="www.magenta.tv" site_id="415148584246" lang="de" xmltv_id="">rbb fernsehen Brandenburg</channel>
-  <channel site="www.magenta.tv" site_id="415148584247" lang="de" xmltv_id="">TVP Polonia</channel>
-  <channel site="www.magenta.tv" site_id="415148584248" lang="de" xmltv_id="">RTL Bremen &amp; Niedersachsen</channel>
-  <channel site="www.magenta.tv" site_id="415148584249" lang="de" xmltv_id="">WDR Fernsehen Siegen</channel>
-  <channel site="www.magenta.tv" site_id="415148584250" lang="de" xmltv_id="">SAT.1 Rheinland-Pfalz und Hessen</channel>
-  <channel site="www.magenta.tv" site_id="415148584251" lang="de" xmltv_id="">NDR Fernsehen Hamburg</channel>
-  <channel site="www.magenta.tv" site_id="415148584252" lang="de" xmltv_id="">RTL Hamburg &amp; Schleswig-Holstein</channel>
-  <channel site="www.magenta.tv" site_id="415148584253" lang="de" xmltv_id="">RTL Hessen</channel>
-  <channel site="www.magenta.tv" site_id="415148584254" lang="de" xmltv_id="">SAT.1 Hamburg und Schleswig-Holstein</channel>
-  <channel site="www.magenta.tv" site_id="415149608108" lang="de" xmltv_id="">MDR-Fernsehen Thüringen</channel>
-  <channel site="www.magenta.tv" site_id="415149608150" lang="de" xmltv_id="">SAT.1 Niedersachsen und Bremen</channel>
-  <channel site="www.magenta.tv" site_id="415149608151" lang="de" xmltv_id="">MDR-Fernsehen Sachsen-Anhalt</channel>
-  <channel site="www.magenta.tv" site_id="415149608152" lang="de" xmltv_id="">WDR Fernsehen Bonn</channel>
-  <channel site="www.magenta.tv" site_id="415149608153" lang="de" xmltv_id="">RTL Hessen</channel>
-  <channel site="www.magenta.tv" site_id="415149608154" lang="de" xmltv_id="">NDR Fernsehen Mecklenburg-Vorpommern</channel>
-  <channel site="www.magenta.tv" site_id="415149608155" lang="de" xmltv_id="">NDR Fernsehen Schleswig-Holstein</channel>
-  <channel site="www.magenta.tv" site_id="415149608156" lang="de" xmltv_id="">RTL Nordrhein-Westfalen</channel>
-  <channel site="www.magenta.tv" site_id="415149608157" lang="de" xmltv_id="">RTL Bremen &amp; Niedersachsen</channel>
-  <channel site="www.magenta.tv" site_id="415150120077" lang="de" xmltv_id="">WDR Fernsehen Essen</channel>
-  <channel site="www.magenta.tv" site_id="415150120078" lang="de" xmltv_id="">SAT.1 Nordrhein-Westfalen</channel>
-  <channel site="www.magenta.tv" site_id="415150120094" lang="de" xmltv_id="">SAT.1 Nordrhein-Westfalen</channel>
-  <channel site="www.magenta.tv" site_id="415150120095" lang="de" xmltv_id="">WDR Fernsehen Dortmund</channel>
-  <channel site="www.magenta.tv" site_id="415150120096" lang="de" xmltv_id="">ERT World</channel>
-  <channel site="www.magenta.tv" site_id="415150120097" lang="de" xmltv_id="">Euronews English</channel>
-  <channel site="www.magenta.tv" site_id="415150120143" lang="de" xmltv_id="">WDR Fernsehen Bielefeld</channel>
-  <channel site="www.magenta.tv" site_id="415150120169" lang="de" xmltv_id="">SAT.1 Niedersachsen und Bremen</channel>
-  <channel site="www.magenta.tv" site_id="415150632065" lang="de" xmltv_id="">WDR Fernsehen Aachen</channel>
-  <channel site="www.magenta.tv" site_id="415150632109" lang="de" xmltv_id="">WDR Fernsehen Wuppertal</channel>
-  <channel site="www.magenta.tv" site_id="415150632110" lang="de" xmltv_id="">RTL Hamburg &amp; Schleswig-Holstein</channel>
-  <channel site="www.magenta.tv" site_id="415150632111" lang="de" xmltv_id="">WDR Fernsehen Düsseldorf</channel>
-  <channel site="www.magenta.tv" site_id="415150632112" lang="de" xmltv_id="">Imearth</channel>
-  <channel site="www.magenta.tv" site_id="415150632113" lang="de" xmltv_id="">RTL Nordrhein-Westfalen</channel>
-  <channel site="www.magenta.tv" site_id="415150632114" lang="de" xmltv_id="">SAT.1 Hamburg und Schleswig-Holstein</channel>
-  <channel site="www.magenta.tv" site_id="415151144338" lang="de" xmltv_id="">SAT.1 Rheinland-Pfalz und Hessen</channel>
-  <channel site="www.magenta.tv" site_id="415151144359" lang="de" xmltv_id="">WDR Fernsehen Münster</channel>
-  <channel site="www.magenta.tv" site_id="415151144360" lang="de" xmltv_id="">BR Fernsehen Nord</channel>
-  <channel site="www.magenta.tv" site_id="463893544181" lang="de" xmltv_id="">France 2</channel>
-  <channel site="www.magenta.tv" site_id="463895080134" lang="de" xmltv_id="">France 3</channel>
-  <channel site="www.magenta.tv" site_id="481691176161" lang="de" xmltv_id="">RTL Bayern</channel>
-  <channel site="www.magenta.tv" site_id="481691176162" lang="de" xmltv_id="">RTL Rhein-Neckar</channel>
-  <channel site="www.magenta.tv" site_id="481694759991" lang="de" xmltv_id="">RTL Rhein-Neckar</channel>
-  <channel site="www.magenta.tv" site_id="481694759992" lang="de" xmltv_id="">RTL Bayern</channel>
-  <channel site="www.magenta.tv" site_id="488325160190" lang="de" xmltv_id="">ATV Avrupa</channel>
-  <channel site="www.magenta.tv" site_id="488325160191" lang="de" xmltv_id="">TRT Cocuk</channel>
-  <channel site="www.magenta.tv" site_id="492496936303" lang="de" xmltv_id="">Disney Channel</channel>
-  <channel site="www.magenta.tv" site_id="492496936304" lang="de" xmltv_id="">TV Mainfranken</channel>
-  <channel site="www.magenta.tv" site_id="492496936305" lang="de" xmltv_id="">ProSiebenSat.1</channel>
-  <channel site="www.magenta.tv" site_id="492496936306" lang="de" xmltv_id="">TV Oberfranken</channel>
-  <channel site="www.magenta.tv" site_id="492496936307" lang="de" xmltv_id="">ems TV</channel>
-  <channel site="www.magenta.tv" site_id="492496936308" lang="de" xmltv_id="">TV Westsachsen</channel>
-  <channel site="www.magenta.tv" site_id="492496936309" lang="de" xmltv_id="">Hamburg 1</channel>
-  <channel site="www.magenta.tv" site_id="492496936310" lang="de" xmltv_id="">a.tv</channel>
-  <channel site="www.magenta.tv" site_id="492497448192" lang="de" xmltv_id="">tv.ingolstadt</channel>
-  <channel site="www.magenta.tv" site_id="492497448194" lang="de" xmltv_id="">Baden TV Süd</channel>
-  <channel site="www.magenta.tv" site_id="492497448195" lang="de" xmltv_id="">NIEDERBAYERN TV Deggendorf - Straubing</channel>
-  <channel site="www.magenta.tv" site_id="492497448196" lang="de" xmltv_id="">RFO</channel>
-  <channel site="www.magenta.tv" site_id="492497448197" lang="de" xmltv_id="">NIEDERBAYERN TV Passau</channel>
-  <channel site="www.magenta.tv" site_id="492497448198" lang="de" xmltv_id="">TVA Ostbayern</channel>
-  <channel site="www.magenta.tv" site_id="492497960281" lang="de" xmltv_id="">TV Mittelrhein</channel>
-  <channel site="www.magenta.tv" site_id="492497960282" lang="de" xmltv_id="">RFH Regionalfernsehen Harz</channel>
-  <channel site="www.magenta.tv" site_id="492497960283" lang="de" xmltv_id="">MDF.1 Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="492497960284" lang="de" xmltv_id="">JenaTV</channel>
-  <channel site="www.magenta.tv" site_id="492497960285" lang="de" xmltv_id="">allgäu.tv</channel>
-  <channel site="www.magenta.tv" site_id="492498472231" lang="de" xmltv_id="">münchen.tv</channel>
-  <channel site="www.magenta.tv" site_id="492498472232" lang="de" xmltv_id="">salve.tv</channel>
-  <channel site="www.magenta.tv" site_id="492498472233" lang="de" xmltv_id="">Oberpfalz TV</channel>
-  <channel site="www.magenta.tv" site_id="492498984397" lang="de" xmltv_id="">OK:TV Mainz</channel>
-  <channel site="www.magenta.tv" site_id="492498984398" lang="de" xmltv_id="">OK54 Trier</channel>
-  <channel site="www.magenta.tv" site_id="492498984399" lang="de" xmltv_id="">OK4</channel>
-  <channel site="www.magenta.tv" site_id="492498984400" lang="de" xmltv_id="">LAUSITZWELLE</channel>
-  <channel site="www.magenta.tv" site_id="492498984401" lang="de" xmltv_id="">Baden TV</channel>
-  <channel site="www.magenta.tv" site_id="492498984402" lang="de" xmltv_id="">rheinlOKal</channel>
-  <channel site="www.magenta.tv" site_id="492499496075" lang="de" xmltv_id="">Franken Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="492499496076" lang="de" xmltv_id="">DELUXE MUSIC</channel>
-  <channel site="www.magenta.tv" site_id="492499496077" lang="de" xmltv_id="">Disney Channel</channel>
-  <channel site="www.magenta.tv" site_id="492499496078" lang="de" xmltv_id="">SRF</channel>
-  <channel site="www.magenta.tv" site_id="492499496079" lang="de" xmltv_id="">Rennsteig.TV</channel>
-  <channel site="www.magenta.tv" site_id="492499496080" lang="de" xmltv_id="">HGTV</channel>
-  <channel site="www.magenta.tv" site_id="492499496081" lang="de" xmltv_id="">NRWision</channel>
-  <channel site="www.magenta.tv" site_id="492499496082" lang="de" xmltv_id="">Regio TV</channel>
-  <channel site="www.magenta.tv" site_id="492499496083" lang="de" xmltv_id="">NIEDERBAYERN TV Landshut</channel>
-  <channel site="www.magenta.tv" site_id="492499496084" lang="de" xmltv_id="">Friesischer Rundfunk</channel>
-  <channel site="www.magenta.tv" site_id="492499496085" lang="de" xmltv_id="">OK Weinstraße</channel>
-  <channel site="www.magenta.tv" site_id="509713959991" lang="de" xmltv_id="">Sky Cinema Highlights</channel>
-  <channel site="www.magenta.tv" site_id="516781096166" lang="de" xmltv_id="">France 5</channel>
-  <channel site="www.magenta.tv" site_id="516781096167" lang="de" xmltv_id="">BBC News</channel>
-  <channel site="www.magenta.tv" site_id="516782120054" lang="de" xmltv_id="">lausitz.tv</channel>
-  <channel site="www.magenta.tv" site_id="516783656172" lang="de" xmltv_id="">altenburg.tv</channel>
-  <channel site="www.magenta.tv" site_id="516784168005" lang="de" xmltv_id="">France 4</channel>
-  <channel site="www.magenta.tv" site_id="561114664140" lang="de" xmltv_id="">Glück Auf! TV</channel>
-  <channel site="www.magenta.tv" site_id="561123367987" lang="de" xmltv_id="">RBW</channel>
-  <channel site="www.magenta.tv" site_id="587597352323" lang="de" xmltv_id="">Stimmungsgarten TV</channel>
-  <channel site="www.magenta.tv" site_id="587598887992" lang="de" xmltv_id="">RiC.today</channel>
-  <channel site="www.magenta.tv" site_id="587598887993" lang="de" xmltv_id="">Fix&amp;Foxi TV</channel>
-  <channel site="www.magenta.tv" site_id="587599400156" lang="de" xmltv_id="">Hope TV</channel>
-  <channel site="www.magenta.tv" site_id="597433895959" lang="de" xmltv_id="">Travelxp 4K</channel>
-  <channel site="www.magenta.tv" site_id="610214440158" lang="de" xmltv_id="">teltOwkanal</channel>
-  <channel site="www.magenta.tv" site_id="636955688283" lang="de" xmltv_id="">HT SPOR</channel>
-  <channel site="www.magenta.tv" site_id="658197032097" lang="de" xmltv_id="">BLK TV</channel>
-  <channel site="www.magenta.tv" site_id="658197544149" lang="de" xmltv_id="">Lilo.TV</channel>
-  <channel site="www.magenta.tv" site_id="662243367962" lang="de" xmltv_id="">Juwelo</channel>
-  <channel site="www.magenta.tv" site_id="662243880190" lang="de" xmltv_id="">RAN1</channel>
-  <channel site="www.magenta.tv" site_id="669655079976" lang="de" xmltv_id="">QVC ZWEI</channel>
-  <channel site="www.magenta.tv" site_id="695561768145" lang="de" xmltv_id="">Romance TV (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="695561768146" lang="de" xmltv_id="">National Geographic (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="695563816191" lang="de" xmltv_id="">Jukebox (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="695564328412" lang="de" xmltv_id="">Beate-Uhse.TV (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="695564328413" lang="de" xmltv_id="">Heimatkanal (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="698208807980" lang="de" xmltv_id="">kulturmd</channel>
-  <channel site="www.magenta.tv" site_id="701488168394" lang="de" xmltv_id="">National Geographic Wild (Sky)</channel>
-  <channel site="www.magenta.tv" site_id="704010792353" lang="de" xmltv_id="">GüstrowTV</channel>
-  <channel site="www.magenta.tv" site_id="736340520422" lang="de" xmltv_id="">World of Freesports</channel>
-  <channel site="www.magenta.tv" site_id="736340520423" lang="de" xmltv_id="">Filmgold</channel>
-  <channel site="www.magenta.tv" site_id="736344616035" lang="de" xmltv_id="">KultKrimi</channel>
-  <channel site="www.magenta.tv" site_id="736345639978" lang="de" xmltv_id="">Telenovela ZDF</channel>
-  <channel site="www.magenta.tv" site_id="738497064302" lang="de" xmltv_id="">Landlust TV</channel>
-  <channel site="www.magenta.tv" site_id="738500136328" lang="de" xmltv_id="">Scooore</channel>
-  <channel site="www.magenta.tv" site_id="745871912203" lang="de" xmltv_id="">SYLT1</channel>
-  <channel site="www.magenta.tv" site_id="746148392381" lang="de" xmltv_id="">MS GOLF 1</channel>
-  <channel site="www.magenta.tv" site_id="746150440202" lang="de" xmltv_id="">MS GOLF 2</channel>
-  <channel site="www.magenta.tv" site_id="750315048280" lang="de" xmltv_id="">Baby TV</channel>
-  <channel site="www.magenta.tv" site_id="754135080287" lang="de" xmltv_id="">Spiegel TV</channel>
-  <channel site="www.magenta.tv" site_id="754135080288" lang="de" xmltv_id="">Grjngo</channel>
-  <channel site="www.magenta.tv" site_id="754136616350" lang="de" xmltv_id="">NARUTO</channel>
-  <channel site="www.magenta.tv" site_id="754137640065" lang="de" xmltv_id="">TOP SCI-FI</channel>
-  <channel site="www.magenta.tv" site_id="754137640066" lang="de" xmltv_id="">TOP TRUE CRIME</channel>
-  <channel site="www.magenta.tv" site_id="754138152287" lang="de" xmltv_id="">Royalworld</channel>
-  <channel site="www.magenta.tv" site_id="754138663958" lang="de" xmltv_id="">Terra Mater WILD</channel>
-  <channel site="www.magenta.tv" site_id="764249128121" lang="de" xmltv_id="">Moviedome</channel>
-  <channel site="www.magenta.tv" site_id="764249640071" lang="de" xmltv_id="">Fabella</channel>
-  <channel site="www.magenta.tv" site_id="764523048346" lang="de" xmltv_id="">Shopping Queen</channel>
-  <channel site="www.magenta.tv" site_id="764523560413" lang="de" xmltv_id="">hundkatzemaus</channel>
-  <channel site="www.magenta.tv" site_id="764524584021" lang="de" xmltv_id="">Bauer sucht Frau</channel>
-  <channel site="www.magenta.tv" site_id="764525608043" lang="de" xmltv_id="">Alarm für Cobra 11 / Balko</channel>
-  <channel site="www.magenta.tv" site_id="767935016341" lang="de" xmltv_id="">tv.berlin</channel>
-  <channel site="www.magenta.tv" site_id="767936040120" lang="de" xmltv_id="">ALEX Berlin</channel>
-  <channel site="www.magenta.tv" site_id="767936552360" lang="de" xmltv_id="">L-TV</channel>
-  <channel site="www.magenta.tv" site_id="767936552361" lang="de" xmltv_id="">Leipzig Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="767936552362" lang="de" xmltv_id="">Studio 47</channel>
-  <channel site="www.magenta.tv" site_id="767937064033" lang="de" xmltv_id="">Dresden Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="767937576117" lang="de" xmltv_id="">Chemnitz Fernsehen</channel>
-  <channel site="www.magenta.tv" site_id="769865767977" lang="de" xmltv_id="">Sky Sport Bundesliga</channel>
-  <channel site="www.magenta.tv" site_id="769867816329" lang="de" xmltv_id="">Sky Sport</channel>
-  <channel site="www.magenta.tv" site_id="492498472234" lang="de" xmltv_id="">RTL</channel>
+    <channel site="www.magenta.tv" site_id="262730280155" lang="de" xmltv_id="3sat.de@HD">3sat</channel>
+    <channel site="www.magenta.tv" site_id="262729768201" lang="de" xmltv_id="13thStreetUniversal.de@HD">13TH STREET</channel>
+    <channel site="www.magenta.tv" site_id="389264936244" lang="de" xmltv_id="13thStreetUniversal.de@HD">13TH STREET (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389265448065" lang="de" xmltv_id="123live.de@HD">123.live</channel>
+    <channel site="www.magenta.tv" site_id="764525608043" lang="de" xmltv_id="AlarmfurCobra11Balko.de@SD">Alarm für Cobra 11 / Balko</channel>
+    <channel site="www.magenta.tv" site_id="767936040120" lang="de" xmltv_id="AlexBerlin.de@SD">ALEX Berlin</channel>
+    <channel site="www.magenta.tv" site_id="389265960215" lang="de" xmltv_id="AlJazeera.qa@HD">Al Jazeera English</channel>
+    <channel site="www.magenta.tv" site_id="492497960285" lang="de" xmltv_id="AllgauTV.de@HD">allgäu.tv</channel>
+    <channel site="www.magenta.tv" site_id="516783656172" lang="de" xmltv_id="AltenburgTV.de@HD">altenburg.tv</channel>
+    <channel site="www.magenta.tv" site_id="389264936264" lang="de" xmltv_id="AnimalPlanet.de@HD">Animal Planet</channel>
+    <channel site="www.magenta.tv" site_id="389264936261" lang="de" xmltv_id="AnixeHDSerie.de@HD">ANIXE Serie</channel>
+    <channel site="www.magenta.tv" site_id="389265448050" lang="de" xmltv_id="AnixePlus.de@HD">ANIXE+</channel>
+    <channel site="www.magenta.tv" site_id="389264424233" lang="de" xmltv_id="ARDalpha.de@HD">ARD-alpha</channel>
+    <channel site="www.magenta.tv" site_id="274352679972" lang="de" xmltv_id="arte.de@HD">ARTE</channel>
+    <channel site="www.magenta.tv" site_id="389265960218" lang="de" xmltv_id="AsharqNews.sa@HD">Asharq News</channel>
+    <channel site="www.magenta.tv" site_id="492496936310" lang="de" xmltv_id="atv.de@HD">a.tv</channel>
+    <channel site="www.magenta.tv" site_id="488325160190" lang="de" xmltv_id="ATVAvrupa.tr@SD">ATV Avrupa</channel>
+    <channel site="www.magenta.tv" site_id="389266472177" lang="de" xmltv_id="automotorundsport.de@HD">auto motor und sport</channel>
+    <channel site="www.magenta.tv" site_id="389264936253" lang="de" xmltv_id="AXNBlack.de@HD">AXN Black</channel>
+    <channel site="www.magenta.tv" site_id="389266472155" lang="de" xmltv_id="AXNWhite.de@HD">AXN White</channel>
+    <channel site="www.magenta.tv" site_id="750315048280" lang="de" xmltv_id="BabyTV.uk@UK">Baby TV</channel>
+    <channel site="www.magenta.tv" site_id="492498984401" lang="de" xmltv_id="BadenTV.de@SD">Baden TV</channel>
+    <channel site="www.magenta.tv" site_id="492497448194" lang="de" xmltv_id="BadenTVSud.de@SD">Baden TV Süd</channel>
+    <channel site="www.magenta.tv" site_id="389264936254" lang="de" xmltv_id="BallermannTV.de@HD">Ballermann TV</channel>
+    <channel site="www.magenta.tv" site_id="764524584021" lang="de" xmltv_id="BauersuchtFrau.de@SD">Bauer sucht Frau</channel>
+    <channel site="www.magenta.tv" site_id="516781096167" lang="de" xmltv_id="BBCNews.uk@UKHD">BBC News</channel>
+    <channel site="www.magenta.tv" site_id="695564328412" lang="de" xmltv_id="BeateUhseTV.de@HD">Beate-Uhse.TV (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389265960212" lang="de" xmltv_id="beINIZ.tr@HD">beIN iZ</channel>
+    <channel site="www.magenta.tv" site_id="389264424243" lang="de" xmltv_id="beINMoviesTurk.tr@HD">beIN Movies Turk</channel>
+    <channel site="www.magenta.tv" site_id="389264936270" lang="de" xmltv_id="Bergblick.de@HD">Bergblick</channel>
+    <channel site="www.magenta.tv" site_id="389263912233" lang="de" xmltv_id="BibelTV.de@HD">Bibel TV</channel>
+    <channel site="www.magenta.tv" site_id="658197032097" lang="de" xmltv_id="BLKTV.de@HD">BLK TV</channel>
+    <channel site="www.magenta.tv" site_id="389265960211" lang="de" xmltv_id="BlueHustler.nl@SD">Blue Hustler</channel>
+    <channel site="www.magenta.tv" site_id="389264936259" lang="de" xmltv_id="BonGusto.de@HD">BonGusto</channel>
+    <channel site="www.magenta.tv" site_id="415151144360" lang="de" xmltv_id="BRFernsehen.de@Nord">BR Fernsehen Nord</channel>
+    <channel site="www.magenta.tv" site_id="262730792005" lang="de" xmltv_id="BRFernsehen.de@Sud">BR Fernsehen Süd</channel>
+    <channel site="www.magenta.tv" site_id="389265960231" lang="de" xmltv_id="Cartoonito.de@HD">Cartoonito</channel>
+    <channel site="www.magenta.tv" site_id="389266472181" lang="de" xmltv_id="CartoonitoSky.de@HD">Cartoonito (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389264936255" lang="de" xmltv_id="CartoonNetwork.de@HD">Cartoon Network</channel>
+    <channel site="www.magenta.tv" site_id="389263912230" lang="de" xmltv_id="CartoonNetworkSky.de@HD">Cartoon Network (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389263912216" lang="de" xmltv_id="Channel21.de@HD">CHANNEL21</channel>
+    <channel site="www.magenta.tv" site_id="767937576117" lang="de" xmltv_id="ChemnitzFernsehen.de@SD">Chemnitz Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="415148584245" lang="de" xmltv_id="CNBCInternational.de@HD">CNBC International</channel>
+    <channel site="www.magenta.tv" site_id="389265960223" lang="de" xmltv_id="CNNInternational.us@MENA">CNN International</channel>
+    <channel site="www.magenta.tv" site_id="389265448051" lang="de" xmltv_id="CNNInternational.us@MENAHD">CNN International</channel>
+    <channel site="www.magenta.tv" site_id="389265960208" lang="de" xmltv_id="ComedyCentral.de@HD">Comedy Central</channel>
+    <channel site="www.magenta.tv" site_id="389265448045" lang="de" xmltv_id="ComedyCentral.de@SD">Comedy Central</channel>
+    <channel site="www.magenta.tv" site_id="389265448071" lang="de" xmltv_id="CrimePlusInvestigation.de@HD">Crime+Investigation</channel>
+    <channel site="www.magenta.tv" site_id="389266472182" lang="de" xmltv_id="CrimePlusInvestigation.de@HD">Crime+Investigation (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389266472178" lang="de" xmltv_id="CuriosityChannel.de@HD">Curiosity Channel</channel>
+    <channel site="www.magenta.tv" site_id="259549736360" lang="de" xmltv_id="DasErste.de@HD">Das Erste</channel>
+    <channel site="www.magenta.tv" site_id="389265960241" lang="de" xmltv_id="DeluxeMusic.de@HD">DELUXE MUSIC</channel>
+    <channel site="www.magenta.tv" site_id="492499496076" lang="de" xmltv_id="DeluxeMusic.de@SD">DELUXE MUSIC</channel>
+    <channel site="www.magenta.tv" site_id="389263912245" lang="de" xmltv_id="DF1.de@HD">DF1</channel>
+    <channel site="www.magenta.tv" site_id="389264424250" lang="de" xmltv_id="DiscoveryChannel.de@HD">Discovery Channel</channel>
+    <channel site="www.magenta.tv" site_id="492496936303" lang="de" xmltv_id="DisneyChannel.de@HD">Disney Channel</channel>
+    <channel site="www.magenta.tv" site_id="492499496077" lang="de" xmltv_id="DisneyChannel.de@SD">Disney Channel</channel>
+    <channel site="www.magenta.tv" site_id="274351656120" lang="de" xmltv_id="DMAX.de@HD">DMAX</channel>
+    <channel site="www.magenta.tv" site_id="389265960233" lang="de" xmltv_id="DMAX.de@SD">DMAX</channel>
+    <channel site="www.magenta.tv" site_id="389265448057" lang="de" xmltv_id="DMF.de@HD">DMF</channel>
+    <channel site="www.magenta.tv" site_id="767937064033" lang="de" xmltv_id="DresdenFernsehen.de@SD">Dresden Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="492496936307" lang="de" xmltv_id="emsTV.de@SD">ems TV</channel>
+    <channel site="www.magenta.tv" site_id="389265448044" lang="de" xmltv_id="EnterFilm.ua@HD">MagentaTV Info</channel>
+    <channel site="www.magenta.tv" site_id="415150120096" lang="de" xmltv_id="ERTCosmos.gr@HD">ERT Cosmos</channel>
+    <channel site="www.magenta.tv" site_id="389264424273" lang="de" xmltv_id="Espreso.de@SD">Espreso</channel>
+    <channel site="www.magenta.tv" site_id="389265960191" lang="de" xmltv_id="EuroD.tr@SD">Euro D</channel>
+    <channel site="www.magenta.tv" site_id="415150120097" lang="de" xmltv_id="EuronewsEnglish.fr@HD">Euronews English</channel>
+    <channel site="www.magenta.tv" site_id="389265960201" lang="de" xmltv_id="EuronewsGerman.fr@SD">Euronews Deutsch</channel>
+    <channel site="www.magenta.tv" site_id="389266472166" lang="de" xmltv_id="EuronewsItalian.fr@SD">Euronews Italiano</channel>
+    <channel site="www.magenta.tv" site_id="389265960224" lang="de" xmltv_id="EuronewsRusski.de@SD">Euronews Russki</channel>
+    <channel site="www.magenta.tv" site_id="274351656125" lang="de" xmltv_id="Eurosport1.fr@Germany">Eurosport 1</channel>
+    <channel site="www.magenta.tv" site_id="262731304141" lang="de" xmltv_id="Eurosport1.fr@GermanyHD">Eurosport 1</channel>
+    <channel site="www.magenta.tv" site_id="274351656128" lang="de" xmltv_id="Eurosport2.fr@HD">Eurosport 2</channel>
+    <channel site="www.magenta.tv" site_id="389266472179" lang="de" xmltv_id="EuroStar.tr@SD">Eurostar TV</channel>
+    <channel site="www.magenta.tv" site_id="764249640071" lang="de" xmltv_id="Fabella.de@HD">Fabella</channel>
+    <channel site="www.magenta.tv" site_id="389266472172" lang="de" xmltv_id="FashionTV.de@HD">Fashion TV</channel>
+    <channel site="www.magenta.tv" site_id="736340520423" lang="de" xmltv_id="Filmgold.de@HD">Filmgold</channel>
+    <channel site="www.magenta.tv" site_id="587598887993" lang="de" xmltv_id="FixFoxi.de@SD">Fix&amp;Foxi TV</channel>
+    <channel site="www.magenta.tv" site_id="389265960205" lang="de" xmltv_id="FolxMusicTelevision.de@HD">FOLX MUSIC TELEVISION</channel>
+    <channel site="www.magenta.tv" site_id="463893544181" lang="de" xmltv_id="France2.fr@HD">France 2</channel>
+    <channel site="www.magenta.tv" site_id="463895080134" lang="de" xmltv_id="France3.fr@ParisIledeFrance">France 3</channel>
+    <channel site="www.magenta.tv" site_id="516784168005" lang="de" xmltv_id="France4.fr@HD">France 4</channel>
+    <channel site="www.magenta.tv" site_id="516781096166" lang="de" xmltv_id="France5.fr@HD">France 5</channel>
+    <channel site="www.magenta.tv" site_id="389265960207" lang="de" xmltv_id="France24.fr@HD">France 24 francais</channel>
+    <channel site="www.magenta.tv" site_id="389265960237" lang="de" xmltv_id="France24.fr@HD">France 24 english</channel>
+    <channel site="www.magenta.tv" site_id="492499496075" lang="de" xmltv_id="FrankenFernsehen.de@HD">Franken Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="389265448054" lang="de" xmltv_id="FREEDOM.ua@SD">FREEDOM</channel>
+    <channel site="www.magenta.tv" site_id="492499496084" lang="de" xmltv_id="FriesischerRundfunk.de@SD">Friesischer Rundfunk</channel>
+    <channel site="www.magenta.tv" site_id="782116904356" lang="de" xmltv_id="FUSSBALLTV1.de@HD">FUSSBALL.TV 1</channel>
+    <channel site="www.magenta.tv" site_id="782107176207" lang="de" xmltv_id="FUSSBALLTV1.de@UHD">FUSSBALL.TV 1</channel>
+    <channel site="www.magenta.tv" site_id="787857448345" lang="de" xmltv_id="FUSSBALLTV2.de@HD">FUSSBALL.TV 2</channel>
+    <channel site="www.magenta.tv" site_id="787860008051" lang="de" xmltv_id="FUSSBALLTV2.de@UHD">FUSSBALL.TV 2</channel>
+    <channel site="www.magenta.tv" site_id="789927976326" lang="de" xmltv_id="FUSSBALLTV3.de@HD">FUSSBALL.TV 3</channel>
+    <channel site="www.magenta.tv" site_id="789927976327" lang="de" xmltv_id="FUSSBALLTV3.de@UHD">FUSSBALL.TV 3</channel>
+    <channel site="www.magenta.tv" site_id="389266472173" lang="de" xmltv_id="GEOTelevision.de@HD">GEO Television</channel>
+    <channel site="www.magenta.tv" site_id="561114664140" lang="de" xmltv_id="GluckAufTV.de@HD">Glück Auf! TV</channel>
+    <channel site="www.magenta.tv" site_id="754135080288" lang="de" xmltv_id="Grjngo.pl@HD">Grjngo</channel>
+    <channel site="www.magenta.tv" site_id="704010792353" lang="de" xmltv_id="GustrowTV.de@HD">GüstrowTV</channel>
+    <channel site="www.magenta.tv" site_id="389264424252" lang="de" xmltv_id="HaberturkTV.tr@SD">Habertürk TV</channel>
+    <channel site="www.magenta.tv" site_id="492496936309" lang="de" xmltv_id="Hamburg1.de@SD">Hamburg 1</channel>
+    <channel site="www.magenta.tv" site_id="389263912228" lang="de" xmltv_id="Heimatkanal.de@SD">Heimatkanal</channel>
+    <channel site="www.magenta.tv" site_id="695564328413" lang="de" xmltv_id="Heimatkanal.de@SD">Heimatkanal (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389265448053" lang="de" xmltv_id="HGTV.de@HD">HGTV</channel>
+    <channel site="www.magenta.tv" site_id="492499496080" lang="de" xmltv_id="HGTV.de@SD">HGTV</channel>
+    <channel site="www.magenta.tv" site_id="389264424263" lang="de" xmltv_id="History.de@HD">The HISTORY Channel</channel>
+    <channel site="www.magenta.tv" site_id="389266472153" lang="de" xmltv_id="History.de@HD">The HISTORY Channel (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="587599400156" lang="de" xmltv_id="HopeTV.de@HD">Hope TV</channel>
+    <channel site="www.magenta.tv" site_id="274350120288" lang="de" xmltv_id="hrfernsehen.de@HD">hr-fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="389266472174" lang="de" xmltv_id="HSE.de@HD">HSE</channel>
+    <channel site="www.magenta.tv" site_id="636955688283" lang="de" xmltv_id="HTSPOR.de@HD">HT SPOR</channel>
+    <channel site="www.magenta.tv" site_id="764523560413" lang="de" xmltv_id="hundkatzemaus.de@SD">hundkatzemaus</channel>
+    <channel site="www.magenta.tv" site_id="415150632112" lang="de" xmltv_id="IMEARTH.fr@SD">Imearth</channel>
+    <channel site="www.magenta.tv" site_id="389264936278" lang="de" xmltv_id="ITVN.za@SD">iTVN</channel>
+    <channel site="www.magenta.tv" site_id="492497960284" lang="de" xmltv_id="JenaTV.de@SD">JenaTV</channel>
+    <channel site="www.magenta.tv" site_id="389263912248" lang="de" xmltv_id="Jukebox.de@HD">Jukebox</channel>
+    <channel site="www.magenta.tv" site_id="695563816191" lang="de" xmltv_id="Jukebox.de@HD">Jukebox (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="662243367962" lang="de" xmltv_id="Juwelo.de@HD">Juwelo</channel>
+    <channel site="www.magenta.tv" site_id="262280744415" lang="de" xmltv_id="kabeleins.de@HD">Kabel Eins</channel>
+    <channel site="www.magenta.tv" site_id="274350120289" lang="de" xmltv_id="kabeleins.de@SD">Kabel Eins</channel>
+    <channel site="www.magenta.tv" site_id="389264424231" lang="de" xmltv_id="kabeleinsClassics.de@HD">Kabel Eins CLASSICS</channel>
+    <channel site="www.magenta.tv" site_id="389264936279" lang="de" xmltv_id="kabeleinsDoku.de@HD">Kabel Eins Doku</channel>
+    <channel site="www.magenta.tv" site_id="389263912238" lang="de" xmltv_id="kabeleinsDoku.de@SD">Kabel Eins Doku</channel>
+    <channel site="www.magenta.tv" site_id="389266472176" lang="de" xmltv_id="Kanal7.de@HD">Kanal 7</channel>
+    <channel site="www.magenta.tv" site_id="262281768126" lang="de" xmltv_id="KiKA.de@HD">KiKA</channel>
+    <channel site="www.magenta.tv" site_id="389265448069" lang="de" xmltv_id="KINO.si@SD">Kinomir</channel>
+    <channel site="www.magenta.tv" site_id="389263912223" lang="de" xmltv_id="KinoweltTV.de@HD">KinoweltTV</channel>
+    <channel site="www.magenta.tv" site_id="389265960229" lang="de" xmltv_id="KTV.de@HD">K-TV</channel>
+    <channel site="www.magenta.tv" site_id="736344616035" lang="de" xmltv_id="KultKrimi.de@HD">KultKrimi</channel>
+    <channel site="www.magenta.tv" site_id="698208807980" lang="de" xmltv_id="KulturMD.de@HD">kulturmd</channel>
+    <channel site="www.magenta.tv" site_id="738497064302" lang="de" xmltv_id="LandlustTV.de@HD">Landlust TV</channel>
+    <channel site="www.magenta.tv" site_id="516782120054" lang="de" xmltv_id="LausitzTV.de@HD">lausitz.tv</channel>
+    <channel site="www.magenta.tv" site_id="492498984400" lang="de" xmltv_id="Lausitzwelle.de@SD">LAUSITZWELLE</channel>
+    <channel site="www.magenta.tv" site_id="767936552361" lang="de" xmltv_id="LeipzigFernsehen.de@SD">Leipzig Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="658197544149" lang="de" xmltv_id="LiloTV.de@HD">Lilo.TV</channel>
+    <channel site="www.magenta.tv" site_id="767936552360" lang="de" xmltv_id="LTV.de@SD">L-TV</channel>
+    <channel site="www.magenta.tv" site_id="389265960242" lang="de" xmltv_id="LustPur.de@HD">Lust pur</channel>
+    <channel site="www.magenta.tv" site_id="389263912220" lang="de" xmltv_id="MagentaMusik1.de@HD">Magenta Musik 1</channel>
+    <channel site="www.magenta.tv" site_id="389264424236" lang="de" xmltv_id="MagentaMusik2.de@HD">Magenta Musik 2</channel>
+    <channel site="www.magenta.tv" site_id="389263912227" lang="de" xmltv_id="MagentaSport.de@HD">MagentaSport</channel>
+    <channel site="www.magenta.tv" site_id="389265448049" lang="de" xmltv_id="MarcoPoloTV.de@HD">Marco Polo TV</channel>
+    <channel site="www.magenta.tv" site_id="492497960283" lang="de" xmltv_id="MDF1.de@SD">MDF.1 Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="274352168018" lang="de" xmltv_id="MDRFernsehen.de@HD">MDR-Fernsehen Sachsen</channel>
+    <channel site="www.magenta.tv" site_id="415149608108" lang="de" xmltv_id="MDRFernsehen.de@HD">MDR-Fernsehen Thüringen</channel>
+    <channel site="www.magenta.tv" site_id="415149608151" lang="de" xmltv_id="MDRFernsehen.de@HD">MDR-Fernsehen Sachsen-Anhalt</channel>
+    <channel site="www.magenta.tv" site_id="389266472185" lang="de" xmltv_id="MOMENTS.de@HD">MOMENTS</channel>
+    <channel site="www.magenta.tv" site_id="389263912234" lang="de" xmltv_id="MoreThanSportsTV.de@HD">More Than Sports TV</channel>
+    <channel site="www.magenta.tv" site_id="389265448047" lang="de" xmltv_id="MotorvisionPlus.de@HD">Motorvision+</channel>
+    <channel site="www.magenta.tv" site_id="764249128121" lang="de" xmltv_id="Moviedome.us@HD">Moviedome</channel>
+    <channel site="www.magenta.tv" site_id="746148392381" lang="de" xmltv_id="MSGOLF1.de@HD">MS GOLF 1</channel>
+    <channel site="www.magenta.tv" site_id="746150440202" lang="de" xmltv_id="MSGOLF2.de@HD">MS GOLF 2</channel>
+    <channel site="www.magenta.tv" site_id="389266472165" lang="de" xmltv_id="MSSport.de@HD">MS Sport</channel>
+    <channel site="www.magenta.tv" site_id="389265960221" lang="de" xmltv_id="MTV.de@HD">MTV</channel>
+    <channel site="www.magenta.tv" site_id="389265448060" lang="de" xmltv_id="MTV.de@SD">MTV</channel>
+    <channel site="www.magenta.tv" site_id="492498472231" lang="de" xmltv_id="MunchenTV.de@HD">münchen.tv</channel>
+    <channel site="www.magenta.tv" site_id="389265960220" lang="de" xmltv_id="N24Doku.de@HD">N24 Doku</channel>
+    <channel site="www.magenta.tv" site_id="389264936281" lang="de" xmltv_id="N24Doku.de@SD">N24 Doku</channel>
+    <channel site="www.magenta.tv" site_id="754136616350" lang="de" xmltv_id="Naruto.us@Germany">NARUTO</channel>
+    <channel site="www.magenta.tv" site_id="274351656127" lang="de" xmltv_id="NationalGeographic.de@HD">National Geographic</channel>
+    <channel site="www.magenta.tv" site_id="695561768146" lang="de" xmltv_id="NationalGeographic.de@HD">National Geographic (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389263912244" lang="de" xmltv_id="NationalGeographicWild.de@HD">National Geographic Wild</channel>
+    <channel site="www.magenta.tv" site_id="701488168394" lang="de" xmltv_id="NationalGeographicWild.de@HD">National Geographic Wild (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="274352679975" lang="de" xmltv_id="NDRFernsehen.de@HD">NDR Fernsehen Niedersachsen</channel>
+    <channel site="www.magenta.tv" site_id="415148584251" lang="de" xmltv_id="NDRFernsehen.de@HD">NDR Fernsehen Hamburg</channel>
+    <channel site="www.magenta.tv" site_id="415149608154" lang="de" xmltv_id="NDRFernsehen.de@HD">NDR Fernsehen Mecklenburg-Vorpommern</channel>
+    <channel site="www.magenta.tv" site_id="415149608155" lang="de" xmltv_id="NDRFernsehen.de@HD">NDR Fernsehen Schleswig-Holstein</channel>
+    <channel site="www.magenta.tv" site_id="389266472175" lang="de" xmltv_id="NickComedyCentralPlus1.de@HD">Nick/Comedy Central+1</channel>
+    <channel site="www.magenta.tv" site_id="389265960222" lang="de" xmltv_id="NickComedyCentralPlus1.de@SD">Nick/Comedy Central+1</channel>
+    <channel site="www.magenta.tv" site_id="389265960198" lang="de" xmltv_id="NickJr.de@SD">Nick Jr. (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389265960216" lang="de" xmltv_id="NickJr.de@SD">Nick Jr.</channel>
+    <channel site="www.magenta.tv" site_id="389265448075" lang="de" xmltv_id="Nicktoons.de@SD">Nicktoons (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="492497448195" lang="de" xmltv_id="NiederbayernTVDeggendorfStraubing.de@HD">NIEDERBAYERN TV Deggendorf - Straubing</channel>
+    <channel site="www.magenta.tv" site_id="492499496083" lang="de" xmltv_id="NiederbayernTVLandshut.de@HD">NIEDERBAYERN TV Landshut</channel>
+    <channel site="www.magenta.tv" site_id="492497448197" lang="de" xmltv_id="NiederbayernTVPassau.de@HD">NIEDERBAYERN TV Passau</channel>
+    <channel site="www.magenta.tv" site_id="274351656122" lang="de" xmltv_id="Nitro.de@HD">NITRO</channel>
+    <channel site="www.magenta.tv" site_id="389263912217" lang="de" xmltv_id="Nitro.de@SD">NITRO</channel>
+    <channel site="www.magenta.tv" site_id="492499496081" lang="de" xmltv_id="NRWision.de@HD">NRWision</channel>
+    <channel site="www.magenta.tv" site_id="262731304143" lang="de" xmltv_id="ntv.de@HD">ntv</channel>
+    <channel site="www.magenta.tv" site_id="274352168016" lang="de" xmltv_id="ntv.de@SD">ntv</channel>
+    <channel site="www.magenta.tv" site_id="492498472233" lang="de" xmltv_id="OberpfalzTV.de@HD">Oberpfalz TV</channel>
+    <channel site="www.magenta.tv" site_id="492498984399" lang="de" xmltv_id="OK4.de@HD">OK4</channel>
+    <channel site="www.magenta.tv" site_id="492498984398" lang="de" xmltv_id="OK54.de@HD">OK54 Trier</channel>
+    <channel site="www.magenta.tv" site_id="492498984397" lang="de" xmltv_id="OKTVMainz.de@HD">OK:TV Mainz</channel>
+    <channel site="www.magenta.tv" site_id="492499496085" lang="de" xmltv_id="OKWeinstrasse.de@HD">OK Weinstraße</channel>
+    <channel site="www.magenta.tv" site_id="389264424246" lang="de" xmltv_id="One.de@HD">ONE</channel>
+    <channel site="www.magenta.tv" site_id="389264424248" lang="de" xmltv_id="OneMusicTelevision.de@HD">ONE MUSIC TELEVISION</channel>
+    <channel site="www.magenta.tv" site_id="389264936272" lang="de" xmltv_id="OstWest.de@SD">OstWest</channel>
+    <channel site="www.magenta.tv" site_id="389264424268" lang="de" xmltv_id="OUTtv.de@HD">OUTtv</channel>
+    <channel site="www.magenta.tv" site_id="389265960199" lang="de" xmltv_id="PenthousePassion.us@HD">Penthouse Passion</channel>
+    <channel site="www.magenta.tv" site_id="262729768199" lang="de" xmltv_id="phoenix.de@HD">phoenix</channel>
+    <channel site="www.magenta.tv" site_id="389264936271" lang="de" xmltv_id="PlayboyEurope.de@SD">Playboy Europe</channel>
+    <channel site="www.magenta.tv" site_id="262270504165" lang="de" xmltv_id="ProSieben.de@HD">ProSieben</channel>
+    <channel site="www.magenta.tv" site_id="274352679970" lang="de" xmltv_id="ProSieben.de@SD">ProSieben</channel>
+    <channel site="www.magenta.tv" site_id="492496936305" lang="de" xmltv_id="ProSieben.de@UHD">ProSiebenSat.1</channel>
+    <channel site="www.magenta.tv" site_id="274351656121" lang="de" xmltv_id="ProSiebenFun.de@HD">ProSieben FUN</channel>
+    <channel site="www.magenta.tv" site_id="389264424238" lang="de" xmltv_id="ProSiebenMaxx.de@HD">ProSieben MAXX</channel>
+    <channel site="www.magenta.tv" site_id="389265448059" lang="de" xmltv_id="ProSiebenMaxx.de@SD">ProSieben MAXX</channel>
+    <channel site="www.magenta.tv" site_id="389264424227" lang="de" xmltv_id="QVC.de@HD">QVC</channel>
+    <channel site="www.magenta.tv" site_id="669655079976" lang="de" xmltv_id="QVCZwei.de@HD">QVC ZWEI</channel>
+    <channel site="www.magenta.tv" site_id="274352679971" lang="de" xmltv_id="RadioBremenTV.de@HD">Radio Bremen TV</channel>
+    <channel site="www.magenta.tv" site_id="389265960214" lang="de" xmltv_id="Rai1.it@SD">Rai 1</channel>
+    <channel site="www.magenta.tv" site_id="389265960195" lang="de" xmltv_id="Rai2.it@SD">Rai 2</channel>
+    <channel site="www.magenta.tv" site_id="389264936267" lang="de" xmltv_id="Rai3.it@SD">Rai 3</channel>
+    <channel site="www.magenta.tv" site_id="662243880190" lang="de" xmltv_id="RAN1.de@HD">RAN1</channel>
+    <channel site="www.magenta.tv" site_id="274351656123" lang="de" xmltv_id="rbbFernsehen.de@HD">rbb fernsehen Berlin</channel>
+    <channel site="www.magenta.tv" site_id="415148584246" lang="de" xmltv_id="rbbFernsehen.de@HD">rbb fernsehen Brandenburg</channel>
+    <channel site="www.magenta.tv" site_id="561123367987" lang="de" xmltv_id="RBW.de@HD">RBW</channel>
+    <channel site="www.magenta.tv" site_id="389264936262" lang="de" xmltv_id="RedBullTV.at@DE">Red Bull TV Motorsport</channel>
+    <channel site="www.magenta.tv" site_id="389265960225" lang="de" xmltv_id="RedBullTV.at@DE">Red Bull TV</channel>
+    <channel site="www.magenta.tv" site_id="492499496082" lang="de" xmltv_id="RegioTV.sk@SD">Regio TV</channel>
+    <channel site="www.magenta.tv" site_id="492499496079" lang="de" xmltv_id="RennsteigTV.de@SD">Rennsteig.TV</channel>
+    <channel site="www.magenta.tv" site_id="492497960282" lang="de" xmltv_id="RFHRegionalfernsehenHarz.de@SD">RFH Regionalfernsehen Harz</channel>
+    <channel site="www.magenta.tv" site_id="492497448196" lang="de" xmltv_id="RFO.de@HD">RFO</channel>
+    <channel site="www.magenta.tv" site_id="492498984402" lang="de" xmltv_id="rheinlOKal.de@HD">rheinlOKal</channel>
+    <channel site="www.magenta.tv" site_id="389264424254" lang="de" xmltv_id="RiC.de@HD">RiC</channel>
+    <channel site="www.magenta.tv" site_id="587598887992" lang="de" xmltv_id="RiCtoday.de@HD">RiC.today</channel>
+    <channel site="www.magenta.tv" site_id="389264424262" lang="de" xmltv_id="RomanceTV.de@HD">Romance TV</channel>
+    <channel site="www.magenta.tv" site_id="695561768145" lang="de" xmltv_id="RomanceTV.de@HD">Romance TV (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="754138152287" lang="de" xmltv_id="Royalworld.pl@FAST">Royalworld</channel>
+    <channel site="www.magenta.tv" site_id="259549736358" lang="de" xmltv_id="RTL.de@HD">RTL</channel>
+    <channel site="www.magenta.tv" site_id="259728423995" lang="de" xmltv_id="RTL.de@SD">RTL</channel>
+    <channel site="www.magenta.tv" site_id="492498472234" lang="de" xmltv_id="RTL.de@UHD">RTL</channel>
+    <channel site="www.magenta.tv" site_id="481691176161" lang="de" xmltv_id="RTLBayern.de@HD">RTL Bayern</channel>
+    <channel site="www.magenta.tv" site_id="481694759992" lang="de" xmltv_id="RTLBayern.de@SD">RTL Bayern</channel>
+    <channel site="www.magenta.tv" site_id="415149608157" lang="de" xmltv_id="RTLBremenandNiedersachsen.de@HD">RTL Bremen &amp; Niedersachsen</channel>
+    <channel site="www.magenta.tv" site_id="415148584248" lang="de" xmltv_id="RTLBremenandNiedersachsen.de@SD">RTL Bremen &amp; Niedersachsen</channel>
+    <channel site="www.magenta.tv" site_id="274350120290" lang="de" xmltv_id="RTLCrime.de@HD">RTL Crime</channel>
+    <channel site="www.magenta.tv" site_id="415150632110" lang="de" xmltv_id="RTLHamburgandSchleswigHolstein.de@HD">RTL Hamburg &amp; Schleswig-Holstein</channel>
+    <channel site="www.magenta.tv" site_id="415148584252" lang="de" xmltv_id="RTLHamburgandSchleswigHolstein.de@SD">RTL Hamburg &amp; Schleswig-Holstein</channel>
+    <channel site="www.magenta.tv" site_id="415148584253" lang="de" xmltv_id="RTLHessen.de@HD">RTL Hessen</channel>
+    <channel site="www.magenta.tv" site_id="415149608153" lang="de" xmltv_id="RTLHessen.de@SD">RTL Hessen</channel>
+    <channel site="www.magenta.tv" site_id="389265960204" lang="de" xmltv_id="RTLLiving.de@HD">RTL Living</channel>
+    <channel site="www.magenta.tv" site_id="415150632113" lang="de" xmltv_id="RTLNordrheinWestfalen.de@HD">RTL Nordrhein-Westfalen</channel>
+    <channel site="www.magenta.tv" site_id="415149608156" lang="de" xmltv_id="RTLNordrheinWestfalen.de@SD">RTL Nordrhein-Westfalen</channel>
+    <channel site="www.magenta.tv" site_id="389264424257" lang="de" xmltv_id="RTLPassion.de@HD">RTL Passion</channel>
+    <channel site="www.magenta.tv" site_id="481691176162" lang="de" xmltv_id="RTLRheinNeckar.de@HD">RTL Rhein-Neckar</channel>
+    <channel site="www.magenta.tv" site_id="481694759991" lang="de" xmltv_id="RTLRheinNeckar.de@SD">RTL Rhein-Neckar</channel>
+    <channel site="www.magenta.tv" site_id="262277160060" lang="de" xmltv_id="RTLSuper.de@HD">Super RTL</channel>
+    <channel site="www.magenta.tv" site_id="274352679977" lang="de" xmltv_id="RTLSuper.de@SD">Super RTL</channel>
+    <channel site="www.magenta.tv" site_id="274351656126" lang="de" xmltv_id="RTLup.de@HD">RTLup</channel>
+    <channel site="www.magenta.tv" site_id="389264424253" lang="de" xmltv_id="RTLup.de@SD">RTLup</channel>
+    <channel site="www.magenta.tv" site_id="262277160057" lang="de" xmltv_id="RTLZwei.de@HD">RTLZWEI</channel>
+    <channel site="www.magenta.tv" site_id="274352679973" lang="de" xmltv_id="RTLZwei.de@SD">RTLZWEI</channel>
+    <channel site="www.magenta.tv" site_id="492498472232" lang="de" xmltv_id="SalveTV.de@HD">salve.tv</channel>
+    <channel site="www.magenta.tv" site_id="262270504164" lang="de" xmltv_id="SAT1.de@HD">SAT.1</channel>
+    <channel site="www.magenta.tv" site_id="415147560392" lang="de" xmltv_id="SAT1.de@HD">SAT.1 Bayern</channel>
+    <channel site="www.magenta.tv" site_id="415148584254" lang="de" xmltv_id="SAT1.de@HD">SAT.1 Hamburg und Schleswig-Holstein</channel>
+    <channel site="www.magenta.tv" site_id="415149608150" lang="de" xmltv_id="SAT1.de@HD">SAT.1 Niedersachsen und Bremen</channel>
+    <channel site="www.magenta.tv" site_id="415151144338" lang="de" xmltv_id="SAT1.de@HD">SAT.1 Rheinland-Pfalz und Hessen</channel>
+    <channel site="www.magenta.tv" site_id="262269992391" lang="de" xmltv_id="SAT1.de@SD">SAT.1</channel>
+    <channel site="www.magenta.tv" site_id="415147560393" lang="de" xmltv_id="SAT1.de@SD">SAT.1 Bayern</channel>
+    <channel site="www.magenta.tv" site_id="415148584250" lang="de" xmltv_id="SAT1.de@SD">SAT.1 Rheinland-Pfalz und Hessen</channel>
+    <channel site="www.magenta.tv" site_id="415150120169" lang="de" xmltv_id="SAT1.de@SD">SAT.1 Niedersachsen und Bremen</channel>
+    <channel site="www.magenta.tv" site_id="415150632114" lang="de" xmltv_id="SAT1.de@SD">SAT.1 Hamburg und Schleswig-Holstein</channel>
+    <channel site="www.magenta.tv" site_id="274352679974" lang="de" xmltv_id="SAT1emotions.de@HD">SAT.1 emotions</channel>
+    <channel site="www.magenta.tv" site_id="274352168017" lang="de" xmltv_id="SAT1Gold.de@HD">SAT.1 GOLD</channel>
+    <channel site="www.magenta.tv" site_id="389263912235" lang="de" xmltv_id="SAT1Gold.de@SD">SAT.1 GOLD</channel>
+    <channel site="www.magenta.tv" site_id="415150120078" lang="de" xmltv_id="SAT1NRW.de@HD">SAT.1 Nordrhein-Westfalen</channel>
+    <channel site="www.magenta.tv" site_id="415150120094" lang="de" xmltv_id="SAT1NRW.de@SD">SAT.1 Nordrhein-Westfalen</channel>
+    <channel site="www.magenta.tv" site_id="389265448056" lang="de" xmltv_id="SchlagerDeluxe.de@HD">SCHLAGER DELUXE</channel>
+    <channel site="www.magenta.tv" site_id="389263912219" lang="de" xmltv_id="SchlagerparadiesTV.de@HD">Schlagerparadies.TV</channel>
+    <channel site="www.magenta.tv" site_id="738500136328" lang="de" xmltv_id="Scooore.de@HD">Scooore</channel>
+    <channel site="www.magenta.tv" site_id="389263912249" lang="de" xmltv_id="ShopLC.de@HD">Shop LC</channel>
+    <channel site="www.magenta.tv" site_id="764523048346" lang="de" xmltv_id="ShoppingQueen.de@SD">Shopping Queen</channel>
+    <channel site="www.magenta.tv" site_id="389265960197" lang="de" xmltv_id="ShowMax.tr@HD">Show Max</channel>
+    <channel site="www.magenta.tv" site_id="389264936257" lang="de" xmltv_id="ShowTurk.tr@HD">Show Turk</channel>
+    <channel site="www.magenta.tv" site_id="389266472164" lang="de" xmltv_id="sixx.de@HD">sixx</channel>
+    <channel site="www.magenta.tv" site_id="389263912226" lang="de" xmltv_id="sixx.de@SD">sixx</channel>
+    <channel site="www.magenta.tv" site_id="389264424264" lang="de" xmltv_id="SkyAtlantic.de@HD">Sky Atlantic</channel>
+    <channel site="www.magenta.tv" site_id="389264936248" lang="de" xmltv_id="SkyCinemaAction.de@HD">Sky Cinema Action</channel>
+    <channel site="www.magenta.tv" site_id="389264424259" lang="de" xmltv_id="SkyCinemaClassics.de@HD">Sky Cinema Classics</channel>
+    <channel site="www.magenta.tv" site_id="389264936266" lang="de" xmltv_id="SkyCinemaPremiere.uk@HD">Sky Cinema Premiere</channel>
+    <channel site="www.magenta.tv" site_id="389266472159" lang="de" xmltv_id="SkyCinemaPremieren.de@HD">Sky Cinema Feelgood</channel>
+    <channel site="www.magenta.tv" site_id="509713959991" lang="de" xmltv_id="SkyCinemaPremieren.de@HD">Sky Cinema Blockbuster</channel>
+    <channel site="www.magenta.tv" site_id="389265960239" lang="de" xmltv_id="SkyCrime.de@HD">Sky Crime</channel>
+    <channel site="www.magenta.tv" site_id="389265960232" lang="de" xmltv_id="SkyDocumentaries.de@HD">Sky Documentaries</channel>
+    <channel site="www.magenta.tv" site_id="389264424272" lang="de" xmltv_id="SkyKrimi.de@HD">Sky Krimi</channel>
+    <channel site="www.magenta.tv" site_id="389266472149" lang="de" xmltv_id="SkyNature.de@HD">Sky Nature</channel>
+    <channel site="www.magenta.tv" site_id="389264936273" lang="de" xmltv_id="SkyOne.de@HD">Sky One</channel>
+    <channel site="www.magenta.tv" site_id="389264424228" lang="de" xmltv_id="SkySciFi.uk@HD">Sky Sci-Fi</channel>
+    <channel site="www.magenta.tv" site_id="389266472148" lang="de" xmltv_id="SkySciFi.uk@HD">Sky Sci-Fi (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389266472150" lang="de" xmltv_id="SkyShowcase.de@HD">Sky Showcase</channel>
+    <channel site="www.magenta.tv" site_id="389263912242" lang="de" xmltv_id="SkySport1.de@HD">Sky Sport 1</channel>
+    <channel site="www.magenta.tv" site_id="389264936252" lang="de" xmltv_id="SkySport2.de@HD">Sky Sport 2</channel>
+    <channel site="www.magenta.tv" site_id="389264424271" lang="de" xmltv_id="SkySport3.de@HD">Sky Sport 3</channel>
+    <channel site="www.magenta.tv" site_id="389266472169" lang="de" xmltv_id="SkySport4.de@HD">Sky Sport 4</channel>
+    <channel site="www.magenta.tv" site_id="389263912221" lang="de" xmltv_id="SkySport5.de@HD">Sky Sport 5</channel>
+    <channel site="www.magenta.tv" site_id="389264936258" lang="de" xmltv_id="SkySport6.de@HD">Sky Sport 6</channel>
+    <channel site="www.magenta.tv" site_id="389266472171" lang="de" xmltv_id="SkySport7.de@HD">Sky Sport 7</channel>
+    <channel site="www.magenta.tv" site_id="389265960226" lang="de" xmltv_id="SkySport8.de@HD">Sky Sport 8</channel>
+    <channel site="www.magenta.tv" site_id="389264936247" lang="de" xmltv_id="SkySport9.de@HD">Sky Sport 9</channel>
+    <channel site="www.magenta.tv" site_id="389266472183" lang="de" xmltv_id="SkySport10.de@HD">Sky Sport 10</channel>
+    <channel site="www.magenta.tv" site_id="769867816329" lang="de" xmltv_id="SkySport.de@UHD">Sky Sport</channel>
+    <channel site="www.magenta.tv" site_id="389263912237" lang="de" xmltv_id="SkySportBundesliga1.de@HD">Sky Sport Bundesliga 1</channel>
+    <channel site="www.magenta.tv" site_id="389265960192" lang="de" xmltv_id="SkySportBundesliga2.de@HD">Sky Sport Bundesliga 2</channel>
+    <channel site="www.magenta.tv" site_id="389265448068" lang="de" xmltv_id="SkySportBundesliga3.de@HD">Sky Sport Bundesliga 3</channel>
+    <channel site="www.magenta.tv" site_id="389264424240" lang="de" xmltv_id="SkySportBundesliga4.de@HD">Sky Sport Bundesliga 4</channel>
+    <channel site="www.magenta.tv" site_id="389265448062" lang="de" xmltv_id="SkySportBundesliga5.de@HD">Sky Sport Bundesliga 5</channel>
+    <channel site="www.magenta.tv" site_id="389264424242" lang="de" xmltv_id="SkySportBundesliga6.de@HD">Sky Sport Bundesliga 6</channel>
+    <channel site="www.magenta.tv" site_id="389263912224" lang="de" xmltv_id="SkySportBundesliga7.de@HD">Sky Sport Bundesliga 7</channel>
+    <channel site="www.magenta.tv" site_id="389264936260" lang="de" xmltv_id="SkySportBundesliga8.de@HD">Sky Sport Bundesliga 8</channel>
+    <channel site="www.magenta.tv" site_id="389265448058" lang="de" xmltv_id="SkySportBundesliga9.de@HD">Sky Sport Bundesliga 9</channel>
+    <channel site="www.magenta.tv" site_id="389264936256" lang="de" xmltv_id="SkySportBundesliga10.de@HD">Sky Sport Bundesliga 10</channel>
+    <channel site="www.magenta.tv" site_id="389264424237" lang="de" xmltv_id="SkySportBundesliga.de@HD">Sky Sport Bundesliga</channel>
+    <channel site="www.magenta.tv" site_id="769865767977" lang="de" xmltv_id="SkySportBundesliga.de@UHD">Sky Sport Bundesliga</channel>
+    <channel site="www.magenta.tv" site_id="389263912236" lang="de" xmltv_id="SkySportF1.de@HD">Sky Sport F1</channel>
+    <channel site="www.magenta.tv" site_id="389263912231" lang="de" xmltv_id="SkySportGolf.de@HD">Sky Sport Golf</channel>
+    <channel site="www.magenta.tv" site_id="389265448046" lang="de" xmltv_id="SkySportKompakt1.de@HD">Sky Sport Kompakt 1</channel>
+    <channel site="www.magenta.tv" site_id="389263912250" lang="de" xmltv_id="SkySportMix.de@HD">Sky Sport Mix</channel>
+    <channel site="www.magenta.tv" site_id="389264424255" lang="de" xmltv_id="SkySportNews.de@HD">Sky Sport News</channel>
+    <channel site="www.magenta.tv" site_id="389263912232" lang="de" xmltv_id="SkySportPremierLeague.de@HD">Sky Sport Premier League</channel>
+    <channel site="www.magenta.tv" site_id="389264936243" lang="de" xmltv_id="SkySportTennis.de@HD">Sky Sport Tennis</channel>
+    <channel site="www.magenta.tv" site_id="389265448072" lang="de" xmltv_id="SkySportTopEvent.de@HD">Sky Sport Top Event</channel>
+    <channel site="www.magenta.tv" site_id="389265960219" lang="de" xmltv_id="SonnenklarTV.de@HD">sonnenklar.TV</channel>
+    <channel site="www.magenta.tv" site_id="389265960227" lang="de" xmltv_id="SpiegelGeschichte.de@HD">Spiegel Geschichte</channel>
+    <channel site="www.magenta.tv" site_id="754135080287" lang="de" xmltv_id="SpiegelTV.de@HD">Spiegel TV</channel>
+    <channel site="www.magenta.tv" site_id="262729768197" lang="de" xmltv_id="Sport1.de@HD">Sport 1 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389263912240" lang="de" xmltv_id="Sport1.de@HD">Sport 18 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389264424244" lang="de" xmltv_id="Sport1.de@HD">Sport 17 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389264936263" lang="de" xmltv_id="Sport1.de@HD">eSportsONE</channel>
+    <channel site="www.magenta.tv" site_id="389265448052" lang="de" xmltv_id="Sport1.de@HD">SPORT1</channel>
+    <channel site="www.magenta.tv" site_id="389265448063" lang="de" xmltv_id="Sport1.de@HD">Sport 11 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265448067" lang="de" xmltv_id="Sport1.de@HD">Sport 14 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265448073" lang="de" xmltv_id="Sport1.de@HD">Sport 16 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265960209" lang="de" xmltv_id="Sport1.de@HD">Sport 12 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389266472157" lang="de" xmltv_id="Sport1.de@HD">Sport 13 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389266472161" lang="de" xmltv_id="Sport1.de@HD">Sport 15 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389266472162" lang="de" xmltv_id="Sport1.de@HD">Sport 10 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265448066" lang="de" xmltv_id="Sport1.de@SD">SPORT1</channel>
+    <channel site="www.magenta.tv" site_id="389264936251" lang="de" xmltv_id="Sport2myTeamTV.de@HD">Sport 2 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389264424230" lang="de" xmltv_id="Sport3myTeamTV.de@HD">Sport 3 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389264424269" lang="de" xmltv_id="Sport4myTeamTV.de@HD">Sport 4 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389263912222" lang="de" xmltv_id="Sport5myTeamTV.de@HD">Sport 5 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389266472167" lang="de" xmltv_id="Sport6.xk@HD">Sport 6 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265960200" lang="de" xmltv_id="Sport7myTeamTV.de@HD">Sport 7 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389264936249" lang="de" xmltv_id="Sport8myTeamTV.de@HD">Sport 8 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389266472152" lang="de" xmltv_id="Sport9myTeamTV.de@HD">Sport 9 - myTeamTV</channel>
+    <channel site="www.magenta.tv" site_id="389265960236" lang="de" xmltv_id="Sportdigital1Plus.de@HD">Sportdigital1+</channel>
+    <channel site="www.magenta.tv" site_id="389264424241" lang="de" xmltv_id="SportdigitalFUSSBALL.de@HD">SPORTDIGITAL FUSSBALL</channel>
+    <channel site="www.magenta.tv" site_id="492499496078" lang="de" xmltv_id="SRF.de@SD">SRF</channel>
+    <channel site="www.magenta.tv" site_id="274352679976" lang="de" xmltv_id="SRFernsehen.de@HD">SR Fernsehen</channel>
+    <channel site="www.magenta.tv" site_id="587597352323" lang="de" xmltv_id="StimmungsgartenTV.at@HD">Stimmungsgarten TV</channel>
+    <channel site="www.magenta.tv" site_id="389264424239" lang="de" xmltv_id="StingrayClassica.ca@HD">Stingray Classica</channel>
+    <channel site="www.magenta.tv" site_id="389264936269" lang="de" xmltv_id="StingrayDJAZZ.ca@HD">Stingray DJAZZ</channel>
+    <channel site="www.magenta.tv" site_id="389264424274" lang="de" xmltv_id="StingrayiConcerts.ca@HD">Stingray iConcerts</channel>
+    <channel site="www.magenta.tv" site_id="767936552362" lang="de" xmltv_id="Studio47.de@SD">Studio 47</channel>
+    <channel site="www.magenta.tv" site_id="274350120291" lang="de" xmltv_id="SWRFernsehenBW.de@HD">SWR Fernsehen BW</channel>
+    <channel site="www.magenta.tv" site_id="389265960196" lang="de" xmltv_id="SWRFernsehenRP.de@HD">SWR Fernsehen RP</channel>
+    <channel site="www.magenta.tv" site_id="745871912203" lang="de" xmltv_id="Sylt1.de@HD">SYLT1</channel>
+    <channel site="www.magenta.tv" site_id="389265448048" lang="de" xmltv_id="tagesschau24.de@HD">tagesschau24</channel>
+    <channel site="www.magenta.tv" site_id="389266472168" lang="de" xmltv_id="TELE5.de@HD">TELE 5</channel>
+    <channel site="www.magenta.tv" site_id="389265960210" lang="de" xmltv_id="TELE5.de@SD">TELE 5</channel>
+    <channel site="www.magenta.tv" site_id="389264424261" lang="de" xmltv_id="Telebom.de@SD">TeleBom/TeleDom</channel>
+    <channel site="www.magenta.tv" site_id="736345639978" lang="de" xmltv_id="Telenovela.kr@HD">Telenovela ZDF</channel>
+    <channel site="www.magenta.tv" site_id="610214440158" lang="de" xmltv_id="teltOwkanal.de@HD">teltOwkanal</channel>
+    <channel site="www.magenta.tv" site_id="754138663958" lang="de" xmltv_id="TerraMaterWILD.de@German">Terra Mater WILD</channel>
+    <channel site="www.magenta.tv" site_id="389265448055" lang="de" xmltv_id="TLC.de@HD">TLC</channel>
+    <channel site="www.magenta.tv" site_id="389263912229" lang="de" xmltv_id="TLC.de@SD">TLC</channel>
+    <channel site="www.magenta.tv" site_id="389266472146" lang="de" xmltv_id="TOGGOplus.de@HD">TOGGO plus</channel>
+    <channel site="www.magenta.tv" site_id="389264424245" lang="de" xmltv_id="TOGGOplus.de@SD">TOGGO plus</channel>
+    <channel site="www.magenta.tv" site_id="754137640065" lang="de" xmltv_id="TOPSCIFI.de@HD">TOP SCI-FI</channel>
+    <channel site="www.magenta.tv" site_id="389265960213" lang="de" xmltv_id="TOPSERIEN.de@HD">TOP SERIEN</channel>
+    <channel site="www.magenta.tv" site_id="754137640066" lang="de" xmltv_id="TOPTRUECRIME.de@HD">TOP TRUE CRIME</channel>
+    <channel site="www.magenta.tv" site_id="597433895959" lang="de" xmltv_id="Travelxp.in@4KHDR">Travelxp</channel>
+    <channel site="www.magenta.tv" site_id="389266472163" lang="de" xmltv_id="Travelxp.in@HD">Travelxp</channel>
+    <channel site="www.magenta.tv" site_id="488325160191" lang="de" xmltv_id="TRTCocuk.tr@HD">TRT Cocuk</channel>
+    <channel site="www.magenta.tv" site_id="389264424226" lang="de" xmltv_id="TV5MondeEurope.fr@Netherlands">TV5MONDE Europe</channel>
+    <channel site="www.magenta.tv" site_id="389263912247" lang="de" xmltv_id="TV8int.tr@SD">TV8 Int</channel>
+    <channel site="www.magenta.tv" site_id="492497448198" lang="de" xmltv_id="TVAOstbayern.de@HD">TVA Ostbayern</channel>
+    <channel site="www.magenta.tv" site_id="767935016341" lang="de" xmltv_id="TVBerlin.de@SD">tv.berlin</channel>
+    <channel site="www.magenta.tv" site_id="492497448192" lang="de" xmltv_id="TVIngolstadt.de@HD">tv.ingolstadt</channel>
+    <channel site="www.magenta.tv" site_id="492496936304" lang="de" xmltv_id="TVMainfranken.de@HD">TV Mainfranken</channel>
+    <channel site="www.magenta.tv" site_id="492497960281" lang="de" xmltv_id="TVMittelrhein.de@SD">TV Mittelrhein</channel>
+    <channel site="www.magenta.tv" site_id="492496936306" lang="de" xmltv_id="TVOberfranken.de@HD">TV Oberfranken</channel>
+    <channel site="www.magenta.tv" site_id="415148584247" lang="de" xmltv_id="TVPPolonia.pl@USA">TVP Polonia</channel>
+    <channel site="www.magenta.tv" site_id="492496936308" lang="de" xmltv_id="TVWestsachsen.de@SD">TV Westsachsen</channel>
+    <channel site="www.magenta.tv" site_id="389263912218" lang="de" xmltv_id="UlkeTV.tr@HD">ÜLKE TV</channel>
+    <channel site="www.magenta.tv" site_id="389264424256" lang="de" xmltv_id="UniversalTV.de@HD">Universal TV</channel>
+    <channel site="www.magenta.tv" site_id="389266472154" lang="de" xmltv_id="UniversalTV.de@HD">Universal TV (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="389265448061" lang="de" xmltv_id="VolksmusikTV.de@HD">Volksmusik.TV</channel>
+    <channel site="www.magenta.tv" site_id="262282280173" lang="de" xmltv_id="VOX.de@HD">VOX</channel>
+    <channel site="www.magenta.tv" site_id="274350120287" lang="de" xmltv_id="VOX.de@SD">VOX</channel>
+    <channel site="www.magenta.tv" site_id="389264424232" lang="de" xmltv_id="Voxup.de@HD">VOXup</channel>
+    <channel site="www.magenta.tv" site_id="389266472147" lang="de" xmltv_id="Voxup.de@SD">VOXup</channel>
+    <channel site="www.magenta.tv" site_id="262730280165" lang="de" xmltv_id="WarnerTVComedy.de@HD">Warner TV Comedy</channel>
+    <channel site="www.magenta.tv" site_id="389263912243" lang="de" xmltv_id="WarnerTVComedy.de@HD">Warner TV Comedy (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="262730280151" lang="de" xmltv_id="WarnerTVFilm.de@HD">Warner TV Film</channel>
+    <channel site="www.magenta.tv" site_id="389264424235" lang="de" xmltv_id="WarnerTVFilm.de@HD">Warner TV Film (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="262729768198" lang="de" xmltv_id="WarnerTVSerie.de@HD">Warner TV Serie</channel>
+    <channel site="www.magenta.tv" site_id="389264424258" lang="de" xmltv_id="WarnerTVSerie.de@HD">Warner TV Serie (Sky)</channel>
+    <channel site="www.magenta.tv" site_id="262729768202" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Köln</channel>
+    <channel site="www.magenta.tv" site_id="415147560391" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Duisburg</channel>
+    <channel site="www.magenta.tv" site_id="415148584249" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Siegen</channel>
+    <channel site="www.magenta.tv" site_id="415149608152" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Bonn</channel>
+    <channel site="www.magenta.tv" site_id="415150120077" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Essen</channel>
+    <channel site="www.magenta.tv" site_id="415150120095" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Dortmund</channel>
+    <channel site="www.magenta.tv" site_id="415150120143" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Bielefeld</channel>
+    <channel site="www.magenta.tv" site_id="415150632065" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Aachen</channel>
+    <channel site="www.magenta.tv" site_id="415150632109" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Wuppertal</channel>
+    <channel site="www.magenta.tv" site_id="415150632111" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Düsseldorf</channel>
+    <channel site="www.magenta.tv" site_id="415151144359" lang="de" xmltv_id="WDRFernsehen.de@HD">WDR Fernsehen Münster</channel>
+    <channel site="www.magenta.tv" site_id="262731304145" lang="de" xmltv_id="WELT.de@HD">WELT</channel>
+    <channel site="www.magenta.tv" site_id="389264424234" lang="de" xmltv_id="WELT.de@HD">Welt der Wunder</channel>
+    <channel site="www.magenta.tv" site_id="274351656124" lang="de" xmltv_id="WELT.de@SD">WELT</channel>
+    <channel site="www.magenta.tv" site_id="389266472151" lang="de" xmltv_id="WettercomTV.de@SD">wetter.com TV</channel>
+    <channel site="www.magenta.tv" site_id="389264424249" lang="de" xmltv_id="WKBSTV475.us@HD">wedotv Movies</channel>
+    <channel site="www.magenta.tv" site_id="736340520422" lang="de" xmltv_id="WorldofFreesports.de@HD">World of Freesports</channel>
+    <channel site="www.magenta.tv" site_id="262264872014" lang="de" xmltv_id="ZDF.de@HD">ZDF</channel>
+    <channel site="www.magenta.tv" site_id="389266472186" lang="de" xmltv_id="ZDFinfo.de@HD">ZDFinfo</channel>
+    <channel site="www.magenta.tv" site_id="262729768194" lang="de" xmltv_id="ZDFneo.de@HD">ZDFneo</channel>
+    <channel site="www.magenta.tv" site_id="389265960194" lang="de" xmltv_id="ZweiMusicTelevision.de@HD">ZWEI MUSIC TELEVISION</channel>
 </channels>

--- a/sites/www.magenta.tv/www.magenta.tv.config.js
+++ b/sites/www.magenta.tv/www.magenta.tv.config.js
@@ -1,6 +1,8 @@
 const axios = require('axios')
 const crypto = require('crypto')
 const dayjs = require('dayjs')
+const fs = require('fs')
+const path = require('path')
 const utc = require('dayjs/plugin/utc')
 const customParseFormat = require('dayjs/plugin/customParseFormat')
 
@@ -13,342 +15,858 @@ const PORTAL = 'release'
 const SUBSCRIBER_TYPE = 'FTV_FREEMIUM_DT'
 const CHANNEL_PAGE_SIZE = 100
 const CHANNEL_PAGE_LIMIT = 1000
+const DATABASE_DIR = path.resolve(__dirname, '../../temp/data')
 
 const FALLBACK_MPX = Object.freeze({
-  accountPid: 'mdeprod',
-  locationIdUri: 'http://data.entertainment.tv.theplatform.eu/entertainment/data/Location/245991976396',
-  feeds: {
-    allChannelSchedulesFeed:
-      'https://feed.entertainment.tv.theplatform.eu/f/{MpxAccountPid}/{MpxAccountPid}-all-channel-schedules',
-    allChannelStationsFeed:
-      'https://feed.entertainment.tv.theplatform.eu/f/{MpxAccountPid}/{MpxAccountPid}-channel-stations-main'
-  }
+    accountPid: 'mdeprod',
+    locationIdUri:
+        'http://data.entertainment.tv.theplatform.eu/entertainment/data/Location/245991976396',
+    feeds: {
+        allChannelSchedulesFeed:
+            'https://feed.entertainment.tv.theplatform.eu/f/{MpxAccountPid}/{MpxAccountPid}-all-channel-schedules',
+        allChannelStationsFeed:
+            'https://feed.entertainment.tv.theplatform.eu/f/{MpxAccountPid}/{MpxAccountPid}-channel-stations-main'
+    }
 })
+
+const QUALITY_DEFINITIONS = Object.freeze([
+    {
+        kind: '8K',
+        label: '8K',
+        aliases: ['8K', '4320P'],
+        formats: ['4320p']
+    },
+    {
+        kind: 'UHD',
+        label: 'UHD',
+        aliases: ['UHD', 'ULTRA HD', 'ULTRAHD', '4K', '2160P'],
+        formats: ['2160p']
+    },
+    {
+        kind: 'HD',
+        label: 'HD',
+        aliases: ['FULL HD', 'FULLHD', 'FHD', 'HD', '720P', '1080I', '1080P'],
+        formats: ['720p', '1080i', '1080p']
+    },
+    {
+        kind: 'SD',
+        label: 'SD',
+        aliases: ['SD', '480I', '480P', '576I', '576P'],
+        formats: ['480i', '480p', '576i', '576p']
+    }
+])
 
 let session
 let manifestPromise
+let databasePromise
 
 module.exports = {
-  site: 'www.magenta.tv',
-  days: 2,
-  request: {
-    cache: {
-      ttl: 60 * 60 * 1000 // 1 hour
+    site: 'www.magenta.tv',
+    days: 2,
+    request: {
+        cache: {
+            ttl: 60 * 60 * 1000 // 1 hour
+        }
+    },
+    async url({ channel, date }) {
+        const mpx = await getMpxConfig()
+        const currentSession = getSession()
+        const window = getUtcWindow(date)
+
+        return buildScheduleUrl({
+            mpx,
+            session: currentSession,
+            siteIds: [channel.site_id],
+            window
+        })
+    },
+    async parser({ content, channel }) {
+        return parseScheduleResponse(content, channel)
+    },
+    async channels() {
+        const [mpx, database] = await Promise.all([getMpxConfig(), getDatabase()])
+        const currentSession = getSession()
+        const channels = []
+
+        for (let start = 1; start <= CHANNEL_PAGE_LIMIT; start += CHANNEL_PAGE_SIZE) {
+            const entries = await getChannelEntries({
+                mpx,
+                session: currentSession,
+                start,
+                end: start + CHANNEL_PAGE_SIZE - 1
+            })
+
+            if (!entries.length) break
+
+            entries.forEach(entry => {
+                const channel = parseChannel(entry, database)
+                if (channel) channels.push(channel)
+            })
+
+            if (entries.length < CHANNEL_PAGE_SIZE) break
+        }
+
+        return channels
     }
-  },
-  async url({ channel, date }) {
-    const mpx = await getMpxConfig()
-    const currentSession = getSession()
-    const window = getUtcWindow(date)
-
-    return buildScheduleUrl({
-      mpx,
-      session: currentSession,
-      siteIds: [channel.site_id],
-      window
-    })
-  },
-  async parser({ content, channel }) {
-    return parseScheduleResponse(content, channel)
-  },
-  async channels() {
-    const mpx = await getMpxConfig()
-    const currentSession = getSession()
-    const channels = []
-
-    for (let start = 1; start <= CHANNEL_PAGE_LIMIT; start += CHANNEL_PAGE_SIZE) {
-      const entries = await getChannelEntries({
-        mpx,
-        session: currentSession,
-        start,
-        end: start + CHANNEL_PAGE_SIZE - 1
-      })
-
-      if (!entries.length) break
-
-      entries.forEach(entry => {
-        const channel = parseChannel(entry)
-        if (channel) channels.push(channel)
-      })
-
-      if (entries.length < CHANNEL_PAGE_SIZE) break
-    }
-
-    return channels
-  }
 }
 
 function createSession() {
-  return {
-    deviceId: crypto.randomUUID(),
-    sessionId: crypto.randomUUID()
-  }
+    return {
+        deviceId: crypto.randomUUID(),
+        sessionId: crypto.randomUUID()
+    }
 }
 
 function getSession() {
-  if (!session) {
-    session = createSession()
-  }
+    if (!session) {
+        session = createSession()
+    }
 
-  return session
+    return session
 }
 
 function buildCid(currentSession) {
-  return `${currentSession.sessionId}::${crypto.randomUUID()}`
+    return `${currentSession.sessionId}::${crypto.randomUUID()}`
 }
 
 function getManifestRequestConfig(currentSession) {
-  return {
-    headers: {
-      'X-DT-Call-ID': crypto.randomUUID(),
-      'X-DT-Session-ID': currentSession.sessionId
-    },
-    params: {
-      deviceId: currentSession.deviceId,
-      deviceModel: DEVICE_MODEL,
-      portal: PORTAL,
-      subscriberType: SUBSCRIBER_TYPE,
-      $redirect: false,
-      sid: currentSession.sessionId
+    return {
+        headers: {
+            'X-DT-Call-ID': crypto.randomUUID(),
+            'X-DT-Session-ID': currentSession.sessionId
+        },
+        params: {
+            deviceId: currentSession.deviceId,
+            deviceModel: DEVICE_MODEL,
+            portal: PORTAL,
+            subscriberType: SUBSCRIBER_TYPE,
+            $redirect: false,
+            sid: currentSession.sessionId
+        }
     }
-  }
 }
 
 async function getManifest() {
-  if (!manifestPromise) {
-    manifestPromise = axios
-      .get(MANIFEST_URL, getManifestRequestConfig(getSession()))
-      .then(r => r.data)
-      .catch(() => null)
-  }
+    if (!manifestPromise) {
+        manifestPromise = axios
+            .get(MANIFEST_URL, getManifestRequestConfig(getSession()))
+            .then(r => r.data)
+            .catch(() => null)
+    }
 
-  return manifestPromise
+    return manifestPromise
 }
 
 async function getMpxConfig() {
-  const manifest = await getManifest()
-  const manifestMpx = manifest && manifest.mpx ? manifest.mpx : {}
+    const manifest = await getManifest()
+    const manifestMpx = manifest && manifest.mpx ? manifest.mpx : {}
 
-  return {
-    ...FALLBACK_MPX,
-    ...manifestMpx,
-    feeds: {
-      ...FALLBACK_MPX.feeds,
-      ...(manifestMpx.feeds || {})
+    return {
+        ...FALLBACK_MPX,
+        ...manifestMpx,
+        feeds: {
+            ...FALLBACK_MPX.feeds,
+            ...(manifestMpx.feeds || {})
+        }
     }
-  }
+}
+
+async function getDatabase() {
+    if (!databasePromise) {
+        databasePromise = Promise.all([
+            loadDatabaseFile('channels'),
+            loadDatabaseFile('feeds')
+        ]).then(([channels, feeds]) => buildDatabaseIndex(channels, feeds))
+    }
+
+    return databasePromise
+}
+
+async function loadDatabaseFile(basename) {
+    const filepath = path.resolve(DATABASE_DIR, `${basename}.json`)
+
+    try {
+        const content = await fs.promises.readFile(filepath, 'utf8')
+        const data = JSON.parse(content)
+
+        return Array.isArray(data) ? data : []
+    } catch {
+        return []
+    }
+}
+
+function buildDatabaseIndex(channels, feeds) {
+    const feedsByChannel = new Map()
+
+    feeds.forEach(feed => {
+        if (!feed || !feed.channel || !feed.id) return
+
+        const channelFeeds = feedsByChannel.get(feed.channel) || []
+        channelFeeds.push(feed)
+        feedsByChannel.set(feed.channel, channelFeeds)
+    })
+
+    return {
+        channels: channels.filter(channel => channel && channel.id && channel.name),
+        feedsByChannel
+    }
 }
 
 async function getChannelEntries({ mpx, session, start, end }) {
-  const url = buildChannelFeedUrl({ mpx, session, start, end })
-  const data = await axios
-    .get(url)
-    .then(r => r.data)
-    .catch(() => null)
+    const url = buildChannelFeedUrl({ mpx, session, start, end })
+    const data = await axios
+        .get(url)
+        .then(r => r.data)
+        .catch(() => null)
 
-  return Array.isArray(data && data.entries) ? data.entries : []
+    return Array.isArray(data && data.entries) ? data.entries : []
 }
 
 function buildChannelFeedUrl({ mpx, session, start, end }) {
-  const url = new URL(resolveFeedTemplate(mpx.feeds.allChannelStationsFeed, mpx.accountPid))
+    const url = new URL(resolveFeedTemplate(mpx.feeds.allChannelStationsFeed, mpx.accountPid))
 
-  url.searchParams.set('lang', 'short-de')
-  url.searchParams.set('sort', 'dt$displayChannelNumber')
-  url.searchParams.set('range', `${start}-${end}`)
-  url.searchParams.set('cid', buildCid(session))
+    url.searchParams.set('lang', 'short-de')
+    url.searchParams.set('sort', 'dt$displayChannelNumber')
+    url.searchParams.set('range', `${start}-${end}`)
+    url.searchParams.set('cid', buildCid(session))
 
-  return url.toString()
+    return url.toString()
 }
 
 function buildScheduleUrl({ mpx, session, siteIds, window }) {
-  const url = new URL(resolveFeedTemplate(mpx.feeds.allChannelSchedulesFeed, mpx.accountPid))
+    const url = new URL(resolveFeedTemplate(mpx.feeds.allChannelSchedulesFeed, mpx.accountPid))
 
-  url.searchParams.set('byId', siteIds.join('|'))
-  url.searchParams.set('byListingTime', window)
-  url.searchParams.set('byLocationId', mpx.locationIdUri)
-  url.searchParams.set('cid', buildCid(session))
+    url.searchParams.set('byId', siteIds.join('|'))
+    url.searchParams.set('byListingTime', window)
+    url.searchParams.set('byLocationId', mpx.locationIdUri)
+    url.searchParams.set('cid', buildCid(session))
 
-  return url.toString()
+    return url.toString()
 }
 
 function resolveFeedTemplate(template, accountPid) {
-  return template.replaceAll('{MpxAccountPid}', accountPid)
+    return template.replaceAll('{MpxAccountPid}', accountPid)
 }
 
 function getUtcWindow(date) {
-  const start = date.utc().startOf('day')
-  const end = start.add(1, 'day')
+    const start = date.utc().startOf('day')
+    const end = start.add(1, 'day')
 
-  return `${start.toISOString()}~${end.toISOString()}`
+    return `${start.toISOString()}~${end.toISOString()}`
 }
 
 function parseScheduleResponse(content, channel) {
-  const data = parseJson(content)
-  const entries = Array.isArray(data && data.entries) ? data.entries : []
-  const targetSiteId = channel && channel.site_id ? String(channel.site_id) : null
-  const programs = []
+    const data = parseJson(content)
+    const entries = Array.isArray(data && data.entries) ? data.entries : []
+    const targetSiteId = channel && channel.site_id ? String(channel.site_id) : null
+    const programs = []
 
-  entries.forEach(entry => {
-    if (targetSiteId && extractNumericId(entry.id) !== targetSiteId) return
-    if (!Array.isArray(entry.listings)) return
+    entries.forEach(entry => {
+        if (targetSiteId && extractNumericId(entry.id) !== targetSiteId) return
+        if (!Array.isArray(entry.listings)) return
 
-    entry.listings.forEach(listing => {
-      const program = parseProgramme(entry, listing)
-      if (program) programs.push(program)
+        entry.listings.forEach(listing => {
+            const program = parseProgramme(entry, listing)
+            if (program) programs.push(program)
+        })
     })
-  })
 
-  return programs
+    return programs
 }
 
-function parseChannel(entry) {
-  if (!entry || entry['dt$isRadio']) return null
+function parseChannel(entry, database) {
+    if (!entry || entry['dt$isRadio']) return null
 
-  const station = getFirstStation(entry)
-  const siteId = extractNumericId(entry.id)
-  const name = station && station.title ? station.title : entry.title
+    const station = getFirstStation(entry)
+    const siteId = extractNumericId(entry.id)
 
-  if (!station || !siteId || !name) return null
+    if (!station || !siteId) return null
 
-  return {
-    lang: 'de',
-    site_id: siteId,
-    name
-  }
+    const quality = parseChannelQuality(entry, station)
+    const name = parseChannelName(entry, station, quality)
+
+    if (!name) return null
+
+    return {
+        lang: 'de',
+        site_id: siteId,
+        xmltv_id: resolveXmltvId(entry, station, name, quality, database),
+        name
+    }
+}
+
+function resolveXmltvId(entry, station, displayName, quality, database) {
+    const match = database.channels.length
+        ? findChannelMatch(entry, station, quality, database.channels)
+        : null
+
+    const baseName = parseBaseChannelName(entry, station, quality)
+    const channelId = match ? match.channel.id : buildGeneratedChannelId(baseName)
+
+    if (!channelId) return ''
+
+    const feeds = match ? database.feedsByChannel.get(match.channel.id) || [] : []
+    const feed = match ? findFeedMatch(displayName, quality, match, feeds) : null
+    const feedId = feed ? feed.id : buildGeneratedFeedId(quality)
+
+    return feedId ? `${channelId}@${feedId}` : channelId
+}
+
+function findChannelMatch(entry, station, quality, channels) {
+    const providerNames = getProviderChannelNames(entry, station, quality)
+    const matches = []
+
+    channels.forEach(channel => {
+        const databaseNames = [channel.name, ...(channel.alt_names || [])]
+            .filter(Boolean)
+            .map(name => ({
+                value: name,
+                normalized: normalizeName(name)
+            }))
+            .filter(item => item.normalized)
+
+        let bestScore = 0
+        let matchedName = null
+
+        providerNames.forEach(providerName => {
+            databaseNames.forEach(databaseName => {
+                if (providerName.normalized === databaseName.normalized) {
+                    const score = providerName.weight + 100
+
+                    if (score > bestScore) {
+                        bestScore = score
+                        matchedName = databaseName.value
+                    }
+
+                    return
+                }
+
+                if (
+                    databaseName.normalized.length >= 4 &&
+                    providerName.normalized.startsWith(databaseName.normalized)
+                ) {
+                    const score =
+                        providerName.weight + 40 + Math.min(databaseName.normalized.length, 30)
+
+                    if (score > bestScore) {
+                        bestScore = score
+                        matchedName = databaseName.value
+                    }
+                }
+            })
+        })
+
+        if (!bestScore || !matchedName) return
+
+        if (channel.country === 'DE') bestScore += 15
+        if (channel.closed || channel.replaced_by) bestScore -= 100
+
+        matches.push({
+            channel,
+            matchedName,
+            score: bestScore
+        })
+    })
+
+    matches.sort((a, b) => b.score - a.score)
+
+    if (!matches.length || matches[0].score <= 0) return null
+    if (matches[1] && matches[0].score === matches[1].score) return null
+
+    return matches[0]
+}
+
+function getProviderChannelNames(entry, station, quality) {
+    const names = [
+        {
+            value: station.title,
+            weight: 100
+        },
+        {
+            value: stripQuality(cleanChannelTitle(entry.title), quality),
+            weight: 95
+        },
+        {
+            value: stripQuality(humanizeProviderId(station['dt$serviceId']), quality),
+            weight: 75
+        },
+        {
+            value: stripQuality(humanizeProviderId(station.guid), quality),
+            weight: 70
+        }
+    ]
+
+    const seen = new Set()
+
+    return names
+        .filter(item => item.value)
+        .map(item => ({
+            ...item,
+            normalized: normalizeName(item.value)
+        }))
+        .filter(item => {
+            if (!item.normalized || seen.has(item.normalized)) return false
+
+            seen.add(item.normalized)
+
+            return true
+        })
+}
+
+function findFeedMatch(displayName, quality, channelMatch, feeds) {
+    if (!feeds.length) return null
+
+    if (quality.kind === 'UNKNOWN') {
+        const mainFeeds = feeds.filter(feed => feed.is_main)
+
+        if (mainFeeds.length === 1) return mainFeeds[0]
+        if (feeds.length === 1) return feeds[0]
+
+        return null
+    }
+
+    const compatibleFeeds = feeds.filter(feed => isFeedCompatibleWithQuality(feed, quality))
+
+    if (!compatibleFeeds.length) return null
+
+    const providerVariant = getProviderVariant(
+        displayName,
+        channelMatch.matchedName,
+        quality
+    )
+
+    const matches = compatibleFeeds.map(feed => {
+        let score = 0
+
+        const feedNames = [feed.id, feed.name, ...(feed.alt_names || [])]
+            .filter(Boolean)
+            .map(normalizeName)
+            .filter(Boolean)
+
+        if (providerVariant) {
+            const variantWithoutQuality = stripNormalizedQuality(providerVariant, quality)
+
+            feedNames.forEach(feedName => {
+                if (feedName === providerVariant) {
+                    score = Math.max(score, 180)
+                }
+
+                if (variantWithoutQuality && feedName === variantWithoutQuality) {
+                    score = Math.max(score, 160)
+                }
+
+                if (feedName && providerVariant.startsWith(feedName)) {
+                    score = Math.max(score, 120)
+                }
+            })
+        }
+
+        const qualityAliases = getNormalizedQualityAliases(quality)
+
+        feedNames.forEach(feedName => {
+            if (qualityAliases.includes(feedName)) {
+                score = Math.max(score, 110)
+            }
+
+            if (qualityAliases.some(alias => alias && feedName.endsWith(alias))) {
+                score = Math.max(score, 90)
+            }
+        })
+
+        if (quality.formats.includes(feed.format)) score += 60
+        if ((feed.broadcast_area || []).includes('c/DE')) score += 30
+        if ((feed.timezones || []).includes('Europe/Berlin')) score += 15
+        if ((feed.languages || []).includes('deu')) score += 10
+        if (feed.is_main) score += 2
+
+        return {
+            feed,
+            score
+        }
+    })
+
+    matches.sort((a, b) => b.score - a.score)
+
+    if (!matches.length || matches[0].score <= 0) return null
+    if (matches[1] && matches[0].score === matches[1].score) return null
+
+    return matches[0].feed
+}
+
+function isFeedCompatibleWithQuality(feed, quality) {
+    if (quality.kind === 'UNKNOWN') return true
+
+    const feedNames = [feed.id, feed.name, ...(feed.alt_names || [])]
+        .filter(Boolean)
+        .map(normalizeName)
+
+    const aliases = getNormalizedQualityAliases(quality)
+
+    if (feedNames.some(name => aliases.some(alias => alias && name.endsWith(alias)))) {
+        return true
+    }
+
+    return quality.formats.includes(feed.format)
+}
+
+function getProviderVariant(displayName, matchedChannelName, quality) {
+    const providerName = normalizeName(displayName)
+    const channelName = normalizeName(matchedChannelName)
+
+    if (!providerName || !channelName || !providerName.startsWith(channelName)) {
+        return ''
+    }
+
+    return stripNormalizedQuality(providerName.slice(channelName.length), quality)
+}
+
+function stripNormalizedQuality(value, quality) {
+    let normalized = value
+
+    getNormalizedQualityAliases(quality).forEach(alias => {
+        if (alias && normalized.endsWith(alias)) {
+            normalized = normalized.slice(0, -alias.length)
+        }
+    })
+
+    return normalized
+}
+
+function getNormalizedQualityAliases(quality) {
+    const aliases = quality.definition ? quality.definition.aliases : [quality.raw]
+
+    return aliases.map(normalizeName).filter(Boolean)
+}
+
+function parseChannelQuality(entry, station) {
+    const explicitQuality = normalizeWhitespace(station['dt$quality'])
+
+    if (explicitQuality) {
+        const definition = findQualityDefinition(explicitQuality)
+        const detectedQuality = definition ? null : findQualityInText(explicitQuality)
+
+        if (detectedQuality) {
+            return {
+                ...detectedQuality,
+                raw: explicitQuality
+            }
+        }
+
+        return {
+            kind: definition ? definition.kind : 'OTHER',
+            label: definition ? definition.label : explicitQuality,
+            raw: explicitQuality,
+            formats: definition ? definition.formats : [],
+            definition
+        }
+    }
+
+    const values = [entry.title, station.guid, station['dt$serviceId']]
+
+    for (const value of values) {
+        const match = findQualityInText(value)
+        if (match) return match
+    }
+
+    if (station.isHd === true) {
+        const definition = QUALITY_DEFINITIONS.find(item => item.kind === 'HD')
+
+        return {
+            kind: definition.kind,
+            label: definition.label,
+            raw: definition.label,
+            formats: definition.formats,
+            definition
+        }
+    }
+
+    return {
+        kind: 'UNKNOWN',
+        label: null,
+        raw: null,
+        formats: [],
+        definition: null
+    }
+}
+
+function findQualityDefinition(value) {
+    const normalized = normalizeName(value)
+
+    return QUALITY_DEFINITIONS.find(definition =>
+        definition.aliases.some(alias => normalizeName(alias) === normalized)
+    )
+}
+
+function findQualityInText(value) {
+    if (!value || typeof value !== 'string') return null
+
+    const text = value.replaceAll(/[_-]+/g, ' ')
+
+    for (const definition of QUALITY_DEFINITIONS) {
+        for (const alias of definition.aliases) {
+            const pattern = new RegExp(
+                `(^|[^a-z0-9])${escapeRegExp(alias)}($|[^a-z0-9])`,
+                'i'
+            )
+
+            if (!pattern.test(text)) continue
+
+            return {
+                kind: definition.kind,
+                label: definition.label,
+                raw: alias,
+                formats: definition.formats,
+                definition
+            }
+        }
+    }
+
+    return null
+}
+
+function parseChannelName(entry, station, quality) {
+    return parseBaseChannelName(entry, station, quality) || null
+}
+
+function parseBaseChannelName(entry, station, quality) {
+    const stationName = normalizeWhitespace(station.title)
+    const providerName = cleanChannelTitle(entry.title)
+    const baseName = stationName || providerName
+
+    return stripQuality(baseName, quality)
+}
+
+function buildGeneratedChannelId(name) {
+    if (!name) return ''
+
+    const id = String(name)
+        .normalize('NFKD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replaceAll('ß', 'ss')
+        .replaceAll('&', 'and')
+        .replaceAll('+', 'Plus')
+        .replace(/[^a-z0-9]/gi, '')
+
+    return id ? `${id}.de` : ''
+}
+
+function buildGeneratedFeedId(quality) {
+    if (!quality || quality.kind === 'UNKNOWN') return ''
+
+    if (quality.label) {
+        return sanitizeIdPart(quality.label)
+    }
+
+    return sanitizeIdPart(quality.raw)
+}
+
+function sanitizeIdPart(value) {
+    return String(value || '')
+        .normalize('NFKD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replaceAll('ß', 'ss')
+        .replace(/[^a-z0-9]/gi, '')
+}
+
+function cleanChannelTitle(value) {
+    return normalizeWhitespace(value)
+        .replace(/\s+-\s+Main$/i, '')
+        .trim()
+}
+
+function stripQuality(value, quality) {
+    let result = normalizeWhitespace(value)
+
+    if (!result) return ''
+
+    const aliases = quality.definition ? quality.definition.aliases : [quality.raw]
+
+    aliases.filter(Boolean).forEach(alias => {
+        const pattern = new RegExp(
+            `(^|[^a-z0-9])${escapeRegExp(alias)}(?=$|[^a-z0-9])`,
+            'gi'
+        )
+
+        result = result.replace(pattern, '$1')
+    })
+
+    return normalizeWhitespace(result)
+}
+
+function humanizeProviderId(value) {
+    if (!value || typeof value !== 'string') return ''
+
+    return normalizeWhitespace(value.replaceAll(/[_-]+/g, ' '))
+}
+
+function normalizeName(value) {
+    if (!value) return ''
+
+    return String(value)
+        .normalize('NFKD')
+        .replace(/\p{Diacritic}/gu, '')
+        .replaceAll('ß', 'ss')
+        .replaceAll('&', 'and')
+        .replaceAll('+', 'plus')
+        .replace(/[^a-z0-9]/gi, '')
+        .toLowerCase()
+}
+
+function normalizeWhitespace(value) {
+    return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function parseProgramme(entry, listing) {
-  if (
-    !listing ||
-    !listing.program ||
-    listing.startTime === null ||
-    listing.startTime === undefined ||
-    listing.endTime === null ||
-    listing.endTime === undefined
-  ) {
-    return null
-  }
+    if (
+        !listing ||
+        !listing.program ||
+        listing.startTime === null ||
+        listing.startTime === undefined ||
+        listing.endTime === null ||
+        listing.endTime === undefined
+    ) {
+        return null
+    }
 
-  const program = listing.program
-  const programInfo = parseProgramInfo(listing['dt$programInfo'])
-  const title = program.title
+    const program = listing.program
+    const programInfo = parseProgramInfo(listing['dt$programInfo'])
+    const title = program.title
 
-  if (!title) return null
+    if (!title) return null
 
-  const parsed = {
-    title,
-    description: program.description || null,
-    category: parseCategories(program.tags),
-    sub_title: parseSubTitle(program, listing),
-    rating: parseRating(program.ratings),
-    season: normalizeNumber(program.tvSeasonNumber ?? programInfo.tvSeasonNumber),
-    episode: normalizeNumber(
-      program.tvSeasonEpisodeNumber ??
-        programInfo.tvSeasonEpisodeNumber ??
-        programInfo.seriesEpisodeNumber
-    ),
-    image: parseProgramImage(program),
-    icon: parseProgramImage(program),
-    start: dayjs(Number(listing.startTime)),
-    stop: dayjs(Number(listing.endTime)),
-    country: parseCountry(program['dt$countries']),
-    date: program.year ? String(program.year) : null
-  }
+    const parsed = {
+        title,
+        description: program.description || null,
+        category: parseCategories(program.tags),
+        sub_title: parseSubTitle(program, listing),
+        rating: parseRating(program.ratings),
+        season: normalizeNumber(program.tvSeasonNumber ?? programInfo.tvSeasonNumber),
+        episode: normalizeNumber(
+            program.tvSeasonEpisodeNumber ??
+            programInfo.tvSeasonEpisodeNumber ??
+            programInfo.seriesEpisodeNumber
+        ),
+        image: parseProgramImage(program),
+        icon: parseProgramImage(program),
+        start: dayjs(Number(listing.startTime)),
+        stop: dayjs(Number(listing.endTime)),
+        country: parseCountry(program['dt$countries']),
+        date: program.year ? String(program.year) : null
+    }
 
-  if (parsed.image === null) delete parsed.image
-  if (parsed.icon === null) delete parsed.icon
-  if (parsed.category === null) delete parsed.category
-  if (parsed.sub_title === null) delete parsed.sub_title
-  if (parsed.rating === null) delete parsed.rating
-  if (parsed.season === null) delete parsed.season
-  if (parsed.episode === null) delete parsed.episode
-  if (parsed.country === null) delete parsed.country
-  if (parsed.date === null) delete parsed.date
+    if (parsed.image === null) delete parsed.image
+    if (parsed.icon === null) delete parsed.icon
+    if (parsed.category === null) delete parsed.category
+    if (parsed.sub_title === null) delete parsed.sub_title
+    if (parsed.rating === null) delete parsed.rating
+    if (parsed.season === null) delete parsed.season
+    if (parsed.episode === null) delete parsed.episode
+    if (parsed.country === null) delete parsed.country
+    if (parsed.date === null) delete parsed.date
 
-  return parsed
+    return parsed
 }
 
 function parseSubTitle(program, listing) {
-  if (program.secondaryTitle && program.secondaryTitle !== program.title) {
-    return program.secondaryTitle
-  }
+    if (program.secondaryTitle && program.secondaryTitle !== program.title) {
+        return program.secondaryTitle
+    }
 
-  if (listing['dt$seriesTitle'] && listing['dt$seriesTitle'] !== program.title) {
-    return listing['dt$seriesTitle']
-  }
+    if (listing['dt$seriesTitle'] && listing['dt$seriesTitle'] !== program.title) {
+        return listing['dt$seriesTitle']
+    }
 
-  return null
+    return null
 }
 
 function parseCategories(tags) {
-  if (!Array.isArray(tags)) return null
+    if (!Array.isArray(tags)) return null
 
-  const categories = tags
-    .filter(tag => ['category', 'genre-primary', 'genre-secondary'].includes(tag.scheme) && tag.title)
-    .map(tag => tag.title)
+    const categories = tags
+        .filter(
+            tag =>
+                ['category', 'genre-primary', 'genre-secondary'].includes(tag.scheme) &&
+                tag.title
+        )
+        .map(tag => tag.title)
 
-  return categories.length ? [...new Set(categories)] : null
+    return categories.length ? [...new Set(categories)] : null
 }
 
 function parseRating(ratings) {
-  if (!Array.isArray(ratings)) return null
+    if (!Array.isArray(ratings)) return null
 
-  const rating = ratings.find(item => item && item.rating && item.rating !== 'UNKNOWN')
-  if (!rating) return null
+    const rating = ratings.find(item => item && item.rating && item.rating !== 'UNKNOWN')
 
-  return {
-    system: rating.scheme || 'magenta',
-    value: rating.rating
-  }
+    if (!rating) return null
+
+    return {
+        system: rating.scheme || 'magenta',
+        value: rating.rating
+    }
 }
 
 function parseProgramInfo(value) {
-  if (!value || typeof value !== 'string') return {}
+    if (!value || typeof value !== 'string') return {}
 
-  try {
-    return JSON.parse(value.replaceAll("'", '"'))
-  } catch {
-    return {}
-  }
+    try {
+        return JSON.parse(value.replaceAll("'", '"'))
+    } catch {
+        return {}
+    }
 }
 
 function parseProgramImage(program) {
-  if (!program || !program.thumbnails) return null
+    if (!program || !program.thumbnails) return null
 
-  const thumbnails = Object.values(program.thumbnails)
-    .filter(thumbnail => thumbnail && thumbnail.url)
-    .sort((a, b) => (b.width || 0) * (b.height || 0) - (a.width || 0) * (a.height || 0))
+    const thumbnails = Object.values(program.thumbnails)
+        .filter(thumbnail => thumbnail && thumbnail.url)
+        .sort(
+            (a, b) =>
+                (b.width || 0) * (b.height || 0) -
+                (a.width || 0) * (a.height || 0)
+        )
 
-  return thumbnails[0] ? thumbnails[0].url : null
+    return thumbnails[0] ? thumbnails[0].url : null
 }
 
 function parseCountry(value) {
-  if (!value || typeof value !== 'string') return null
-  return value.toUpperCase()
+    if (!value || typeof value !== 'string') return null
+
+    return value.toUpperCase()
 }
 
 function getFirstStation(entry) {
-  if (!entry || !entry.stations || typeof entry.stations !== 'object') return null
-  return Object.values(entry.stations)[0] || null
+    if (!entry || !entry.stations || typeof entry.stations !== 'object') {
+        return null
+    }
+
+    return Object.values(entry.stations)[0] || null
 }
 
 function extractNumericId(uri) {
-  if (!uri || typeof uri !== 'string') return null
-  const match = uri.match(/(\d+)(?!.*\d)/)
-  return match ? match[1] : null
+    if (!uri || typeof uri !== 'string') return null
+
+    const match = uri.match(/(\d+)(?!.*\d)/)
+
+    return match ? match[1] : null
 }
 
 function normalizeNumber(value) {
-  return value === null || value === undefined || value === '' ? null : value
+    return value === null || value === undefined || value === '' ? null : value
 }
 
 function parseJson(content) {
-  if (!content) return {}
-  if (typeof content !== 'string') return content
+    if (!content) return {}
+    if (typeof content !== 'string') return content
 
-  try {
-    return JSON.parse(content)
-  } catch {
-    return {}
-  }
+    try {
+        return JSON.parse(content)
+    } catch {
+        return {}
+    }
 }


### PR DESCRIPTION
## Summary

- automatically derive `xmltv_id` values for `www.magenta.tv` channels from MagentaTV provider metadata
- prefer canonical channel and feed IDs from the local iptv-org database
- generate deterministic fallback IDs for channels or feed variants that are not yet present in the database
- support SD, HD, UHD, 4K, 2160p and other provider quality values
- prefer config-generated IDs when refreshing an existing channel list

## Changes

### Channel ID generation

The MagentaTV channel parser now uses the provider metadata available for each station, including:

- station title
- channel title
- `dt$quality`
- `dt$serviceId`
- station GUID
- channel logos

The resolver first attempts to match the station against the locally downloaded iptv-org channel and feed data.

For example:

```text
RTL + HD  -> RTL.de@HD
RTL + SD  -> RTL.de@SD
RTL + UHD -> RTL.de@UHD
````

When no canonical database entry can be found, a deterministic fallback ID is generated from the provider name and quality:

```text
FUSSBALL.TV 1 + HD  -> FUSSBALLTV1.de@HD
FUSSBALL.TV 1 + UHD -> FUSSBALLTV1.de@UHD
```

The quality is encoded in the feed portion of the `xmltv_id` and is no longer required in the channel display name.

### Channel list refresh

`channels:parse` now prefers an ID returned by the site config and only falls back to the existing XML value when the config does not provide one.

This prevents stale or empty values in an existing `*.channels.xml` file from overwriting newly generated IDs.

## Testing

```sh
npm test -- tests/commands/channels/parse.test.ts
npm test -- www.magenta.tv

npx eslint \
  scripts/commands/channels/parse.ts \
  tests/commands/channels/parse.test.ts \
  sites/www.magenta.tv/www.magenta.tv.config.js \
  sites/www.magenta.tv/www.magenta.tv.test.js

npm run channels:parse -- \
  --config=./sites/www.magenta.tv/www.magenta.tv.config.js \
  --output=./sites/www.magenta.tv/www.magenta.tv.channels.xml

npm run channels:lint -- \
  sites/www.magenta.tv/www.magenta.tv.channels.xml

npm run channels:validate -- \
  sites/www.magenta.tv/www.magenta.tv.channels.xml
```

```
