### PR TITLE
fix ontvtonight parser for titles

### DIFF
--- a/sites/ontvtonight.com/ontvtonight.com.config.js
+++ b/sites/ontvtonight.com/ontvtonight.com.config.js
@@ -149,11 +149,11 @@ function parseStart($item, date, channel) {
 }
 
 function parseTitle($item) {
-  return $item.find('td:nth-child(2) > h5').text().trim()
+  return $item.find('td:nth-child(2) h5').text().trim()
 }
 
 function parseDescription($item) {
-  return $item.find('td:nth-child(2) > h6').text().trim()
+  return $item.find('td:nth-child(2) h6').text().trim()
 }
 
 function parseItems(content) {

--- a/sites/ontvtonight.com/ontvtonight.com.test.js
+++ b/sites/ontvtonight.com/ontvtonight.com.test.js
@@ -60,6 +60,37 @@ it('can parse response', () => {
   ])
 })
 
+it('can parse nested title and description markup', () => {
+  const content = `
+    <table>
+      <tbody>
+        <tr>
+          <td><h5>8:30 pm</h5></td>
+          <td>
+            <div>
+              <h5><a href="#">The Princess Diaries</a></h5>
+            </div>
+            <h6>Movie description</h6>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `
+
+  const result = parser({ content, channel, date }).map(p => {
+    p.start = p.start.toJSON()
+    p.stop = p.stop.toJSON()
+    return p
+  })
+
+  expect(result).toMatchObject([
+    {
+      title: 'The Princess Diaries',
+      description: 'Movie description'
+    }
+  ])
+})
+
 it('can handle empty guide', () => {
   const result = parser({
     date,


### PR DESCRIPTION
I would assume the HTML itself has updated for ontvtonight.

The output when running the grab is consistently just descriptions without titles in the XML. This would look like
```
<programme start="20260819020000 +0000" stop="20260819030000 +0000" channel="us#number"><desc lang="en">insert description</desc></programme>
```

Let me know if this is acceptable or if there is a better approach to solve this, thanks!