### PR TITLE
Fix orangetv.orange.es segment cache leaking programs across channels

### DIFF
--- a/sites/orangetv.orange.es/orangetv.orange.es.config.js
+++ b/sites/orangetv.orange.es/orangetv.orange.es.config.js
@@ -31,26 +31,25 @@ module.exports = {
   async parser({ content, channel, date }) {
     const programs = []
     const items = parseItems(content, channel)
-    if (items.length) {
-      const queues = []
-      // fetch other segments or use cache if exist
-      for (let i = 2; i <= 3; i++) {
-        const url = segmentUrl(date, i)
-        if (caches[url] !== undefined) {
-          items.push(...caches[url])
-        } else {
-          queues.push({ url, params: module.exports.request })
+    const queues = []
+    // fetch other segments or use cache if exist
+    for (let i = 2; i <= 3; i++) {
+      const url = segmentUrl(date, i)
+      if (caches[url] !== undefined) {
+        items.push(...parseItems(caches[url], channel))
+      } else {
+        queues.push({ url, params: module.exports.request })
+      }
+    }
+    if (queues.length) {
+      await doFetch(queues, (queue, res) => {
+        if (caches[queue.url] === undefined) {
+          caches[queue.url] = res
         }
-      }
-      if (queues.length) {
-        await doFetch(queues, (queue, res) => {
-          const segments = parseItems(res, channel)
-          items.push(...segments)
-          if (caches[queue.url] === undefined) {
-            caches[queue.url] = segments
-          }
-        })
-      }
+        items.push(...parseItems(res, channel))
+      })
+    }
+    if (items.length) {
       programs.push(
         ...items.map(item => {
           return {
@@ -110,7 +109,7 @@ function parseItems(content, channel) {
     typeof content === 'string' ? JSON.parse(content) : Array.isArray(content) ? content : []
   if (Array.isArray(json)) {
     json
-      .filter(i => i.channelExternalId === channel.site_id)
+      .filter(i => String(i.channelExternalId) === String(channel.site_id))
       .forEach(i => {
         result.push(...i.programs)
       })


### PR DESCRIPTION
### Problem

`sites/orangetv.orange.es/orangetv.orange.es.config.js` fetches each day in three 8-hour segments and caches segments 2-3 in a module-level `caches` object. But it stores the items **after** filtering them for the channel that happened to fetch the segment first:

```js
const segments = parseItems(res, channel)
items.push(...segments)
if (caches[queue.url] === undefined) {
  caches[queue.url] = segments   // <- channel-filtered!
}
```

Every channel parsed afterwards for the same date does `items.push(...caches[url])` and inherits that first channel's segment 2-3 programs. In a multi-channel grab this puts the same show on ~100 channels (screenshot below shows TRECE's "El cascabel" appearing on virtually every channel at 22:00):

Two smaller issues fixed along the way:

- The `if (items.length)` guard skipped segments 2-3 whenever a channel had no programs in segment 1 (00:00-08:00), so channels idle overnight came out completely empty even though the feed has their programs in segments 2-3.
- `i.channelExternalId === channel.site_id` compares strictly while the feed mixes numeric and string ids; compare as strings.

### Fix

Cache the raw segment payload and run `parseItems` per channel; always fetch segments 2-3; compare ids as strings.

### Testing

- `npm test --- orangetv.orange.es` passes (3/3)
- Full grab of 131 Orange channels × 3 days: each channel now carries only its own schedule (verified "El cascabel" appears only on TRECE, site_id 1017, matching the raw feed), and previously-empty channels (e.g. 12TV) now have programs.