### PR TITLE
Fix invalid VinTV and Canal NOS xmltv_ids in Portuguese channel lists

### DIFF
--- a/sites/meo.pt/meo.pt.channels.xml
+++ b/sites/meo.pt/meo.pt.channels.xml
@@ -201,7 +201,7 @@
   <channel site="meo.pt" site_id="UNIFE" lang="pt" xmltv_id="UnifeTV.pt@SD">Unifé TV</channel>
   <channel site="meo.pt" site_id="VEJA" lang="pt" xmltv_id="Veja.pt@SD">Veja</channel>
   <channel site="meo.pt" site_id="VENUS" lang="pt" xmltv_id="Venus.ar@SD">Venus</channel>
-  <channel site="meo.pt" site_id="VINTV" lang="pt" xmltv_id="VinTV.pt@SD">VinTV</channel>
+  <channel site="meo.pt" site_id="VINTV" lang="pt" xmltv_id="VinTV.pt@HD">VinTV</channel>
   <channel site="meo.pt" site_id="AZORES" lang="pt" xmltv_id="VITECAzoresTV.pt@SD">Azores TV</channel>
   <channel site="meo.pt" site_id="VIXEN" lang="pt" xmltv_id="VixenTV.ca@SD">VIXEN</channel>
   <channel site="meo.pt" site_id="VMAISTVI" lang="pt" xmltv_id="VPlusTVI.pt@SD">V+ TVI</channel>

--- a/sites/nostv.pt/nostv.pt.channels.xml
+++ b/sites/nostv.pt/nostv.pt.channels.xml
@@ -27,7 +27,7 @@
   <channel site="nostv.pt" site_id="588" lang="pt" xmltv_id="CanalGaleria.pt@SD">Canal Galeria</channel>
   <channel site="nostv.pt" site_id="14" lang="pt" xmltv_id="CanalHollywood.pt@SD">Canal Hollywood</channel>
   <channel site="nostv.pt" site_id="714" lang="pt" xmltv_id="CanalMacau.mo@SD">TDM</channel>
-  <channel site="nostv.pt" site_id="408" lang="pt" xmltv_id="CanalNOS.pt@HD">Canal NOS</channel>
+  <channel site="nostv.pt" site_id="408" lang="pt" xmltv_id="CanalNos.pt@SD">Canal NOS</channel>
   <channel site="nostv.pt" site_id="593" lang="pt" xmltv_id="CanalPanda.pt@SD">Canal Panda</channel>
   <channel site="nostv.pt" site_id="235" lang="pt" xmltv_id="CanalQ.pt@SD">Canal Q</channel>
   <channel site="nostv.pt" site_id="713" lang="pt" xmltv_id="Cartoonito.pt@SD">Cartoonito</channel>
@@ -149,7 +149,7 @@
   <channel site="nostv.pt" site_id="123" lang="pt" xmltv_id="TVRInternational.ro@SD">TVR Internacional</channel>
   <channel site="nostv.pt" site_id="708" lang="pt" xmltv_id="TVZimboInternacional.ao@HD">TV Zimbo</channel>
   <channel site="nostv.pt" site_id="689" lang="pt" xmltv_id="UnifeTV.pt@SD">Unifé TV</channel>
-  <channel site="nostv.pt" site_id="176" lang="pt" xmltv_id="VinTV.pt@SD">VinTV</channel>
+  <channel site="nostv.pt" site_id="176" lang="pt" xmltv_id="VinTV.pt@HD">VinTV</channel>
   <channel site="nostv.pt" site_id="571" lang="pt" xmltv_id="VITECAzoresTV.pt@SD">Azores TV</channel>
   <channel site="nostv.pt" site_id="574" lang="pt" xmltv_id="VPlusTVI.pt@SD">V+TVI</channel>
   <channel site="nostv.pt" site_id="701" lang="en" xmltv_id="WSport.za@SD">W-Sport</channel>


### PR DESCRIPTION
Related to #3196

The Biggs → VinTV rename requested in the issue is already applied on master, but three of the resulting `xmltv_id` values don't validate against the current channels database:

- `VinTV.pt@SD` (nostv.pt, meo.pt) — the only feed defined for `VinTV.pt` is `@HD` → updated both entries to `VinTV.pt@HD`
- `CanalNOS.pt@HD` (nostv.pt) — wrong casing and wrong feed: the database channel is `CanalNos.pt` and its only feed is `@SD` → updated to `CanalNos.pt@SD`

`npm run channels:validate` on both files: 0 errors, and the VinTV/CanalNos entries no longer appear among the warnings (the remaining 51 warnings are pre-existing entries unrelated to this change).

For the record, the other empty `xmltv_id` entries suggested in the issue (Horse TV, BNT World, Caça e Pesca, Canal Galeria, Canal Convidado, OneToro TV, New Brasil, HGTV Portugal) can't be filled yet — those channels/feeds don't exist in the database, which is why the issue author's own attempt failed `validate.ts`. They'd need to be added to iptv-org/database first.