### PR TITLE
Drop implausible season/episode numbers in ziggogo.tv

### DIFF
--- a/sites/ziggogo.tv/ziggogo.tv.config.js
+++ b/sites/ziggogo.tv/ziggogo.tv.config.js
@@ -72,8 +72,8 @@ module.exports = {
           subTitle: event.episodeName,
           description: event.longDescription ? event.longDescription : event.shortDescription,
           category: event.genres,
-          season: event.seasonNumber,
-          episode: event.episodeNumber,
+          season: parsePlausibleNumber(event.seasonNumber, 1000),
+          episode: parsePlausibleNumber(event.episodeNumber, 100000),
           country: event.countryOfOrigin,
           actor: event.actors,
           director: event.directors,
@@ -113,6 +113,13 @@ module.exports = {
 
     return channels
   }
+}
+
+function parsePlausibleNumber(value, max) {
+  // events without real season/episode data carry internal ids in these fields
+  // (e.g. seasonNumber 93850000, episodeNumber 513104549); the ziggogo.tv
+  // frontend hides such values, so drop anything outside a plausible range
+  return value > 0 && value < max ? value : null
 }
 
 function segmentUrl(date, segment = 0) {

--- a/sites/ziggogo.tv/ziggogo.tv.test.js
+++ b/sites/ziggogo.tv/ziggogo.tv.test.js
@@ -67,8 +67,10 @@ it('can parse response', async () => {
     description:
       'Homeshoppingprogramma waarin de kijker via de telefoon allerlei producten kan aanschaffen.',
     category: ["Consumentenprogramma's", 'Shoppen'],
-    season: 78610000,
-    episode: 492767862
+    // The source sends internal ids here rather than real numbering
+    // (season 78610000, episode 492767862), so they are dropped.
+    season: null,
+    episode: null
   })
   expect(result[19]).toMatchObject({
     start: '2026-05-30T22:44:00.000Z',


### PR DESCRIPTION
Fixes #2977

Events without real season/episode data get internal ids leaked into `seasonNumber`/`episodeNumber` by the upstream API. Sampled live data today:

| title | seasonNumber | episodeNumber |
|---|---|---|
| UVandaag | 93850000 | 513104564 |
| Tekst TV | 5110000 | 513104549 |
| Route C | 5070000 | 2026073018 (encodes today's date) |

The ziggogo.tv frontend hides these values; this PR does the same by dropping `season` outside `(0, 1000)` and `episode` outside `(0, 100000)`. The gap between real data (seasons ≤ ~100, episodes ≤ ~10k for daily shows) and the garbage (≥ 5×10⁶) is several orders of magnitude, so the thresholds have wide safety margins on both sides — addressing the concern raised in the issue thread about long-running shows with 4-digit episode numbers, which are preserved.

Verified against today's live guide for NPO 1: 52 programmes parsed, real values kept (`S9 E10`, `S2 E11`), bogus ids now omitted.