### PR TITLE
Fix movistarplus.es logos and update channel list

### DIFF
--- a/sites/movistarplus.es/movistarplus.es.channels.xml
+++ b/sites/movistarplus.es/movistarplus.es.channels.xml
@@ -1,141 +1,146 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <channels>
-  <channel site="movistarplus.es" site_id="13TV" lang="es" xmltv_id="">TRECE</channel>
-  <channel site="movistarplus.es" site_id="24H" lang="es" xmltv_id="">24 Horas</channel>
-  <channel site="movistarplus.es" site_id="A3" lang="es" xmltv_id="">Antena 3</channel>
-  <channel site="movistarplus.es" site_id="ALJAZE" lang="es" xmltv_id="">Al Jazeera English</channel>
-  <channel site="movistarplus.es" site_id="ANTV" lang="es" xmltv_id="">Canal Sur Andalucía</channel>
-  <channel site="movistarplus.es" site_id="ARAGON" lang="es" xmltv_id="">Aragón TV Int</channel>
-  <channel site="movistarplus.es" site_id="ARTHUR" lang="es" xmltv_id="">M+ Deportes 2</channel>
-  <channel site="movistarplus.es" site_id="ATRESS" lang="es" xmltv_id="">Atreseries</channel>
-  <channel site="movistarplus.es" site_id="AXN" lang="es" xmltv_id="">AXN</channel>
-  <channel site="movistarplus.es" site_id="BABY" lang="es" xmltv_id="">Baby TV</channel>
-  <channel site="movistarplus.es" site_id="BBC" lang="es" xmltv_id="">BBC News</channel>
-  <channel site="movistarplus.es" site_id="BBCEAR" lang="es" xmltv_id="">BBC Earth</channel>
-  <channel site="movistarplus.es" site_id="BBCLIF" lang="es" xmltv_id="">BBC Lifestyle</channel>
-  <channel site="movistarplus.es" site_id="BBDRA" lang="es" xmltv_id="">BBC Series</channel>
-  <channel site="movistarplus.es" site_id="BBFOO" lang="es" xmltv_id="">BBC Food</channel>
-  <channel site="movistarplus.es" site_id="BBGEA" lang="es" xmltv_id="">BBC Top Gear</channel>
-  <channel site="movistarplus.es" site_id="BBHIS" lang="es" xmltv_id="">BBC History</channel>
-  <channel site="movistarplus.es" site_id="BEMAD" lang="es" xmltv_id="">BE MAD</channel>
-  <channel site="movistarplus.es" site_id="BL" lang="es" xmltv_id="">Bloomberg</channel>
-  <channel site="movistarplus.es" site_id="BOING" lang="es" xmltv_id="">Boing</channel>
-  <channel site="movistarplus.es" site_id="C4" lang="es" xmltv_id="">Cuatro</channel>
-  <channel site="movistarplus.es" site_id="CAZPES" lang="es" xmltv_id="">Caza y Pesca</channel>
-  <channel site="movistarplus.es" site_id="CCTV-E" lang="es" xmltv_id="">CGTN Español</channel>
-  <channel site="movistarplus.es" site_id="CHAP1" lang="es" xmltv_id="">M+ Liga de Campeones 2</channel>
-  <channel site="movistarplus.es" site_id="CHAP2" lang="es" xmltv_id="">M+ Liga de Campeones 3</channel>
-  <channel site="movistarplus.es" site_id="CHAP3" lang="es" xmltv_id="">M+ Liga de Campeones 4</channel>
-  <channel site="movistarplus.es" site_id="CHAP4" lang="es" xmltv_id="">M+ Liga de Campeones 5</channel>
-  <channel site="movistarplus.es" site_id="CHAP5" lang="es" xmltv_id="">M+ Liga de Campeones 6</channel>
-  <channel site="movistarplus.es" site_id="CHAP6" lang="es" xmltv_id="">M+ Liga de Campeones 7</channel>
-  <channel site="movistarplus.es" site_id="CHAP7" lang="es" xmltv_id="">M+ Liga de Campeones 8</channel>
-  <channel site="movistarplus.es" site_id="CHAP8" lang="es" xmltv_id="">M+ Liga de Campeones 9</channel>
-  <channel site="movistarplus.es" site_id="CHAP9" lang="es" xmltv_id="">M+ Liga de Campeones 10</channel>
-  <channel site="movistarplus.es" site_id="CHAP10" lang="es" xmltv_id="">M+ Liga de Campeones 11</channel>
-  <channel site="movistarplus.es" site_id="CHAP11" lang="es" xmltv_id="">M+ Liga de Campeones 12</channel>
-  <channel site="movistarplus.es" site_id="CHAP12" lang="es" xmltv_id="">M+ Liga de Campeones 13</channel>
-  <channel site="movistarplus.es" site_id="CHAPIO" lang="es" xmltv_id="">M+ Liga de Campeones</channel>
-  <channel site="movistarplus.es" site_id="CL13" lang="es" xmltv_id="">Calle 13</channel>
-  <channel site="movistarplus.es" site_id="CLANTV" lang="es" xmltv_id="">Clan TVE</channel>
-  <channel site="movistarplus.es" site_id="CLASSD" lang="es" xmltv_id="">Classica</channel>
-  <channel site="movistarplus.es" site_id="CNN" lang="es" xmltv_id="">CNN Int</channel>
-  <channel site="movistarplus.es" site_id="COSMO" lang="es" xmltv_id="">COSMO</channel>
-  <channel site="movistarplus.es" site_id="CPACCI" lang="es" xmltv_id="">M+ Acción</channel>
-  <channel site="movistarplus.es" site_id="CPCOLE" lang="es" xmltv_id="">M+ Drama</channel>
-  <channel site="movistarplus.es" site_id="CPCOME" lang="es" xmltv_id="">M+ Comedia</channel>
-  <channel site="movistarplus.es" site_id="CPDEP" lang="es" xmltv_id="">M+ Deportes</channel>
-  <channel site="movistarplus.es" site_id="DAZB2" lang="es" xmltv_id="">DAZN Baloncesto 2</channel>
-  <channel site="movistarplus.es" site_id="DAZB3" lang="es" xmltv_id="">DAZN Baloncesto 3</channel>
-  <channel site="movistarplus.es" site_id="DAZBA" lang="es" xmltv_id="">DAZN Baloncesto</channel>
-  <channel site="movistarplus.es" site_id="DAZN3" lang="es" xmltv_id="">DAZN 3</channel>
-  <channel site="movistarplus.es" site_id="DAZN4" lang="es" xmltv_id="">DAZN 4</channel>
-  <channel site="movistarplus.es" site_id="DAZNL2" lang="es" xmltv_id="">DAZN LALIGA 2</channel>
-  <channel site="movistarplus.es" site_id="DAZNLI" lang="es" xmltv_id="">DAZN LALIGA</channel>
-  <channel site="movistarplus.es" site_id="DCESP" lang="es" xmltv_id="">M+ Cine Español</channel>
-  <channel site="movistarplus.es" site_id="DCR" lang="es" xmltv_id="">Discovery</channel>
-  <channel site="movistarplus.es" site_id="DCRMAX" lang="es" xmltv_id="">DMAX</channel>
-  <channel site="movistarplus.es" site_id="DIVINI" lang="es" xmltv_id="">Divinity</channel>
-  <channel site="movistarplus.es" site_id="DKISS" lang="es" xmltv_id="">DKISS</channel>
-  <channel site="movistarplus.es" site_id="DWSP" lang="es" xmltv_id="">Dreamworks</channel>
-  <channel site="movistarplus.es" site_id="ENERGY" lang="es" xmltv_id="">Energy</channel>
-  <channel site="movistarplus.es" site_id="ENW" lang="es" xmltv_id="">Euronews</channel>
-  <channel site="movistarplus.es" site_id="ESP" lang="es" xmltv_id="">Eurosport 1</channel>
-  <channel site="movistarplus.es" site_id="ESP2" lang="es" xmltv_id="">Eurosport 2</channel>
-  <channel site="movistarplus.es" site_id="ETB" lang="es" xmltv_id="">EITB Basque</channel>
-  <channel site="movistarplus.es" site_id="EXTREM" lang="es" xmltv_id="">Canal Extremadura Sat</channel>
-  <channel site="movistarplus.es" site_id="FDFIC" lang="es" xmltv_id="">Factoría de Ficción</channel>
-  <channel site="movistarplus.es" site_id="FLIX1" lang="es" xmltv_id="">Canal FlixOlé 1</channel>
-  <channel site="movistarplus.es" site_id="FLIX2" lang="es" xmltv_id="">Canal FlixOlé 2</channel>
-  <channel site="movistarplus.es" site_id="FOXGE" lang="es" xmltv_id="">STAR Channel</channel>
-  <channel site="movistarplus.es" site_id="FRANCE" lang="es" xmltv_id="">FRANCE24 (FR)</channel>
-  <channel site="movistarplus.es" site_id="GARAGE" lang="es" xmltv_id="">El Garage TV</channel>
-  <channel site="movistarplus.es" site_id="GOL" lang="es" xmltv_id="">GOL</channel>
-  <channel site="movistarplus.es" site_id="GOLF2" lang="es" xmltv_id="">M+ Golf 2</channel>
-  <channel site="movistarplus.es" site_id="GOLF+" lang="es" xmltv_id="">M+ Golf</channel>
-  <channel site="movistarplus.es" site_id="INTECO" lang="es" xmltv_id="">El Toro TV</channel>
-  <channel site="movistarplus.es" site_id="INTEUA" lang="es" xmltv_id="">1+1 Internacional</channel>
-  <channel site="movistarplus.es" site_id="LA2" lang="es" xmltv_id="">LA 2</channel>
-  <channel site="movistarplus.es" site_id="M1SD" lang="es" xmltv_id="">DAZN 1</channel>
-  <channel site="movistarplus.es" site_id="M2SD" lang="es" xmltv_id="">DAZN 2</channel>
-  <channel site="movistarplus.es" site_id="MAXAVA" lang="es" xmltv_id="">HBO Max Avances</channel>
-  <channel site="movistarplus.es" site_id="MCIBE" lang="es" xmltv_id="">M+ Cine bélico</channel>
-  <channel site="movistarplus.es" site_id="MCLAS" lang="es" xmltv_id="">M+ Clásicos</channel>
-  <channel site="movistarplus.es" site_id="MCOPA" lang="es" xmltv_id="">Primera Federación</channel>
-  <channel site="movistarplus.es" site_id="MDOC" lang="es" xmltv_id="">M+ Documentales</channel>
-  <channel site="movistarplus.es" site_id="MEGA" lang="es" xmltv_id="">Mega</channel>
-  <channel site="movistarplus.es" site_id="MELLAV" lang="es" xmltv_id="">M+ Ellas V</channel>
-  <channel site="movistarplus.es" site_id="MEZZLI" lang="es" xmltv_id="">Mezzo Live</channel>
-  <channel site="movistarplus.es" site_id="MEZZO" lang="es" xmltv_id="">Mezzo</channel>
-  <channel site="movistarplus.es" site_id="MHITS" lang="es" xmltv_id="">M+ Hits</channel>
-  <channel site="movistarplus.es" site_id="MINDI" lang="es" xmltv_id="">M+ Indie</channel>
-  <channel site="movistarplus.es" site_id="MLIG1" lang="es" xmltv_id="">M+ LALIGA 2</channel>
-  <channel site="movistarplus.es" site_id="MLIG2" lang="es" xmltv_id="">M+ LALIGA 3</channel>
-  <channel site="movistarplus.es" site_id="MLIG3" lang="es" xmltv_id="">M+ LALIGA 4</channel>
-  <channel site="movistarplus.es" site_id="MLIGA" lang="es" xmltv_id="">M+ LALIGA</channel>
-  <channel site="movistarplus.es" site_id="MLIGS" lang="es" xmltv_id="">LALIGA TV HYPERMOTION</channel>
-  <channel site="movistarplus.es" site_id="MLIGS2" lang="es" xmltv_id="">LALIGA TV HYPERMOTION 2</channel>
-  <channel site="movistarplus.es" site_id="MLIGS3" lang="es" xmltv_id="">LALIGA TV HYPERMOTION 3</channel>
-  <channel site="movistarplus.es" site_id="MORIG" lang="es" xmltv_id="">M+ Originales</channel>
-  <channel site="movistarplus.es" site_id="MPLUS" lang="es" xmltv_id="">Movistar Plus+</channel>
-  <channel site="movistarplus.es" site_id="MTV" lang="es" xmltv_id="">MTV</channel>
-  <channel site="movistarplus.es" site_id="MULTI6" lang="es" xmltv_id="">M+ Deportes 7</channel>
-  <channel site="movistarplus.es" site_id="MULTI8" lang="es" xmltv_id="">M+ Deportes 6</channel>
-  <channel site="movistarplus.es" site_id="MULTI9" lang="es" xmltv_id="">M+ Deportes 8</channel>
-  <channel site="movistarplus.es" site_id="MV1" lang="es" xmltv_id="">M+ Estrenos</channel>
-  <channel site="movistarplus.es" site_id="MVF1" lang="es" xmltv_id="">DAZN F1</channel>
-  <channel site="movistarplus.es" site_id="NATGEO" lang="es" xmltv_id="">National Geographic</channel>
-  <channel site="movistarplus.es" site_id="NATGW" lang="es" xmltv_id="">Nat Geo Wild</channel>
-  <channel site="movistarplus.es" site_id="NBC" lang="es" xmltv_id="">CNBC</channel>
-  <channel site="movistarplus.es" site_id="NEGOTV" lang="es" xmltv_id="">Negocios TV</channel>
-  <channel site="movistarplus.es" site_id="NEOX" lang="es" xmltv_id="">Neox</channel>
-  <channel site="movistarplus.es" site_id="NICK" lang="es" xmltv_id="">Nickelodeon</channel>
-  <channel site="movistarplus.es" site_id="NICKJR" lang="es" xmltv_id="">NICK JR</channel>
-  <channel site="movistarplus.es" site_id="NOVA" lang="es" xmltv_id="">Nova</channel>
-  <channel site="movistarplus.es" site_id="PCM" lang="es" xmltv_id="">Comedy Central</channel>
-  <channel site="movistarplus.es" site_id="PLAYDC" lang="es" xmltv_id="">Disney Junior</channel>
-  <channel site="movistarplus.es" site_id="REALM" lang="es" xmltv_id="">Real Madrid TV</channel>
-  <channel site="movistarplus.es" site_id="SCI-FI" lang="es" xmltv_id="">SYFY</channel>
-  <channel site="movistarplus.es" site_id="SET" lang="es" xmltv_id="">AXN Movies</channel>
-  <channel site="movistarplus.es" site_id="SEXTA" lang="es" xmltv_id="">La Sexta</channel>
-  <channel site="movistarplus.es" site_id="SKYSHO" lang="es" xmltv_id="">SkyShowtime 1</channel>
-  <channel site="movistarplus.es" site_id="SQUI" lang="es" xmltv_id="">Squirrel</channel>
-  <channel site="movistarplus.es" site_id="T5" lang="es" xmltv_id="">Telecinco</channel>
-  <channel site="movistarplus.es" site_id="TCM" lang="es" xmltv_id="">TCM</channel>
-  <channel site="movistarplus.es" site_id="TDEP" lang="es" xmltv_id="">Teledeporte</channel>
-  <channel site="movistarplus.es" site_id="TELMIN" lang="es" xmltv_id="">Telemadrid Int.</channel>
-  <channel site="movistarplus.es" site_id="TEN" lang="es" xmltv_id="">Ten</channel>
-  <channel site="movistarplus.es" site_id="TNT" lang="es" xmltv_id="">Warner TV</channel>
-  <channel site="movistarplus.es" site_id="TV5" lang="es" xmltv_id="">TV5MONDE</channel>
-  <channel site="movistarplus.es" site_id="TVC" lang="es" xmltv_id="">TV3 Cat</channel>
-  <channel site="movistarplus.es" site_id="TVE" lang="es" xmltv_id="">LA 1</channel>
-  <channel site="movistarplus.es" site_id="TVG" lang="es" xmltv_id="">TVG Europa</channel>
-  <channel site="movistarplus.es" site_id="UBEAT" lang="es" xmltv_id="">Ubeat</channel>
-  <channel site="movistarplus.es" site_id="UCL" lang="es" xmltv_id="">UCL</channel>
-  <channel site="movistarplus.es" site_id="USOP2" lang="es" xmltv_id="">M+ Deportes 3</channel>
-  <channel site="movistarplus.es" site_id="USOP3" lang="es" xmltv_id="">M+ Deportes 4</channel>
-  <channel site="movistarplus.es" site_id="USOP11" lang="es" xmltv_id="">M+ Deportes 5</channel>
-  <channel site="movistarplus.es" site_id="VAM2SD" lang="es" xmltv_id="">M+ Vamos 2</channel>
-  <channel site="movistarplus.es" site_id="VAMOSD" lang="es" xmltv_id="">M+ Vamos</channel>
-  <channel site="movistarplus.es" site_id="VEO7" lang="es" xmltv_id="">Veo7</channel>
+  <channel site="movistarplus.es" site_id="13TV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/13TV" xmltv_id="Trece.es@SD">TRECE</channel>
+  <channel site="movistarplus.es" site_id="24H" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/24H" xmltv_id="24Horas.es@SD">24 Horas</channel>
+  <channel site="movistarplus.es" site_id="A3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/A3" xmltv_id="Antena3.es@National">Antena 3</channel>
+  <channel site="movistarplus.es" site_id="ALJAZE" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ALJAZE" xmltv_id="AlJazeera.qa@Arabic">Al Jazeera English</channel>
+  <channel site="movistarplus.es" site_id="ANTV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ANTV" xmltv_id="CanalSurAndalucia.es@SD">Canal Sur Andalucía</channel>
+  <channel site="movistarplus.es" site_id="ARAGON" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ARAGON" xmltv_id="AragonTVInternacional.es@SD">Aragón TV Int</channel>
+  <channel site="movistarplus.es" site_id="ARTHUR" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ARTHUR" xmltv_id="Deportes2porMovistarPlus.es@SD">M+ Deportes 2</channel>
+  <channel site="movistarplus.es" site_id="ATRESS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ATRESS" xmltv_id="Atreseries.es@SD">Atreseries</channel>
+  <channel site="movistarplus.es" site_id="AXN" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/AXN" xmltv_id="AXN.es@SD">AXN</channel>
+  <channel site="movistarplus.es" site_id="BABY" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BABY" xmltv_id="BabyTV.uk@UK">Baby TV</channel>
+  <channel site="movistarplus.es" site_id="BBC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBC" xmltv_id="BBCNews.uk@UK">BBC News</channel>
+  <channel site="movistarplus.es" site_id="BBCEAR" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBCEAR" xmltv_id="">BBC Earth</channel>
+  <channel site="movistarplus.es" site_id="BBCLIF" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBCLIF" xmltv_id="BBCLifestyle.uk@Singapore">BBC Lifestyle</channel>
+  <channel site="movistarplus.es" site_id="BBDRA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBDRA" xmltv_id="">BBC Series</channel>
+  <channel site="movistarplus.es" site_id="BBFOO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBFOO" xmltv_id="">BBC Food</channel>
+  <channel site="movistarplus.es" site_id="BBGEA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBGEA" xmltv_id="">BBC Top Gear</channel>
+  <channel site="movistarplus.es" site_id="BBHIS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BBHIS" xmltv_id="">BBC History</channel>
+  <channel site="movistarplus.es" site_id="BEMAD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BEMAD" xmltv_id="BeMad.es@SD">BE MAD</channel>
+  <channel site="movistarplus.es" site_id="BL" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BL" xmltv_id="">Bloomberg</channel>
+  <channel site="movistarplus.es" site_id="BOING" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/BOING" xmltv_id="Boing.es@SD">Boing</channel>
+  <channel site="movistarplus.es" site_id="C4" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/C4" xmltv_id="Cuatro.es@SD">Cuatro</channel>
+  <channel site="movistarplus.es" site_id="CAZPES" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CAZPES" xmltv_id="CazayPesca.es@SD">Caza y Pesca</channel>
+  <channel site="movistarplus.es" site_id="CCTV-E" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CCTV-E" xmltv_id="CGTNSpanish.cn@SD">CGTN Español</channel>
+  <channel site="movistarplus.es" site_id="CHAP1" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP1" xmltv_id="LigadeCampeones2porMovistarPlusPlus.es@SD">M+ Liga de Campeones 2</channel>
+  <channel site="movistarplus.es" site_id="CHAP2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP2" xmltv_id="LigadeCampeones3porMovistarPlusPlus.es@SD">M+ Liga de Campeones 3</channel>
+  <channel site="movistarplus.es" site_id="CHAP3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP3" xmltv_id="LigadeCampeones4porMovistarPlusPlus.es@SD">M+ Liga de Campeones 4</channel>
+  <channel site="movistarplus.es" site_id="CHAP4" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP4" xmltv_id="LigadeCampeones5porMovistarPlusPlus.es@SD">M+ Liga de Campeones 5</channel>
+  <channel site="movistarplus.es" site_id="CHAP5" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP5" xmltv_id="LigadeCampeones6porMovistarPlusPlus.es@SD">M+ Liga de Campeones 6</channel>
+  <channel site="movistarplus.es" site_id="CHAP6" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP6" xmltv_id="LigadeCampeones7porMovistarPlusPlus.es@SD">M+ Liga de Campeones 7</channel>
+  <channel site="movistarplus.es" site_id="CHAP7" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP7" xmltv_id="LigadeCampeones8porMovistarPlusPlus.es@SD">M+ Liga de Campeones 8</channel>
+  <channel site="movistarplus.es" site_id="CHAP8" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP8" xmltv_id="LigadeCampeones9porMovistarPlusPlus.es@SD">M+ Liga de Campeones 9</channel>
+  <channel site="movistarplus.es" site_id="CHAP9" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP9" xmltv_id="LigadeCampeones10porMovistarPlusPlus.es@SD">M+ Liga de Campeones 10</channel>
+  <channel site="movistarplus.es" site_id="CHAP10" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP10" xmltv_id="LigadeCampeones11porMovistarPlusPlus.es@SD">M+ Liga de Campeones 11</channel>
+  <channel site="movistarplus.es" site_id="CHAP11" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP11" xmltv_id="LigadeCampeones12porMovistarPlusPlus.es@SD">M+ Liga de Campeones 12</channel>
+  <channel site="movistarplus.es" site_id="CHAP12" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAP12" xmltv_id="LigadeCampeones13porMovistarPlusPlus.es@SD">M+ Liga de Campeones 13</channel>
+  <channel site="movistarplus.es" site_id="CHAPIO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CHAPIO" xmltv_id="LigadeCampeonesporMovistarPlusPlus.es@SD">M+ Liga de Campeones</channel>
+  <channel site="movistarplus.es" site_id="CL13" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CL13" xmltv_id="Calle13Universal.es@SD">Calle 13</channel>
+  <channel site="movistarplus.es" site_id="CLANTV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CLANTV" xmltv_id="ClanInternacional.es@SD">Clan TVE</channel>
+  <channel site="movistarplus.es" site_id="CLASSD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CLASSD" xmltv_id="Classica.us@SD">Classica</channel>
+  <channel site="movistarplus.es" site_id="CNN" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CNN" xmltv_id="CNNInternational.us@MENA">CNN Int</channel>
+  <channel site="movistarplus.es" site_id="COSMO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/COSMO" xmltv_id="COSMO.es@SD">COSMO</channel>
+  <channel site="movistarplus.es" site_id="CPACCI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CPACCI" xmltv_id="AccionporMovistarPlusPlus.es@SD">M+ Acción</channel>
+  <channel site="movistarplus.es" site_id="CPCOLE" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CPCOLE" xmltv_id="DramaporMovistarPlusPlus.es@SD">M+ Drama</channel>
+  <channel site="movistarplus.es" site_id="CPCOME" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CPCOME" xmltv_id="ComediaporMovistarPlusPlus.es@SD">M+ Comedia</channel>
+  <channel site="movistarplus.es" site_id="CPDEP" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/CPDEP" xmltv_id="DeportesporMovistarPlusPlus.es@SD">M+ Deportes</channel>
+  <channel site="movistarplus.es" site_id="DAZB2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZB2" xmltv_id="">DAZN Baloncesto 2</channel>
+  <channel site="movistarplus.es" site_id="DAZB3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZB3" xmltv_id="">DAZN Baloncesto 3</channel>
+  <channel site="movistarplus.es" site_id="DAZBA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZBA" xmltv_id="">DAZN Baloncesto</channel>
+  <channel site="movistarplus.es" site_id="DAZMOT" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZMOT" xmltv_id="">DAZN MotoGP</channel>
+  <channel site="movistarplus.es" site_id="DAZN3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZN3" xmltv_id="DAZN3.uk@Belgium">DAZN 3</channel>
+  <channel site="movistarplus.es" site_id="DAZN4" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZN4" xmltv_id="DAZN4.uk@Portugal">DAZN 4</channel>
+  <channel site="movistarplus.es" site_id="DAZNL2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZNL2" xmltv_id="DAZNLaLiga2.uk@Spain">DAZN LALIGA 2</channel>
+  <channel site="movistarplus.es" site_id="DAZNLI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DAZNLI" xmltv_id="DAZNLaLiga.uk@Spain">DAZN LALIGA</channel>
+  <channel site="movistarplus.es" site_id="DCESP" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DCESP" xmltv_id="CineEspanolporMovistarPlusPlus.es@SD">M+ Cine Español</channel>
+  <channel site="movistarplus.es" site_id="DCR" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DCR" xmltv_id="DiscoveryChannel.nz@SD">Discovery</channel>
+  <channel site="movistarplus.es" site_id="DCRMAX" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DCRMAX" xmltv_id="DMAX.es@SD">DMAX</channel>
+  <channel site="movistarplus.es" site_id="DIVINI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DIVINI" xmltv_id="Divinity.es@SD">Divinity</channel>
+  <channel site="movistarplus.es" site_id="DKISS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DKISS" xmltv_id="DKISS.es@SD">DKISS</channel>
+  <channel site="movistarplus.es" site_id="DWSP" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/DWSP" xmltv_id="DreamWorks.fr@SD">Dreamworks</channel>
+  <channel site="movistarplus.es" site_id="ENERGY" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ENERGY" xmltv_id="Energy.es@SD">Energy</channel>
+  <channel site="movistarplus.es" site_id="ENW" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ENW" xmltv_id="EuronewsSpanish.fr@SD">Euronews</channel>
+  <channel site="movistarplus.es" site_id="ESP" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ESP" xmltv_id="Eurosport1.fr@France">Eurosport 1</channel>
+  <channel site="movistarplus.es" site_id="ESP2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ESP2" xmltv_id="Eurosport2.fr@France">Eurosport 2</channel>
+  <channel site="movistarplus.es" site_id="ETB" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ETB" xmltv_id="ETB2On.es@HD">etb2ON</channel>
+  <channel site="movistarplus.es" site_id="ETB3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/ETB3" xmltv_id="ETB1On.es@HD">etb1ON</channel>
+  <channel site="movistarplus.es" site_id="EXTREM" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/EXTREM" xmltv_id="CanalExtremaduraSatelite.es@SD">Canal Extremadura Sat</channel>
+  <channel site="movistarplus.es" site_id="FDFIC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/FDFIC" xmltv_id="FactoriadeFiccion.es@SD">Factoría de Ficción</channel>
+  <channel site="movistarplus.es" site_id="FLIX1" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/FLIX1" xmltv_id="">Canal FlixOlé 1</channel>
+  <channel site="movistarplus.es" site_id="FLIX2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/FLIX2" xmltv_id="">Canal FlixOlé 2</channel>
+  <channel site="movistarplus.es" site_id="FOXGE" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/FOXGE" xmltv_id="StarChannel.es@SD">STAR Channel</channel>
+  <channel site="movistarplus.es" site_id="FRANCE" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/FRANCE" xmltv_id="France24.fr@French">FRANCE24 (FR)</channel>
+  <channel site="movistarplus.es" site_id="GOL" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/GOL" xmltv_id="Gol.es@SD">GOL</channel>
+  <channel site="movistarplus.es" site_id="GOLF2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/GOLF2" xmltv_id="Golf2porMovistarPlusPlus.es@SD">M+ Golf 2</channel>
+  <channel site="movistarplus.es" site_id="GOLF+" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/GOLF%2B" xmltv_id="GolfporMovistarPlusPlus.es@SD">M+ Golf</channel>
+  <channel site="movistarplus.es" site_id="INTECO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/INTECO" xmltv_id="ElToroTV.es@SD">El Toro TV</channel>
+  <channel site="movistarplus.es" site_id="INTEUA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/INTEUA" xmltv_id="1Plus1International.ua@SD">1+1 Internacional</channel>
+  <channel site="movistarplus.es" site_id="LA2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/LA2" xmltv_id="La2.es@SD">LA 2</channel>
+  <channel site="movistarplus.es" site_id="M1SD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/M1SD" xmltv_id="DAZN1.uk@UKHD">DAZN 1</channel>
+  <channel site="movistarplus.es" site_id="M2SD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/M2SD" xmltv_id="DAZN2.uk@Belgium">DAZN 2</channel>
+  <channel site="movistarplus.es" site_id="MAXAVA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MAXAVA" xmltv_id="">HBO Max Avances</channel>
+  <channel site="movistarplus.es" site_id="MBALC2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MBALC2" xmltv_id="">M+ Baloncesto 2</channel>
+  <channel site="movistarplus.es" site_id="MBALC3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MBALC3" xmltv_id="">M+ Baloncesto 3</channel>
+  <channel site="movistarplus.es" site_id="MBALCT" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MBALCT" xmltv_id="">M+ Baloncesto</channel>
+  <channel site="movistarplus.es" site_id="MCLAS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MCLAS" xmltv_id="ClasicosporMovistarPlusPlus.es@SD">M+ Clásicos</channel>
+  <channel site="movistarplus.es" site_id="MCOPA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MCOPA" xmltv_id="">Primera Federación</channel>
+  <channel site="movistarplus.es" site_id="MDOC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MDOC" xmltv_id="DocumentalesporMovistarPlusPlus.es@SD">M+ Documentales</channel>
+  <channel site="movistarplus.es" site_id="MEGA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MEGA" xmltv_id="Mega.es@SD">Mega</channel>
+  <channel site="movistarplus.es" site_id="MELLAV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MELLAV" xmltv_id="EllasVamosporMovistarPlusPlus.es@SD">M+ Vamos 3</channel>
+  <channel site="movistarplus.es" site_id="MEZZLI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MEZZLI" xmltv_id="MezzoLive.fr@SD">Mezzo Live</channel>
+  <channel site="movistarplus.es" site_id="MEZZO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MEZZO" xmltv_id="Mezzo.fr@SD">Mezzo</channel>
+  <channel site="movistarplus.es" site_id="MHITS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MHITS" xmltv_id="">M+ Hits</channel>
+  <channel site="movistarplus.es" site_id="MINDI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MINDI" xmltv_id="IndieporMovistarPlusPlus.es@SD">M+ Indie</channel>
+  <channel site="movistarplus.es" site_id="MLIG1" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIG1" xmltv_id="LaLigaTV2porMovistarPlusPlus.es@SD">M+ LALIGA 2</channel>
+  <channel site="movistarplus.es" site_id="MLIG2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIG2" xmltv_id="LaLigaTV3porMovistarPlusPlus.es@SD">M+ LALIGA 3</channel>
+  <channel site="movistarplus.es" site_id="MLIG3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIG3" xmltv_id="LaLigaTV4porMovistarPlusPlus.es@SD">M+ LALIGA 4</channel>
+  <channel site="movistarplus.es" site_id="MLIGA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIGA" xmltv_id="LaLigaTVporMovistarPlusPlus.es@SD">M+ LALIGA</channel>
+  <channel site="movistarplus.es" site_id="MLIGS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIGS" xmltv_id="LaLigaHypermotion.es@SD">LALIGA TV HYPERMOTION</channel>
+  <channel site="movistarplus.es" site_id="MLIGS2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIGS2" xmltv_id="LaLigaHypermotion2.es@SD">LALIGA TV HYPERMOTION 2</channel>
+  <channel site="movistarplus.es" site_id="MLIGS3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MLIGS3" xmltv_id="LaLigaHypermotion3.es@SD">LALIGA TV HYPERMOTION 3</channel>
+  <channel site="movistarplus.es" site_id="MORGUL" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MORGUL" xmltv_id="">M+ Orgullo</channel>
+  <channel site="movistarplus.es" site_id="MORIG" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MORIG" xmltv_id="OriginalesporMovistarPlusPlus.es@SD">M+ Originales</channel>
+  <channel site="movistarplus.es" site_id="MPLUS" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MPLUS" xmltv_id="MovistarPlusPlus.es@SD">Movistar Plus</channel>
+  <channel site="movistarplus.es" site_id="MTV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MTV" xmltv_id="MTV.es@SD">MTV</channel>
+  <channel site="movistarplus.es" site_id="MULTI6" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MULTI6" xmltv_id="Deportes7porMovistarPlus.es@SD">M+ Deportes 7</channel>
+  <channel site="movistarplus.es" site_id="MULTI8" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MULTI8" xmltv_id="Deportes6porMovistarPlus.es@SD">M+ Deportes 6</channel>
+  <channel site="movistarplus.es" site_id="MULTI9" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MULTI9" xmltv_id="Deportes8porMovistarPlus.es@SD">M+ Deportes 8</channel>
+  <channel site="movistarplus.es" site_id="MV1" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MV1" xmltv_id="CineporMovistarPlusPlus.es@SD">M+ Estrenos</channel>
+  <channel site="movistarplus.es" site_id="MVCIVA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MVCIVA" xmltv_id="">M+ Vacaciones</channel>
+  <channel site="movistarplus.es" site_id="MVF1" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/MVF1" xmltv_id="DAZNF1.uk@Spain">DAZN F1</channel>
+  <channel site="movistarplus.es" site_id="NATGEO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NATGEO" xmltv_id="NationalGeographic.es@SD">National Geographic</channel>
+  <channel site="movistarplus.es" site_id="NATGW" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NATGW" xmltv_id="">Nat Geo Wild</channel>
+  <channel site="movistarplus.es" site_id="NBC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NBC" xmltv_id="CNBCEurope.uk@SD">CNBC</channel>
+  <channel site="movistarplus.es" site_id="NEGOTV" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NEGOTV" xmltv_id="NegociosTV.es@SD">Negocios TV</channel>
+  <channel site="movistarplus.es" site_id="NEOX" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NEOX" xmltv_id="Neox.es@SD">Neox</channel>
+  <channel site="movistarplus.es" site_id="NICK" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NICK" xmltv_id="Nickelodeon.es@SD">Nickelodeon</channel>
+  <channel site="movistarplus.es" site_id="NICKJR" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NICKJR" xmltv_id="NickJr.es@SD">NICK JR</channel>
+  <channel site="movistarplus.es" site_id="NOVA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/NOVA" xmltv_id="Nova.es@SD">Nova</channel>
+  <channel site="movistarplus.es" site_id="PCM" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/PCM" xmltv_id="ComedyCentral.es@SD">Comedy Central</channel>
+  <channel site="movistarplus.es" site_id="PLAYDC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/PLAYDC" xmltv_id="DisneyChannel.es@SD">Disney Channel</channel>
+  <channel site="movistarplus.es" site_id="REALM" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/REALM" xmltv_id="RealMadridTV.es@SD">Real Madrid TV</channel>
+  <channel site="movistarplus.es" site_id="RED" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/RED" xmltv_id="CanalRed.es@SD">Canal RED</channel>
+  <channel site="movistarplus.es" site_id="SCI-FI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/SCI-FI" xmltv_id="Syfy.es@SD">SYFY</channel>
+  <channel site="movistarplus.es" site_id="SET" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/SET" xmltv_id="AXNMovies.es@SD">AXN Movies</channel>
+  <channel site="movistarplus.es" site_id="SEXTA" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/SEXTA" xmltv_id="LaSexta.es@SD">La Sexta</channel>
+  <channel site="movistarplus.es" site_id="SKYSHO" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/SKYSHO" xmltv_id="">SkyShowtime 1</channel>
+  <channel site="movistarplus.es" site_id="SQUI" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/SQUI" xmltv_id="Squirrel.es@SD">Squirrel</channel>
+  <channel site="movistarplus.es" site_id="T5" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/T5" xmltv_id="Telecinco.es@SD">Telecinco</channel>
+  <channel site="movistarplus.es" site_id="TCM" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TCM" xmltv_id="TCM.es@SD">TCM</channel>
+  <channel site="movistarplus.es" site_id="TDEP" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TDEP" xmltv_id="Teledeporte.es@SD">Teledeporte</channel>
+  <channel site="movistarplus.es" site_id="TELMIN" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TELMIN" xmltv_id="TelemadridINT.es@SD">Telemadrid Int.</channel>
+  <channel site="movistarplus.es" site_id="TEN" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TEN" xmltv_id="TEN.es@SD">Ten</channel>
+  <channel site="movistarplus.es" site_id="TNT" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TNT" xmltv_id="WarnerTV.es@SD">Warner TV</channel>
+  <channel site="movistarplus.es" site_id="TV5" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TV5" xmltv_id="TV5MondeEurope.fr@SD">TV5MONDE</channel>
+  <channel site="movistarplus.es" site_id="TVC" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TVC" xmltv_id="TV3CAT.es@SD">TV3 Cat</channel>
+  <channel site="movistarplus.es" site_id="TVE" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TVE" xmltv_id="La1.es@SD">LA 1</channel>
+  <channel site="movistarplus.es" site_id="TVG" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/TVG" xmltv_id="GaliciaTVEuropa.es@SD">TVG Europa</channel>
+  <channel site="movistarplus.es" site_id="UCL" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/UCL" xmltv_id="UCL.uy@SD">UCL</channel>
+  <channel site="movistarplus.es" site_id="USOP2" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/USOP2" xmltv_id="Deportes3porMovistarPlus.es@SD">M+ Deportes 3</channel>
+  <channel site="movistarplus.es" site_id="USOP3" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/USOP3" xmltv_id="Deportes4porMovistarPlus.es@SD">M+ Deportes 4</channel>
+  <channel site="movistarplus.es" site_id="USOP11" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/USOP11" xmltv_id="Deportes5porMovistarPlus.es@SD">M+ Deportes 5</channel>
+  <channel site="movistarplus.es" site_id="VAM2SD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/VAM2SD" xmltv_id="">M+ Vamos 2</channel>
+  <channel site="movistarplus.es" site_id="VAMOSD" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/VAMOSD" xmltv_id="VamosporMovistarPlusPlus.es@SD">M+ Vamos</channel>
+  <channel site="movistarplus.es" site_id="VEO7" lang="es" logo="https://estatico.emisiondof6.com/recorte/m-DP/wpmos/VEO7" xmltv_id="Veo7.es@SD">Veo7</channel>
 </channels>

--- a/sites/movistarplus.es/movistarplus.es.config.js
+++ b/sites/movistarplus.es/movistarplus.es.config.js
@@ -55,7 +55,7 @@ module.exports = {
         lang: 'es',
         site_id: channel.CodCadenaTv,
         name: channel.Nombre,
-        logo: channel.Logo ? channel.Logos[0].url : null
+        logo: channel.Logo || channel.Logos?.[0]?.uri || null
       }
     })
   }


### PR DESCRIPTION
### Problem

Every channel grabbed from `movistarplus.es` comes out without a logo. The `channels()` parser reads `channel.Logos[0].url`, but the Movistar API names that field `uri` (there is also a top-level `Logo` string), so the expression always evaluates to `undefined`:

```js
logo: channel.Logo ? channel.Logos[0].url : null
```

Since almost all entries in `movistarplus.es.channels.xml` also have an empty `xmltv_id`, the API logo fallback in `epg/grab` can't kick in either, so guides from this site end up with no `<icon>` at all.

### Fix

- Read `channel.Logo`, falling back to `channel.Logos?.[0]?.uri`.
- Regenerate `movistarplus.es.channels.xml` with `channels:parse` using the fixed config: 143 channels from the live lineup (was 139), all with logos.
- Map 120 of the 143 channels to their `xmltv_id` (verified against the iptv-org API; the remaining 23 are pop-up/event channels with no database entry).

### Testing

- `npm test --- movistarplus.es` passes (3/3)
- `channels:lint` and `channels:validate` pass on the updated file
- Full grab of all 143 channels × 3 days completes without errors; output contains an `<icon>` for every channel

