### PR TITLE
fix telebilbao.es accents

### DIFF
--- a/sites/telebilbao.es/telebilbao.es.config.js
+++ b/sites/telebilbao.es/telebilbao.es.config.js
@@ -24,7 +24,7 @@ module.exports = {
     let programs = []
     const items = parseItems(content, date)
     items.forEach(item => {
-      const prev = programs[programs.length - 1]
+      const prev = programs.at(-1)
       let start = parseStart(item, date)
       if (prev) {
         if (start.isBefore(prev.start)) {
@@ -50,12 +50,19 @@ function parseStart(item, date) {
   return dayjs.tz(`${date.format('YYYY-MM-DD')} ${item.time}`, 'YYYY-MM-DD HH:mm', 'Europe/Madrid')
 }
 
+function removeAccents(value) {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+}
+
 function parseItems(content, date) {
   const $ = cheerio.load(content)
   const tableHtml = $('table.programacion').html()
   let tableArray = table2array(`<table>${tableHtml}</table>`)
-  const day = date.locale('es').format('dddd\nD MMMM').toUpperCase()
+  const day = removeAccents(date.locale('es').format('dddd\nD MMMM')).toUpperCase()
   if (!tableArray[0]) return []
+  for(let i = 0; i < tableArray[0].length; i++) {
+    tableArray[0][i] = removeAccents(tableArray[0][i]).toUpperCase()
+  }
   const indexOfColumn = tableArray[0].indexOf(day)
   tableArray.pop()
   const items = []

--- a/sites/telebilbao.es/telebilbao.es.test.js
+++ b/sites/telebilbao.es/telebilbao.es.test.js
@@ -35,6 +35,16 @@ it('can parse response', () => {
   })
 })
 
+it('can parse response with accents', () => {
+  const date = dayjs.utc('2025-01-18', 'YYYY-MM-DD').startOf('d')
+  const content = fs.readFileSync(path.resolve(__dirname, '__data__/content.html'))
+  let results = parser({ content, date })
+
+  expect(results.length).toBe(50)
+
+  results.forEach(r => expect(r.title).not.toBeUndefined())
+})
+
 it('can handle empty guide', () => {
   const results = parser({
     date,


### PR DESCRIPTION
https://github.com/iptv-org/epg/blob/335458005387e07417a98399eb423c78d62a3bd9/sites/telebilbao.es/telebilbao.es.config.js#L57

That code returns the days in spanish with accents (e.g., MIÉRCOLES)

But on the website, they don’t have accents, so in those cases `indexOfColumn` returns `-1` and causes `title` to be undefined.

https://github.com/iptv-org/epg/blob/335458005387e07417a98399eb423c78d62a3bd9/sites/telebilbao.es/telebilbao.es.config.js#L59

What I’m doing in this PR is normalizing the text to remove the accents and capitalize both words, just in case they might appear in lowercase on the website due to a typo.

I've added a test that checks for a day with an accent (SÁBADO) and verifies that no title is undefined.