### PR TITLE
Fix jiotv.com program image URLs

### DIFF
--- a/sites/jiotv.com/jiotv.com.config.js
+++ b/sites/jiotv.com/jiotv.com.config.js
@@ -64,15 +64,19 @@ function parseList(string) {
 }
 
 function parseIcon(item) {
-  return item.episodeThumbnail
-    ? `https://jiotvimages.cdn.jio.com/dare_images/shows/700/-/${item.episodeThumbnail}`
-    : null
+  return parseImageUrl(item.episodeThumbnail)
 }
 
 function parseImage(item) {
-  return item.episodePoster
-    ? `https://jiotvimages.cdn.jio.com/dare_images/shows/700/-/${item.episodePoster}`
-    : null
+  return parseImageUrl(item.episodePoster)
+}
+
+function parseImageUrl(value) {
+  if (!value) return null
+  // paths like "epgdata/<hash>.jpg" are served from the CDN root, not from /dare_images/shows/<width>/-/
+  if (value.startsWith('epgdata/')) return `https://jiotvimages.cdn.jio.com/${value}`
+
+  return `https://jiotvimages.cdn.jio.com/dare_images/shows/700/-/${value}`
 }
 
 function parseItems(content) {

--- a/sites/jiotv.com/jiotv.com.test.js
+++ b/sites/jiotv.com/jiotv.com.test.js
@@ -79,6 +79,29 @@ it('can parse response', () => {
   })
 })
 
+it('can parse images served from the epgdata path', () => {
+  const content = JSON.stringify({
+    epg: [
+      {
+        showname: 'Power Lunch',
+        director: '',
+        starCast: '',
+        episodeThumbnail: 'epgdata/0e9fd651fd47416d3308954342235146.jpg',
+        episodePoster: 'epgdata/0e9fd651fd47416d3308954342235146.jpg',
+        startEpoch: 1753641000000,
+        endEpoch: 1753642800000
+      }
+    ]
+  })
+
+  const results = parser({ content })
+
+  expect(results[0]).toMatchObject({
+    icon: 'https://jiotvimages.cdn.jio.com/epgdata/0e9fd651fd47416d3308954342235146.jpg',
+    image: 'https://jiotvimages.cdn.jio.com/epgdata/0e9fd651fd47416d3308954342235146.jpg'
+  })
+})
+
 it('can handle empty guide', () => {
   const results = parser({
     content: ''


### PR DESCRIPTION
Fixes #3216

The EPG API now returns image paths prefixed with `epgdata/` (e.g. `epgdata/0e9fd651fd47416d3308954342235146.jpg`). The parser was prepending the old base `https://jiotvimages.cdn.jio.com/dare_images/shows/700/-/`, producing URLs that 404.

Checked against the live CDN:

- `https://jiotvimages.cdn.jio.com/dare_images/shows/700/-/epgdata/<hash>.jpg` → **404** (current output)
- `https://jiotvimages.cdn.jio.com/epgdata/<hash>.jpg` → **200**

All `episodeThumbnail`/`episodePoster` values sampled across several channels (143, 154, 289) now use the `epgdata/` format, so the parser routes those to the CDN root and keeps the legacy `dare_images/shows/700/-/` base as a fallback for old-style paths (which is also what the stored test fixture uses).

Added a test case for the new format; `npm test -- jiotv.com` passes (4/4).