### PR TITLE
Add JTBS Classic EPG worker (jtbsclassic.dpdns.org/epg)

### DIFF
--- a/workers.txt
+++ b/workers.txt
@@ -1,3 +1,4 @@
 worker-9dd4.onrender.com
 raw.githubusercontent.com/StrangeDrVN/epg/public/output
 194.163.157.137:8080
+jtbsclassic.dpdns.org/epg/


### PR DESCRIPTION
### Community Guide Worker Submission for JTBS Classic

Added `jtbsclassic.dpdns.org/epg` to `workers.txt`.

#### Server Status Verification:
- **Worker JSON**: https://jtbsclassic.dpdns.org/epg/worker.json (HTTP 200 OK)
- **Channels XML**: https://jtbsclassic.dpdns.org/epg/channels.xml (HTTP 200 OK, xmltv_id="JTBSClassic.in")
- **Guide XML**: https://jtbsclassic.dpdns.org/main.epg.xml (HTTP 200 OK, <channel id="JTBSClassic.in">)

All endpoints are live, deployed on production, returning `Access-Control-Allow-Origin: *`, and fully compliant with CONTRIBUTING.md guidelines.
