### PR TITLE
fix: fix tv.dir.bg parsing previous date data

### DIFF
--- a/sites/tv.dir.bg/tv.dir.bg.config.js
+++ b/sites/tv.dir.bg/tv.dir.bg.config.js
@@ -204,6 +204,15 @@ function parseItems(content) {
     }
     
     const $ = cheerio.load(json.html)
+    // Now the site gives 3 columns (prev day, current day, next day)
+    // Before it was 2 columns (current day, next day)
+    const broadcasts = $('.day-broadcast-list')
+
+    // Remove prev day column
+    if (broadcasts.length >= 3) {
+      broadcasts.first().remove()
+    }
+    
     const items = $('.broadcast-item').toArray()
     
     return items

--- a/sites/tv.dir.bg/tv.dir.bg.test.js
+++ b/sites/tv.dir.bg/tv.dir.bg.test.js
@@ -25,15 +25,15 @@ it('can parse response', () => {
     return p
   })
 
- expect(results.length).toBe(63)
+ expect(results.length).toBe(46)
 
  expect(results[0]).toMatchObject({
-  start: '2025-06-30T03:00:00.000Z',
-  stop: '2025-06-30T03:30:00.000Z',
-  title: 'Светът на здравето'
+  start: '2025-06-30T03:15:00.000Z',
+  stop: '2025-06-30T03:57:00.000Z',
+  title: 'Лице в лице'
  })
 
- expect(results[62]).toMatchObject({
+ expect(results[45]).toMatchObject({
   start: '2025-07-01T02:00:00.000Z',
   stop: '2025-07-01T02:30:00.000Z',
   title: 'Убийства в Рая , сезон 1 , епизод 7'


### PR DESCRIPTION
tv.dir.bg EPG result saves guide with previous date as today and today as next day even if you set days as 1, since the website is having 3 columns with data (prev, current, next day) the previous date one must be skipped

https://github.com/iptv-org/epg/issues/3249